### PR TITLE
Rusoto mock with json body serializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Add MediaStore support
 - Expose raw BufferedHttpResponse on ::Unknown error variants
 - Removed Ceph test for `Luminous`
+- Honor profile region in `Default` implementation for `Region`
 
 ## [0.34.0] - 2018-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@
 - Add MediaStore support
 - Expose raw BufferedHttpResponse on ::Unknown error variants
 - Removed Ceph test for `Luminous`
-- Honor profile region in `Default` implementation for `Region`
 
 ## [0.34.0] - 2018-09-05
 

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -18,7 +18,8 @@ homepage = "https://www.rusoto.org/"
 chrono = "0.4.0"
 futures = "0.1.16"
 http = "0.1.7"
-
+serde = "1.0.2"
+serde_json = "1.0.2"
 [dependencies.clippy]
 optional = true
 version = "0.0"

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -56,6 +56,8 @@ impl MockRequestDispatcher {
         self
     }
 
+    /// Mocks the json serialized response body what would be
+    /// returned from AWS
     pub fn with_json_body<B>(mut self, body: B) -> MockRequestDispatcher
         where B: Serialize {
         self.body = serde_json::to_vec(&body).expect("failed to deserialize into json");

--- a/mock/src/lib.rs
+++ b/mock/src/lib.rs
@@ -4,6 +4,8 @@ extern crate chrono;
 extern crate futures;
 extern crate http;
 extern crate rusoto_core;
+extern crate serde;
+extern crate serde_json;
 
 use std::fs::File;
 use std::io::Read;
@@ -13,6 +15,7 @@ use std::time::Duration;
 use rusoto_core::{DispatchSignedRequest, HttpDispatchError};
 use rusoto_core::credential::{ProvideAwsCredentials, CredentialsError, AwsCredentials};
 use rusoto_core::request::{Headers, HttpResponse};
+use serde::Serialize;
 use rusoto_core::signature::SignedRequest;
 use futures::future::{FutureResult, ok};
 use futures::stream::once;
@@ -50,6 +53,12 @@ impl MockRequestDispatcher {
 
     pub fn with_body(mut self, body: &str) -> MockRequestDispatcher {
         self.body = body.as_bytes().to_vec();
+        self
+    }
+
+    pub fn with_json_body<B>(mut self, body: B) -> MockRequestDispatcher
+        where B: Serialize {
+        self.body = serde_json::to_vec(&body).expect("failed to deserialize into json");
         self
     }
 

--- a/rusoto/services/acm-pca/src/generated.rs
+++ b/rusoto/services/acm-pca/src/generated.rs
@@ -91,6 +91,7 @@ pub struct ASN1Subject {
 
 /// <p>Contains information about your private certificate authority (CA). Your private CA can issue and revoke X.509 digital certificates. Digital certificates verify that the entity named in the certificate <b>Subject</b> field owns or controls the public key contained in the <b>Subject Public Key Info</b> field. Call the <a>CreateCertificateAuthority</a> operation to create your private CA. You must then call the <a>GetCertificateAuthorityCertificate</a> operation to retrieve a private CA certificate signing request (CSR). Take the CSR to your on-premises CA and sign it with the root CA certificate or a subordinate certificate. Call the <a>ImportCertificateAuthorityCertificate</a> operation to import the signed certificate into AWS Certificate Manager (ACM). </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CertificateAuthority {
     /// <p>Amazon Resource Name (ARN) for your private certificate authority (CA). The format is <code> <i>12345678-1234-1234-1234-123456789012</i> </code>.</p>
     #[serde(rename = "Arn")]
@@ -170,6 +171,7 @@ pub struct CreateCertificateAuthorityAuditReportRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateCertificateAuthorityAuditReportResponse {
     /// <p>An alphanumeric string that contains a report identifier.</p>
     #[serde(rename = "AuditReportId")]
@@ -200,6 +202,7 @@ pub struct CreateCertificateAuthorityRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateCertificateAuthorityResponse {
     /// <p>If successful, the Amazon Resource Name (ARN) of the certificate authority (CA). This is of the form: </p> <p> <code>arn:aws:acm-pca:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i> </code>. </p>
     #[serde(rename = "CertificateAuthorityArn")]
@@ -249,6 +252,7 @@ pub struct DescribeCertificateAuthorityAuditReportRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeCertificateAuthorityAuditReportResponse {
     /// <p>Specifies whether report creation is in progress, has succeeded, or has failed.</p>
     #[serde(rename = "AuditReportStatus")]
@@ -276,6 +280,7 @@ pub struct DescribeCertificateAuthorityRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeCertificateAuthorityResponse {
     /// <p>A <a>CertificateAuthority</a> structure that contains information about your private CA.</p>
     #[serde(rename = "CertificateAuthority")]
@@ -291,6 +296,7 @@ pub struct GetCertificateAuthorityCertificateRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetCertificateAuthorityCertificateResponse {
     /// <p>Base64-encoded certificate authority (CA) certificate.</p>
     #[serde(rename = "Certificate")]
@@ -310,6 +316,7 @@ pub struct GetCertificateAuthorityCsrRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetCertificateAuthorityCsrResponse {
     /// <p>The base64 PEM-encoded certificate signing request (CSR) for your private CA certificate.</p>
     #[serde(rename = "Csr")]
@@ -328,6 +335,7 @@ pub struct GetCertificateRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetCertificateResponse {
     /// <p>The base64 PEM-encoded certificate specified by the <code>CertificateArn</code> parameter.</p>
     #[serde(rename = "Certificate")]
@@ -388,6 +396,7 @@ pub struct IssueCertificateRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct IssueCertificateResponse {
     /// <p>The Amazon Resource Name (ARN) of the issued certificate and the certificate serial number. This is of the form:</p> <p> <code>arn:aws:acm-pca:<i>region</i>:<i>account</i>:certificate-authority/<i>12345678-1234-1234-1234-123456789012</i>/certificate/<i>286535153982981100925020015808220737245</i> </code> </p>
     #[serde(rename = "CertificateArn")]
@@ -408,6 +417,7 @@ pub struct ListCertificateAuthoritiesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListCertificateAuthoritiesResponse {
     /// <p>Summary information about each certificate authority you have created.</p>
     #[serde(rename = "CertificateAuthorities")]
@@ -435,6 +445,7 @@ pub struct ListTagsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagsResponse {
     /// <p>When the list is truncated, this value is present and should be used for the <b>NextToken</b> parameter in a subsequent pagination request. </p>
     #[serde(rename = "NextToken")]

--- a/rusoto/services/acm/src/generated.rs
+++ b/rusoto/services/acm/src/generated.rs
@@ -40,6 +40,7 @@ pub struct AddTagsToCertificateRequest {
 
 /// <p>Contains metadata about an ACM certificate. This structure is returned in the response to a <a>DescribeCertificate</a> request. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CertificateDetail {
     /// <p>The Amazon Resource Name (ARN) of the certificate. For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a> in the <i>AWS General Reference</i>.</p>
     #[serde(rename = "CertificateArn")]
@@ -158,6 +159,7 @@ pub struct CertificateOptions {
 
 /// <p>This structure is returned in the response object of <a>ListCertificates</a> action. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CertificateSummary {
     /// <p>Amazon Resource Name (ARN) of the certificate. This is of the form:</p> <p> <code>arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012</code> </p> <p>For more information about ARNs, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>. </p>
     #[serde(rename = "CertificateArn")]
@@ -184,6 +186,7 @@ pub struct DescribeCertificateRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeCertificateResponse {
     /// <p>Metadata about an ACM certificate.</p>
     #[serde(rename = "Certificate")]
@@ -193,6 +196,7 @@ pub struct DescribeCertificateResponse {
 
 /// <p>Contains information about the validation of each domain name in the certificate.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DomainValidation {
     /// <p>A fully qualified domain name (FQDN) in the certificate. For example, <code>www.example.com</code> or <code>example.com</code>. </p>
     #[serde(rename = "DomainName")]
@@ -246,6 +250,7 @@ pub struct ExportCertificateRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ExportCertificateResponse {
     /// <p>The base64 PEM-encoded certificate.</p>
     #[serde(rename = "Certificate")]
@@ -263,6 +268,7 @@ pub struct ExportCertificateResponse {
 
 /// <p>The Extended Key Usage X.509 v3 extension defines one or more purposes for which the public key can be used. This is in addition to or in place of the basic purposes specified by the Key Usage extension. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ExtendedKeyUsage {
     /// <p>The name of an Extended Key Usage value.</p>
     #[serde(rename = "Name")]
@@ -299,6 +305,7 @@ pub struct GetCertificateRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetCertificateResponse {
     /// <p>String that contains the ACM certificate represented by the ARN specified at input.</p>
     #[serde(rename = "Certificate")]
@@ -343,6 +350,7 @@ pub struct ImportCertificateRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ImportCertificateResponse {
     /// <p>The <a href="http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Name (ARN)</a> of the imported certificate.</p>
     #[serde(rename = "CertificateArn")]
@@ -352,6 +360,7 @@ pub struct ImportCertificateResponse {
 
 /// <p>The Key Usage X.509 v3 extension defines the purpose of the public key contained in the certificate.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct KeyUsage {
     /// <p>A string value that contains a Key Usage extension name.</p>
     #[serde(rename = "Name")]
@@ -380,6 +389,7 @@ pub struct ListCertificatesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListCertificatesResponse {
     /// <p>A list of ACM certificates.</p>
     #[serde(rename = "CertificateSummaryList")]
@@ -399,6 +409,7 @@ pub struct ListTagsForCertificateRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagsForCertificateResponse {
     /// <p>The key-value pairs that define the applied tags.</p>
     #[serde(rename = "Tags")]
@@ -418,6 +429,7 @@ pub struct RemoveTagsFromCertificateRequest {
 
 /// <p>Contains information about the status of ACM's <a href="http://docs.aws.amazon.com/acm/latest/userguide/acm-renewal.html">managed renewal</a> for the certificate. This structure exists only when the certificate type is <code>AMAZON_ISSUED</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RenewalSummary {
     /// <p>Contains information about the validation of each domain name in the certificate, as it pertains to ACM's <a href="http://docs.aws.amazon.com/acm/latest/userguide/acm-renewal.html">managed renewal</a>. This is different from the initial validation that occurs as a result of the <a>RequestCertificate</a> request. This field exists only when the certificate type is <code>AMAZON_ISSUED</code>.</p>
     #[serde(rename = "DomainValidationOptions")]
@@ -459,6 +471,7 @@ pub struct RequestCertificateRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RequestCertificateResponse {
     /// <p>String that contains the ARN of the issued certificate. This must be of the form:</p> <p> <code>arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012</code> </p>
     #[serde(rename = "CertificateArn")]
@@ -481,6 +494,7 @@ pub struct ResendValidationEmailRequest {
 
 /// <p>Contains a DNS record value that you can use to can use to validate ownership or control of a domain. This is used by the <a>DescribeCertificate</a> action. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResourceRecord {
     /// <p>The name of the DNS record to create in your domain. This is supplied by ACM.</p>
     #[serde(rename = "Name")]

--- a/rusoto/services/alexaforbusiness/src/generated.rs
+++ b/rusoto/services/alexaforbusiness/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>An address book with attributes.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddressBook {
     /// <p>The ARN of the address book.</p>
     #[serde(rename = "AddressBookArn")]
@@ -47,6 +48,7 @@ pub struct AddressBook {
 
 /// <p>Information related to an address book.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddressBookData {
     /// <p>The ARN of the address book.</p>
     #[serde(rename = "AddressBookArn")]
@@ -73,6 +75,7 @@ pub struct AssociateContactWithAddressBookRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociateContactWithAddressBookResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -88,6 +91,7 @@ pub struct AssociateDeviceWithRoomRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociateDeviceWithRoomResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -103,10 +107,12 @@ pub struct AssociateSkillGroupWithRoomRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociateSkillGroupWithRoomResponse {}
 
 /// <p>A contact with attributes.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Contact {
     /// <p>The ARN of the contact.</p>
     #[serde(rename = "ContactArn")]
@@ -132,6 +138,7 @@ pub struct Contact {
 
 /// <p>Information related to a contact.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ContactData {
     /// <p>The ARN of the contact.</p>
     #[serde(rename = "ContactArn")]
@@ -171,6 +178,7 @@ pub struct CreateAddressBookRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateAddressBookResponse {
     /// <p>The ARN of the newly created address book.</p>
     #[serde(rename = "AddressBookArn")]
@@ -201,6 +209,7 @@ pub struct CreateContactRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateContactResponse {
     /// <p>The ARN of the newly created address book.</p>
     #[serde(rename = "ContactArn")]
@@ -247,6 +256,7 @@ pub struct CreateProfileRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateProfileResponse {
     /// <p>The ARN of the newly created room profile in the response.</p>
     #[serde(rename = "ProfileArn")]
@@ -282,6 +292,7 @@ pub struct CreateRoomRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateRoomResponse {
     /// <p>The ARN of the newly created room in the response.</p>
     #[serde(rename = "RoomArn")]
@@ -305,6 +316,7 @@ pub struct CreateSkillGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateSkillGroupResponse {
     /// <p>The ARN of the newly created skill group in the response.</p>
     #[serde(rename = "SkillGroupArn")]
@@ -340,6 +352,7 @@ pub struct CreateUserRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateUserResponse {
     /// <p>The ARN of the newly created user in the response.</p>
     #[serde(rename = "UserArn")]
@@ -355,6 +368,7 @@ pub struct DeleteAddressBookRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteAddressBookResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -365,6 +379,7 @@ pub struct DeleteContactRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteContactResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -376,6 +391,7 @@ pub struct DeleteProfileRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteProfileResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -387,6 +403,7 @@ pub struct DeleteRoomRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteRoomResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -404,6 +421,7 @@ pub struct DeleteRoomSkillParameterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteRoomSkillParameterResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -415,6 +433,7 @@ pub struct DeleteSkillGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteSkillGroupResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -429,10 +448,12 @@ pub struct DeleteUserRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteUserResponse {}
 
 /// <p>A device with attributes.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Device {
     /// <p>The ARN of a device.</p>
     #[serde(rename = "DeviceArn")]
@@ -474,6 +495,7 @@ pub struct Device {
 
 /// <p>Device attributes.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeviceData {
     /// <p>The ARN of a device.</p>
     #[serde(rename = "DeviceArn")]
@@ -519,6 +541,7 @@ pub struct DeviceData {
 
 /// <p>The list of device events.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeviceEvent {
     /// <p>The time (in epoch) when the event occurred. </p>
     #[serde(rename = "Timestamp")]
@@ -536,6 +559,7 @@ pub struct DeviceEvent {
 
 /// <p>Details of a device’s status.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeviceStatusDetail {
     /// <p>The device status detail code.</p>
     #[serde(rename = "Code")]
@@ -545,6 +569,7 @@ pub struct DeviceStatusDetail {
 
 /// <p>Detailed information about a device's status.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeviceStatusInfo {
     /// <p>The latest available information about the connection status of a device. </p>
     #[serde(rename = "ConnectionStatus")]
@@ -567,6 +592,7 @@ pub struct DisassociateContactFromAddressBookRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisassociateContactFromAddressBookResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -578,6 +604,7 @@ pub struct DisassociateDeviceFromRoomRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisassociateDeviceFromRoomResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -593,6 +620,7 @@ pub struct DisassociateSkillGroupFromRoomRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisassociateSkillGroupFromRoomResponse {}
 
 /// <p>A filter name and value pair that is used to return a more specific list of results. Filters can be used to match a set of resources by various criteria.</p>
@@ -614,6 +642,7 @@ pub struct GetAddressBookRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetAddressBookResponse {
     /// <p>The details of the requested address book.</p>
     #[serde(rename = "AddressBook")]
@@ -629,6 +658,7 @@ pub struct GetContactRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetContactResponse {
     /// <p>The details of the requested contact.</p>
     #[serde(rename = "Contact")]
@@ -645,6 +675,7 @@ pub struct GetDeviceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDeviceResponse {
     /// <p>The details of the device requested. Required.</p>
     #[serde(rename = "Device")]
@@ -661,6 +692,7 @@ pub struct GetProfileRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetProfileResponse {
     /// <p>The details of the room profile requested. Required.</p>
     #[serde(rename = "Profile")]
@@ -677,6 +709,7 @@ pub struct GetRoomRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetRoomResponse {
     /// <p>The details of the room requested.</p>
     #[serde(rename = "Room")]
@@ -699,6 +732,7 @@ pub struct GetRoomSkillParameterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetRoomSkillParameterResponse {
     /// <p>The details of the room skill parameter requested. Required.</p>
     #[serde(rename = "RoomSkillParameter")]
@@ -715,6 +749,7 @@ pub struct GetSkillGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetSkillGroupResponse {
     /// <p>The details of the skill group requested. Required.</p>
     #[serde(rename = "SkillGroup")]
@@ -742,6 +777,7 @@ pub struct ListDeviceEventsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListDeviceEventsResponse {
     /// <p><p/></p>
     #[serde(rename = "DeviceEvents")]
@@ -770,6 +806,7 @@ pub struct ListSkillsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListSkillsResponse {
     /// <p>The token returned to indicate that there is more data available.</p>
     #[serde(rename = "NextToken")]
@@ -797,6 +834,7 @@ pub struct ListTagsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagsResponse {
     /// <p>The token returned to indicate that there is more data available.</p>
     #[serde(rename = "NextToken")]
@@ -810,6 +848,7 @@ pub struct ListTagsResponse {
 
 /// <p>A room profile with attributes.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Profile {
     /// <p>The address of a room profile.</p>
     #[serde(rename = "Address")]
@@ -855,6 +894,7 @@ pub struct Profile {
 
 /// <p>The data of a room profile.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ProfileData {
     /// <p>The address of a room profile.</p>
     #[serde(rename = "Address")]
@@ -901,6 +941,7 @@ pub struct PutRoomSkillParameterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutRoomSkillParameterResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -914,6 +955,7 @@ pub struct ResolveRoomRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResolveRoomResponse {
     /// <p>The ARN of the room from which the skill request was invoked.</p>
     #[serde(rename = "RoomArn")]
@@ -942,10 +984,12 @@ pub struct RevokeInvitationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RevokeInvitationResponse {}
 
 /// <p>A room with attributes.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Room {
     /// <p>The description of a room.</p>
     #[serde(rename = "Description")]
@@ -971,6 +1015,7 @@ pub struct Room {
 
 /// <p>The data of a room.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RoomData {
     /// <p>The description of a room.</p>
     #[serde(rename = "Description")]
@@ -1030,6 +1075,7 @@ pub struct SearchAddressBooksRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SearchAddressBooksResponse {
     /// <p>The address books that meet the specified set of filter criteria, in sort order.</p>
     #[serde(rename = "AddressBooks")]
@@ -1066,6 +1112,7 @@ pub struct SearchContactsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SearchContactsResponse {
     /// <p>The contacts that meet the specified set of filter criteria, in sort order.</p>
     #[serde(rename = "Contacts")]
@@ -1102,6 +1149,7 @@ pub struct SearchDevicesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SearchDevicesResponse {
     /// <p>The devices that meet the specified set of filter criteria, in sort order.</p>
     #[serde(rename = "Devices")]
@@ -1138,6 +1186,7 @@ pub struct SearchProfilesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SearchProfilesResponse {
     /// <p>The token returned to indicate that there is more data available.</p>
     #[serde(rename = "NextToken")]
@@ -1174,6 +1223,7 @@ pub struct SearchRoomsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SearchRoomsResponse {
     /// <p>The token returned to indicate that there is more data available.</p>
     #[serde(rename = "NextToken")]
@@ -1210,6 +1260,7 @@ pub struct SearchSkillGroupsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SearchSkillGroupsResponse {
     /// <p>The token returned to indicate that there is more data available.</p>
     #[serde(rename = "NextToken")]
@@ -1246,6 +1297,7 @@ pub struct SearchUsersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SearchUsersResponse {
     /// <p>The token returned to indicate that there is more data available.</p>
     #[serde(rename = "NextToken")]
@@ -1270,10 +1322,12 @@ pub struct SendInvitationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SendInvitationResponse {}
 
 /// <p>A skill group with attributes.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SkillGroup {
     /// <p>The description of a skill group.</p>
     #[serde(rename = "Description")]
@@ -1291,6 +1345,7 @@ pub struct SkillGroup {
 
 /// <p>The attributes of a skill group.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SkillGroupData {
     /// <p>The description of a skill group.</p>
     #[serde(rename = "Description")]
@@ -1308,6 +1363,7 @@ pub struct SkillGroupData {
 
 /// <p>The summary of skills.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SkillSummary {
     /// <p>The ARN of the skill summary.</p>
     #[serde(rename = "SkillId")]
@@ -1350,6 +1406,7 @@ pub struct StartDeviceSyncRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartDeviceSyncResponse {}
 
 /// <p>A key-value pair that can be associated with a resource. </p>
@@ -1376,6 +1433,7 @@ pub struct TagResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TagResourceResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1389,6 +1447,7 @@ pub struct UntagResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UntagResourceResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1407,6 +1466,7 @@ pub struct UpdateAddressBookRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateAddressBookResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1433,6 +1493,7 @@ pub struct UpdateContactRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateContactResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1448,6 +1509,7 @@ pub struct UpdateDeviceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateDeviceResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1495,6 +1557,7 @@ pub struct UpdateProfileRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateProfileResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1522,6 +1585,7 @@ pub struct UpdateRoomRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateRoomResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1541,10 +1605,12 @@ pub struct UpdateSkillGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateSkillGroupResponse {}
 
 /// <p>Information related to a user.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UserData {
     /// <p>The email of a user.</p>
     #[serde(rename = "Email")]

--- a/rusoto/services/apigateway/src/generated.rs
+++ b/rusoto/services/apigateway/src/generated.rs
@@ -31,6 +31,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Access log settings, including the access log format and access log destination ARN.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AccessLogSettings {
     /// <p>The ARN of the CloudWatch Logs log group to receive access logs.</p>
     #[serde(rename = "destinationArn")]
@@ -44,6 +45,7 @@ pub struct AccessLogSettings {
 
 /// <p><p>Represents an AWS account that is associated with API Gateway.</p> <div class="remarks"> <p>To view the account info, call <code>GET</code> on this resource.</p> <h4>Error Codes</h4> <p>The following exception may be thrown when the request fails.</p> <ul> <li>UnauthorizedException</li> <li>NotFoundException</li> <li>TooManyRequestsException</li> </ul> <p>For detailed error code information, including the corresponding HTTP Status Codes, see <a href="http://docs.aws.amazon.com/apigateway/api-reference/handling-errors/#api-error-codes">API Gateway Error Codes</a></p> <h4>Example: Get the information about an account.</h4> <h5>Request</h5> <pre><code>GET /account HTTP/1.1 Content-Type: application/json Host: apigateway.us-east-1.amazonaws.com X-Amz-Date: 20160531T184618Z Authorization: AWS4-HMAC-SHA256 Credential={access<em>key</em>ID}/us-east-1/apigateway/aws4<em>request, SignedHeaders=content-type;host;x-amz-date, Signature={sig4</em>hash} </code></pre> <h5>Response</h5> <p>The successful response returns a <code>200 OK</code> status code and a payload similar to the following:</p> <pre><code>{ &quot;_links&quot;: { &quot;curies&quot;: { &quot;href&quot;: &quot;http://docs.aws.amazon.com/apigateway/latest/developerguide/account-apigateway-{rel}.html&quot;, &quot;name&quot;: &quot;account&quot;, &quot;templated&quot;: true }, &quot;self&quot;: { &quot;href&quot;: &quot;/account&quot; }, &quot;account:update&quot;: { &quot;href&quot;: &quot;/account&quot; } }, &quot;cloudwatchRoleArn&quot;: &quot;arn:aws:iam::123456789012:role/apigAwsProxyRole&quot;, &quot;throttleSettings&quot;: { &quot;rateLimit&quot;: 500, &quot;burstLimit&quot;: 1000 } } </code></pre> <p>In addition to making the REST API call directly, you can use the AWS CLI and an AWS SDK to access this resource.</p> </div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-limits.html">API Gateway Limits</a> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/welcome.html">Developer Guide</a>, <a href="http://docs.aws.amazon.com/cli/latest/reference/apigateway/get-account.html">AWS CLI</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Account {
     /// <p>The version of the API keys used for the account.</p>
     #[serde(rename = "apiKeyVersion")]
@@ -65,6 +67,7 @@ pub struct Account {
 
 /// <p><p>A resource that can be distributed to callers for executing <a>Method</a> resources that require an API key. API keys can be mapped to any <a>Stage</a> on any <a>RestApi</a>, which indicates that the callers with the API key can make requests to that stage.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-api-keys.html">Use API Keys</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ApiKey {
     /// <p>The timestamp when the API Key was created.</p>
     #[serde(rename = "createdDate")]
@@ -106,6 +109,7 @@ pub struct ApiKey {
 
 /// <p>The identifier of an <a>ApiKey</a> used in a <a>UsagePlan</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ApiKeyIds {
     /// <p>A list of all the <a>ApiKey</a> identifiers.</p>
     #[serde(rename = "ids")]
@@ -119,6 +123,7 @@ pub struct ApiKeyIds {
 
 /// <p><p>Represents a collection of API keys as represented by an <a>ApiKeys</a> resource.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-api-keys.html">Use API Keys</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ApiKeys {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -152,6 +157,7 @@ pub struct ApiStage {
 
 /// <p><p>Represents an authorization layer for methods. If enabled on a method, API Gateway will activate the authorizer when a client calls the method.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html">Enable custom authorization</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Authorizer {
     /// <p>Optional customer-defined field, used in Swagger imports and exports without functional impact.</p>
     #[serde(rename = "authType")]
@@ -197,6 +203,7 @@ pub struct Authorizer {
 
 /// <p><p>Represents a collection of <a>Authorizer</a> resources.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html">Enable custom authorization</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Authorizers {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -209,6 +216,7 @@ pub struct Authorizers {
 
 /// <p><p>Represents the base path that callers of the API must provide as part of the URL after the domain name.</p> <div class="remarks">A custom domain name plus a <code>BasePathMapping</code> specification identifies a deployed <a>RestApi</a> in a given stage of the owner <a>Account</a>.</div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html">Use Custom Domain Names</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BasePathMapping {
     /// <p>The base path name that callers of the API must provide as part of the URL after the domain name.</p>
     #[serde(rename = "basePath")]
@@ -226,6 +234,7 @@ pub struct BasePathMapping {
 
 /// <p><p>Represents a collection of <a>BasePathMapping</a> resources.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html">Use Custom Domain Names</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BasePathMappings {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -259,6 +268,7 @@ pub struct CanarySettings {
 
 /// <p><p>Represents a client certificate used to configure client-side SSL authentication while sending requests to the integration endpoint.</p> <div class="remarks">Client certificates are used to authenticate an API by the backend server. To authenticate an API client (or user), use IAM roles and policies, a custom <a>Authorizer</a> or an Amazon Cognito user pool.</div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/getting-started-client-side-ssl-authentication.html">Use Client-Side Certificate</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ClientCertificate {
     /// <p>The identifier of the client certificate.</p>
     #[serde(rename = "clientCertificateId")]
@@ -284,6 +294,7 @@ pub struct ClientCertificate {
 
 /// <p><p>Represents a collection of <a>ClientCertificate</a> resources.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/getting-started-client-side-ssl-authentication.html">Use Client-Side Certificate</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ClientCertificates {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -921,6 +932,7 @@ pub struct DeleteVpcLinkRequest {
 
 /// <p><p>An immutable representation of a <a>RestApi</a> resource that can be called by users using <a>Stages</a>. A deployment must be associated with a <a>Stage</a> for it to be callable over the Internet.</p> <div class="remarks">To create a deployment, call <code>POST</code> on the <a>Deployments</a> resource of a <a>RestApi</a>. To view, update, or delete a deployment, call <code>GET</code>, <code>PATCH</code>, or <code>DELETE</code> on the specified deployment resource (<code>/restapis/{restapi<em>id}/deployments/{deployment</em>id}</code>).</div> <div class="seeAlso"><a>RestApi</a>, <a>Deployments</a>, <a>Stage</a>, <a href="http://docs.aws.amazon.com/cli/latest/reference/apigateway/get-deployment.html">AWS CLI</a>, <a href="https://aws.amazon.com/tools/">AWS SDKs</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Deployment {
     /// <p>A summary of the <a>RestApi</a> at the date and time that the deployment resource was created.</p>
     #[serde(rename = "apiSummary")]
@@ -961,6 +973,7 @@ pub struct DeploymentCanarySettings {
 
 /// <p><p>Represents a collection resource that contains zero or more references to your existing deployments, and links that guide you on how to interact with your collection. The collection offers a paginated view of the contained deployments.</p> <div class="remarks">To create a new deployment of a <a>RestApi</a>, make a <code>POST</code> request against this resource. To view, update, or delete an existing deployment, make a <code>GET</code>, <code>PATCH</code>, or <code>DELETE</code> request, respectively, on a specified <a>Deployment</a> resource.</div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-deploy-api.html">Deploying an API</a>, <a href="http://docs.aws.amazon.com/cli/latest/reference/apigateway/get-deployment.html">AWS CLI</a>, <a href="https://aws.amazon.com/tools/">AWS SDKs</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Deployments {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -973,6 +986,7 @@ pub struct Deployments {
 
 /// <p><p>A documentation part for a targeted API entity.</p> <div class="remarks"> <p>A documentation part consists of a content map (<code>properties</code>) and a target (<code>location</code>). The target specifies an API entity to which the documentation content applies. The supported API entity types are <code>API</code>, <code>AUTHORIZER</code>, <code>MODEL</code>, <code>RESOURCE</code>, <code>METHOD</code>, <code>PATH<em>PARAMETER</code>, <code>QUERY</em>PARAMETER</code>, <code>REQUEST<em>HEADER</code>, <code>REQUEST</em>BODY</code>, <code>RESPONSE</code>, <code>RESPONSE<em>HEADER</code>, and <code>RESPONSE</em>BODY</code>. Valid <code>location</code> fields depend on the API entity type. All valid fields are not required.</p> <p>The content map is a JSON string of API-specific key-value pairs. Although an API can use any shape for the content map, only the Swagger-compliant documentation fields will be injected into the associated API entity definition in the exported Swagger definition file.</p></div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-documenting-api.html">Documenting an API</a>, <a>DocumentationParts</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DocumentationPart {
     /// <p>The <a>DocumentationPart</a> identifier, generated by API Gateway when the <code>DocumentationPart</code> is created.</p>
     #[serde(rename = "id")]
@@ -990,6 +1004,7 @@ pub struct DocumentationPart {
 
 /// <p><p>A collection of the imported <a>DocumentationPart</a> identifiers.</p> <div class="remarks">This is used to return the result when documentation parts in an external (e.g., Swagger) file are imported into API Gateway</div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-documenting-api.html">Documenting an API</a>, <a href="http://docs.aws.amazon.com/apigateway/api-reference/link-relation/documentationpart-import/">documentationpart:import</a>, <a>DocumentationPart</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DocumentationPartIds {
     /// <p>A list of the returned documentation part identifiers.</p>
     #[serde(rename = "ids")]
@@ -1027,6 +1042,7 @@ pub struct DocumentationPartLocation {
 
 /// <p><p>The collection of documentation parts of an API.</p> <div class="remarks"/> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-documenting-api.html">Documenting an API</a>, <a>DocumentationPart</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DocumentationParts {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -1039,6 +1055,7 @@ pub struct DocumentationParts {
 
 /// <p><p>A snapshot of the documentation of an API.</p> <div class="remarks"><p>Publishing API documentation involves creating a documentation version associated with an API stage and exporting the versioned documentation to an external (e.g., Swagger) file.</p></div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-documenting-api.html">Documenting an API</a>, <a>DocumentationPart</a>, <a>DocumentationVersions</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DocumentationVersion {
     /// <p>The date when the API documentation snapshot is created.</p>
     #[serde(rename = "createdDate")]
@@ -1056,6 +1073,7 @@ pub struct DocumentationVersion {
 
 /// <p><p>The collection of documentation snapshots of an API. </p> <div class="remarks"><p>Use the <a>DocumentationVersions</a> to manage documentation snapshots associated with various API stages.</p></div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-documenting-api.html">Documenting an API</a>, <a>DocumentationPart</a>, <a>DocumentationVersion</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DocumentationVersions {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -1068,6 +1086,7 @@ pub struct DocumentationVersions {
 
 /// <p><p>Represents a custom domain name as a user-friendly host name of an API (<a>RestApi</a>).</p> <div class="Remarks"> <p>When you deploy an API, API Gateway creates a default host name for the API. This default API host name is of the <code>{restapi-id}.execute-api.{region}.amazonaws.com</code> format. With the default host name, you can access the API&#39;s root resource with the URL of <code>https://{restapi-id}.execute-api.{region}.amazonaws.com/{stage}/</code>. When you set up a custom domain name of <code>apis.example.com</code> for this API, you can then access the same resource using the URL of the <code>https://apis.examples.com/myApi</code>, where <code>myApi</code> is the base path mapping (<a>BasePathMapping</a>) of your API under the custom domain name. </p> </div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html">Set a Custom Host Name for an API</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DomainName {
     /// <p>The reference to an AWS-managed certificate that will be used by edge-optimized endpoint for this domain name. AWS Certificate Manager is the only supported source.</p>
     #[serde(rename = "certificateArn")]
@@ -1117,6 +1136,7 @@ pub struct DomainName {
 
 /// <p><p>Represents a collection of <a>DomainName</a> resources.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html">Use Client-Side Certificate</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DomainNames {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -1171,6 +1191,7 @@ pub struct FlushStageCacheRequest {
 
 /// <p><p>A gateway response of a given response type and status code, with optional response parameters and mapping templates.</p> <div class="remarks"> For more information about valid gateway response types, see <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/supported-gateway-response-types.html">Gateway Response Types Supported by API Gateway</a> <div class="example"> <h4>Example: Get a Gateway Response of a given response type</h4> <h5>Request</h5> <p>This example shows how to get a gateway response of the <code>MISSING<em>AUTHENTICATION</em>TOKEN</code> type.</p> <pre><code>GET /restapis/o81lxisefl/gatewayresponses/MISSING<em>AUTHENTICATION</em>TOKEN HTTP/1.1 Host: beta-apigateway.us-east-1.amazonaws.com Content-Type: application/json X-Amz-Date: 20170503T202516Z Authorization: AWS4-HMAC-SHA256 Credential={access-key-id}/20170503/us-east-1/apigateway/aws4<em>request, SignedHeaders=content-type;host;x-amz-date, Signature=1b52460e3159c1a26cff29093855d50ea141c1c5b937528fecaf60f51129697a Cache-Control: no-cache Postman-Token: 3b2a1ce9-c848-2e26-2e2f-9c2caefbed45 </code></pre> <p>The response type is specified as a URL path.</p> <h5>Response</h5> <p>The successful operation returns the <code>200 OK</code> status code and a payload similar to the following:</p> <pre><code>{ &quot;</em>links&quot;: { &quot;curies&quot;: { &quot;href&quot;: &quot;http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-gatewayresponse-{rel}.html&quot;, &quot;name&quot;: &quot;gatewayresponse&quot;, &quot;templated&quot;: true }, &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/MISSING<em>AUTHENTICATION</em>TOKEN&quot; }, &quot;gatewayresponse:delete&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/MISSING<em>AUTHENTICATION</em>TOKEN&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response<em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/MISSING</em>AUTHENTICATION<em>TOKEN&quot; } }, &quot;defaultResponse&quot;: false, &quot;responseParameters&quot;: { &quot;gatewayresponse.header.x-request-path&quot;: &quot;method.request.path.petId&quot;, &quot;gatewayresponse.header.Access-Control-Allow-Origin&quot;: &quot;&apos;a.b.c&apos;&quot;, &quot;gatewayresponse.header.x-request-query&quot;: &quot;method.request.querystring.q&quot;, &quot;gatewayresponse.header.x-request-header&quot;: &quot;method.request.header.Accept&quot; }, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{\n &quot;message&quot;: $context.error.messageString,\n &quot;type&quot;: &quot;$context.error.responseType&quot;,\n &quot;stage&quot;: &quot;$context.stage&quot;,\n &quot;resourcePath&quot;: &quot;$context.resourcePath&quot;,\n &quot;stageVariables.a&quot;: &quot;$stageVariables.a&quot;,\n &quot;statusCode&quot;: &quot;&apos;404&apos;&quot;\n}&quot; }, &quot;responseType&quot;: &quot;MISSING</em>AUTHENTICATION_TOKEN&quot;, &quot;statusCode&quot;: &quot;404&quot; }</code></pre> <p></p> </div> </div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/customize-gateway-responses.html">Customize Gateway Responses</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GatewayResponse {
     /// <p>A Boolean flag to indicate whether this <a>GatewayResponse</a> is the default gateway response (<code>true</code>) or not (<code>false</code>). A default gateway response is one generated by API Gateway without any customization by an API developer. </p>
     #[serde(rename = "defaultResponse")]
@@ -1196,6 +1217,7 @@ pub struct GatewayResponse {
 
 /// <p><p>The collection of the <a>GatewayResponse</a> instances of a <a>RestApi</a> as a <code>responseType</code>-to-<a>GatewayResponse</a> object map of key-value pairs. As such, pagination is not supported for querying this collection.</p> <div class="remarks"> For more information about valid gateway response types, see <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/supported-gateway-response-types.html">Gateway Response Types Supported by API Gateway</a> <div class="example"> <h4>Example: Get the collection of gateway responses of an API</h4> <h5>Request</h5> <p>This example request shows how to retrieve the <a>GatewayResponses</a> collection from an API.</p> <pre><code>GET /restapis/o81lxisefl/gatewayresponses HTTP/1.1 Host: beta-apigateway.us-east-1.amazonaws.com Content-Type: application/json X-Amz-Date: 20170503T220604Z Authorization: AWS4-HMAC-SHA256 Credential={access-key-id}/20170503/us-east-1/apigateway/aws4<em>request, SignedHeaders=content-type;host;x-amz-date, Signature=59b42fe54a76a5de8adf2c67baa6d39206f8e9ad49a1d77ccc6a5da3103a398a Cache-Control: no-cache Postman-Token: 5637af27-dc29-fc5c-9dfe-0645d52cb515 </code></pre> <p></p> <h5>Response</h5> <p>The successful operation returns the <code>200 OK</code> status code and a payload similar to the following:</p> <pre><code>{ &quot;</em>links&quot;: { &quot;curies&quot;: { &quot;href&quot;: &quot;http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-gatewayresponse-{rel}.html&quot;, &quot;name&quot;: &quot;gatewayresponse&quot;, &quot;templated&quot;: true }, &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses&quot; }, &quot;first&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses&quot; }, &quot;gatewayresponse:by-type&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response<em>type}&quot;, &quot;templated&quot;: true }, &quot;item&quot;: [ { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/INTEGRATION</em>FAILURE&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/RESOURCE<em>NOT</em>FOUND&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/REQUEST<em>TOO</em>LARGE&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/THROTTLED&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/UNSUPPORTED<em>MEDIA</em>TYPE&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/AUTHORIZER<em>CONFIGURATION</em>ERROR&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/DEFAULT<em>5XX&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/DEFAULT</em>4XX&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/BAD<em>REQUEST</em>PARAMETERS&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/BAD<em>REQUEST</em>BODY&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/EXPIRED<em>TOKEN&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/ACCESS</em>DENIED&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/INVALID<em>API</em>KEY&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/UNAUTHORIZED&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/API<em>CONFIGURATION</em>ERROR&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/QUOTA<em>EXCEEDED&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/INTEGRATION</em>TIMEOUT&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/MISSING<em>AUTHENTICATION</em>TOKEN&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/INVALID<em>SIGNATURE&quot; }, { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/AUTHORIZER</em>FAILURE&quot; } ] }, &quot;<em>embedded&quot;: { &quot;item&quot;: [ { &quot;</em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/INTEGRATION<em>FAILURE&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/INTEGRATION<em>FAILURE&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;INTEGRATION</em>FAILURE&quot;, &quot;statusCode&quot;: &quot;504&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/RESOURCE</em>NOT<em>FOUND&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/RESOURCE<em>NOT</em>FOUND&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;RESOURCE<em>NOT</em>FOUND&quot;, &quot;statusCode&quot;: &quot;404&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/REQUEST</em>TOO<em>LARGE&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/REQUEST<em>TOO</em>LARGE&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;REQUEST<em>TOO</em>LARGE&quot;, &quot;statusCode&quot;: &quot;413&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/THROTTLED&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/THROTTLED&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;THROTTLED&quot;, &quot;statusCode&quot;: &quot;429&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/UNSUPPORTED</em>MEDIA<em>TYPE&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/UNSUPPORTED<em>MEDIA</em>TYPE&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;UNSUPPORTED<em>MEDIA</em>TYPE&quot;, &quot;statusCode&quot;: &quot;415&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/AUTHORIZER</em>CONFIGURATION<em>ERROR&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/AUTHORIZER<em>CONFIGURATION</em>ERROR&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;AUTHORIZER<em>CONFIGURATION</em>ERROR&quot;, &quot;statusCode&quot;: &quot;500&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/DEFAULT</em>5XX&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response<em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/DEFAULT</em>5XX&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;DEFAULT<em>5XX&quot; }, { &quot;</em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/DEFAULT<em>4XX&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/DEFAULT<em>4XX&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;DEFAULT</em>4XX&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/BAD</em>REQUEST<em>PARAMETERS&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/BAD<em>REQUEST</em>PARAMETERS&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;BAD<em>REQUEST</em>PARAMETERS&quot;, &quot;statusCode&quot;: &quot;400&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/BAD</em>REQUEST<em>BODY&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/BAD<em>REQUEST</em>BODY&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;BAD<em>REQUEST</em>BODY&quot;, &quot;statusCode&quot;: &quot;400&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/EXPIRED</em>TOKEN&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response<em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/EXPIRED</em>TOKEN&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;EXPIRED<em>TOKEN&quot;, &quot;statusCode&quot;: &quot;403&quot; }, { &quot;</em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/ACCESS<em>DENIED&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/ACCESS<em>DENIED&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;ACCESS</em>DENIED&quot;, &quot;statusCode&quot;: &quot;403&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/INVALID</em>API<em>KEY&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/INVALID<em>API</em>KEY&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;INVALID<em>API</em>KEY&quot;, &quot;statusCode&quot;: &quot;403&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/UNAUTHORIZED&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/UNAUTHORIZED&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;UNAUTHORIZED&quot;, &quot;statusCode&quot;: &quot;401&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/API</em>CONFIGURATION<em>ERROR&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/API<em>CONFIGURATION</em>ERROR&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;API<em>CONFIGURATION</em>ERROR&quot;, &quot;statusCode&quot;: &quot;500&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/QUOTA</em>EXCEEDED&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response<em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/QUOTA</em>EXCEEDED&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;QUOTA<em>EXCEEDED&quot;, &quot;statusCode&quot;: &quot;429&quot; }, { &quot;</em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/INTEGRATION<em>TIMEOUT&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/INTEGRATION<em>TIMEOUT&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;INTEGRATION</em>TIMEOUT&quot;, &quot;statusCode&quot;: &quot;504&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/MISSING</em>AUTHENTICATION<em>TOKEN&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/MISSING<em>AUTHENTICATION</em>TOKEN&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;MISSING<em>AUTHENTICATION</em>TOKEN&quot;, &quot;statusCode&quot;: &quot;403&quot; }, { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/INVALID</em>SIGNATURE&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response<em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/INVALID</em>SIGNATURE&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;INVALID<em>SIGNATURE&quot;, &quot;statusCode&quot;: &quot;403&quot; }, { &quot;</em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/AUTHORIZER<em>FAILURE&quot; }, &quot;gatewayresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/{response</em>type}&quot;, &quot;templated&quot;: true }, &quot;gatewayresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/o81lxisefl/gatewayresponses/AUTHORIZER<em>FAILURE&quot; } }, &quot;defaultResponse&quot;: true, &quot;responseParameters&quot;: {}, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;{&quot;message&quot;:$context.error.messageString}&quot; }, &quot;responseType&quot;: &quot;AUTHORIZER</em>FAILURE&quot;, &quot;statusCode&quot;: &quot;500&quot; } ] } }</code></pre> <p></p> </div> </div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/customize-gateway-responses.html">Customize Gateway Responses</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GatewayResponses {
     /// <p>Returns the entire collection, because of no pagination support.</p>
     #[serde(rename = "items")]
@@ -1937,6 +1959,7 @@ pub struct ImportRestApiRequest {
 
 /// <p><p>Represents an HTTP, HTTP<em>PROXY, AWS, AWS</em>PROXY, or Mock integration.</p> <div class="remarks">In the API Gateway console, the built-in Lambda integration is an AWS integration.</div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html">Creating an API</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Integration {
     /// <p>Specifies the integration's cache key parameters.</p>
     #[serde(rename = "cacheKeyParameters")]
@@ -1998,6 +2021,7 @@ pub struct Integration {
 
 /// <p><p>Represents an integration response. The status code must map to an existing <a>MethodResponse</a>, and parameters and templates can be used to transform the back-end response.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html">Creating an API</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct IntegrationResponse {
     /// <p>Specifies how to handle response payload content type conversions. Supported values are <code>CONVERT_TO_BINARY</code> and <code>CONVERT_TO_TEXT</code>, with the following behaviors:</p> <ul> <li><p><code>CONVERT_TO_BINARY</code>: Converts a response payload from a Base64-encoded string to the corresponding binary blob.</p></li> <li><p><code>CONVERT_TO_TEXT</code>: Converts a response payload from a binary blob to a Base64-encoded string.</p></li> </ul> <p>If this property is not defined, the response payload will be passed through from the integration response to the method response without modification.</p>
     #[serde(rename = "contentHandling")]
@@ -2023,6 +2047,7 @@ pub struct IntegrationResponse {
 
 /// <p><p> Represents a client-facing interface by which the client calls the API to access back-end resources. A <b>Method</b> resource is integrated with an <a>Integration</a> resource. Both consist of a request and one or more responses. The method request takes the client input that is passed to the back end through the integration request. A method response returns the output from the back end to the client through an integration response. A method request is embodied in a <b>Method</b> resource, whereas an integration request is embodied in an <a>Integration</a> resource. On the other hand, a method response is represented by a <a>MethodResponse</a> resource, whereas an integration response is represented by an <a>IntegrationResponse</a> resource. </p> <div class="remarks"> <p/> <h4>Example: Retrive the GET method on a specified resource</h4> <h5>Request</h5> <p>The following example request retrieves the information about the GET method on an API resource (<code>3kzxbg5sa2</code>) of an API (<code>fugvjdxtri</code>). </p> <pre><code>GET /restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET HTTP/1.1 Content-Type: application/json Host: apigateway.us-east-1.amazonaws.com X-Amz-Date: 20160603T210259Z Authorization: AWS4-HMAC-SHA256 Credential={access<em>key</em>ID}/20160603/us-east-1/apigateway/aws4<em>request, SignedHeaders=content-type;host;x-amz-date, Signature={sig4</em>hash}</code></pre> <h5>Response</h5> <p>The successful response returns a <code>200 OK</code> status code and a payload similar to the following:</p> <pre><code>{ &quot;<em>links&quot;: { &quot;curies&quot;: [ { &quot;href&quot;: &quot;http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-integration-{rel}.html&quot;, &quot;name&quot;: &quot;integration&quot;, &quot;templated&quot;: true }, { &quot;href&quot;: &quot;http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-integration-response-{rel}.html&quot;, &quot;name&quot;: &quot;integrationresponse&quot;, &quot;templated&quot;: true }, { &quot;href&quot;: &quot;http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-method-{rel}.html&quot;, &quot;name&quot;: &quot;method&quot;, &quot;templated&quot;: true }, { &quot;href&quot;: &quot;http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-method-response-{rel}.html&quot;, &quot;name&quot;: &quot;methodresponse&quot;, &quot;templated&quot;: true } ], &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET&quot;, &quot;name&quot;: &quot;GET&quot;, &quot;title&quot;: &quot;GET&quot; }, &quot;integration:put&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration&quot; }, &quot;method:delete&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET&quot; }, &quot;method:integration&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration&quot; }, &quot;method:responses&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200&quot;, &quot;name&quot;: &quot;200&quot;, &quot;title&quot;: &quot;200&quot; }, &quot;method:update&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET&quot; }, &quot;methodresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/{status</em>code}&quot;, &quot;templated&quot;: true } }, &quot;apiKeyRequired&quot;: true, &quot;authorizationType&quot;: &quot;NONE&quot;, &quot;httpMethod&quot;: &quot;GET&quot;, &quot;<em>embedded&quot;: { &quot;method:integration&quot;: { &quot;</em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration&quot; }, &quot;integration:delete&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration&quot; }, &quot;integration:responses&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/200&quot;, &quot;name&quot;: &quot;200&quot;, &quot;title&quot;: &quot;200&quot; }, &quot;integration:update&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration&quot; }, &quot;integrationresponse:put&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/{status<em>code}&quot;, &quot;templated&quot;: true } }, &quot;cacheKeyParameters&quot;: [], &quot;cacheNamespace&quot;: &quot;3kzxbg5sa2&quot;, &quot;credentials&quot;: &quot;arn:aws:iam::123456789012:role/apigAwsProxyRole&quot;, &quot;httpMethod&quot;: &quot;POST&quot;, &quot;passthroughBehavior&quot;: &quot;WHEN</em>NO<em>MATCH&quot;, &quot;requestParameters&quot;: { &quot;integration.request.header.Content-Type&quot;: &quot;&#39;application/x-amz-json-1.1&#39;&quot; }, &quot;requestTemplates&quot;: { &quot;application/json&quot;: &quot;{\n}&quot; }, &quot;type&quot;: &quot;AWS&quot;, &quot;uri&quot;: &quot;arn:aws:apigateway:us-east-1:kinesis:action/ListStreams&quot;, &quot;</em>embedded&quot;: { &quot;integration:responses&quot;: { &quot;<em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/200&quot;, &quot;name&quot;: &quot;200&quot;, &quot;title&quot;: &quot;200&quot; }, &quot;integrationresponse:delete&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/200&quot; }, &quot;integrationresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/integration/responses/200&quot; } }, &quot;responseParameters&quot;: { &quot;method.response.header.Content-Type&quot;: &quot;&#39;application/xml&#39;&quot; }, &quot;responseTemplates&quot;: { &quot;application/json&quot;: &quot;$util.urlDecode(&quot;%3CkinesisStreams%3E%23foreach(%24stream%20in%20%24input.path(%27%24.StreamNames%27))%3Cstream%3E%3Cname%3E%24stream%3C%2Fname%3E%3C%2Fstream%3E%23end%3C%2FkinesisStreams%3E&quot;)&quot; }, &quot;statusCode&quot;: &quot;200&quot; } } }, &quot;method:responses&quot;: { &quot;</em>links&quot;: { &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200&quot;, &quot;name&quot;: &quot;200&quot;, &quot;title&quot;: &quot;200&quot; }, &quot;methodresponse:delete&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200&quot; }, &quot;methodresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200&quot; } }, &quot;responseModels&quot;: { &quot;application/json&quot;: &quot;Empty&quot; }, &quot;responseParameters&quot;: { &quot;method.response.header.Content-Type&quot;: false }, &quot;statusCode&quot;: &quot;200&quot; } } }</code></pre> <p>In the example above, the response template for the <code>200 OK</code> response maps the JSON output from the <code>ListStreams</code> action in the back end to an XML output. The mapping template is URL-encoded as <code>%3CkinesisStreams%3E%23foreach(%24stream%20in%20%24input.path(%27%24.StreamNames%27))%3Cstream%3E%3Cname%3E%24stream%3C%2Fname%3E%3C%2Fstream%3E%23end%3C%2FkinesisStreams%3E</code> and the output is decoded using the <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#util-templat-reference">$util.urlDecode()</a> helper function.</p> </div> <div class="seeAlso"> <a>MethodResponse</a>, <a>Integration</a>, <a>IntegrationResponse</a>, <a>Resource</a>, <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-method-settings.html">Set up an API&#39;s method</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Method {
     /// <p>A boolean flag specifying whether a valid <a>ApiKey</a> is required to invoke this method.</p>
     #[serde(rename = "apiKeyRequired")]
@@ -2072,6 +2097,7 @@ pub struct Method {
 
 /// <p><p>Represents a method response of a given HTTP status code returned to the client. The method response is passed from the back end through the associated integration response that can be transformed using a mapping template. </p> <div class="remarks"> <p/> <h4>Example: A <b>MethodResponse</b> instance of an API</h4> <h5>Request</h5> <p>The example request retrieves a <b>MethodResponse</b> of the 200 status code.</p> <pre><code>GET /restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200 HTTP/1.1 Content-Type: application/json Host: apigateway.us-east-1.amazonaws.com X-Amz-Date: 20160603T222952Z Authorization: AWS4-HMAC-SHA256 Credential={access<em>key</em>ID}/20160603/us-east-1/apigateway/aws4<em>request, SignedHeaders=content-type;host;x-amz-date, Signature={sig4</em>hash}</code></pre> <h5>Response</h5> <p>The successful response returns <code>200 OK</code> status and a payload as follows:</p> <pre><code>{ &quot;_links&quot;: { &quot;curies&quot;: { &quot;href&quot;: &quot;http://docs.aws.amazon.com/apigateway/latest/developerguide/restapi-method-response-{rel}.html&quot;, &quot;name&quot;: &quot;methodresponse&quot;, &quot;templated&quot;: true }, &quot;self&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200&quot;, &quot;title&quot;: &quot;200&quot; }, &quot;methodresponse:delete&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200&quot; }, &quot;methodresponse:update&quot;: { &quot;href&quot;: &quot;/restapis/fugvjdxtri/resources/3kzxbg5sa2/methods/GET/responses/200&quot; } }, &quot;responseModels&quot;: { &quot;application/json&quot;: &quot;Empty&quot; }, &quot;responseParameters&quot;: { &quot;method.response.header.Content-Type&quot;: false }, &quot;statusCode&quot;: &quot;200&quot; }</code></pre> <p/> </div> <div class="seeAlso"> <a>Method</a>, <a>IntegrationResponse</a>, <a>Integration</a> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html">Creating an API</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MethodResponse {
     /// <p>Specifies the <a>Model</a> resources used for the response's content-type. Response models are represented as a key/value map, with a content-type as the key and a <a>Model</a> name as the value.</p>
     #[serde(rename = "responseModels")]
@@ -2089,6 +2115,7 @@ pub struct MethodResponse {
 
 /// <p>Specifies the method setting properties.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MethodSetting {
     /// <p>Specifies whether the cached responses are encrypted. The PATCH path for this setting is <code>/{method_setting_key}/caching/dataEncrypted</code>, and the value is a Boolean.</p>
     #[serde(rename = "cacheDataEncrypted")]
@@ -2134,6 +2161,7 @@ pub struct MethodSetting {
 
 /// <p>Represents a summary of a <a>Method</a> resource, given a particular date and time.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MethodSnapshot {
     /// <p>Specifies whether the method requires a valid <a>ApiKey</a>.</p>
     #[serde(rename = "apiKeyRequired")]
@@ -2147,6 +2175,7 @@ pub struct MethodSnapshot {
 
 /// <p><p>Represents the data structure of a method&#39;s request or response payload.</p> <div class="remarks"> <p>A request model defines the data structure of the client-supplied request payload. A response model defines the data structure of the response payload returned by the back end. Although not required, models are useful for mapping payloads between the front end and back end.</p> <p>A model is used for generating an API&#39;s SDK, validating the input request body, and creating a skeletal mapping template.</p> </div> <div class="seeAlso"> <a>Method</a>, <a>MethodResponse</a>, <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html">Models and Mappings</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Model {
     /// <p>The content-type for the model.</p>
     #[serde(rename = "contentType")]
@@ -2172,6 +2201,7 @@ pub struct Model {
 
 /// <p><p>Represents a collection of <a>Model</a> resources.</p> <div class="seeAlso"> <a>Method</a>, <a>MethodResponse</a>, <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html">Models and Mappings</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Models {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -2441,6 +2471,7 @@ pub struct QuotaSettings {
 
 /// <p><p>A set of validation rules for incoming <a>Method</a> requests.</p> <div class="remarks"> <p>In Swagger, a <a>RequestValidator</a> of an API is defined by the <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions.html#api-gateway-swagger-extensions-request-validators.requestValidator.html">x-amazon-apigateway-request-validators.requestValidator</a> object. It the referenced using the <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions.html#api-gateway-swagger-extensions-request-validator">x-amazon-apigateway-request-validator</a> property.</p> </div> <div class="seeAlso"><a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-method-request-validation.html">Enable Basic Request Validation in API Gateway</a></div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RequestValidator {
     /// <p>The identifier of this <a>RequestValidator</a>.</p>
     #[serde(rename = "id")]
@@ -2462,6 +2493,7 @@ pub struct RequestValidator {
 
 /// <p><p>A collection of <a>RequestValidator</a> resources of a given <a>RestApi</a>.</p> <div class="remarks"> <p>In Swagger, the <a>RequestValidators</a> of an API is defined by the <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions.html#api-gateway-swagger-extensions-request-validators.html">x-amazon-apigateway-request-validators</a> extension.</p> </div> <div class="seeAlso"><a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-method-request-validation.html">Enable Basic Request Validation in API Gateway</a></div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RequestValidators {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -2474,6 +2506,7 @@ pub struct RequestValidators {
 
 /// <p><p>Represents an API resource.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html">Create an API</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Resource {
     /// <p>The resource's identifier.</p>
     #[serde(rename = "id")]
@@ -2499,6 +2532,7 @@ pub struct Resource {
 
 /// <p><p>Represents a collection of <a>Resource</a> resources.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html">Create an API</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Resources {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -2511,6 +2545,7 @@ pub struct Resources {
 
 /// <p><p>Represents a REST API.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html">Create an API</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RestApi {
     /// <p>The source of the API key for metering requests according to a usage plan. Valid values are: <ul><li><code>HEADER</code> to read the API key from the <code>X-API-Key</code> header of a request. </li><li><code>AUTHORIZER</code> to read the API key from the <code>UsageIdentifierKey</code> from a custom authorizer.</li></ul> </p>
     #[serde(rename = "apiKeySource")]
@@ -2560,6 +2595,7 @@ pub struct RestApi {
 
 /// <p><p>Contains references to your APIs and links that guide you in how to interact with your collection. A collection offers a paginated view of your APIs.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-create-api.html">Create an API</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RestApis {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -2572,6 +2608,7 @@ pub struct RestApis {
 
 /// <p>A configuration property of an SDK type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SdkConfigurationProperty {
     /// <p>The default value of an <a>SdkType</a> configuration property.</p>
     #[serde(rename = "defaultValue")]
@@ -2608,6 +2645,7 @@ pub struct SdkResponse {
 
 /// <p>A type of SDK that API Gateway can generate.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SdkType {
     /// <p>A list of configuration properties of an <a>SdkType</a>.</p>
     #[serde(rename = "configurationProperties")]
@@ -2629,6 +2667,7 @@ pub struct SdkType {
 
 /// <p>The collection of <a>SdkType</a> instances.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SdkTypes {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -2641,6 +2680,7 @@ pub struct SdkTypes {
 
 /// <p><p>Represents a unique identifier for a version of a deployed <a>RestApi</a> that is callable by users.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-deploy-api.html">Deploy an API</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Stage {
     /// <p>Settings for logging access in this stage.</p>
     #[serde(rename = "accessLogSettings")]
@@ -2719,6 +2759,7 @@ pub struct StageKey {
 
 /// <p><p>A list of <a>Stage</a> resources that are associated with the <a>ApiKey</a> resource.</p> <div class="seeAlso"><a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/stages.html">Deploying API in Stages</a></div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Stages {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "item")]
@@ -2739,6 +2780,7 @@ pub struct TagResourceRequest {
 
 /// <p>The collection of tags. Each tag element is associated with a given resource.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Tags {
     /// <p>The collection of tags. Each tag element is associated with a given resource.</p>
     #[serde(rename = "tags")]
@@ -2748,6 +2790,7 @@ pub struct Tags {
 
 /// <p><p>Represents a mapping template used to transform a payload.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html#models-mappings-mappings">Mapping Templates</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Template {
     /// <p>The Apache <a href="http://velocity.apache.org/engine/devel/vtl-reference-guide.html" target="_blank">Velocity Template Language (VTL)</a> template content used for the template resource.</p>
     #[serde(rename = "value")]
@@ -2788,6 +2831,7 @@ pub struct TestInvokeAuthorizerRequest {
 
 /// <p>Represents the response of the test invoke request for a custom <a>Authorizer</a></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TestInvokeAuthorizerResponse {
     #[serde(rename = "authorization")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2854,6 +2898,7 @@ pub struct TestInvokeMethodRequest {
 
 /// <p><p>Represents the response of the test invoke request in the HTTP method.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-test-method.html#how-to-test-method-console">Test API using the API Gateway console</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TestInvokeMethodResponse {
     /// <p>The body of the HTTP response.</p>
     #[serde(rename = "body")]
@@ -3227,6 +3272,7 @@ pub struct UpdateVpcLinkRequest {
 
 /// <p><p>Represents the usage data of a usage plan.</p> <div class="remarks"/> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html">Create and Use Usage Plans</a>, <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-create-usage-plans-with-console.html#api-gateway-usage-plan-manage-usage">Manage Usage in a Usage Plan</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Usage {
     /// <p>The ending date of the usage data.</p>
     #[serde(rename = "endDate")]
@@ -3251,6 +3297,7 @@ pub struct Usage {
 
 /// <p><p>Represents a usage plan than can specify who can assess associated API stages with specified request limits and quotas.</p> <div class="remarks"> <p>In a usage plan, you associate an API by specifying the API&#39;s Id and a stage name of the specified API. You add plan customers by adding API keys to the plan. </p> </div> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html">Create and Use Usage Plans</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UsagePlan {
     /// <p>The associated API stages of a usage plan.</p>
     #[serde(rename = "apiStages")]
@@ -3284,6 +3331,7 @@ pub struct UsagePlan {
 
 /// <p><p>Represents a usage plan key to identify a plan customer.</p> <div class="remarks"> <p>To associate an API stage with a selected API key in a usage plan, you must create a UsagePlanKey resource to represent the selected <a>ApiKey</a>.</p> </div>&quot; <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html">Create and Use Usage Plans</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UsagePlanKey {
     /// <p>The Id of a usage plan key.</p>
     #[serde(rename = "id")]
@@ -3305,6 +3353,7 @@ pub struct UsagePlanKey {
 
 /// <p><p>Represents the collection of usage plan keys added to usage plans for the associated API keys and, possibly, other types of keys.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html">Create and Use Usage Plans</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UsagePlanKeys {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -3317,6 +3366,7 @@ pub struct UsagePlanKeys {
 
 /// <p><p>Represents a collection of usage plans for an AWS account.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-api-usage-plans.html">Create and Use Usage Plans</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UsagePlans {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]
@@ -3329,6 +3379,7 @@ pub struct UsagePlans {
 
 /// <p><p>A API Gateway VPC link for a <a>RestApi</a> to access resources in an Amazon Virtual Private Cloud (VPC).</p> <div class="remarks"> <p><p>To enable access to a resource in an Amazon Virtual Private Cloud through Amazon API Gateway, you, as an API developer, create a <a>VpcLink</a> resource targeted for one or more network load balancers of the VPC and then integrate an API method with a private integration that uses the <a>VpcLink</a>. The private integration has an integration type of <code>HTTP</code> or <code>HTTP<em>PROXY</code> and has a connection type of <code>VPC</em>LINK</code>. The integration uses the <code>connectionId</code> property to identify the <a>VpcLink</a> used.</p> </p> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VpcLink {
     /// <p>The description of the VPC link.</p>
     #[serde(rename = "description")]
@@ -3358,6 +3409,7 @@ pub struct VpcLink {
 
 /// <p><p>The collection of VPC links under the caller&#39;s account in a region.</p> <div class="seeAlso"> <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/getting-started-with-private-integration.html">Getting Started with Private Integrations</a>, <a href="http://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-private-integration.html">Set up Private Integrations</a> </div></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VpcLinks {
     /// <p>The current page of elements from this collection.</p>
     #[serde(rename = "items")]

--- a/rusoto/services/application-autoscaling/src/generated.rs
+++ b/rusoto/services/application-autoscaling/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Represents a CloudWatch alarm associated with a scaling policy.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Alarm {
     /// <p>The Amazon Resource Name (ARN) of the alarm.</p>
     #[serde(rename = "AlarmARN")]
@@ -78,6 +79,7 @@ pub struct DeleteScalingPolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteScalingPolicyResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -98,6 +100,7 @@ pub struct DeleteScheduledActionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteScheduledActionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -114,6 +117,7 @@ pub struct DeregisterScalableTargetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeregisterScalableTargetResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -140,6 +144,7 @@ pub struct DescribeScalableTargetsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeScalableTargetsResponse {
     /// <p>The token required to get the next set of results. This value is <code>null</code> if there are no more results to return.</p>
     #[serde(rename = "NextToken")]
@@ -175,6 +180,7 @@ pub struct DescribeScalingActivitiesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeScalingActivitiesResponse {
     /// <p>The token required to get the next set of results. This value is <code>null</code> if there are no more results to return.</p>
     #[serde(rename = "NextToken")]
@@ -214,6 +220,7 @@ pub struct DescribeScalingPoliciesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeScalingPoliciesResponse {
     /// <p>The token required to get the next set of results. This value is <code>null</code> if there are no more results to return.</p>
     #[serde(rename = "NextToken")]
@@ -253,6 +260,7 @@ pub struct DescribeScheduledActionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeScheduledActionsResponse {
     /// <p>The token required to get the next set of results. This value is <code>null</code> if there are no more results to return.</p>
     #[serde(rename = "NextToken")]
@@ -317,6 +325,7 @@ pub struct PutScalingPolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutScalingPolicyResponse {
     /// <p>The CloudWatch alarms created for the target tracking policy.</p>
     #[serde(rename = "Alarms")]
@@ -361,6 +370,7 @@ pub struct PutScheduledActionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutScheduledActionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -389,10 +399,12 @@ pub struct RegisterScalableTargetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegisterScalableTargetResponse {}
 
 /// <p>Represents a scalable target.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ScalableTarget {
     /// <p>The Unix timestamp for when the scalable target was created.</p>
     #[serde(rename = "CreationTime")]
@@ -432,6 +444,7 @@ pub struct ScalableTargetAction {
 
 /// <p>Represents a scaling activity.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ScalingActivity {
     /// <p>The unique identifier of the scaling activity.</p>
     #[serde(rename = "ActivityId")]
@@ -473,6 +486,7 @@ pub struct ScalingActivity {
 
 /// <p>Represents a scaling policy.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ScalingPolicy {
     /// <p>The CloudWatch alarms associated with the scaling policy.</p>
     #[serde(rename = "Alarms")]
@@ -512,6 +526,7 @@ pub struct ScalingPolicy {
 
 /// <p>Represents a scheduled action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ScheduledAction {
     /// <p>The date and time that the scheduled action was created.</p>
     #[serde(rename = "CreationTime")]

--- a/rusoto/services/appstream/src/generated.rs
+++ b/rusoto/services/appstream/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Describes an application in the application catalog.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Application {
     /// <p>The application name for display.</p>
     #[serde(rename = "DisplayName")]
@@ -72,6 +73,7 @@ pub struct AssociateFleetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociateFleetResult {}
 
 /// <p>Describes the capacity for a fleet.</p>
@@ -84,6 +86,7 @@ pub struct ComputeCapacity {
 
 /// <p>Describes the capacity status for a fleet.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ComputeCapacityStatus {
     /// <p>The number of currently available instances that can be used to stream sessions.</p>
     #[serde(rename = "Available")]
@@ -120,6 +123,7 @@ pub struct CopyImageRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CopyImageResponse {
     /// <p>The name of the destination image.</p>
     #[serde(rename = "DestinationImageName")]
@@ -141,6 +145,7 @@ pub struct CreateDirectoryConfigRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDirectoryConfigResult {
     /// <p>Information about the directory configuration.</p>
     #[serde(rename = "DirectoryConfig")]
@@ -202,6 +207,7 @@ pub struct CreateFleetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateFleetResult {
     /// <p>Information about the fleet.</p>
     #[serde(rename = "Fleet")]
@@ -252,6 +258,7 @@ pub struct CreateImageBuilderRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateImageBuilderResult {
     /// <p>Information about the image builder.</p>
     #[serde(rename = "ImageBuilder")]
@@ -271,6 +278,7 @@ pub struct CreateImageBuilderStreamingURLRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateImageBuilderStreamingURLResult {
     /// <p>The elapsed time, in seconds after the Unix epoch, when this URL expires.</p>
     #[serde(rename = "Expires")]
@@ -314,6 +322,7 @@ pub struct CreateStackRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateStackResult {
     /// <p>Information about the stack.</p>
     #[serde(rename = "Stack")]
@@ -347,6 +356,7 @@ pub struct CreateStreamingURLRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateStreamingURLResult {
     /// <p>The elapsed time, in seconds after the Unix epoch, when this URL expires.</p>
     #[serde(rename = "Expires")]
@@ -366,6 +376,7 @@ pub struct DeleteDirectoryConfigRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteDirectoryConfigResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -376,6 +387,7 @@ pub struct DeleteFleetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteFleetResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -386,6 +398,7 @@ pub struct DeleteImageBuilderRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteImageBuilderResult {
     /// <p>Information about the image builder.</p>
     #[serde(rename = "ImageBuilder")]
@@ -404,6 +417,7 @@ pub struct DeleteImagePermissionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteImagePermissionsResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -414,6 +428,7 @@ pub struct DeleteImageRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteImageResult {
     /// <p>Information about the image.</p>
     #[serde(rename = "Image")]
@@ -429,6 +444,7 @@ pub struct DeleteStackRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteStackResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -448,6 +464,7 @@ pub struct DescribeDirectoryConfigsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeDirectoryConfigsResult {
     /// <p>Information about the directory configurations. Note that although the response syntax in this topic includes the account password, this password is not returned in the actual response. </p>
     #[serde(rename = "DirectoryConfigs")]
@@ -472,6 +489,7 @@ pub struct DescribeFleetsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeFleetsResult {
     /// <p>Information about the fleets.</p>
     #[serde(rename = "Fleets")]
@@ -500,6 +518,7 @@ pub struct DescribeImageBuildersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeImageBuildersResult {
     /// <p>Information about the image builders.</p>
     #[serde(rename = "ImageBuilders")]
@@ -531,6 +550,7 @@ pub struct DescribeImagePermissionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeImagePermissionsResult {
     /// <p>The name of the private image.</p>
     #[serde(rename = "Name")]
@@ -571,6 +591,7 @@ pub struct DescribeImagesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeImagesResult {
     /// <p>Information about the images.</p>
     #[serde(rename = "Images")]
@@ -609,6 +630,7 @@ pub struct DescribeSessionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeSessionsResult {
     /// <p>The pagination token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>
     #[serde(rename = "NextToken")]
@@ -633,6 +655,7 @@ pub struct DescribeStacksRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeStacksResult {
     /// <p>The pagination token to use to retrieve the next page of results for this operation. If there are no more pages, this value is null.</p>
     #[serde(rename = "NextToken")]
@@ -646,6 +669,7 @@ pub struct DescribeStacksResult {
 
 /// <p>Configuration information for the directory used to join domains.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DirectoryConfig {
     /// <p>The time the directory configuration was created.</p>
     #[serde(rename = "CreatedTime")]
@@ -675,6 +699,7 @@ pub struct DisassociateFleetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisassociateFleetResult {}
 
 /// <p>Contains the information needed to join a Microsoft Active Directory domain.</p>
@@ -698,10 +723,12 @@ pub struct ExpireSessionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ExpireSessionResult {}
 
 /// <p>Contains the parameters for a fleet.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Fleet {
     /// <p>The ARN for the fleet.</p>
     #[serde(rename = "Arn")]
@@ -770,6 +797,7 @@ pub struct Fleet {
 
 /// <p>Describes a fleet error.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FleetError {
     /// <p>The error code.</p>
     #[serde(rename = "ErrorCode")]
@@ -783,6 +811,7 @@ pub struct FleetError {
 
 /// <p>Describes an image.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Image {
     /// <p>The applications associated with the image.</p>
     #[serde(rename = "Applications")]
@@ -847,6 +876,7 @@ pub struct Image {
 
 /// <p>Describes a streaming instance used for editing an image. New images are created from a snapshot through an image builder.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ImageBuilder {
     /// <p>The version of the AppStream 2.0 agent that is currently being used by this image builder. </p>
     #[serde(rename = "AppstreamAgentVersion")]
@@ -911,6 +941,7 @@ pub struct ImageBuilder {
 
 /// <p>Describes the reason why the last image builder state change occurred.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ImageBuilderStateChangeReason {
     /// <p>The state change reason code.</p>
     #[serde(rename = "Code")]
@@ -937,6 +968,7 @@ pub struct ImagePermissions {
 
 /// <p>Describes the reason why the last image state change occurred.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ImageStateChangeReason {
     /// <p>The state change reason code.</p>
     #[serde(rename = "Code")]
@@ -960,6 +992,7 @@ pub struct ListAssociatedFleetsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAssociatedFleetsResult {
     /// <p>The name of the fleet.</p>
     #[serde(rename = "Names")]
@@ -983,6 +1016,7 @@ pub struct ListAssociatedStacksRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAssociatedStacksResult {
     /// <p>The name of the stack.</p>
     #[serde(rename = "Names")]
@@ -1002,6 +1036,7 @@ pub struct ListTagsForResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagsForResourceResponse {
     /// <p>The information about the tags.</p>
     #[serde(rename = "Tags")]
@@ -1011,6 +1046,7 @@ pub struct ListTagsForResourceResponse {
 
 /// <p>The network details of the fleet instance for the streaming session.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct NetworkAccessConfiguration {
     /// <p>The resource identifier of the elastic network interface that is attached to instances in your VPC. All network interfaces have the eni-xxxxxxxx resource identifier.</p>
     #[serde(rename = "EniId")]
@@ -1024,6 +1060,7 @@ pub struct NetworkAccessConfiguration {
 
 /// <p>Describes a resource error.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResourceError {
     /// <p>The error code.</p>
     #[serde(rename = "ErrorCode")]
@@ -1052,6 +1089,7 @@ pub struct ServiceAccountCredentials {
 
 /// <p>Describes a streaming session.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Session {
     /// <p>The authentication method. The user is authenticated using a streaming URL (<code>API</code>) or SAML federation (<code>SAML</code>).</p>
     #[serde(rename = "AuthenticationType")]
@@ -1080,6 +1118,7 @@ pub struct Session {
 
 /// <p>Describes the permissions that are available to the specified AWS account for a shared image.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SharedImagePermissions {
     /// <p>Describes the permissions for a shared image.</p>
     #[serde(rename = "imagePermissions")]
@@ -1091,6 +1130,7 @@ pub struct SharedImagePermissions {
 
 /// <p>Describes a stack.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Stack {
     /// <p>The ARN of the stack.</p>
     #[serde(rename = "Arn")]
@@ -1135,6 +1175,7 @@ pub struct Stack {
 
 /// <p>Describes a stack error.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StackError {
     /// <p>The error code.</p>
     #[serde(rename = "ErrorCode")]
@@ -1154,6 +1195,7 @@ pub struct StartFleetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartFleetResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1168,6 +1210,7 @@ pub struct StartImageBuilderRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartImageBuilderResult {
     /// <p>Information about the image builder.</p>
     #[serde(rename = "ImageBuilder")]
@@ -1183,6 +1226,7 @@ pub struct StopFleetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopFleetResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1193,6 +1237,7 @@ pub struct StopImageBuilderRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopImageBuilderResult {
     /// <p>Information about the image builder.</p>
     #[serde(rename = "ImageBuilder")]
@@ -1227,6 +1272,7 @@ pub struct TagResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TagResourceResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1240,6 +1286,7 @@ pub struct UntagResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UntagResourceResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1258,6 +1305,7 @@ pub struct UpdateDirectoryConfigRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateDirectoryConfigResult {
     /// <p>Information about the Directory Config object.</p>
     #[serde(rename = "DirectoryConfig")]
@@ -1322,6 +1370,7 @@ pub struct UpdateFleetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateFleetResult {
     /// <p>Information about the fleet.</p>
     #[serde(rename = "Fleet")]
@@ -1343,6 +1392,7 @@ pub struct UpdateImagePermissionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateImagePermissionsResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1381,6 +1431,7 @@ pub struct UpdateStackRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateStackResult {
     /// <p>Information about the stack.</p>
     #[serde(rename = "Stack")]

--- a/rusoto/services/athena/src/generated.rs
+++ b/rusoto/services/athena/src/generated.rs
@@ -36,6 +36,7 @@ pub struct BatchGetNamedQueryInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchGetNamedQueryOutput {
     /// <p>Information about the named query IDs submitted.</p>
     #[serde(rename = "NamedQueries")]
@@ -55,6 +56,7 @@ pub struct BatchGetQueryExecutionInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchGetQueryExecutionOutput {
     /// <p>Information about a query execution.</p>
     #[serde(rename = "QueryExecutions")]
@@ -68,6 +70,7 @@ pub struct BatchGetQueryExecutionOutput {
 
 /// <p>Information about the columns in a query execution result.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ColumnInfo {
     /// <p>Indicates whether values in the column are case-sensitive.</p>
     #[serde(rename = "CaseSensitive")]
@@ -131,6 +134,7 @@ pub struct CreateNamedQueryInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateNamedQueryOutput {
     /// <p>The unique ID of the query.</p>
     #[serde(rename = "NamedQueryId")]
@@ -140,6 +144,7 @@ pub struct CreateNamedQueryOutput {
 
 /// <p>A piece of data (a field in the table).</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Datum {
     /// <p>The value of the datum.</p>
     #[serde(rename = "VarCharValue")]
@@ -155,6 +160,7 @@ pub struct DeleteNamedQueryInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteNamedQueryOutput {}
 
 /// <p>If query results are encrypted in Amazon S3, indicates the Amazon S3 encryption option used.</p>
@@ -177,6 +183,7 @@ pub struct GetNamedQueryInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetNamedQueryOutput {
     /// <p>Information about the query.</p>
     #[serde(rename = "NamedQuery")]
@@ -192,6 +199,7 @@ pub struct GetQueryExecutionInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetQueryExecutionOutput {
     /// <p>Information about the query execution.</p>
     #[serde(rename = "QueryExecution")]
@@ -215,6 +223,7 @@ pub struct GetQueryResultsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetQueryResultsOutput {
     /// <p>A token to be used by the next request if this request is truncated.</p>
     #[serde(rename = "NextToken")]
@@ -239,6 +248,7 @@ pub struct ListNamedQueriesInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListNamedQueriesOutput {
     /// <p>The list of unique query IDs.</p>
     #[serde(rename = "NamedQueryIds")]
@@ -263,6 +273,7 @@ pub struct ListQueryExecutionsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListQueryExecutionsOutput {
     /// <p>A token to be used by the next request if this request is truncated.</p>
     #[serde(rename = "NextToken")]
@@ -276,6 +287,7 @@ pub struct ListQueryExecutionsOutput {
 
 /// <p>A query, where <code>QueryString</code> is the SQL query statements that comprise the query.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct NamedQuery {
     /// <p>The database to which the query belongs.</p>
     #[serde(rename = "Database")]
@@ -298,6 +310,7 @@ pub struct NamedQuery {
 
 /// <p>Information about a single instance of a query execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct QueryExecution {
     /// <p>The SQL query statements which the query execution ran.</p>
     #[serde(rename = "Query")]
@@ -336,6 +349,7 @@ pub struct QueryExecutionContext {
 
 /// <p>The amount of data scanned during the query execution and the amount of time that it took to execute.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct QueryExecutionStatistics {
     /// <p>The number of bytes in the data that was queried.</p>
     #[serde(rename = "DataScannedInBytes")]
@@ -349,6 +363,7 @@ pub struct QueryExecutionStatistics {
 
 /// <p>The completion date, current state, submission time, and state change reason (if applicable) for the query execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct QueryExecutionStatus {
     /// <p>The date and time that the query completed.</p>
     #[serde(rename = "CompletionDateTime")]
@@ -382,6 +397,7 @@ pub struct ResultConfiguration {
 
 /// <p>The metadata and rows that comprise a query result set. The metadata describes the column structure and data types.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResultSet {
     /// <p>The metadata that describes the column structure and data types of a table of query results.</p>
     #[serde(rename = "ResultSetMetadata")]
@@ -395,6 +411,7 @@ pub struct ResultSet {
 
 /// <p>The metadata that describes the column structure and data types of a table of query results.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResultSetMetadata {
     /// <p>Information about the columns in a query execution result.</p>
     #[serde(rename = "ColumnInfo")]
@@ -404,6 +421,7 @@ pub struct ResultSetMetadata {
 
 /// <p>The rows that comprise a query result table.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Row {
     /// <p>The data that populates a row in a query result table.</p>
     #[serde(rename = "Data")]
@@ -430,6 +448,7 @@ pub struct StartQueryExecutionInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartQueryExecutionOutput {
     /// <p>The unique ID of the query that ran as a result of this request.</p>
     #[serde(rename = "QueryExecutionId")]
@@ -445,10 +464,12 @@ pub struct StopQueryExecutionInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopQueryExecutionOutput {}
 
 /// <p>Information about a named query ID that could not be processed.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UnprocessedNamedQueryId {
     /// <p>The error code returned when the processing request for the named query failed, if applicable.</p>
     #[serde(rename = "ErrorCode")]
@@ -466,6 +487,7 @@ pub struct UnprocessedNamedQueryId {
 
 /// <p>Describes a query execution that failed to process.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UnprocessedQueryExecutionId {
     /// <p>The error code returned when the query execution failed to process, if applicable.</p>
     #[serde(rename = "ErrorCode")]

--- a/rusoto/services/autoscaling-plans/src/generated.rs
+++ b/rusoto/services/autoscaling-plans/src/generated.rs
@@ -55,6 +55,7 @@ pub struct CreateScalingPlanRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateScalingPlanResponse {
     /// <p>The version of the scaling plan. This value is always 1.</p>
     #[serde(rename = "ScalingPlanVersion")]
@@ -94,6 +95,7 @@ pub struct DeleteScalingPlanRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteScalingPlanResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -115,6 +117,7 @@ pub struct DescribeScalingPlanResourcesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeScalingPlanResourcesResponse {
     /// <p>The token required to get the next set of results. This value is <code>null</code> if there are no more results to return.</p>
     #[serde(rename = "NextToken")]
@@ -151,6 +154,7 @@ pub struct DescribeScalingPlansRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeScalingPlansResponse {
     /// <p>The token required to get the next set of results. This value is <code>null</code> if there are no more results to return.</p>
     #[serde(rename = "NextToken")]
@@ -210,6 +214,7 @@ pub struct ScalingInstruction {
 
 /// <p>Represents a scaling plan.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ScalingPlan {
     /// <p>The application source.</p>
     #[serde(rename = "ApplicationSource")]
@@ -242,6 +247,7 @@ pub struct ScalingPlan {
 
 /// <p>Represents a scalable resource.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ScalingPlanResource {
     /// <p><p>The ID of the resource. This string consists of the resource type and unique identifier.</p> <ul> <li> <p>Auto Scaling group - The resource type is <code>autoScalingGroup</code> and the unique identifier is the name of the Auto Scaling group. Example: <code>autoScalingGroup/my-asg</code>.</p> </li> <li> <p>ECS service - The resource type is <code>service</code> and the unique identifier is the cluster name and service name. Example: <code>service/default/sample-webapp</code>.</p> </li> <li> <p>Spot fleet request - The resource type is <code>spot-fleet-request</code> and the unique identifier is the Spot fleet request ID. Example: <code>spot-fleet-request/sfr-73fbd2ce-aa30-494c-8788-1cee4EXAMPLE</code>.</p> </li> <li> <p>DynamoDB table - The resource type is <code>table</code> and the unique identifier is the resource ID. Example: <code>table/my-table</code>.</p> </li> <li> <p>DynamoDB global secondary index - The resource type is <code>index</code> and the unique identifier is the resource ID. Example: <code>table/my-table/index/my-table-index</code>.</p> </li> <li> <p>Aurora DB cluster - The resource type is <code>cluster</code> and the unique identifier is the cluster name. Example: <code>cluster:my-db-cluster</code>.</p> </li> </ul></p>
     #[serde(rename = "ResourceId")]
@@ -273,6 +279,7 @@ pub struct ScalingPlanResource {
 
 /// <p>Represents a scaling policy.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ScalingPolicy {
     /// <p>The name of the scaling policy.</p>
     #[serde(rename = "PolicyName")]
@@ -350,6 +357,7 @@ pub struct UpdateScalingPlanRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateScalingPlanResponse {}
 
 /// Errors returned by CreateScalingPlan

--- a/rusoto/services/batch/src/generated.rs
+++ b/rusoto/services/batch/src/generated.rs
@@ -39,6 +39,7 @@ pub struct ArrayProperties {
 
 /// <p>An object representing the array properties of a job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ArrayPropertiesDetail {
     /// <p>The job index within the array that is associated with this job. This parameter is returned for array job children.</p>
     #[serde(rename = "index")]
@@ -56,6 +57,7 @@ pub struct ArrayPropertiesDetail {
 
 /// <p>An object representing the array properties of a job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ArrayPropertiesSummary {
     /// <p>The job index within the array that is associated with this job. This parameter is returned for children of array jobs.</p>
     #[serde(rename = "index")]
@@ -69,6 +71,7 @@ pub struct ArrayPropertiesSummary {
 
 /// <p>An object representing the details of a container that is part of a job attempt.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AttemptContainerDetail {
     /// <p>The Amazon Resource Name (ARN) of the Amazon ECS container instance that hosts the job attempt.</p>
     #[serde(rename = "containerInstanceArn")]
@@ -94,6 +97,7 @@ pub struct AttemptContainerDetail {
 
 /// <p>An object representing a job attempt.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AttemptDetail {
     /// <p>Details about the container in this job attempt.</p>
     #[serde(rename = "container")]
@@ -124,10 +128,12 @@ pub struct CancelJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CancelJobResponse {}
 
 /// <p>An object representing an AWS Batch compute environment.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ComputeEnvironmentDetail {
     /// <p>The Amazon Resource Name (ARN) of the compute environment. </p>
     #[serde(rename = "computeEnvironmentArn")]
@@ -244,6 +250,7 @@ pub struct ComputeResourceUpdate {
 
 /// <p>An object representing the details of a container that is part of a job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ContainerDetail {
     /// <p>The command that is passed to the container. </p>
     #[serde(rename = "command")]
@@ -388,6 +395,7 @@ pub struct ContainerProperties {
 
 /// <p>An object representing summary details of a container within a job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ContainerSummary {
     /// <p>The exit code to return upon completion.</p>
     #[serde(rename = "exitCode")]
@@ -421,6 +429,7 @@ pub struct CreateComputeEnvironmentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateComputeEnvironmentResponse {
     /// <p>The Amazon Resource Name (ARN) of the compute environment. </p>
     #[serde(rename = "computeEnvironmentArn")]
@@ -450,6 +459,7 @@ pub struct CreateJobQueueRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateJobQueueResponse {
     /// <p>The Amazon Resource Name (ARN) of the job queue.</p>
     #[serde(rename = "jobQueueArn")]
@@ -467,6 +477,7 @@ pub struct DeleteComputeEnvironmentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteComputeEnvironmentResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -477,6 +488,7 @@ pub struct DeleteJobQueueRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteJobQueueResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -487,6 +499,7 @@ pub struct DeregisterJobDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeregisterJobDefinitionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -506,6 +519,7 @@ pub struct DescribeComputeEnvironmentsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeComputeEnvironmentsResponse {
     /// <p>The list of compute environments.</p>
     #[serde(rename = "computeEnvironments")]
@@ -542,6 +556,7 @@ pub struct DescribeJobDefinitionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeJobDefinitionsResponse {
     /// <p>The list of job definitions. </p>
     #[serde(rename = "jobDefinitions")]
@@ -570,6 +585,7 @@ pub struct DescribeJobQueuesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeJobQueuesResponse {
     /// <p>The list of job queues. </p>
     #[serde(rename = "jobQueues")]
@@ -589,6 +605,7 @@ pub struct DescribeJobsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeJobsResponse {
     /// <p>The list of jobs. </p>
     #[serde(rename = "jobs")]
@@ -607,6 +624,7 @@ pub struct Host {
 
 /// <p>An object representing an AWS Batch job definition.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct JobDefinition {
     /// <p>An object with various properties specific to container-based jobs. </p>
     #[serde(rename = "containerProperties")]
@@ -657,6 +675,7 @@ pub struct JobDependency {
 
 /// <p>An object representing an AWS Batch job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct JobDetail {
     /// <p>The array properties of the job, if it is an array job.</p>
     #[serde(rename = "arrayProperties")]
@@ -720,6 +739,7 @@ pub struct JobDetail {
 
 /// <p>An object representing the details of an AWS Batch job queue.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct JobQueueDetail {
     /// <p>The compute environments that are attached to the job queue and the order in which job placement is preferred. Compute environments are selected for job placement in ascending order.</p>
     #[serde(rename = "computeEnvironmentOrder")]
@@ -748,6 +768,7 @@ pub struct JobQueueDetail {
 
 /// <p>An object representing summary details of a job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct JobSummary {
     /// <p>The array properties of the job, if it is an array job.</p>
     #[serde(rename = "arrayProperties")]
@@ -832,6 +853,7 @@ pub struct ListJobsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListJobsResponse {
     /// <p>A list of job summaries that match the request.</p>
     #[serde(rename = "jobSummaryList")]
@@ -886,6 +908,7 @@ pub struct RegisterJobDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegisterJobDefinitionResponse {
     /// <p>The Amazon Resource Name (ARN) of the job definition. </p>
     #[serde(rename = "jobDefinitionArn")]
@@ -945,6 +968,7 @@ pub struct SubmitJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SubmitJobResponse {
     /// <p>The unique identifier for the job.</p>
     #[serde(rename = "jobId")]
@@ -965,6 +989,7 @@ pub struct TerminateJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TerminateJobResponse {}
 
 /// <p>The <code>ulimit</code> settings to pass to the container.</p>
@@ -1001,6 +1026,7 @@ pub struct UpdateComputeEnvironmentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateComputeEnvironmentResponse {
     /// <p>The Amazon Resource Name (ARN) of the compute environment. </p>
     #[serde(rename = "computeEnvironmentArn")]
@@ -1032,6 +1058,7 @@ pub struct UpdateJobQueueRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateJobQueueResponse {
     /// <p>The Amazon Resource Name (ARN) of the job queue.</p>
     #[serde(rename = "jobQueueArn")]

--- a/rusoto/services/budgets/src/generated.rs
+++ b/rusoto/services/budgets/src/generated.rs
@@ -140,6 +140,7 @@ pub struct CreateBudgetRequest {
 
 /// <p> Response of CreateBudget </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateBudgetResponse {}
 
 /// <p> Request of CreateNotification </p>
@@ -161,6 +162,7 @@ pub struct CreateNotificationRequest {
 
 /// <p> Response of CreateNotification </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateNotificationResponse {}
 
 /// <p> Request of CreateSubscriber </p>
@@ -182,6 +184,7 @@ pub struct CreateSubscriberRequest {
 
 /// <p> Response of CreateSubscriber </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateSubscriberResponse {}
 
 /// <p> Request of DeleteBudget </p>
@@ -197,6 +200,7 @@ pub struct DeleteBudgetRequest {
 
 /// <p> Response of DeleteBudget </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteBudgetResponse {}
 
 /// <p> Request of DeleteNotification </p>
@@ -215,6 +219,7 @@ pub struct DeleteNotificationRequest {
 
 /// <p> Response of DeleteNotification </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteNotificationResponse {}
 
 /// <p> Request of DeleteSubscriber </p>
@@ -236,6 +241,7 @@ pub struct DeleteSubscriberRequest {
 
 /// <p> Response of DeleteSubscriber </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteSubscriberResponse {}
 
 /// <p> Request of DescribeBudget </p>
@@ -251,6 +257,7 @@ pub struct DescribeBudgetRequest {
 
 /// <p> Response of DescribeBudget </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeBudgetResponse {
     /// <p>The description of the budget.</p>
     #[serde(rename = "Budget")]
@@ -276,6 +283,7 @@ pub struct DescribeBudgetsRequest {
 
 /// <p> Response of DescribeBudgets </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeBudgetsResponse {
     /// <p>A list of budgets.</p>
     #[serde(rename = "Budgets")]
@@ -308,6 +316,7 @@ pub struct DescribeNotificationsForBudgetRequest {
 
 /// <p> Response of GetNotificationsForBudget </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeNotificationsForBudgetResponse {
     /// <p>The pagination token that indicates the next set of results that you can retrieve.</p>
     #[serde(rename = "NextToken")]
@@ -343,6 +352,7 @@ pub struct DescribeSubscribersForNotificationRequest {
 
 /// <p> Response of DescribeSubscribersForNotification </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeSubscribersForNotificationResponse {
     /// <p>The pagination token that indicates the next set of results that you can retrieve.</p>
     #[serde(rename = "NextToken")]
@@ -431,6 +441,7 @@ pub struct UpdateBudgetRequest {
 
 /// <p> Response of UpdateBudget </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateBudgetResponse {}
 
 /// <p> Request of UpdateNotification </p>
@@ -452,6 +463,7 @@ pub struct UpdateNotificationRequest {
 
 /// <p> Response of UpdateNotification </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateNotificationResponse {}
 
 /// <p> Request of UpdateSubscriber </p>
@@ -476,6 +488,7 @@ pub struct UpdateSubscriberRequest {
 
 /// <p> Response of UpdateSubscriber </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateSubscriberResponse {}
 
 /// Errors returned by CreateBudget

--- a/rusoto/services/ce/src/generated.rs
+++ b/rusoto/services/ce/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>The amount of instance usage that a reservation covered.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Coverage {
     /// <p>The amount of instance usage that a reservation covered, in hours.</p>
     #[serde(rename = "CoverageHours")]
@@ -39,6 +40,7 @@ pub struct Coverage {
 
 /// <p>Reservation coverage for a specified period, in hours.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CoverageByTime {
     /// <p>The groups of instances that are covered by a reservation.</p>
     #[serde(rename = "Groups")]
@@ -56,6 +58,7 @@ pub struct CoverageByTime {
 
 /// <p>How long a running instance either used a reservation or was On-Demand.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CoverageHours {
     /// <p>The percentage of instance hours that are covered by a reservation.</p>
     #[serde(rename = "CoverageHoursPercentage")]
@@ -101,6 +104,7 @@ pub struct DimensionValues {
 
 /// <p>The metadata of a specific type that you can use to filter and group your results. You can use <code>GetDimensionValues</code> to find specific values.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DimensionValuesWithAttributes {
     /// <p>The attribute that applies to a specific <code>Dimension</code>.</p>
     #[serde(rename = "Attributes")]
@@ -114,6 +118,7 @@ pub struct DimensionValuesWithAttributes {
 
 /// <p>Details about the EC2 instances that AWS recommends that you purchase.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EC2InstanceDetails {
     /// <p>The Availability Zone of the recommended reservation.</p>
     #[serde(rename = "AvailabilityZone")]
@@ -160,6 +165,7 @@ pub struct EC2Specification {
 
 /// <p>Details about the ES instances that AWS recommends that you purchase.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ESInstanceDetails {
     /// <p>Whether the recommendation is for a current generation instance.</p>
     #[serde(rename = "CurrentGeneration")]
@@ -185,6 +191,7 @@ pub struct ESInstanceDetails {
 
 /// <p>Details about the ElastiCache instances that AWS recommends that you purchase.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ElastiCacheInstanceDetails {
     /// <p>Whether the recommendation is for a current generation instance.</p>
     #[serde(rename = "CurrentGeneration")]
@@ -266,6 +273,7 @@ pub struct GetCostAndUsageRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetCostAndUsageResponse {
     /// <p>The groups that are specified by the <code>Filter</code> or <code>GroupBy</code> parameters in the request.</p>
     #[serde(rename = "GroupDefinitions")]
@@ -304,6 +312,7 @@ pub struct GetDimensionValuesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDimensionValuesResponse {
     /// <p><p>The filters that you used to filter your request. Some dimensions are available only for a specific context:</p> <p>If you set the context to <code>COST<em>AND</em>USAGE</code>, you can use the following dimensions for searching:</p> <ul> <li> <p>AZ - The Availability Zone. An example is <code>us-east-1a</code>.</p> </li> <li> <p>DATABASE<em>ENGINE - The Amazon Relational Database Service database. Examples are Aurora or MySQL.</p> </li> <li> <p>INSTANCE</em>TYPE - The type of EC2 instance. An example is <code>m4.xlarge</code>.</p> </li> <li> <p>LEGAL<em>ENTITY</em>NAME - The name of the organization that sells you AWS services, such as Amazon Web Services.</p> </li> <li> <p>LINKED<em>ACCOUNT - The description in the attribute map that includes the full name of the member account. The value field contains the AWS ID of the member account.</p> </li> <li> <p>OPERATING</em>SYSTEM - The operating system. Examples are Windows or Linux.</p> </li> <li> <p>OPERATION - The action performed. Examples include <code>RunInstance</code> and <code>CreateBucket</code>.</p> </li> <li> <p>PLATFORM - The EC2 operating system. Examples are Windows or Linux.</p> </li> <li> <p>PURCHASE<em>TYPE - The reservation type of the purchase to which this usage is related. Examples include On-Demand Instances and Standard Reserved Instances.</p> </li> <li> <p>SERVICE - The AWS service such as Amazon DynamoDB.</p> </li> <li> <p>USAGE</em>TYPE - The type of usage. An example is DataTransfer-In-Bytes. The response for the <code>GetDimensionValues</code> operation includes a unit attribute. Examples include GB and Hrs.</p> </li> <li> <p>USAGE<em>TYPE</em>GROUP - The grouping of common usage types. An example is EC2: CloudWatch – Alarms. The response for this operation includes a unit attribute.</p> </li> <li> <p>RECORD<em>TYPE - The different types of charges such as RI fees, usage costs, tax refunds, and credits.</p> </li> </ul> <p>If you set the context to <code>RESERVATIONS</code>, you can use the following dimensions for searching:</p> <ul> <li> <p>AZ - The Availability Zone. An example is <code>us-east-1a</code>.</p> </li> <li> <p>CACHE</em>ENGINE - The Amazon ElastiCache operating system. Examples are Windows or Linux.</p> </li> <li> <p>DEPLOYMENT<em>OPTION - The scope of Amazon Relational Database Service deployments. Valid values are <code>SingleAZ</code> and <code>MultiAZ</code>.</p> </li> <li> <p>INSTANCE</em>TYPE - The type of EC2 instance. An example is <code>m4.xlarge</code>.</p> </li> <li> <p>LINKED_ACCOUNT - The description in the attribute map that includes the full name of the member account. The value field contains the AWS ID of the member account.</p> </li> <li> <p>PLATFORM - The EC2 operating system. Examples are Windows or Linux.</p> </li> <li> <p>REGION - The AWS Region.</p> </li> <li> <p>SCOPE (Utilization only) - The scope of a Reserved Instance (RI). Values are regional or a single Availability Zone.</p> </li> <li> <p>TAG (Coverage only) - The tags that are associated with a Reserved Instance (RI).</p> </li> <li> <p>TENANCY - The tenancy of a resource. Examples are shared or dedicated.</p> </li> </ul></p>
     #[serde(rename = "DimensionValues")]
@@ -345,6 +354,7 @@ pub struct GetReservationCoverageRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetReservationCoverageResponse {
     /// <p>The amount of time that your reservations covered.</p>
     #[serde(rename = "CoveragesByTime")]
@@ -399,6 +409,7 @@ pub struct GetReservationPurchaseRecommendationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetReservationPurchaseRecommendationResponse {
     /// <p>Information about this specific recommendation call, such as the time stamp for when Cost Explorer generated this recommendation.</p>
     #[serde(rename = "Metadata")]
@@ -438,6 +449,7 @@ pub struct GetReservationUtilizationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetReservationUtilizationResponse {
     /// <p>The token for the next set of retrievable results. AWS provides the token when the response from a previous call has more results than the maximum page size.</p>
     #[serde(rename = "NextPageToken")]
@@ -472,6 +484,7 @@ pub struct GetTagsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetTagsResponse {
     /// <p>The token for the next set of retrievable results. AWS provides the token when the response from a previous call has more results than the maximum page size.</p>
     #[serde(rename = "NextPageToken")]
@@ -490,6 +503,7 @@ pub struct GetTagsResponse {
 
 /// <p>One level of grouped data within the results.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Group {
     /// <p>The keys that are included in this group.</p>
     #[serde(rename = "Keys")]
@@ -516,6 +530,7 @@ pub struct GroupDefinition {
 
 /// <p>Details about the instances that AWS recommends that you purchase.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceDetails {
     /// <p>The EC2 instances that AWS recommends that you purchase.</p>
     #[serde(rename = "EC2InstanceDetails")]
@@ -541,6 +556,7 @@ pub struct InstanceDetails {
 
 /// <p>The aggregated value for a metric.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MetricValue {
     /// <p>The actual number that represents the metric.</p>
     #[serde(rename = "Amount")]
@@ -554,6 +570,7 @@ pub struct MetricValue {
 
 /// <p>Details about the RDS instances that AWS recommends that you purchase.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RDSInstanceDetails {
     /// <p>Whether the recommendation is for a current generation instance. </p>
     #[serde(rename = "CurrentGeneration")]
@@ -595,6 +612,7 @@ pub struct RDSInstanceDetails {
 
 /// <p>Details about the Amazon Redshift instances that AWS recommends that you purchase.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RedshiftInstanceDetails {
     /// <p>Whether the recommendation is for a current generation instance.</p>
     #[serde(rename = "CurrentGeneration")]
@@ -620,6 +638,7 @@ pub struct RedshiftInstanceDetails {
 
 /// <p>The aggregated numbers for your Reserved Instance (RI) usage.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReservationAggregates {
     /// <p>The monthly cost of your RI, amortized over the RI period.</p>
     #[serde(rename = "AmortizedRecurringFee")]
@@ -665,6 +684,7 @@ pub struct ReservationAggregates {
 
 /// <p>A group of reservations that share a set of attributes.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReservationCoverageGroup {
     /// <p>The attributes for this group of reservations.</p>
     #[serde(rename = "Attributes")]
@@ -678,6 +698,7 @@ pub struct ReservationCoverageGroup {
 
 /// <p>A specific reservation that AWS recommends for purchase.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReservationPurchaseRecommendation {
     /// <p>The account scope that AWS recommends that you purchase this instance for. For example, you can purchase this reservation for an entire organization in AWS Organizations.</p>
     #[serde(rename = "AccountScope")]
@@ -711,6 +732,7 @@ pub struct ReservationPurchaseRecommendation {
 
 /// <p>Details about your recommended reservation purchase.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReservationPurchaseRecommendationDetail {
     /// <p>The average number of normalized units that you used in an hour during the historical period. AWS uses this to calculate your recommended reservation purchases.</p>
     #[serde(rename = "AverageNormalizedUnitsUsedPerHour")]
@@ -788,6 +810,7 @@ pub struct ReservationPurchaseRecommendationDetail {
 
 /// <p>Information about this specific recommendation, such as the time stamp for when AWS made a specific recommendation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReservationPurchaseRecommendationMetadata {
     /// <p>The time stamp for when AWS made this recommendation.</p>
     #[serde(rename = "GenerationTimestamp")]
@@ -801,6 +824,7 @@ pub struct ReservationPurchaseRecommendationMetadata {
 
 /// <p>A summary about this recommendation, such as the currency code, the amount that AWS estimates that you could save, and the total amount of reservation to purchase.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReservationPurchaseRecommendationSummary {
     /// <p>The currency code used for this recommendation.</p>
     #[serde(rename = "CurrencyCode")]
@@ -818,6 +842,7 @@ pub struct ReservationPurchaseRecommendationSummary {
 
 /// <p>A group of Reserved Instances (RIs) that share a set of attributes.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReservationUtilizationGroup {
     /// <p>The attributes for this group of RIs.</p>
     #[serde(rename = "Attributes")]
@@ -839,6 +864,7 @@ pub struct ReservationUtilizationGroup {
 
 /// <p>The result that is associated with a time period.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResultByTime {
     /// <p>Whether this result is estimated.</p>
     #[serde(rename = "Estimated")]
@@ -882,6 +908,7 @@ pub struct TagValues {
 
 /// <p>The amount of utilization, in hours.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UtilizationByTime {
     /// <p>The groups that are included in this utilization result.</p>
     #[serde(rename = "Groups")]

--- a/rusoto/services/cloud9/src/generated.rs
+++ b/rusoto/services/cloud9/src/generated.rs
@@ -59,6 +59,7 @@ pub struct CreateEnvironmentEC2Request {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateEnvironmentEC2Result {
     /// <p>The ID of the environment that was created.</p>
     #[serde(rename = "environmentId")]
@@ -80,6 +81,7 @@ pub struct CreateEnvironmentMembershipRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateEnvironmentMembershipResult {
     /// <p>Information about the environment member that was added.</p>
     #[serde(rename = "membership")]
@@ -98,6 +100,7 @@ pub struct DeleteEnvironmentMembershipRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteEnvironmentMembershipResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -108,6 +111,7 @@ pub struct DeleteEnvironmentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteEnvironmentResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -135,6 +139,7 @@ pub struct DescribeEnvironmentMembershipsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEnvironmentMembershipsResult {
     /// <p>Information about the environment members for the environment.</p>
     #[serde(rename = "memberships")]
@@ -154,6 +159,7 @@ pub struct DescribeEnvironmentStatusRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEnvironmentStatusResult {
     /// <p>Any informational message about the status of the environment.</p>
     #[serde(rename = "message")]
@@ -173,6 +179,7 @@ pub struct DescribeEnvironmentsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEnvironmentsResult {
     /// <p>Information about the environments that are returned.</p>
     #[serde(rename = "environments")]
@@ -182,6 +189,7 @@ pub struct DescribeEnvironmentsResult {
 
 /// <p>Information about an AWS Cloud9 development environment.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Environment {
     /// <p>The Amazon Resource Name (ARN) of the environment.</p>
     #[serde(rename = "arn")]
@@ -211,6 +219,7 @@ pub struct Environment {
 
 /// <p>Information about an environment member for an AWS Cloud9 development environment.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EnvironmentMember {
     /// <p>The ID of the environment for the environment member.</p>
     #[serde(rename = "environmentId")]
@@ -247,6 +256,7 @@ pub struct ListEnvironmentsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListEnvironmentsResult {
     /// <p>The list of environment identifiers.</p>
     #[serde(rename = "environmentIds")]
@@ -272,6 +282,7 @@ pub struct UpdateEnvironmentMembershipRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateEnvironmentMembershipResult {
     /// <p>Information about the environment member whose settings were changed.</p>
     #[serde(rename = "membership")]
@@ -295,6 +306,7 @@ pub struct UpdateEnvironmentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateEnvironmentResult {}
 
 /// Errors returned by CreateEnvironmentEC2

--- a/rusoto/services/clouddirectory/src/generated.rs
+++ b/rusoto/services/clouddirectory/src/generated.rs
@@ -46,6 +46,7 @@ pub struct AddFacetToObjectRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddFacetToObjectResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -59,6 +60,7 @@ pub struct ApplySchemaRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ApplySchemaResponse {
     /// <p>The applied schema ARN that is associated with the copied schema in the <a>Directory</a>. You can use this ARN to describe the schema information applied on this directory. For more information, see <a>arns</a>.</p>
     #[serde(rename = "AppliedSchemaArn")]
@@ -87,6 +89,7 @@ pub struct AttachObjectRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AttachObjectResponse {
     /// <p>The attached <code>ObjectIdentifier</code>, which is the child <code>ObjectIdentifier</code>.</p>
     #[serde(rename = "AttachedObjectIdentifier")]
@@ -108,6 +111,7 @@ pub struct AttachPolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AttachPolicyResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -124,6 +128,7 @@ pub struct AttachToIndexRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AttachToIndexResponse {
     /// <p>The <code>ObjectIdentifier</code> of the object that was attached to the index.</p>
     #[serde(rename = "AttachedObjectIdentifier")]
@@ -151,6 +156,7 @@ pub struct AttachTypedLinkRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AttachTypedLinkResponse {
     /// <p>Returns a typed link specifier as output.</p>
     #[serde(rename = "TypedLinkSpecifier")]
@@ -210,6 +216,7 @@ pub struct BatchAddFacetToObject {
 
 /// <p>The result of a batch add facet to object operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchAddFacetToObjectResponse {}
 
 /// <p>Represents the output of an <a>AttachObject</a> operation.</p>
@@ -228,6 +235,7 @@ pub struct BatchAttachObject {
 
 /// <p>Represents the output batch <a>AttachObject</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchAttachObjectResponse {
     /// <p>The <code>ObjectIdentifier</code> of the object that has been attached.</p>
     #[serde(rename = "attachedObjectIdentifier")]
@@ -248,6 +256,7 @@ pub struct BatchAttachPolicy {
 
 /// <p>Represents the output of an <a>AttachPolicy</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchAttachPolicyResponse {}
 
 /// <p>Attaches the specified object to the specified index inside a <a>BatchRead</a> operation. For more information, see <a>AttachToIndex</a> and <a>BatchReadRequest$Operations</a>.</p>
@@ -263,6 +272,7 @@ pub struct BatchAttachToIndex {
 
 /// <p>Represents the output of a <a>AttachToIndex</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchAttachToIndexResponse {
     /// <p>The <code>ObjectIdentifier</code> of the object that was attached to the index.</p>
     #[serde(rename = "AttachedObjectIdentifier")]
@@ -289,6 +299,7 @@ pub struct BatchAttachTypedLink {
 
 /// <p>Represents the output of a <a>AttachTypedLink</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchAttachTypedLinkResponse {
     /// <p>Returns a typed link specifier as output.</p>
     #[serde(rename = "TypedLinkSpecifier")]
@@ -321,6 +332,7 @@ pub struct BatchCreateIndex {
 
 /// <p>Represents the output of a <a>CreateIndex</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchCreateIndexResponse {
     /// <p>The <code>ObjectIdentifier</code> of the index created by this operation.</p>
     #[serde(rename = "ObjectIdentifier")]
@@ -353,6 +365,7 @@ pub struct BatchCreateObject {
 
 /// <p>Represents the output of a <a>CreateObject</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchCreateObjectResponse {
     /// <p>The ID that is associated with the object.</p>
     #[serde(rename = "ObjectIdentifier")]
@@ -370,6 +383,7 @@ pub struct BatchDeleteObject {
 
 /// <p>Represents the output of a <a>DeleteObject</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchDeleteObjectResponse {}
 
 /// <p>Detaches the specified object from the specified index inside a <a>BatchRead</a> operation. For more information, see <a>DetachFromIndex</a> and <a>BatchReadRequest$Operations</a>.</p>
@@ -385,6 +399,7 @@ pub struct BatchDetachFromIndex {
 
 /// <p>Represents the output of a <a>DetachFromIndex</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchDetachFromIndexResponse {
     /// <p>The <code>ObjectIdentifier</code> of the object that was detached from the index.</p>
     #[serde(rename = "DetachedObjectIdentifier")]
@@ -409,6 +424,7 @@ pub struct BatchDetachObject {
 
 /// <p>Represents the output of a <a>DetachObject</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchDetachObjectResponse {
     /// <p>The <code>ObjectIdentifier</code> of the detached object.</p>
     #[serde(rename = "detachedObjectIdentifier")]
@@ -429,6 +445,7 @@ pub struct BatchDetachPolicy {
 
 /// <p>Represents the output of a <a>DetachPolicy</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchDetachPolicyResponse {}
 
 /// <p>Detaches a typed link from a specified source and target object inside a <a>BatchRead</a> operation. For more information, see <a>DetachTypedLink</a> and <a>BatchReadRequest$Operations</a>.</p>
@@ -441,6 +458,7 @@ pub struct BatchDetachTypedLink {
 
 /// <p>Represents the output of a <a>DetachTypedLink</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchDetachTypedLinkResponse {}
 
 /// <p>Retrieves attributes that are associated with a typed link inside a <a>BatchRead</a> operation. For more information, see <a>GetLinkAttributes</a> and <a>BatchReadRequest$Operations</a>.</p>
@@ -456,6 +474,7 @@ pub struct BatchGetLinkAttributes {
 
 /// <p>Represents the output of a <a>GetLinkAttributes</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchGetLinkAttributesResponse {
     /// <p>The attributes that are associated with the typed link.</p>
     #[serde(rename = "Attributes")]
@@ -479,6 +498,7 @@ pub struct BatchGetObjectAttributes {
 
 /// <p>Represents the output of a <a>GetObjectAttributes</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchGetObjectAttributesResponse {
     /// <p>The attribute values that are associated with an object.</p>
     #[serde(rename = "Attributes")]
@@ -496,6 +516,7 @@ pub struct BatchGetObjectInformation {
 
 /// <p>Represents the output of a <a>GetObjectInformation</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchGetObjectInformationResponse {
     /// <p>The <code>ObjectIdentifier</code> of the specified object.</p>
     #[serde(rename = "ObjectIdentifier")]
@@ -525,6 +546,7 @@ pub struct BatchListAttachedIndices {
 
 /// <p>Represents the output of a <a>ListAttachedIndices</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchListAttachedIndicesResponse {
     /// <p>The indices attached to the specified object.</p>
     #[serde(rename = "IndexAttachments")]
@@ -562,6 +584,7 @@ pub struct BatchListIncomingTypedLinks {
 
 /// <p>Represents the output of a <a>ListIncomingTypedLinks</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchListIncomingTypedLinksResponse {
     /// <p>Returns one or more typed link specifiers as output.</p>
     #[serde(rename = "LinkSpecifiers")]
@@ -595,6 +618,7 @@ pub struct BatchListIndex {
 
 /// <p>Represents the output of a <a>ListIndex</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchListIndexResponse {
     /// <p>The objects and indexed values attached to the index.</p>
     #[serde(rename = "IndexAttachments")]
@@ -628,6 +652,7 @@ pub struct BatchListObjectAttributes {
 
 /// <p>Represents the output of a <a>ListObjectAttributes</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchListObjectAttributesResponse {
     /// <p>The attributes map that is associated with the object. <code>AttributeArn</code> is the key; attribute value is the value.</p>
     #[serde(rename = "Attributes")]
@@ -657,6 +682,7 @@ pub struct BatchListObjectChildren {
 
 /// <p>Represents the output of a <a>ListObjectChildren</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchListObjectChildrenResponse {
     /// <p>The children structure, which is a map with the key as the <code>LinkName</code> and <code>ObjectIdentifier</code> as the value.</p>
     #[serde(rename = "Children")]
@@ -686,6 +712,7 @@ pub struct BatchListObjectParentPaths {
 
 /// <p>Represents the output of a <a>ListObjectParentPaths</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchListObjectParentPathsResponse {
     /// <p>The pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -715,6 +742,7 @@ pub struct BatchListObjectPolicies {
 
 /// <p>Represents the output of a <a>ListObjectPolicies</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchListObjectPoliciesResponse {
     /// <p>A list of policy <code>ObjectIdentifiers</code>, that are attached to the object.</p>
     #[serde(rename = "AttachedPolicyIds")]
@@ -752,6 +780,7 @@ pub struct BatchListOutgoingTypedLinks {
 
 /// <p>Represents the output of a <a>ListOutgoingTypedLinks</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchListOutgoingTypedLinksResponse {
     /// <p>The pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -781,6 +810,7 @@ pub struct BatchListPolicyAttachments {
 
 /// <p>Represents the output of a <a>ListPolicyAttachments</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchListPolicyAttachmentsResponse {
     /// <p>The pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -810,6 +840,7 @@ pub struct BatchLookupPolicy {
 
 /// <p>Represents the output of a <a>LookupPolicy</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchLookupPolicyResponse {
     /// <p>The pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -823,6 +854,7 @@ pub struct BatchLookupPolicyResponse {
 
 /// <p>The batch read exception structure, which contains the exception type and message.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchReadException {
     /// <p>An exception message that is associated with the failure.</p>
     #[serde(rename = "Message")]
@@ -893,6 +925,7 @@ pub struct BatchReadOperation {
 
 /// <p>Represents the output of a <code>BatchRead</code> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchReadOperationResponse {
     /// <p>Identifies which operation in a batch has failed.</p>
     #[serde(rename = "ExceptionResponse")]
@@ -919,6 +952,7 @@ pub struct BatchReadRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchReadResponse {
     /// <p>A list of all the responses for each batch read.</p>
     #[serde(rename = "Responses")]
@@ -928,6 +962,7 @@ pub struct BatchReadResponse {
 
 /// <p>Represents the output of a <code>BatchRead</code> success response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchReadSuccessfulResponse {
     /// <p>The list of attributes to retrieve from the typed link.</p>
     #[serde(rename = "GetLinkAttributes")]
@@ -996,6 +1031,7 @@ pub struct BatchRemoveFacetFromObject {
 
 /// <p>An empty result that represents success.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchRemoveFacetFromObjectResponse {}
 
 /// <p>Updates a given typed link’s attributes inside a <a>BatchRead</a> operation. Attributes to be updated must not contribute to the typed link’s identity, as defined by its <code>IdentityAttributeOrder</code>. For more information, see <a>UpdateLinkAttributes</a> and <a>BatchReadRequest$Operations</a>.</p>
@@ -1011,6 +1047,7 @@ pub struct BatchUpdateLinkAttributes {
 
 /// <p>Represents the output of a <a>UpdateLinkAttributes</a> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchUpdateLinkAttributesResponse {}
 
 /// <p>Represents the output of a <code>BatchUpdate</code> operation. </p>
@@ -1026,6 +1063,7 @@ pub struct BatchUpdateObjectAttributes {
 
 /// <p>Represents the output of a <code>BatchUpdate</code> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchUpdateObjectAttributesResponse {
     /// <p>ID that is associated with the object.</p>
     #[serde(rename = "ObjectIdentifier")]
@@ -1100,6 +1138,7 @@ pub struct BatchWriteOperation {
 
 /// <p>Represents the output of a <code>BatchWrite</code> response operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchWriteOperationResponse {
     /// <p>The result of an add facet to object batch operation.</p>
     #[serde(rename = "AddFacetToObject")]
@@ -1174,6 +1213,7 @@ pub struct BatchWriteRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchWriteResponse {
     /// <p>A list of all the responses for each batch write.</p>
     #[serde(rename = "Responses")]
@@ -1192,6 +1232,7 @@ pub struct CreateDirectoryRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDirectoryResponse {
     /// <p>The ARN of the published schema in the <a>Directory</a>. Once a published schema is copied into the directory, it has its own ARN, which is referred to applied schema ARN. For more information, see <a>arns</a>.</p>
     #[serde(rename = "AppliedSchemaArn")]
@@ -1225,6 +1266,7 @@ pub struct CreateFacetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateFacetResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1249,6 +1291,7 @@ pub struct CreateIndexRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateIndexResponse {
     /// <p>The <code>ObjectIdentifier</code> of the index created by this operation.</p>
     #[serde(rename = "ObjectIdentifier")]
@@ -1279,6 +1322,7 @@ pub struct CreateObjectRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateObjectResponse {
     /// <p>The identifier that is associated with the object.</p>
     #[serde(rename = "ObjectIdentifier")]
@@ -1294,6 +1338,7 @@ pub struct CreateSchemaRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateSchemaResponse {
     /// <p>The Amazon Resource Name (ARN) that is associated with the schema. For more information, see <a>arns</a>.</p>
     #[serde(rename = "SchemaArn")]
@@ -1312,6 +1357,7 @@ pub struct CreateTypedLinkFacetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateTypedLinkFacetResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1322,6 +1368,7 @@ pub struct DeleteDirectoryRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteDirectoryResponse {
     /// <p>The ARN of the deleted directory.</p>
     #[serde(rename = "DirectoryArn")]
@@ -1339,6 +1386,7 @@ pub struct DeleteFacetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteFacetResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1352,6 +1400,7 @@ pub struct DeleteObjectRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteObjectResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1362,6 +1411,7 @@ pub struct DeleteSchemaRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteSchemaResponse {
     /// <p>The input ARN that is returned as part of the response. For more information, see <a>arns</a>.</p>
     #[serde(rename = "SchemaArn")]
@@ -1380,6 +1430,7 @@ pub struct DeleteTypedLinkFacetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteTypedLinkFacetResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1396,6 +1447,7 @@ pub struct DetachFromIndexRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DetachFromIndexResponse {
     /// <p>The <code>ObjectIdentifier</code> of the object that was detached from the index.</p>
     #[serde(rename = "DetachedObjectIdentifier")]
@@ -1417,6 +1469,7 @@ pub struct DetachObjectRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DetachObjectResponse {
     /// <p>The <code>ObjectIdentifier</code> that was detached from the object.</p>
     #[serde(rename = "DetachedObjectIdentifier")]
@@ -1438,6 +1491,7 @@ pub struct DetachPolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DetachPolicyResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1452,6 +1506,7 @@ pub struct DetachTypedLinkRequest {
 
 /// <p>Directory structure that includes the directory name and directory ARN.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Directory {
     /// <p>The date and time when the directory was created.</p>
     #[serde(rename = "CreationDateTime")]
@@ -1479,6 +1534,7 @@ pub struct DisableDirectoryRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisableDirectoryResponse {
     /// <p>The ARN of the directory that has been disabled.</p>
     #[serde(rename = "DirectoryArn")]
@@ -1493,6 +1549,7 @@ pub struct EnableDirectoryRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EnableDirectoryResponse {
     /// <p>The ARN of the enabled directory.</p>
     #[serde(rename = "DirectoryArn")]
@@ -1501,6 +1558,7 @@ pub struct EnableDirectoryResponse {
 
 /// <p>A structure that contains <code>Name</code>, <code>ARN</code>, <code>Attributes</code>, <code> <a>Rule</a>s</code>, and <code>ObjectTypes</code>. See <a href="http://docs.aws.amazon.com/directoryservice/latest/admin-guide/whatarefacets.html">Facets</a> for more information.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Facet {
     /// <p>The name of the <a>Facet</a>.</p>
     #[serde(rename = "Name")]
@@ -1584,6 +1642,7 @@ pub struct GetAppliedSchemaVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetAppliedSchemaVersionResponse {
     /// <p>Current applied schema ARN, including the minor version in use if one was provided.</p>
     #[serde(rename = "AppliedSchemaArn")]
@@ -1599,6 +1658,7 @@ pub struct GetDirectoryRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDirectoryResponse {
     /// <p>Metadata about the directory.</p>
     #[serde(rename = "Directory")]
@@ -1616,6 +1676,7 @@ pub struct GetFacetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetFacetResponse {
     /// <p>The <a>Facet</a> structure that is associated with the facet.</p>
     #[serde(rename = "Facet")]
@@ -1641,6 +1702,7 @@ pub struct GetLinkAttributesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetLinkAttributesResponse {
     /// <p>The attributes that are associated with the typed link.</p>
     #[serde(rename = "Attributes")]
@@ -1669,6 +1731,7 @@ pub struct GetObjectAttributesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetObjectAttributesResponse {
     /// <p>The attributes that are associated with the object.</p>
     #[serde(rename = "Attributes")]
@@ -1691,6 +1754,7 @@ pub struct GetObjectInformationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetObjectInformationResponse {
     /// <p>The <code>ObjectIdentifier</code> of the specified object.</p>
     #[serde(rename = "ObjectIdentifier")]
@@ -1710,6 +1774,7 @@ pub struct GetSchemaAsJsonRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetSchemaAsJsonResponse {
     /// <p>The JSON representation of the schema document.</p>
     #[serde(rename = "Document")]
@@ -1732,6 +1797,7 @@ pub struct GetTypedLinkFacetInformationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetTypedLinkFacetInformationResponse {
     /// <p>The order of identity attributes for the facet, from most significant to least significant. The ability to filter typed links considers the order that the attributes are defined on the typed link facet. When providing ranges to typed link selection, any inexact ranges must be specified at the end. Any attributes that do not have a range specified are presumed to match the entire range. Filters are interpreted in the order of the attributes on the typed link facet, not the order in which they are supplied to any API calls. For more information about identity attributes, see <a href="http://docs.aws.amazon.com/directoryservice/latest/admin-guide/objectsandlinks.html#typedlink">Typed link</a>.</p>
     #[serde(rename = "IdentityAttributeOrder")]
@@ -1741,6 +1807,7 @@ pub struct GetTypedLinkFacetInformationResponse {
 
 /// <p>Represents an index and an attached object.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct IndexAttachment {
     /// <p>The indexed attribute values.</p>
     #[serde(rename = "IndexedAttributes")]
@@ -1798,6 +1865,7 @@ pub struct ListAppliedSchemaArnsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAppliedSchemaArnsResponse {
     /// <p>The pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -1832,6 +1900,7 @@ pub struct ListAttachedIndicesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAttachedIndicesResponse {
     /// <p>The indices attached to the specified object.</p>
     #[serde(rename = "IndexAttachments")]
@@ -1856,6 +1925,7 @@ pub struct ListDevelopmentSchemaArnsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListDevelopmentSchemaArnsResponse {
     /// <p>The pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -1884,6 +1954,7 @@ pub struct ListDirectoriesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListDirectoriesResponse {
     /// <p>Lists all directories that are associated with your account in pagination fashion.</p>
     #[serde(rename = "Directories")]
@@ -1913,6 +1984,7 @@ pub struct ListFacetAttributesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListFacetAttributesResponse {
     /// <p>The attributes attached to the facet.</p>
     #[serde(rename = "Attributes")]
@@ -1940,6 +2012,7 @@ pub struct ListFacetNamesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListFacetNamesResponse {
     /// <p>The names of facets that exist within the schema.</p>
     #[serde(rename = "FacetNames")]
@@ -1982,6 +2055,7 @@ pub struct ListIncomingTypedLinksRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListIncomingTypedLinksResponse {
     /// <p>Returns one or more typed link specifiers as output.</p>
     #[serde(rename = "LinkSpecifiers")]
@@ -2020,6 +2094,7 @@ pub struct ListIndexRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListIndexResponse {
     /// <p>The objects and indexed values attached to the index.</p>
     #[serde(rename = "IndexAttachments")]
@@ -2058,6 +2133,7 @@ pub struct ListObjectAttributesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListObjectAttributesResponse {
     /// <p>Attributes map that is associated with the object. <code>AttributeArn</code> is the key, and attribute value is the value.</p>
     #[serde(rename = "Attributes")]
@@ -2092,6 +2168,7 @@ pub struct ListObjectChildrenRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListObjectChildrenResponse {
     /// <p>Children structure, which is a map with key as the <code>LinkName</code> and <code>ObjectIdentifier</code> as the value.</p>
     #[serde(rename = "Children")]
@@ -2122,6 +2199,7 @@ pub struct ListObjectParentPathsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListObjectParentPathsResponse {
     /// <p>The pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -2156,6 +2234,7 @@ pub struct ListObjectParentsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListObjectParentsResponse {
     /// <p>The pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -2190,6 +2269,7 @@ pub struct ListObjectPoliciesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListObjectPoliciesResponse {
     /// <p>A list of policy <code>ObjectIdentifiers</code>, that are attached to the object.</p>
     #[serde(rename = "AttachedPolicyIds")]
@@ -2232,6 +2312,7 @@ pub struct ListOutgoingTypedLinksRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListOutgoingTypedLinksResponse {
     /// <p>The pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -2266,6 +2347,7 @@ pub struct ListPolicyAttachmentsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListPolicyAttachmentsResponse {
     /// <p>The pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -2294,6 +2376,7 @@ pub struct ListPublishedSchemaArnsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListPublishedSchemaArnsResponse {
     /// <p>The pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -2321,6 +2404,7 @@ pub struct ListTagsForResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagsForResourceResponse {
     /// <p>The token to use to retrieve the next page of results. This value is null when there are no more results to return.</p>
     #[serde(rename = "NextToken")]
@@ -2351,6 +2435,7 @@ pub struct ListTypedLinkFacetAttributesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTypedLinkFacetAttributesResponse {
     /// <p>An ordered set of attributes associate with the typed link.</p>
     #[serde(rename = "Attributes")]
@@ -2378,6 +2463,7 @@ pub struct ListTypedLinkFacetNamesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTypedLinkFacetNamesResponse {
     /// <p>The names of typed link facets that exist within the schema.</p>
     #[serde(rename = "FacetNames")]
@@ -2408,6 +2494,7 @@ pub struct LookupPolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LookupPolicyResponse {
     /// <p>The pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -2469,6 +2556,7 @@ pub struct ObjectReference {
 
 /// <p>Returns the path to the <code>ObjectIdentifiers</code> that is associated with the directory.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PathToObjectIdentifiers {
     /// <p>Lists <code>ObjectIdentifiers</code> starting from directory root to the object in the request.</p>
     #[serde(rename = "ObjectIdentifiers")]
@@ -2482,6 +2570,7 @@ pub struct PathToObjectIdentifiers {
 
 /// <p>Contains the <code>PolicyType</code>, <code>PolicyId</code>, and the <code>ObjectIdentifier</code> to which it is attached. For more information, see <a href="http://docs.aws.amazon.com/directoryservice/latest/admin-guide/cd_key_concepts.html#policies">Policies</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PolicyAttachment {
     /// <p>The <code>ObjectIdentifier</code> that is associated with <code>PolicyAttachment</code>.</p>
     #[serde(rename = "ObjectIdentifier")]
@@ -2499,6 +2588,7 @@ pub struct PolicyAttachment {
 
 /// <p>Used when a regular object exists in a <a>Directory</a> and you want to find all of the policies that are associated with that object and the parent to that object.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PolicyToPath {
     /// <p>The path that is referenced from the root.</p>
     #[serde(rename = "Path")]
@@ -2529,6 +2619,7 @@ pub struct PublishSchemaRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PublishSchemaResponse {
     /// <p>The ARN that is associated with the published schema. For more information, see <a>arns</a>.</p>
     #[serde(rename = "PublishedSchemaArn")]
@@ -2547,6 +2638,7 @@ pub struct PutSchemaFromJsonRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutSchemaFromJsonResponse {
     /// <p>The ARN of the schema to update.</p>
     #[serde(rename = "Arn")]
@@ -2568,6 +2660,7 @@ pub struct RemoveFacetFromObjectRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RemoveFacetFromObjectResponse {}
 
 /// <p>Contains an Amazon Resource Name (ARN) and parameters that are associated with the rule.</p>
@@ -2620,6 +2713,7 @@ pub struct TagResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TagResourceResponse {}
 
 /// <p>Represents the data for a typed attribute. You can set one, and only one, of the elements. Each attribute in an item is a name-value pair. Attributes have a single value.</p>
@@ -2772,6 +2866,7 @@ pub struct UntagResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UntagResourceResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -2793,6 +2888,7 @@ pub struct UpdateFacetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateFacetResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -2809,6 +2905,7 @@ pub struct UpdateLinkAttributesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateLinkAttributesResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -2825,6 +2922,7 @@ pub struct UpdateObjectAttributesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateObjectAttributesResponse {
     /// <p>The <code>ObjectIdentifier</code> of the updated object.</p>
     #[serde(rename = "ObjectIdentifier")]
@@ -2843,6 +2941,7 @@ pub struct UpdateSchemaRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateSchemaResponse {
     /// <p>The ARN that is associated with the updated schema. For more information, see <a>arns</a>.</p>
     #[serde(rename = "SchemaArn")]
@@ -2867,6 +2966,7 @@ pub struct UpdateTypedLinkFacetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateTypedLinkFacetResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -2884,6 +2984,7 @@ pub struct UpgradeAppliedSchemaRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpgradeAppliedSchemaResponse {
     /// <p>The ARN of the directory that is returned as part of the response.</p>
     #[serde(rename = "DirectoryArn")]
@@ -2913,6 +3014,7 @@ pub struct UpgradePublishedSchemaRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpgradePublishedSchemaResponse {
     /// <p>The ARN of the upgraded schema that is returned as part of the response.</p>
     #[serde(rename = "UpgradedSchemaArn")]

--- a/rusoto/services/cloudhsm/src/generated.rs
+++ b/rusoto/services/cloudhsm/src/generated.rs
@@ -39,6 +39,7 @@ pub struct AddTagsToResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddTagsToResourceResponse {
     /// <p>The status of the operation.</p>
     #[serde(rename = "Status")]
@@ -55,6 +56,7 @@ pub struct CreateHapgRequest {
 
 /// <p>Contains the output of the <a>CreateHAPartitionGroup</a> action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateHapgResponse {
     /// <p>The ARN of the high-availability partition group.</p>
     #[serde(rename = "HapgArn")]
@@ -96,6 +98,7 @@ pub struct CreateHsmRequest {
 
 /// <p>Contains the output of the <code>CreateHsm</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateHsmResponse {
     /// <p>The ARN of the HSM.</p>
     #[serde(rename = "HsmArn")]
@@ -117,6 +120,7 @@ pub struct CreateLunaClientRequest {
 
 /// <p>Contains the output of the <a>CreateLunaClient</a> action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateLunaClientResponse {
     /// <p>The ARN of the client.</p>
     #[serde(rename = "ClientArn")]
@@ -134,6 +138,7 @@ pub struct DeleteHapgRequest {
 
 /// <p>Contains the output of the <a>DeleteHapg</a> action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteHapgResponse {
     /// <p>The status of the action.</p>
     #[serde(rename = "Status")]
@@ -150,6 +155,7 @@ pub struct DeleteHsmRequest {
 
 /// <p>Contains the output of the <a>DeleteHsm</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteHsmResponse {
     /// <p>The status of the operation.</p>
     #[serde(rename = "Status")]
@@ -164,6 +170,7 @@ pub struct DeleteLunaClientRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteLunaClientResponse {
     /// <p>The status of the action.</p>
     #[serde(rename = "Status")]
@@ -180,6 +187,7 @@ pub struct DescribeHapgRequest {
 
 /// <p>Contains the output of the <a>DescribeHapg</a> action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeHapgResponse {
     /// <p>The ARN of the high-availability partition group.</p>
     #[serde(rename = "HapgArn")]
@@ -234,6 +242,7 @@ pub struct DescribeHsmRequest {
 
 /// <p>Contains the output of the <a>DescribeHsm</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeHsmResponse {
     /// <p>The Availability Zone that the HSM is in.</p>
     #[serde(rename = "AvailabilityZone")]
@@ -333,6 +342,7 @@ pub struct DescribeLunaClientRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeLunaClientResponse {
     /// <p>The certificate installed on the HSMs used by this client.</p>
     #[serde(rename = "Certificate")]
@@ -370,6 +380,7 @@ pub struct GetConfigRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetConfigResponse {
     /// <p>The certificate file containing the server.pem files of the HSMs.</p>
     #[serde(rename = "ConfigCred")]
@@ -390,6 +401,7 @@ pub struct GetConfigResponse {
 pub struct ListAvailableZonesRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAvailableZonesResponse {
     /// <p>The list of Availability Zones that have available AWS CloudHSM capacity.</p>
     #[serde(rename = "AZList")]
@@ -406,6 +418,7 @@ pub struct ListHapgsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListHapgsResponse {
     /// <p>The list of high-availability partition groups.</p>
     #[serde(rename = "HapgList")]
@@ -426,6 +439,7 @@ pub struct ListHsmsRequest {
 
 /// <p>Contains the output of the <code>ListHsms</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListHsmsResponse {
     /// <p>The list of ARNs that identify the HSMs.</p>
     #[serde(rename = "HsmList")]
@@ -446,6 +460,7 @@ pub struct ListLunaClientsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListLunaClientsResponse {
     /// <p>The list of clients.</p>
     #[serde(rename = "ClientList")]
@@ -464,6 +479,7 @@ pub struct ListTagsForResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagsForResourceResponse {
     /// <p>One or more tags.</p>
     #[serde(rename = "TagList")]
@@ -486,6 +502,7 @@ pub struct ModifyHapgRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ModifyHapgResponse {
     /// <p>The ARN of the high-availability partition group.</p>
     #[serde(rename = "HapgArn")]
@@ -523,6 +540,7 @@ pub struct ModifyHsmRequest {
 
 /// <p>Contains the output of the <a>ModifyHsm</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ModifyHsmResponse {
     /// <p>The ARN of the HSM.</p>
     #[serde(rename = "HsmArn")]
@@ -541,6 +559,7 @@ pub struct ModifyLunaClientRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ModifyLunaClientResponse {
     /// <p>The ARN of the client.</p>
     #[serde(rename = "ClientArn")]
@@ -559,6 +578,7 @@ pub struct RemoveTagsFromResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RemoveTagsFromResourceResponse {
     /// <p>The status of the operation.</p>
     #[serde(rename = "Status")]

--- a/rusoto/services/cloudhsmv2/src/generated.rs
+++ b/rusoto/services/cloudhsmv2/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Contains information about a backup of an AWS CloudHSM cluster.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Backup {
     /// <p>The identifier (ID) of the backup.</p>
     #[serde(rename = "BackupId")]
@@ -62,6 +63,7 @@ pub struct Backup {
 
 /// <p>Contains one or more certificates or a certificate signing request (CSR).</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Certificates {
     /// <p>The HSM hardware certificate issued (signed) by AWS CloudHSM.</p>
     #[serde(rename = "AwsHardwareCertificate")]
@@ -87,6 +89,7 @@ pub struct Certificates {
 
 /// <p>Contains information about an AWS CloudHSM cluster.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Cluster {
     /// <p>The cluster's backup policy.</p>
     #[serde(rename = "BackupPolicy")]
@@ -151,6 +154,7 @@ pub struct CopyBackupToRegionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CopyBackupToRegionResponse {
     #[serde(rename = "DestinationBackup")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -172,6 +176,7 @@ pub struct CreateClusterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateClusterResponse {
     /// <p>Information about the cluster that was created.</p>
     #[serde(rename = "Cluster")]
@@ -194,6 +199,7 @@ pub struct CreateHsmRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateHsmResponse {
     /// <p>Information about the HSM that was created.</p>
     #[serde(rename = "Hsm")]
@@ -209,6 +215,7 @@ pub struct DeleteClusterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteClusterResponse {
     /// <p>Information about the cluster that was deleted.</p>
     #[serde(rename = "Cluster")]
@@ -236,6 +243,7 @@ pub struct DeleteHsmRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteHsmResponse {
     /// <p>The identifier (ID) of the HSM that was deleted.</p>
     #[serde(rename = "HsmId")]
@@ -263,6 +271,7 @@ pub struct DescribeBackupsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeBackupsResponse {
     /// <p>A list of backups.</p>
     #[serde(rename = "Backups")]
@@ -291,6 +300,7 @@ pub struct DescribeClustersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeClustersResponse {
     /// <p>A list of clusters.</p>
     #[serde(rename = "Clusters")]
@@ -303,6 +313,7 @@ pub struct DescribeClustersResponse {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DestinationBackup {
     #[serde(rename = "CreateTimestamp")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -320,6 +331,7 @@ pub struct DestinationBackup {
 
 /// <p>Contains information about a hardware security module (HSM) in an AWS CloudHSM cluster.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Hsm {
     /// <p>The Availability Zone that contains the HSM.</p>
     #[serde(rename = "AvailabilityZone")]
@@ -368,6 +380,7 @@ pub struct InitializeClusterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InitializeClusterResponse {
     /// <p>The cluster's state.</p>
     #[serde(rename = "State")]
@@ -395,6 +408,7 @@ pub struct ListTagsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagsResponse {
     /// <p>An opaque string that indicates that the response contains only a subset of tags. Use this value in a subsequent <code>ListTags</code> request to get more tags.</p>
     #[serde(rename = "NextToken")]
@@ -427,6 +441,7 @@ pub struct TagResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TagResourceResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -440,6 +455,7 @@ pub struct UntagResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UntagResourceResponse {}
 
 /// Errors returned by CopyBackupToRegion

--- a/rusoto/services/cloudsearchdomain/src/generated.rs
+++ b/rusoto/services/cloudsearchdomain/src/generated.rs
@@ -31,6 +31,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>A container for facet information. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Bucket {
     /// <p>The number of hits that contain the facet value in the specified facet field.</p>
     #[serde(rename = "count")]
@@ -44,6 +45,7 @@ pub struct Bucket {
 
 /// <p>A container for the calculated facet values and counts.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BucketInfo {
     /// <p>A list of the calculated facet values and counts.</p>
     #[serde(rename = "buckets")]
@@ -53,6 +55,7 @@ pub struct BucketInfo {
 
 /// <p>A warning returned by the document service when an issue is discovered while processing an upload request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DocumentServiceWarning {
     /// <p>The description for a warning returned by the document service.</p>
     #[serde(rename = "message")]
@@ -62,6 +65,7 @@ pub struct DocumentServiceWarning {
 
 /// <p>The statistics for a field calculated in the request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FieldStats {
     /// <p>The number of documents that contain a value in the specified field in the result set.</p>
     #[serde(rename = "count")]
@@ -99,6 +103,7 @@ pub struct FieldStats {
 
 /// <p>Information about a document that matches the search request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Hit {
     /// <p>The expressions returned from a document that matches the search request.</p>
     #[serde(rename = "exprs")]
@@ -120,6 +125,7 @@ pub struct Hit {
 
 /// <p>The collection of documents that match the search request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Hits {
     /// <p>A cursor that can be used to retrieve the next set of matching documents when you want to page through a large result set.</p>
     #[serde(rename = "cursor")]
@@ -201,6 +207,7 @@ pub struct SearchRequest {
 
 /// <p>The result of a <code>Search</code> request. Contains the documents that match the specified search criteria and any requested fields, highlights, and facet information.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SearchResponse {
     /// <p>The requested facet information.</p>
     #[serde(rename = "facets")]
@@ -222,6 +229,7 @@ pub struct SearchResponse {
 
 /// <p>Contains the resource id (<code>rid</code>) and the time it took to process the request (<code>timems</code>).</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SearchStatus {
     /// <p>The encrypted resource ID for the request.</p>
     #[serde(rename = "rid")]
@@ -235,6 +243,7 @@ pub struct SearchStatus {
 
 /// <p>Container for the suggestion information returned in a <code>SuggestResponse</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SuggestModel {
     /// <p>The number of documents that were found to match the query string.</p>
     #[serde(rename = "found")]
@@ -267,6 +276,7 @@ pub struct SuggestRequest {
 
 /// <p>Contains the response to a <code>Suggest</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SuggestResponse {
     /// <p>The status of a <code>SuggestRequest</code>. Contains the resource ID (<code>rid</code>) and how long it took to process the request (<code>timems</code>).</p>
     #[serde(rename = "status")]
@@ -280,6 +290,7 @@ pub struct SuggestResponse {
 
 /// <p>Contains the resource id (<code>rid</code>) and the time it took to process the request (<code>timems</code>).</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SuggestStatus {
     /// <p>The encrypted resource ID for the request.</p>
     #[serde(rename = "rid")]
@@ -293,6 +304,7 @@ pub struct SuggestStatus {
 
 /// <p>An autocomplete suggestion that matches the query string specified in a <code>SuggestRequest</code>. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SuggestionMatch {
     /// <p>The document ID of the suggested document.</p>
     #[serde(rename = "id")]
@@ -326,6 +338,7 @@ pub struct UploadDocumentsRequest {
 
 /// <p>Contains the response to an <code>UploadDocuments</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UploadDocumentsResponse {
     /// <p>The number of documents that were added to the search domain.</p>
     #[serde(rename = "adds")]

--- a/rusoto/services/cloudtrail/src/generated.rs
+++ b/rusoto/services/cloudtrail/src/generated.rs
@@ -42,6 +42,7 @@ pub struct AddTagsRequest {
 
 /// <p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddTagsResponse {}
 
 /// <p>Specifies the settings for each trail.</p>
@@ -89,6 +90,7 @@ pub struct CreateTrailRequest {
 
 /// <p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateTrailResponse {
     /// <p>Specifies the Amazon Resource Name (ARN) of the log group to which CloudTrail logs will be delivered.</p>
     #[serde(rename = "CloudWatchLogsLogGroupArn")]
@@ -159,6 +161,7 @@ pub struct DeleteTrailRequest {
 
 /// <p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteTrailResponse {}
 
 /// <p>Returns information about the trail.</p>
@@ -176,6 +179,7 @@ pub struct DescribeTrailsRequest {
 
 /// <p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeTrailsResponse {
     /// <p>The list of trail objects.</p>
     #[serde(rename = "trailList")]
@@ -185,6 +189,7 @@ pub struct DescribeTrailsResponse {
 
 /// <p>Contains information about an event that was returned by a lookup request. The result includes a representation of a CloudTrail event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Event {
     /// <p>A JSON string that contains a representation of the event returned.</p>
     #[serde(rename = "CloudTrailEvent")]
@@ -241,6 +246,7 @@ pub struct GetEventSelectorsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetEventSelectorsResponse {
     /// <p>The event selectors that are configured for the trail.</p>
     #[serde(rename = "EventSelectors")]
@@ -262,6 +268,7 @@ pub struct GetTrailStatusRequest {
 
 /// <p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetTrailStatusResponse {
     /// <p>Whether the CloudTrail is currently logging AWS API calls.</p>
     #[serde(rename = "IsLogging")]
@@ -352,6 +359,7 @@ pub struct ListPublicKeysRequest {
 
 /// <p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListPublicKeysResponse {
     /// <p>Reserved for future use.</p>
     #[serde(rename = "NextToken")]
@@ -377,6 +385,7 @@ pub struct ListTagsRequest {
 
 /// <p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagsResponse {
     /// <p>Reserved for future use.</p>
     #[serde(rename = "NextToken")]
@@ -426,6 +435,7 @@ pub struct LookupEventsRequest {
 
 /// <p>Contains a response to a LookupEvents action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LookupEventsResponse {
     /// <p>A list of events returned based on the lookup attributes specified and the CloudTrail event. The events list is sorted by time. The most recent event is listed first.</p>
     #[serde(rename = "Events")]
@@ -439,6 +449,7 @@ pub struct LookupEventsResponse {
 
 /// <p>Contains information about a returned public key.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PublicKey {
     /// <p>The fingerprint of the public key.</p>
     #[serde(rename = "Fingerprint")]
@@ -473,6 +484,7 @@ pub struct PutEventSelectorsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutEventSelectorsResponse {
     /// <p>Specifies the event selectors configured for your trail.</p>
     #[serde(rename = "EventSelectors")]
@@ -498,10 +510,12 @@ pub struct RemoveTagsRequest {
 
 /// <p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RemoveTagsResponse {}
 
 /// <p>Specifies the type and name of a resource referenced by an event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Resource {
     /// <p>The name of the resource referenced by the event returned. These are user-created names whose values will depend on the environment. For example, the resource name might be "auto-scaling-test-group" for an Auto Scaling Group or "i-1234567" for an EC2 Instance.</p>
     #[serde(rename = "ResourceName")]
@@ -515,6 +529,7 @@ pub struct Resource {
 
 /// <p>A resource tag.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResourceTag {
     /// <p>Specifies the ARN of the resource.</p>
     #[serde(rename = "ResourceId")]
@@ -536,6 +551,7 @@ pub struct StartLoggingRequest {
 
 /// <p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartLoggingResponse {}
 
 /// <p>Passes the request to CloudTrail to stop logging AWS API calls for the specified account.</p>
@@ -548,6 +564,7 @@ pub struct StopLoggingRequest {
 
 /// <p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopLoggingResponse {}
 
 /// <p>A custom key-value pair associated with a resource such as a CloudTrail trail.</p>
@@ -564,6 +581,7 @@ pub struct Tag {
 
 /// <p>The settings for a trail.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Trail {
     /// <p>Specifies an Amazon Resource Name (ARN), a unique identifier that represents the log group to which CloudTrail logs will be delivered.</p>
     #[serde(rename = "CloudWatchLogsLogGroupArn")]
@@ -665,6 +683,7 @@ pub struct UpdateTrailRequest {
 
 /// <p>Returns the objects or data listed below if successful. Otherwise, returns an error.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateTrailResponse {
     /// <p>Specifies the Amazon Resource Name (ARN) of the log group to which CloudTrail logs will be delivered.</p>
     #[serde(rename = "CloudWatchLogsLogGroupArn")]

--- a/rusoto/services/codebuild/src/generated.rs
+++ b/rusoto/services/codebuild/src/generated.rs
@@ -36,6 +36,7 @@ pub struct BatchDeleteBuildsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchDeleteBuildsOutput {
     /// <p>The IDs of the builds that were successfully deleted.</p>
     #[serde(rename = "buildsDeleted")]
@@ -55,6 +56,7 @@ pub struct BatchGetBuildsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchGetBuildsOutput {
     /// <p>Information about the requested builds.</p>
     #[serde(rename = "builds")]
@@ -74,6 +76,7 @@ pub struct BatchGetProjectsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchGetProjectsOutput {
     /// <p>Information about the requested build projects.</p>
     #[serde(rename = "projects")]
@@ -87,6 +90,7 @@ pub struct BatchGetProjectsOutput {
 
 /// <p>Information about a build.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Build {
     /// <p>The Amazon Resource Name (ARN) of the build.</p>
     #[serde(rename = "arn")]
@@ -176,6 +180,7 @@ pub struct Build {
 
 /// <p>Information about build output artifacts.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BuildArtifacts {
     /// <p> Information that tells you if encryption for build artifacts is disabled. </p>
     #[serde(rename = "encryptionDisabled")]
@@ -197,6 +202,7 @@ pub struct BuildArtifacts {
 
 /// <p>Information about a build that could not be successfully deleted.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BuildNotDeleted {
     /// <p>The ID of the build that could not be successfully deleted.</p>
     #[serde(rename = "id")]
@@ -210,6 +216,7 @@ pub struct BuildNotDeleted {
 
 /// <p>Information about a stage for a build.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BuildPhase {
     /// <p>Additional information about a build phase, especially to help troubleshoot a failed build.</p>
     #[serde(rename = "contexts")]
@@ -285,6 +292,7 @@ pub struct CreateProjectInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateProjectOutput {
     /// <p>Information about the build project that was created.</p>
     #[serde(rename = "project")]
@@ -304,6 +312,7 @@ pub struct CreateWebhookInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateWebhookOutput {
     /// <p>Information about a webhook in GitHub that connects repository events to a build project in AWS CodeBuild.</p>
     #[serde(rename = "webhook")]
@@ -319,6 +328,7 @@ pub struct DeleteProjectInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteProjectOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -329,10 +339,12 @@ pub struct DeleteWebhookInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteWebhookOutput {}
 
 /// <p>Information about a Docker image that is managed by AWS CodeBuild.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EnvironmentImage {
     /// <p>The description of the Docker image.</p>
     #[serde(rename = "description")]
@@ -350,6 +362,7 @@ pub struct EnvironmentImage {
 
 /// <p>A set of Docker images that are related by programming language and are managed by AWS CodeBuild.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EnvironmentLanguage {
     /// <p>The list of Docker images that are related by the specified programming language.</p>
     #[serde(rename = "images")]
@@ -363,6 +376,7 @@ pub struct EnvironmentLanguage {
 
 /// <p>A set of Docker images that are related by platform and are managed by AWS CodeBuild.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EnvironmentPlatform {
     /// <p>The list of programming languages that are available for the specified platform.</p>
     #[serde(rename = "languages")]
@@ -397,6 +411,7 @@ pub struct InvalidateProjectCacheInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InvalidateProjectCacheOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -415,6 +430,7 @@ pub struct ListBuildsForProjectInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListBuildsForProjectOutput {
     /// <p>A list of build IDs for the specified build project, with each build ID representing a single build.</p>
     #[serde(rename = "ids")]
@@ -439,6 +455,7 @@ pub struct ListBuildsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListBuildsOutput {
     /// <p>A list of build IDs, with each build ID representing a single build.</p>
     #[serde(rename = "ids")]
@@ -454,6 +471,7 @@ pub struct ListBuildsOutput {
 pub struct ListCuratedEnvironmentImagesInput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListCuratedEnvironmentImagesOutput {
     /// <p>Information about supported platforms for Docker images that are managed by AWS CodeBuild.</p>
     #[serde(rename = "platforms")]
@@ -478,6 +496,7 @@ pub struct ListProjectsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListProjectsOutput {
     /// <p>If there are more than 100 items in the list, only the first 100 items are returned, along with a unique string called a <i>next token</i>. To get the next batch of items in the list, call this operation again, adding the next token to the call.</p>
     #[serde(rename = "nextToken")]
@@ -491,6 +510,7 @@ pub struct ListProjectsOutput {
 
 /// <p>Information about build logs in Amazon CloudWatch Logs.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LogsLocation {
     /// <p>The URL to an individual build log in Amazon CloudWatch Logs.</p>
     #[serde(rename = "deepLink")]
@@ -508,6 +528,7 @@ pub struct LogsLocation {
 
 /// <p>Describes a network interface.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct NetworkInterface {
     /// <p>The ID of the network interface.</p>
     #[serde(rename = "networkInterfaceId")]
@@ -521,6 +542,7 @@ pub struct NetworkInterface {
 
 /// <p>Additional information about a build phase that has an error. You can use this information to help troubleshoot a failed build.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PhaseContext {
     /// <p>An explanation of the build phase's context. This explanation might include a command ID and an exit code.</p>
     #[serde(rename = "message")]
@@ -534,6 +556,7 @@ pub struct PhaseContext {
 
 /// <p>Information about a build project.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Project {
     /// <p>The Amazon Resource Name (ARN) of the build project.</p>
     #[serde(rename = "arn")]
@@ -635,6 +658,7 @@ pub struct ProjectArtifacts {
 
 /// <p>Information about the build badge for the build project.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ProjectBadge {
     /// <p>Set this to true to generate a publicly-accessible URL for your project's build badge.</p>
     #[serde(rename = "badgeEnabled")]
@@ -812,6 +836,7 @@ pub struct StartBuildInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartBuildOutput {
     /// <p>Information about the build to be run.</p>
     #[serde(rename = "build")]
@@ -827,6 +852,7 @@ pub struct StopBuildInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopBuildOutput {
     /// <p>Information about the build.</p>
     #[serde(rename = "build")]
@@ -899,6 +925,7 @@ pub struct UpdateProjectInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateProjectOutput {
     /// <p>Information about the build project that was changed.</p>
     #[serde(rename = "project")]
@@ -922,6 +949,7 @@ pub struct UpdateWebhookInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateWebhookOutput {
     /// <p> Information about a repository's webhook that is associated with a project in AWS CodeBuild. </p>
     #[serde(rename = "webhook")]
@@ -948,6 +976,7 @@ pub struct VpcConfig {
 
 /// <p>Information about a webhook in GitHub that connects repository events to a build project in AWS CodeBuild.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Webhook {
     /// <p>A regular expression used to determine which branches in a repository are built when a webhook is triggered. If the name of a branch matches the regular expression, then it is built. If it doesn't match, then it is not. If branchFilter is empty, then all branches are built.</p>
     #[serde(rename = "branchFilter")]

--- a/rusoto/services/codecommit/src/generated.rs
+++ b/rusoto/services/codecommit/src/generated.rs
@@ -38,6 +38,7 @@ pub struct BatchGetRepositoriesInput {
 
 /// <p>Represents the output of a batch get repositories operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchGetRepositoriesOutput {
     /// <p>A list of repositories returned by the batch get repositories operation.</p>
     #[serde(rename = "repositories")]
@@ -51,6 +52,7 @@ pub struct BatchGetRepositoriesOutput {
 
 /// <p>Returns information about a specific Git blob object.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BlobMetadata {
     /// <p>The full ID of the blob.</p>
     #[serde(rename = "blobId")]
@@ -68,6 +70,7 @@ pub struct BlobMetadata {
 
 /// <p>Returns information about a branch.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BranchInfo {
     /// <p>The name of the branch.</p>
     #[serde(rename = "branchName")]
@@ -81,6 +84,7 @@ pub struct BranchInfo {
 
 /// <p>Returns information about a specific comment.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Comment {
     /// <p>The Amazon Resource Name (ARN) of the person who posted the comment.</p>
     #[serde(rename = "authorArn")]
@@ -118,6 +122,7 @@ pub struct Comment {
 
 /// <p>Returns information about comments on the comparison between two commits.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CommentsForComparedCommit {
     /// <p>The full blob ID of the commit used to establish the 'after' of the comparison.</p>
     #[serde(rename = "afterBlobId")]
@@ -151,6 +156,7 @@ pub struct CommentsForComparedCommit {
 
 /// <p>Returns information about comments on a pull request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CommentsForPullRequest {
     /// <p>The full blob ID of the file on which you want to comment on the source commit.</p>
     #[serde(rename = "afterBlobId")]
@@ -188,6 +194,7 @@ pub struct CommentsForPullRequest {
 
 /// <p>Returns information about a specific commit.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Commit {
     /// <p>Any additional data associated with the specified commit.</p>
     #[serde(rename = "additionalData")]
@@ -252,6 +259,7 @@ pub struct CreatePullRequestInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreatePullRequestOutput {
     /// <p>Information about the newly created pull request.</p>
     #[serde(rename = "pullRequest")]
@@ -272,6 +280,7 @@ pub struct CreateRepositoryInput {
 
 /// <p>Represents the output of a create repository operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateRepositoryOutput {
     /// <p>Information about the newly created repository.</p>
     #[serde(rename = "repositoryMetadata")]
@@ -292,6 +301,7 @@ pub struct DeleteBranchInput {
 
 /// <p>Represents the output of a delete branch operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteBranchOutput {
     /// <p>Information about the branch deleted by the operation, including the branch name and the commit ID that was the tip of the branch.</p>
     #[serde(rename = "deletedBranch")]
@@ -307,6 +317,7 @@ pub struct DeleteCommentContentInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteCommentContentOutput {
     /// <p>Information about the comment you just deleted.</p>
     #[serde(rename = "comment")]
@@ -324,6 +335,7 @@ pub struct DeleteRepositoryInput {
 
 /// <p>Represents the output of a delete repository operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteRepositoryOutput {
     /// <p>The ID of the repository that was deleted.</p>
     #[serde(rename = "repositoryId")]
@@ -355,6 +367,7 @@ pub struct DescribePullRequestEventsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribePullRequestEventsOutput {
     /// <p>An enumeration token that can be used in a request to return the next batch of the results.</p>
     #[serde(rename = "nextToken")]
@@ -367,6 +380,7 @@ pub struct DescribePullRequestEventsOutput {
 
 /// <p>Returns information about a set of differences for a commit specifier.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Difference {
     /// <p>Information about an <code>afterBlob</code> data type object, including the ID, the file mode permission code, and the path.</p>
     #[serde(rename = "afterBlob")]
@@ -395,6 +409,7 @@ pub struct GetBlobInput {
 
 /// <p>Represents the output of a get blob operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetBlobOutput {
     /// <p>The content of the blob, usually a file.</p>
     #[serde(rename = "content")]
@@ -421,6 +436,7 @@ pub struct GetBranchInput {
 
 /// <p>Represents the output of a get branch operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetBranchOutput {
     /// <p>The name of the branch.</p>
     #[serde(rename = "branch")]
@@ -436,6 +452,7 @@ pub struct GetCommentInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetCommentOutput {
     /// <p>The contents of the comment.</p>
     #[serde(rename = "comment")]
@@ -466,6 +483,7 @@ pub struct GetCommentsForComparedCommitInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetCommentsForComparedCommitOutput {
     /// <p>A list of comment objects on the compared commit.</p>
     #[serde(rename = "commentsForComparedCommitData")]
@@ -505,6 +523,7 @@ pub struct GetCommentsForPullRequestInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetCommentsForPullRequestOutput {
     /// <p>An array of comment objects on the pull request.</p>
     #[serde(rename = "commentsForPullRequestData")]
@@ -529,6 +548,7 @@ pub struct GetCommitInput {
 
 /// <p>Represents the output of a get commit operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetCommitOutput {
     /// <p>A commit data type object that contains information about the specified commit.</p>
     #[serde(rename = "commit")]
@@ -566,6 +586,7 @@ pub struct GetDifferencesInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDifferencesOutput {
     /// <p>An enumeration token that can be used in a request to return the next batch of the results.</p>
     #[serde(rename = "NextToken")]
@@ -594,6 +615,7 @@ pub struct GetMergeConflictsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetMergeConflictsOutput {
     /// <p>The commit ID of the destination commit specifier that was used in the merge evaluation.</p>
     #[serde(rename = "destinationCommitId")]
@@ -614,6 +636,7 @@ pub struct GetPullRequestInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetPullRequestOutput {
     /// <p>Information about the specified pull request.</p>
     #[serde(rename = "pullRequest")]
@@ -630,6 +653,7 @@ pub struct GetRepositoryInput {
 
 /// <p>Represents the output of a get repository operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetRepositoryOutput {
     /// <p>Information about the repository.</p>
     #[serde(rename = "repositoryMetadata")]
@@ -647,6 +671,7 @@ pub struct GetRepositoryTriggersInput {
 
 /// <p>Represents the output of a get repository triggers operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetRepositoryTriggersOutput {
     /// <p>The system-generated unique ID for the trigger.</p>
     #[serde(rename = "configurationId")]
@@ -672,6 +697,7 @@ pub struct ListBranchesInput {
 
 /// <p>Represents the output of a list branches operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListBranchesOutput {
     /// <p>The list of branch names.</p>
     #[serde(rename = "branches")]
@@ -707,6 +733,7 @@ pub struct ListPullRequestsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListPullRequestsOutput {
     /// <p>An enumeration token that when provided in a request, returns the next batch of the results.</p>
     #[serde(rename = "nextToken")]
@@ -736,6 +763,7 @@ pub struct ListRepositoriesInput {
 
 /// <p>Represents the output of a list repositories operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListRepositoriesOutput {
     /// <p>An enumeration token that allows the operation to batch the results of the operation. Batch sizes are 1,000 for list repository operations. When the client sends the token back to AWS CodeCommit, another page of 1,000 records is retrieved.</p>
     #[serde(rename = "nextToken")]
@@ -766,6 +794,7 @@ pub struct Location {
 
 /// <p>Returns information about a merge or potential merge between a source reference and a destination reference in a pull request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MergeMetadata {
     /// <p>A Boolean value indicating whether the merge has been made.</p>
     #[serde(rename = "isMerged")]
@@ -792,6 +821,7 @@ pub struct MergePullRequestByFastForwardInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MergePullRequestByFastForwardOutput {
     /// <p>Information about the specified pull request, including information about the merge.</p>
     #[serde(rename = "pullRequest")]
@@ -825,6 +855,7 @@ pub struct PostCommentForComparedCommitInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PostCommentForComparedCommitOutput {
     /// <p>In the directionality you established, the blob ID of the 'after' blob.</p>
     #[serde(rename = "afterBlobId")]
@@ -884,6 +915,7 @@ pub struct PostCommentForPullRequestInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PostCommentForPullRequestOutput {
     /// <p>In the directionality of the pull request, the blob ID of the 'after' blob.</p>
     #[serde(rename = "afterBlobId")]
@@ -934,6 +966,7 @@ pub struct PostCommentReplyInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PostCommentReplyOutput {
     /// <p>Information about the reply to a comment.</p>
     #[serde(rename = "comment")]
@@ -943,6 +976,7 @@ pub struct PostCommentReplyOutput {
 
 /// <p>Returns information about a pull request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PullRequest {
     /// <p>The Amazon Resource Name (ARN) of the user who created the pull request.</p>
     #[serde(rename = "authorArn")]
@@ -984,6 +1018,7 @@ pub struct PullRequest {
 
 /// <p>Returns information about a pull request event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PullRequestEvent {
     /// <p>The Amazon Resource Name (ARN) of the user whose actions resulted in the event. Examples include updating the pull request with additional commits or changing the status of a pull request.</p>
     #[serde(rename = "actorArn")]
@@ -1019,6 +1054,7 @@ pub struct PullRequestEvent {
 
 /// <p>Returns information about the change in the merge state for a pull request event. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PullRequestMergedStateChangedEventMetadata {
     /// <p>The name of the branch that the pull request will be merged into.</p>
     #[serde(rename = "destinationReference")]
@@ -1036,6 +1072,7 @@ pub struct PullRequestMergedStateChangedEventMetadata {
 
 /// <p>Information about an update to the source branch of a pull request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PullRequestSourceReferenceUpdatedEventMetadata {
     /// <p>The full commit ID of the commit in the source branch that was the tip of the branch at the time the pull request was updated.</p>
     #[serde(rename = "afterCommitId")]
@@ -1053,6 +1090,7 @@ pub struct PullRequestSourceReferenceUpdatedEventMetadata {
 
 /// <p>Information about a change to the status of a pull request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PullRequestStatusChangedEventMetadata {
     /// <p>The changed status of the pull request.</p>
     #[serde(rename = "pullRequestStatus")]
@@ -1062,6 +1100,7 @@ pub struct PullRequestStatusChangedEventMetadata {
 
 /// <p>Returns information about a pull request target.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PullRequestTarget {
     /// <p>The full commit ID that is the tip of the destination branch. This is the commit where the pull request was or will be merged.</p>
     #[serde(rename = "destinationCommit")]
@@ -1131,6 +1170,7 @@ pub struct PutFileInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutFileOutput {
     /// <p>The ID of the blob, which is its SHA-1 pointer.</p>
     #[serde(rename = "blobId")]
@@ -1156,6 +1196,7 @@ pub struct PutRepositoryTriggersInput {
 
 /// <p>Represents the output of a put repository triggers operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutRepositoryTriggersOutput {
     /// <p>The system-generated unique ID for the create or update operation.</p>
     #[serde(rename = "configurationId")]
@@ -1165,6 +1206,7 @@ pub struct PutRepositoryTriggersOutput {
 
 /// <p>Information about a repository.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RepositoryMetadata {
     /// <p>The Amazon Resource Name (ARN) of the repository.</p>
     #[serde(rename = "Arn")]
@@ -1210,6 +1252,7 @@ pub struct RepositoryMetadata {
 
 /// <p>Information about a repository name and ID.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RepositoryNameIdPair {
     /// <p>The ID associated with the repository.</p>
     #[serde(rename = "repositoryId")]
@@ -1245,6 +1288,7 @@ pub struct RepositoryTrigger {
 
 /// <p>A trigger failed to run.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RepositoryTriggerExecutionFailure {
     /// <p>Additional message information about the trigger that did not run.</p>
     #[serde(rename = "failureMessage")]
@@ -1284,6 +1328,7 @@ pub struct TestRepositoryTriggersInput {
 
 /// <p>Represents the output of a test repository triggers operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TestRepositoryTriggersOutput {
     /// <p>The list of triggers that were not able to be tested. This list provides the names of the triggers that could not be tested, separated by commas.</p>
     #[serde(rename = "failedExecutions")]
@@ -1306,6 +1351,7 @@ pub struct UpdateCommentInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateCommentOutput {
     /// <p>Information about the updated comment.</p>
     #[serde(rename = "comment")]
@@ -1335,6 +1381,7 @@ pub struct UpdatePullRequestDescriptionInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdatePullRequestDescriptionOutput {
     /// <p>Information about the updated pull request.</p>
     #[serde(rename = "pullRequest")]
@@ -1352,6 +1399,7 @@ pub struct UpdatePullRequestStatusInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdatePullRequestStatusOutput {
     /// <p>Information about the pull request.</p>
     #[serde(rename = "pullRequest")]
@@ -1369,6 +1417,7 @@ pub struct UpdatePullRequestTitleInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdatePullRequestTitleOutput {
     /// <p>Information about the updated pull request.</p>
     #[serde(rename = "pullRequest")]
@@ -1400,6 +1449,7 @@ pub struct UpdateRepositoryNameInput {
 
 /// <p>Information about the user who made a specified commit.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UserInfo {
     /// <p>The date when the specified commit was commited, in timestamp format with GMT offset.</p>
     #[serde(rename = "date")]

--- a/rusoto/services/codedeploy/src/generated.rs
+++ b/rusoto/services/codedeploy/src/generated.rs
@@ -67,6 +67,7 @@ pub struct AlarmConfiguration {
 
 /// <p>Information about an application.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ApplicationInfo {
     /// <p>The application ID.</p>
     #[serde(rename = "applicationId")]
@@ -109,6 +110,7 @@ pub struct AutoRollbackConfiguration {
 
 /// <p>Information about an Auto Scaling group.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AutoScalingGroup {
     /// <p>An Auto Scaling lifecycle event hook name.</p>
     #[serde(rename = "hook")]
@@ -133,6 +135,7 @@ pub struct BatchGetApplicationRevisionsInput {
 
 /// <p>Represents the output of a BatchGetApplicationRevisions operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchGetApplicationRevisionsOutput {
     /// <p>The name of the application that corresponds to the revisions.</p>
     #[serde(rename = "applicationName")]
@@ -158,6 +161,7 @@ pub struct BatchGetApplicationsInput {
 
 /// <p>Represents the output of a BatchGetApplications operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchGetApplicationsOutput {
     /// <p>Information about the applications.</p>
     #[serde(rename = "applicationsInfo")]
@@ -178,6 +182,7 @@ pub struct BatchGetDeploymentGroupsInput {
 
 /// <p>Represents the output of a BatchGetDeploymentGroups operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchGetDeploymentGroupsOutput {
     /// <p>Information about the deployment groups.</p>
     #[serde(rename = "deploymentGroupsInfo")]
@@ -202,6 +207,7 @@ pub struct BatchGetDeploymentInstancesInput {
 
 /// <p>Represents the output of a BatchGetDeploymentInstances operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchGetDeploymentInstancesOutput {
     /// <p>Information about errors that may have occurred during the API call.</p>
     #[serde(rename = "errorMessage")]
@@ -223,6 +229,7 @@ pub struct BatchGetDeploymentsInput {
 
 /// <p>Represents the output of a BatchGetDeployments operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchGetDeploymentsOutput {
     /// <p>Information about the deployments.</p>
     #[serde(rename = "deploymentsInfo")]
@@ -240,6 +247,7 @@ pub struct BatchGetOnPremisesInstancesInput {
 
 /// <p>Represents the output of a BatchGetOnPremisesInstances operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchGetOnPremisesInstancesOutput {
     /// <p>Information about the on-premises instances.</p>
     #[serde(rename = "instanceInfos")]
@@ -299,6 +307,7 @@ pub struct CreateApplicationInput {
 
 /// <p>Represents the output of a CreateApplication operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateApplicationOutput {
     /// <p>A unique application ID.</p>
     #[serde(rename = "applicationId")]
@@ -328,6 +337,7 @@ pub struct CreateDeploymentConfigInput {
 
 /// <p>Represents the output of a CreateDeploymentConfig operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDeploymentConfigOutput {
     /// <p>A unique deployment configuration ID.</p>
     #[serde(rename = "deploymentConfigId")]
@@ -399,6 +409,7 @@ pub struct CreateDeploymentGroupInput {
 
 /// <p>Represents the output of a CreateDeploymentGroup operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDeploymentGroupOutput {
     /// <p>A unique deployment group ID.</p>
     #[serde(rename = "deploymentGroupId")]
@@ -452,6 +463,7 @@ pub struct CreateDeploymentInput {
 
 /// <p>Represents the output of a CreateDeployment operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDeploymentOutput {
     /// <p>A unique deployment ID.</p>
     #[serde(rename = "deploymentId")]
@@ -488,6 +500,7 @@ pub struct DeleteDeploymentGroupInput {
 
 /// <p>Represents the output of a DeleteDeploymentGroup operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteDeploymentGroupOutput {
     /// <p>If the output contains no data, and the corresponding deployment group contained at least one Auto Scaling group, AWS CodeDeploy successfully removed all corresponding Auto Scaling lifecycle event hooks from the Amazon EC2 instances in the Auto Scaling group. If the output contains data, AWS CodeDeploy could not remove some Auto Scaling lifecycle event hooks from the Amazon EC2 instances in the Auto Scaling group.</p>
     #[serde(rename = "hooksNotCleanedUp")]
@@ -506,6 +519,7 @@ pub struct DeleteGitHubAccountTokenInput {
 
 /// <p>Represents the output of a DeleteGitHubAccountToken operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteGitHubAccountTokenOutput {
     /// <p>The name of the GitHub account connection that was deleted.</p>
     #[serde(rename = "tokenName")]
@@ -515,6 +529,7 @@ pub struct DeleteGitHubAccountTokenOutput {
 
 /// <p>Information about a deployment configuration.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeploymentConfigInfo {
     /// <p>The destination platform type for the deployment (<code>Lambda</code> or <code>Server</code>).</p>
     #[serde(rename = "computePlatform")]
@@ -544,6 +559,7 @@ pub struct DeploymentConfigInfo {
 
 /// <p>Information about a deployment group.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeploymentGroupInfo {
     /// <p>A list of alarms associated with the deployment group.</p>
     #[serde(rename = "alarmConfiguration")]
@@ -629,6 +645,7 @@ pub struct DeploymentGroupInfo {
 
 /// <p>Information about a deployment.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeploymentInfo {
     /// <p>Provides information about the results of a deployment, such as whether instances in the original environment in a blue/green deployment were not terminated.</p>
     #[serde(rename = "additionalDeploymentStatusInfo")]
@@ -742,6 +759,7 @@ pub struct DeploymentInfo {
 
 /// <p>Information about the deployment status of the instances in the deployment.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeploymentOverview {
     /// <p>The number of instances in the deployment in a failed state.</p>
     #[serde(rename = "Failed")]
@@ -805,6 +823,7 @@ pub struct DeregisterOnPremisesInstanceInput {
 
 /// <p>Diagnostic information about executable scripts that are part of a deployment.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Diagnostics {
     /// <p><p>The associated error code:</p> <ul> <li> <p>Success: The specified script ran.</p> </li> <li> <p>ScriptMissing: The specified script was not found in the specified location.</p> </li> <li> <p>ScriptNotExecutable: The specified script is not a recognized executable file type.</p> </li> <li> <p>ScriptTimedOut: The specified script did not finish running in the specified time period.</p> </li> <li> <p>ScriptFailed: The specified script failed to run as expected.</p> </li> <li> <p>UnknownError: The specified script did not run for an unknown reason.</p> </li> </ul></p>
     #[serde(rename = "errorCode")]
@@ -861,6 +880,7 @@ pub struct ELBInfo {
 
 /// <p>Information about a deployment error.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ErrorInformation {
     /// <p><p>For information about additional error codes, see <a href="http://docs.aws.amazon.com/codedeploy/latest/userguide/error-codes.html">Error Codes for AWS CodeDeploy</a> in the <a href="http://docs.aws.amazon.com/codedeploy/latest/userguide">AWS CodeDeploy User Guide</a>.</p> <p>The error code:</p> <ul> <li> <p>APPLICATION<em>MISSING: The application was missing. This error code will most likely be raised if the application is deleted after the deployment is created but before it is started.</p> </li> <li> <p>DEPLOYMENT</em>GROUP<em>MISSING: The deployment group was missing. This error code will most likely be raised if the deployment group is deleted after the deployment is created but before it is started.</p> </li> <li> <p>HEALTH</em>CONSTRAINTS: The deployment failed on too many instances to be successfully deployed within the instance health constraints specified.</p> </li> <li> <p>HEALTH<em>CONSTRAINTS</em>INVALID: The revision cannot be successfully deployed within the instance health constraints specified.</p> </li> <li> <p>IAM<em>ROLE</em>MISSING: The service role cannot be accessed.</p> </li> <li> <p>IAM<em>ROLE</em>PERMISSIONS: The service role does not have the correct permissions.</p> </li> <li> <p>INTERNAL<em>ERROR: There was an internal error.</p> </li> <li> <p>NO</em>EC2<em>SUBSCRIPTION: The calling account is not subscribed to the Amazon EC2 service.</p> </li> <li> <p>NO</em>INSTANCES: No instance were specified, or no instance can be found.</p> </li> <li> <p>OVER<em>MAX</em>INSTANCES: The maximum number of instance was exceeded.</p> </li> <li> <p>THROTTLED: The operation was throttled because the calling account exceeded the throttling limits of one or more AWS services.</p> </li> <li> <p>TIMEOUT: The deployment has timed out.</p> </li> <li> <p>REVISION_MISSING: The revision ID was missing. This error code will most likely be raised if the revision is deleted after the deployment is created but before it is started.</p> </li> </ul></p>
     #[serde(rename = "code")]
@@ -874,6 +894,7 @@ pub struct ErrorInformation {
 
 /// <p>Information about an application revision.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GenericRevisionInfo {
     /// <p>The deployment groups for which this is the current target revision.</p>
     #[serde(rename = "deploymentGroups")]
@@ -907,6 +928,7 @@ pub struct GetApplicationInput {
 
 /// <p>Represents the output of a GetApplication operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetApplicationOutput {
     /// <p>Information about the application.</p>
     #[serde(rename = "application")]
@@ -927,6 +949,7 @@ pub struct GetApplicationRevisionInput {
 
 /// <p>Represents the output of a GetApplicationRevision operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetApplicationRevisionOutput {
     /// <p>The name of the application that corresponds to the revision.</p>
     #[serde(rename = "applicationName")]
@@ -952,6 +975,7 @@ pub struct GetDeploymentConfigInput {
 
 /// <p>Represents the output of a GetDeploymentConfig operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDeploymentConfigOutput {
     /// <p>Information about the deployment configuration.</p>
     #[serde(rename = "deploymentConfigInfo")]
@@ -972,6 +996,7 @@ pub struct GetDeploymentGroupInput {
 
 /// <p>Represents the output of a GetDeploymentGroup operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDeploymentGroupOutput {
     /// <p>Information about the deployment group.</p>
     #[serde(rename = "deploymentGroupInfo")]
@@ -1000,6 +1025,7 @@ pub struct GetDeploymentInstanceInput {
 
 /// <p>Represents the output of a GetDeploymentInstance operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDeploymentInstanceOutput {
     /// <p>Information about the instance.</p>
     #[serde(rename = "instanceSummary")]
@@ -1009,6 +1035,7 @@ pub struct GetDeploymentInstanceOutput {
 
 /// <p>Represents the output of a GetDeployment operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDeploymentOutput {
     /// <p>Information about the deployment.</p>
     #[serde(rename = "deploymentInfo")]
@@ -1026,6 +1053,7 @@ pub struct GetOnPremisesInstanceInput {
 
 /// <p>Represents the output of a GetOnPremisesInstance operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetOnPremisesInstanceOutput {
     /// <p>Information about the on-premises instance.</p>
     #[serde(rename = "instanceInfo")]
@@ -1057,6 +1085,7 @@ pub struct GreenFleetProvisioningOption {
 
 /// <p>Information about an on-premises instance.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceInfo {
     /// <p>If the on-premises instance was deregistered, the time at which the on-premises instance was deregistered.</p>
     #[serde(rename = "deregisterTime")]
@@ -1090,6 +1119,7 @@ pub struct InstanceInfo {
 
 /// <p>Information about an instance in a deployment.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceSummary {
     /// <p>The deployment ID.</p>
     #[serde(rename = "deploymentId")]
@@ -1119,6 +1149,7 @@ pub struct InstanceSummary {
 
 /// <p>Information about the most recent attempted or successful deployment to a deployment group.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LastDeploymentInfo {
     /// <p>A timestamp indicating when the most recent deployment to the deployment group started.</p>
     #[serde(rename = "createTime")]
@@ -1140,6 +1171,7 @@ pub struct LastDeploymentInfo {
 
 /// <p>Information about a deployment lifecycle event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LifecycleEvent {
     /// <p>Diagnostic information about the deployment lifecycle event.</p>
     #[serde(rename = "diagnostics")]
@@ -1197,6 +1229,7 @@ pub struct ListApplicationRevisionsInput {
 
 /// <p>Represents the output of a ListApplicationRevisions operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListApplicationRevisionsOutput {
     /// <p>If a large amount of information is returned, an identifier will also be returned. It can be used in a subsequent list application revisions call to return the next set of application revisions in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1219,6 +1252,7 @@ pub struct ListApplicationsInput {
 
 /// <p>Represents the output of a ListApplications operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListApplicationsOutput {
     /// <p>A list of application names.</p>
     #[serde(rename = "applications")]
@@ -1241,6 +1275,7 @@ pub struct ListDeploymentConfigsInput {
 
 /// <p>Represents the output of a ListDeploymentConfigs operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListDeploymentConfigsOutput {
     /// <p>A list of deployment configurations, including built-in configurations such as CodeDeployDefault.OneAtATime.</p>
     #[serde(rename = "deploymentConfigsList")]
@@ -1266,6 +1301,7 @@ pub struct ListDeploymentGroupsInput {
 
 /// <p>Represents the output of a ListDeploymentGroups operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListDeploymentGroupsOutput {
     /// <p>The application name.</p>
     #[serde(rename = "applicationName")]
@@ -1303,6 +1339,7 @@ pub struct ListDeploymentInstancesInput {
 
 /// <p>Represents the output of a ListDeploymentInstances operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListDeploymentInstancesOutput {
     /// <p>A list of instance IDs.</p>
     #[serde(rename = "instancesList")]
@@ -1341,6 +1378,7 @@ pub struct ListDeploymentsInput {
 
 /// <p>Represents the output of a ListDeployments operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListDeploymentsOutput {
     /// <p>A list of deployment IDs.</p>
     #[serde(rename = "deployments")]
@@ -1363,6 +1401,7 @@ pub struct ListGitHubAccountTokenNamesInput {
 
 /// <p>Represents the output of a ListGitHubAccountTokenNames operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListGitHubAccountTokenNamesOutput {
     /// <p>If a large amount of information is returned, an identifier is also returned. It can be used in a subsequent ListGitHubAccountTokenNames call to return the next set of names in the list. </p>
     #[serde(rename = "nextToken")]
@@ -1393,6 +1432,7 @@ pub struct ListOnPremisesInstancesInput {
 
 /// <p>Represents the output of list on-premises instances operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListOnPremisesInstancesOutput {
     /// <p>The list of matching on-premises instance names.</p>
     #[serde(rename = "instanceNames")]
@@ -1456,6 +1496,7 @@ pub struct PutLifecycleEventHookExecutionStatusInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutLifecycleEventHookExecutionStatusOutput {
     /// <p>The execution ID of the lifecycle event hook. A hook is specified in the <code>hooks</code> section of the deployment's AppSpec file.</p>
     #[serde(rename = "lifecycleEventHookExecutionId")]
@@ -1520,6 +1561,7 @@ pub struct RemoveTagsFromOnPremisesInstancesInput {
 
 /// <p>Information about an application revision.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RevisionInfo {
     /// <p>Information about an application revision, including usage details and associated deployment groups.</p>
     #[serde(rename = "genericRevisionInfo")]
@@ -1554,6 +1596,7 @@ pub struct RevisionLocation {
 
 /// <p>Information about a deployment rollback.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RollbackInfo {
     /// <p>The ID of the deployment rollback.</p>
     #[serde(rename = "rollbackDeploymentId")]
@@ -1616,6 +1659,7 @@ pub struct StopDeploymentInput {
 
 /// <p>Represents the output of a StopDeployment operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopDeploymentOutput {
     /// <p><p>The status of the stop deployment operation:</p> <ul> <li> <p>Pending: The stop operation is pending.</p> </li> <li> <p>Succeeded: The stop operation was successful.</p> </li> </ul></p>
     #[serde(rename = "status")]
@@ -1838,6 +1882,7 @@ pub struct UpdateDeploymentGroupInput {
 
 /// <p>Represents the output of an UpdateDeploymentGroup operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateDeploymentGroupOutput {
     /// <p>If the output contains no data, and the corresponding deployment group contained at least one Auto Scaling group, AWS CodeDeploy successfully removed all corresponding Auto Scaling lifecycle event hooks from the AWS account. If the output contains data, AWS CodeDeploy could not remove some Auto Scaling lifecycle event hooks from the AWS account.</p>
     #[serde(rename = "hooksNotCleanedUp")]

--- a/rusoto/services/codepipeline/src/generated.rs
+++ b/rusoto/services/codepipeline/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Represents an AWS session credentials object. These credentials are temporary credentials that are issued by AWS Secure Token Service (STS). They can be used to access input and output artifacts in the Amazon S3 bucket used to store artifact for the pipeline in AWS CodePipeline.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AWSSessionCredentials {
     /// <p>The access key for the session.</p>
     #[serde(rename = "accessKeyId")]
@@ -55,6 +56,7 @@ pub struct AcknowledgeJobInput {
 
 /// <p>Represents the output of an AcknowledgeJob action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AcknowledgeJobOutput {
     /// <p>Whether the job worker has received the specified job.</p>
     #[serde(rename = "status")]
@@ -78,6 +80,7 @@ pub struct AcknowledgeThirdPartyJobInput {
 
 /// <p>Represents the output of an AcknowledgeThirdPartyJob action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AcknowledgeThirdPartyJobOutput {
     /// <p>The status information for the third party job, if any.</p>
     #[serde(rename = "status")]
@@ -87,6 +90,7 @@ pub struct AcknowledgeThirdPartyJobOutput {
 
 /// <p>Represents information about an action configuration.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActionConfiguration {
     /// <p>The configuration data for the action.</p>
     #[serde(rename = "configuration")]
@@ -125,6 +129,7 @@ pub struct ActionConfigurationProperty {
 
 /// <p>Represents the context of an action within the stage of a pipeline to a job worker.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActionContext {
     /// <p>The name of the action within the context of a job.</p>
     #[serde(rename = "name")]
@@ -165,6 +170,7 @@ pub struct ActionDeclaration {
 
 /// <p>Represents information about the run of an action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActionExecution {
     /// <p>The details of an error returned by a URL external to AWS.</p>
     #[serde(rename = "errorDetails")]
@@ -220,6 +226,7 @@ pub struct ActionRevision {
 
 /// <p>Represents information about the state of an action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActionState {
     /// <p>The name of the action.</p>
     #[serde(rename = "actionName")]
@@ -245,6 +252,7 @@ pub struct ActionState {
 
 /// <p>Returns information about the details of an action type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActionType {
     /// <p>The configuration properties for the action type.</p>
     #[serde(rename = "actionConfigurationProperties")]
@@ -316,6 +324,7 @@ pub struct ApprovalResult {
 
 /// <p>Represents information about an artifact that will be worked upon by actions in the pipeline.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Artifact {
     /// <p>The location of an artifact.</p>
     #[serde(rename = "location")]
@@ -344,6 +353,7 @@ pub struct ArtifactDetails {
 
 /// <p>Represents information about the location of an artifact.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ArtifactLocation {
     /// <p>The Amazon S3 bucket that contains the artifact.</p>
     #[serde(rename = "s3Location")]
@@ -357,6 +367,7 @@ pub struct ArtifactLocation {
 
 /// <p>Represents revision details of an artifact. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ArtifactRevision {
     /// <p>The date and time when the most recent revision of the artifact was created, in timestamp format.</p>
     #[serde(rename = "created")]
@@ -440,6 +451,7 @@ pub struct CreateCustomActionTypeInput {
 
 /// <p>Represents the output of a CreateCustomActionType operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateCustomActionTypeOutput {
     /// <p>Returns information about the details of an action type.</p>
     #[serde(rename = "actionType")]
@@ -456,6 +468,7 @@ pub struct CreatePipelineInput {
 
 /// <p>Represents the output of a CreatePipeline action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreatePipelineOutput {
     /// <p>Represents the structure of actions and stages to be performed in the pipeline. </p>
     #[serde(rename = "pipeline")]
@@ -512,6 +525,7 @@ pub struct DeleteWebhookInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteWebhookOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -523,6 +537,7 @@ pub struct DeregisterWebhookWithThirdPartyInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeregisterWebhookWithThirdPartyOutput {}
 
 /// <p>Represents the input of a DisableStageTransition action.</p>
@@ -569,6 +584,7 @@ pub struct EncryptionKey {
 
 /// <p>Represents information about an error in AWS CodePipeline.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ErrorDetails {
     /// <p>The system ID or error number code of the error.</p>
     #[serde(rename = "code")]
@@ -622,6 +638,7 @@ pub struct GetJobDetailsInput {
 
 /// <p>Represents the output of a GetJobDetails action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetJobDetailsOutput {
     /// <p><p>The details of the job.</p> <note> <p>If AWSSessionCredentials is used, a long-running job can call GetJobDetails again to obtain new credentials.</p> </note></p>
     #[serde(rename = "jobDetails")]
@@ -642,6 +659,7 @@ pub struct GetPipelineExecutionInput {
 
 /// <p>Represents the output of a GetPipelineExecution action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetPipelineExecutionOutput {
     /// <p>Represents information about the execution of a pipeline.</p>
     #[serde(rename = "pipelineExecution")]
@@ -663,6 +681,7 @@ pub struct GetPipelineInput {
 
 /// <p>Represents the output of a GetPipeline action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetPipelineOutput {
     /// <p>Represents the pipeline metadata information returned as part of the output of a GetPipeline action.</p>
     #[serde(rename = "metadata")]
@@ -684,6 +703,7 @@ pub struct GetPipelineStateInput {
 
 /// <p>Represents the output of a GetPipelineState action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetPipelineStateOutput {
     /// <p>The date and time the pipeline was created, in timestamp format.</p>
     #[serde(rename = "created")]
@@ -720,6 +740,7 @@ pub struct GetThirdPartyJobDetailsInput {
 
 /// <p>Represents the output of a GetThirdPartyJobDetails action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetThirdPartyJobDetailsOutput {
     /// <p>The details of the job, including any protected values defined for the job.</p>
     #[serde(rename = "jobDetails")]
@@ -737,6 +758,7 @@ pub struct InputArtifact {
 
 /// <p>Represents information about a job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Job {
     /// <p>The ID of the AWS account to use when performing the job.</p>
     #[serde(rename = "accountId")]
@@ -758,6 +780,7 @@ pub struct Job {
 
 /// <p>Represents additional information about a job required for a job worker to complete the job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct JobData {
     /// <p>Represents information about an action configuration.</p>
     #[serde(rename = "actionConfiguration")]
@@ -795,6 +818,7 @@ pub struct JobData {
 
 /// <p>Represents information about the details of a job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct JobDetails {
     /// <p>The AWS account ID associated with the job.</p>
     #[serde(rename = "accountId")]
@@ -825,6 +849,7 @@ pub struct ListActionTypesInput {
 
 /// <p>Represents the output of a ListActionTypes action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListActionTypesOutput {
     /// <p>Provides details of the action types.</p>
     #[serde(rename = "actionTypes")]
@@ -853,6 +878,7 @@ pub struct ListPipelineExecutionsInput {
 
 /// <p>Represents the output of a ListPipelineExecutions action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListPipelineExecutionsOutput {
     /// <p>A token that can be used in the next ListPipelineExecutions call. To view all items in the list, continue to call this operation with each subsequent token until no more nextToken values are returned.</p>
     #[serde(rename = "nextToken")]
@@ -875,6 +901,7 @@ pub struct ListPipelinesInput {
 
 /// <p>Represents the output of a ListPipelines action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListPipelinesOutput {
     /// <p>If the amount of returned information is significantly large, an identifier is also returned which can be used in a subsequent list pipelines call to return the next set of pipelines in the list.</p>
     #[serde(rename = "nextToken")]
@@ -888,6 +915,7 @@ pub struct ListPipelinesOutput {
 
 /// <p>The detail returned for each webhook after listing webhooks, such as the webhook URL, the webhook name, and the webhook ARN.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListWebhookItem {
     /// <p>The Amazon Resource Name (ARN) of the webhook.</p>
     #[serde(rename = "arn")]
@@ -926,6 +954,7 @@ pub struct ListWebhooksInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListWebhooksOutput {
     /// <p>If the amount of returned information is significantly large, an identifier is also returned and can be used in a subsequent ListWebhooks call to return the next set of webhooks in the list. </p>
     #[serde(rename = "NextToken")]
@@ -947,6 +976,7 @@ pub struct OutputArtifact {
 
 /// <p>Represents information about a pipeline to a job worker.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PipelineContext {
     /// <p>The context of an action to a job worker within the stage of a pipeline.</p>
     #[serde(rename = "action")]
@@ -985,6 +1015,7 @@ pub struct PipelineDeclaration {
 
 /// <p>Represents information about an execution of a pipeline.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PipelineExecution {
     /// <p>A list of ArtifactRevision objects included in a pipeline execution.</p>
     #[serde(rename = "artifactRevisions")]
@@ -1010,6 +1041,7 @@ pub struct PipelineExecution {
 
 /// <p>Summary information about a pipeline execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PipelineExecutionSummary {
     /// <p>The date and time of the last change to the pipeline execution, in timestamp format.</p>
     #[serde(rename = "lastUpdateTime")]
@@ -1034,6 +1066,7 @@ pub struct PipelineExecutionSummary {
 
 /// <p>Information about a pipeline.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PipelineMetadata {
     /// <p>The date and time the pipeline was created, in timestamp format.</p>
     #[serde(rename = "created")]
@@ -1051,6 +1084,7 @@ pub struct PipelineMetadata {
 
 /// <p>Returns a summary of a pipeline.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PipelineSummary {
     /// <p>The date and time the pipeline was created, in timestamp format.</p>
     #[serde(rename = "created")]
@@ -1088,6 +1122,7 @@ pub struct PollForJobsInput {
 
 /// <p>Represents the output of a PollForJobs action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PollForJobsOutput {
     /// <p>Information about the jobs to take action on.</p>
     #[serde(rename = "jobs")]
@@ -1109,6 +1144,7 @@ pub struct PollForThirdPartyJobsInput {
 
 /// <p>Represents the output of a PollForThirdPartyJobs action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PollForThirdPartyJobsOutput {
     /// <p>Information about the jobs to take action on.</p>
     #[serde(rename = "jobs")]
@@ -1135,6 +1171,7 @@ pub struct PutActionRevisionInput {
 
 /// <p>Represents the output of a PutActionRevision action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutActionRevisionOutput {
     /// <p>Indicates whether the artifact revision was previously used in an execution of the specified pipeline.</p>
     #[serde(rename = "newRevision")]
@@ -1168,6 +1205,7 @@ pub struct PutApprovalResultInput {
 
 /// <p>Represents the output of a PutApprovalResult action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutApprovalResultOutput {
     /// <p>The timestamp showing when the approval or rejection was submitted.</p>
     #[serde(rename = "approvedAt")]
@@ -1251,6 +1289,7 @@ pub struct PutWebhookInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutWebhookOutput {
     /// <p>The detail returned from creating the webhook, such as the webhook name, webhook URL, and webhook ARN.</p>
     #[serde(rename = "webhook")]
@@ -1267,6 +1306,7 @@ pub struct RegisterWebhookWithThirdPartyInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegisterWebhookWithThirdPartyOutput {}
 
 /// <p>Represents the input of a RetryStageExecution action.</p>
@@ -1288,6 +1328,7 @@ pub struct RetryStageExecutionInput {
 
 /// <p>Represents the output of a RetryStageExecution action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RetryStageExecutionOutput {
     /// <p>The ID of the current workflow execution in the failed stage.</p>
     #[serde(rename = "pipelineExecutionId")]
@@ -1297,6 +1338,7 @@ pub struct RetryStageExecutionOutput {
 
 /// <p>The location of the Amazon S3 bucket that contains a revision.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct S3ArtifactLocation {
     /// <p>The name of the Amazon S3 bucket.</p>
     #[serde(rename = "bucketName")]
@@ -1307,6 +1349,7 @@ pub struct S3ArtifactLocation {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SourceRevision {
     #[serde(rename = "actionName")]
     pub action_name: String,
@@ -1323,6 +1366,7 @@ pub struct SourceRevision {
 
 /// <p>Represents information about a stage to a job worker.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StageContext {
     /// <p>The name of the stage.</p>
     #[serde(rename = "name")]
@@ -1347,6 +1391,7 @@ pub struct StageDeclaration {
 
 /// <p>Represents information about the run of a stage.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StageExecution {
     /// <p>The ID of the pipeline execution associated with the stage.</p>
     #[serde(rename = "pipelineExecutionId")]
@@ -1358,6 +1403,7 @@ pub struct StageExecution {
 
 /// <p>Represents information about the state of the stage.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StageState {
     /// <p>The state of the stage.</p>
     #[serde(rename = "actionStates")]
@@ -1387,6 +1433,7 @@ pub struct StartPipelineExecutionInput {
 
 /// <p>Represents the output of a StartPipelineExecution action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartPipelineExecutionOutput {
     /// <p>The unique system-generated ID of the pipeline execution that was started.</p>
     #[serde(rename = "pipelineExecutionId")]
@@ -1396,6 +1443,7 @@ pub struct StartPipelineExecutionOutput {
 
 /// <p>A response to a PollForThirdPartyJobs request returned by AWS CodePipeline when there is a job to be worked upon by a partner action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ThirdPartyJob {
     /// <p>The clientToken portion of the clientId and clientToken pair used to verify that the calling entity is allowed access to the job and its details.</p>
     #[serde(rename = "clientId")]
@@ -1409,6 +1457,7 @@ pub struct ThirdPartyJob {
 
 /// <p>Represents information about the job data for a partner action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ThirdPartyJobData {
     /// <p>Represents information about an action configuration.</p>
     #[serde(rename = "actionConfiguration")]
@@ -1446,6 +1495,7 @@ pub struct ThirdPartyJobData {
 
 /// <p>The details of a job sent in response to a GetThirdPartyJobDetails request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ThirdPartyJobDetails {
     /// <p>The data to be returned by the third party job worker.</p>
     #[serde(rename = "data")]
@@ -1463,6 +1513,7 @@ pub struct ThirdPartyJobDetails {
 
 /// <p>Represents information about the state of transitions between one stage and another stage.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TransitionState {
     /// <p>The user-specified reason why the transition between two stages of a pipeline was disabled.</p>
     #[serde(rename = "disabledReason")]
@@ -1492,6 +1543,7 @@ pub struct UpdatePipelineInput {
 
 /// <p>Represents the output of an UpdatePipeline action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdatePipelineOutput {
     /// <p>The structure of the updated pipeline.</p>
     #[serde(rename = "pipeline")]

--- a/rusoto/services/codestar/src/generated.rs
+++ b/rusoto/services/codestar/src/generated.rs
@@ -50,6 +50,7 @@ pub struct AssociateTeamMemberRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociateTeamMemberResult {
     /// <p>The user- or system-generated token from the initial request that can be used to repeat the request.</p>
     #[serde(rename = "clientRequestToken")]
@@ -76,6 +77,7 @@ pub struct CreateProjectRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateProjectResult {
     /// <p>Reserved for future use.</p>
     #[serde(rename = "arn")]
@@ -111,6 +113,7 @@ pub struct CreateUserProfileRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateUserProfileResult {
     /// <p>The date the user profile was created, in timestamp format.</p>
     #[serde(rename = "createdTimestamp")]
@@ -153,6 +156,7 @@ pub struct DeleteProjectRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteProjectResult {
     /// <p>The Amazon Resource Name (ARN) of the deleted project.</p>
     #[serde(rename = "projectArn")]
@@ -172,6 +176,7 @@ pub struct DeleteUserProfileRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteUserProfileResult {
     /// <p>The Amazon Resource Name (ARN) of the user deleted from AWS CodeStar.</p>
     #[serde(rename = "userArn")]
@@ -186,6 +191,7 @@ pub struct DescribeProjectRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeProjectResult {
     /// <p>The Amazon Resource Name (ARN) for the project.</p>
     #[serde(rename = "arn")]
@@ -229,6 +235,7 @@ pub struct DescribeUserProfileRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeUserProfileResult {
     /// <p>The date and time when the user profile was created in AWS CodeStar, in timestamp format.</p>
     #[serde(rename = "createdTimestamp")]
@@ -264,6 +271,7 @@ pub struct DisassociateTeamMemberRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisassociateTeamMemberResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -279,6 +287,7 @@ pub struct ListProjectsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListProjectsResult {
     /// <p>The continuation token to use when requesting the next set of results, if there are more results to be returned.</p>
     #[serde(rename = "nextToken")]
@@ -305,6 +314,7 @@ pub struct ListResourcesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListResourcesResult {
     /// <p>The continuation token to use when requesting the next set of results, if there are more results to be returned.</p>
     #[serde(rename = "nextToken")]
@@ -332,6 +342,7 @@ pub struct ListTagsForProjectRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagsForProjectResult {
     /// <p>Reserved for future use.</p>
     #[serde(rename = "nextToken")]
@@ -359,6 +370,7 @@ pub struct ListTeamMembersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTeamMembersResult {
     /// <p>The continuation token to use when requesting the next set of results, if there are more results to be returned.</p>
     #[serde(rename = "nextToken")]
@@ -382,6 +394,7 @@ pub struct ListUserProfilesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListUserProfilesResult {
     /// <p>The continuation token to use when requesting the next set of results, if there are more results to be returned.</p>
     #[serde(rename = "nextToken")]
@@ -394,6 +407,7 @@ pub struct ListUserProfilesResult {
 
 /// <p>Information about the metadata for a project.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ProjectSummary {
     /// <p>The Amazon Resource Name (ARN) of the project.</p>
     #[serde(rename = "projectArn")]
@@ -407,6 +421,7 @@ pub struct ProjectSummary {
 
 /// <p>Information about a resource for a project.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Resource {
     /// <p>The Amazon Resource Name (ARN) of the resource.</p>
     #[serde(rename = "id")]
@@ -424,6 +439,7 @@ pub struct TagProjectRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TagProjectResult {
     /// <p>The tags for the project.</p>
     #[serde(rename = "tags")]
@@ -433,6 +449,7 @@ pub struct TagProjectResult {
 
 /// <p>Information about a team member in a project.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TeamMember {
     /// <p>The role assigned to the user in the project. Project roles have different levels of access. For more information, see <a href="http://docs.aws.amazon.com/codestar/latest/userguide/working-with-teams.html">Working with Teams</a> in the <i>AWS CodeStar User Guide</i>. </p>
     #[serde(rename = "projectRole")]
@@ -457,6 +474,7 @@ pub struct UntagProjectRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UntagProjectResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -475,6 +493,7 @@ pub struct UpdateProjectRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateProjectResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -496,6 +515,7 @@ pub struct UpdateTeamMemberRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateTeamMemberResult {
     /// <p>The project role granted to the user.</p>
     #[serde(rename = "projectRole")]
@@ -531,6 +551,7 @@ pub struct UpdateUserProfileRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateUserProfileResult {
     /// <p>The date the user profile was created, in timestamp format.</p>
     #[serde(rename = "createdTimestamp")]
@@ -559,6 +580,7 @@ pub struct UpdateUserProfileResult {
 
 /// <p>Information about a user's profile in AWS CodeStar.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UserProfileSummary {
     /// <p>The display name of a user in AWS CodeStar. For example, this could be set to both first and last name ("Mary Major") or a single name ("Mary"). The display name is also used to generate the initial icon associated with the user in AWS CodeStar projects. If spaces are included in the display name, the first character that appears after the space will be used as the second character in the user initial icon. The initial icon displays a maximum of two characters, so a display name with more than one space (for example "Mary Jane Major") would generate an initial icon using the first character and the first character after the space ("MJ", not "MM").</p>
     #[serde(rename = "displayName")]

--- a/rusoto/services/cognito-identity/src/generated.rs
+++ b/rusoto/services/cognito-identity/src/generated.rs
@@ -78,6 +78,7 @@ pub struct CreateIdentityPoolInput {
 
 /// <p>Credentials for the provided identity ID.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Credentials {
     /// <p>The Access Key portion of the credentials.</p>
     #[serde(rename = "AccessKeyId")]
@@ -107,6 +108,7 @@ pub struct DeleteIdentitiesInput {
 
 /// <p>Returned in response to a successful <code>DeleteIdentities</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteIdentitiesResponse {
     /// <p>An array of UnprocessedIdentityId objects, each of which contains an ErrorCode and IdentityId.</p>
     #[serde(rename = "UnprocessedIdentityIds")]
@@ -156,6 +158,7 @@ pub struct GetCredentialsForIdentityInput {
 
 /// <p>Returned in response to a successful <code>GetCredentialsForIdentity</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetCredentialsForIdentityResponse {
     /// <p>Credentials for the provided identity ID.</p>
     #[serde(rename = "Credentials")]
@@ -185,6 +188,7 @@ pub struct GetIdInput {
 
 /// <p>Returned in response to a GetId request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetIdResponse {
     /// <p>A unique identifier in the format REGION:GUID.</p>
     #[serde(rename = "IdentityId")]
@@ -202,6 +206,7 @@ pub struct GetIdentityPoolRolesInput {
 
 /// <p>Returned in response to a successful <code>GetIdentityPoolRoles</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetIdentityPoolRolesResponse {
     /// <p>An identity pool ID in the format REGION:GUID.</p>
     #[serde(rename = "IdentityPoolId")]
@@ -238,6 +243,7 @@ pub struct GetOpenIdTokenForDeveloperIdentityInput {
 
 /// <p>Returned in response to a successful <code>GetOpenIdTokenForDeveloperIdentity</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetOpenIdTokenForDeveloperIdentityResponse {
     /// <p>A unique identifier in the format REGION:GUID.</p>
     #[serde(rename = "IdentityId")]
@@ -263,6 +269,7 @@ pub struct GetOpenIdTokenInput {
 
 /// <p>Returned in response to a successful GetOpenIdToken request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetOpenIdTokenResponse {
     /// <p>A unique identifier in the format REGION:GUID. Note that the IdentityId returned may not match the one passed on input.</p>
     #[serde(rename = "IdentityId")]
@@ -276,6 +283,7 @@ pub struct GetOpenIdTokenResponse {
 
 /// <p>A description of the identity.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct IdentityDescription {
     /// <p>Date on which the identity was created.</p>
     #[serde(rename = "CreationDate")]
@@ -331,6 +339,7 @@ pub struct IdentityPool {
 
 /// <p>A description of the identity pool.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct IdentityPoolShortDescription {
     /// <p>An identity pool ID in the format REGION:GUID.</p>
     #[serde(rename = "IdentityPoolId")]
@@ -363,6 +372,7 @@ pub struct ListIdentitiesInput {
 
 /// <p>The response to a ListIdentities request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListIdentitiesResponse {
     /// <p>An object containing a set of identities and associated mappings.</p>
     #[serde(rename = "Identities")]
@@ -392,6 +402,7 @@ pub struct ListIdentityPoolsInput {
 
 /// <p>The result of a successful ListIdentityPools action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListIdentityPoolsResponse {
     /// <p>The identity pools returned by the ListIdentityPools action.</p>
     #[serde(rename = "IdentityPools")]
@@ -429,6 +440,7 @@ pub struct LookupDeveloperIdentityInput {
 
 /// <p>Returned in response to a successful <code>LookupDeveloperIdentity</code> action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LookupDeveloperIdentityResponse {
     /// <p>This is the list of developer user identifiers associated with an identity ID. Cognito supports the association of multiple developer user identifiers with an identity ID.</p>
     #[serde(rename = "DeveloperUserIdentifierList")]
@@ -480,6 +492,7 @@ pub struct MergeDeveloperIdentitiesInput {
 
 /// <p>Returned in response to a successful <code>MergeDeveloperIdentities</code> action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MergeDeveloperIdentitiesResponse {
     /// <p>A unique identifier in the format REGION:GUID.</p>
     #[serde(rename = "IdentityId")]
@@ -559,6 +572,7 @@ pub struct UnlinkIdentityInput {
 
 /// <p>An array of UnprocessedIdentityId objects, each of which contains an ErrorCode and IdentityId.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UnprocessedIdentityId {
     /// <p>The error code indicating the type of error that occurred.</p>
     #[serde(rename = "ErrorCode")]

--- a/rusoto/services/cognito-idp/src/generated.rs
+++ b/rusoto/services/cognito-idp/src/generated.rs
@@ -81,6 +81,7 @@ pub struct AddCustomAttributesRequest {
 
 /// <p>Represents the response from the server for the request to add custom attributes.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddCustomAttributesResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -109,6 +110,7 @@ pub struct AdminConfirmSignUpRequest {
 
 /// <p>Represents the response from the server for the request to confirm registration.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AdminConfirmSignUpResponse {}
 
 /// <p>The configuration for creating a new user profile.</p>
@@ -165,6 +167,7 @@ pub struct AdminCreateUserRequest {
 
 /// <p>Represents the response from the server to the request to create the user.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AdminCreateUserResponse {
     /// <p>The newly created user.</p>
     #[serde(rename = "User")]
@@ -188,6 +191,7 @@ pub struct AdminDeleteUserAttributesRequest {
 
 /// <p>Represents the response received from the server for a request to delete user attributes.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AdminDeleteUserAttributesResponse {}
 
 /// <p>Represents the request to delete a user as an administrator.</p>
@@ -212,6 +216,7 @@ pub struct AdminDisableProviderForUserRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AdminDisableProviderForUserResponse {}
 
 /// <p>Represents the request to disable any user as an administrator.</p>
@@ -227,6 +232,7 @@ pub struct AdminDisableUserRequest {
 
 /// <p>Represents the response received from the server to disable the user as an administrator.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AdminDisableUserResponse {}
 
 /// <p>Represents the request that enables the user as an administrator.</p>
@@ -242,6 +248,7 @@ pub struct AdminEnableUserRequest {
 
 /// <p>Represents the response from the server for the request to enable a user as an administrator.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AdminEnableUserResponse {}
 
 /// <p>Sends the forgot device request, as an administrator.</p>
@@ -274,6 +281,7 @@ pub struct AdminGetDeviceRequest {
 
 /// <p>Gets the device response, as an administrator.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AdminGetDeviceResponse {
     /// <p>The device.</p>
     #[serde(rename = "Device")]
@@ -293,6 +301,7 @@ pub struct AdminGetUserRequest {
 
 /// <p>Represents the response from the server from the request to get the specified user as an administrator.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AdminGetUserResponse {
     /// <p>Indicates that the status is enabled.</p>
     #[serde(rename = "Enabled")]
@@ -363,6 +372,7 @@ pub struct AdminInitiateAuthRequest {
 
 /// <p>Initiates the authentication response, as an administrator.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AdminInitiateAuthResponse {
     /// <p>The result of the authentication response. This is only returned if the caller does not need to pass another challenge. If the caller does need to pass another challenge before it gets tokens, <code>ChallengeName</code>, <code>ChallengeParameters</code>, and <code>Session</code> are returned.</p>
     #[serde(rename = "AuthenticationResult")]
@@ -396,6 +406,7 @@ pub struct AdminLinkProviderForUserRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AdminLinkProviderForUserResponse {}
 
 /// <p>Represents the request to list devices, as an administrator.</p>
@@ -419,6 +430,7 @@ pub struct AdminListDevicesRequest {
 
 /// <p>Lists the device's response, as an administrator.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AdminListDevicesResponse {
     /// <p>The devices in the list of devices response.</p>
     #[serde(rename = "Devices")]
@@ -449,6 +461,7 @@ pub struct AdminListGroupsForUserRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AdminListGroupsForUserResponse {
     /// <p>The groups that the user belongs to.</p>
     #[serde(rename = "Groups")]
@@ -479,6 +492,7 @@ pub struct AdminListUserAuthEventsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AdminListUserAuthEventsResponse {
     /// <p>The response object. It includes the <code>EventID</code>, <code>EventType</code>, <code>CreationDate</code>, <code>EventRisk</code>, and <code>EventResponse</code>.</p>
     #[serde(rename = "AuthEvents")]
@@ -516,6 +530,7 @@ pub struct AdminResetUserPasswordRequest {
 
 /// <p>Represents the response from the server to reset a user password as an administrator.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AdminResetUserPasswordResponse {}
 
 /// <p>The request to respond to the authentication challenge, as an administrator.</p>
@@ -550,6 +565,7 @@ pub struct AdminRespondToAuthChallengeRequest {
 
 /// <p>Responds to the authentication challenge, as an administrator.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AdminRespondToAuthChallengeResponse {
     /// <p>The result returned by the server in response to the authentication request.</p>
     #[serde(rename = "AuthenticationResult")]
@@ -588,6 +604,7 @@ pub struct AdminSetUserMFAPreferenceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AdminSetUserMFAPreferenceResponse {}
 
 /// <p>Represents the request to set user settings as an administrator.</p>
@@ -606,6 +623,7 @@ pub struct AdminSetUserSettingsRequest {
 
 /// <p>Represents the response from the server to set user settings as an administrator.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AdminSetUserSettingsResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -625,6 +643,7 @@ pub struct AdminUpdateAuthEventFeedbackRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AdminUpdateAuthEventFeedbackResponse {}
 
 /// <p>The request to update the device status, as an administrator.</p>
@@ -647,6 +666,7 @@ pub struct AdminUpdateDeviceStatusRequest {
 
 /// <p>The status response from the request to update the device, as an administrator.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AdminUpdateDeviceStatusResponse {}
 
 /// <p>Represents the request to update the user's attributes as an administrator.</p>
@@ -665,6 +685,7 @@ pub struct AdminUpdateUserAttributesRequest {
 
 /// <p>Represents the response from the server for the request to update user attributes as an administrator.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AdminUpdateUserAttributesResponse {}
 
 /// <p>The request to sign out of all devices, as an administrator.</p>
@@ -680,6 +701,7 @@ pub struct AdminUserGlobalSignOutRequest {
 
 /// <p>The global sign-out response, as an administrator.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AdminUserGlobalSignOutResponse {}
 
 /// <p>The Amazon Pinpoint analytics configuration for collecting metrics for a user pool.</p>
@@ -722,6 +744,7 @@ pub struct AssociateSoftwareTokenRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociateSoftwareTokenResponse {
     /// <p>A unique generated shared secret code that is used in the TOTP algorithm to generate a one time code.</p>
     #[serde(rename = "SecretCode")]
@@ -747,6 +770,7 @@ pub struct AttributeType {
 
 /// <p>The authentication event type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AuthEventType {
     /// <p>The challenge responses.</p>
     #[serde(rename = "ChallengeResponses")]
@@ -784,6 +808,7 @@ pub struct AuthEventType {
 
 /// <p>The authentication result.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AuthenticationResultType {
     /// <p>The access token.</p>
     #[serde(rename = "AccessToken")]
@@ -813,6 +838,7 @@ pub struct AuthenticationResultType {
 
 /// <p>The challenge response type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ChallengeResponseType {
     /// <p>The challenge name</p>
     #[serde(rename = "ChallengeName")]
@@ -840,10 +866,12 @@ pub struct ChangePasswordRequest {
 
 /// <p>The response from the server to the change password request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ChangePasswordResponse {}
 
 /// <p>The code delivery details being returned from the server.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CodeDeliveryDetailsType {
     /// <p>The attribute name.</p>
     #[serde(rename = "AttributeName")]
@@ -900,6 +928,7 @@ pub struct ConfirmDeviceRequest {
 
 /// <p>Confirms the device response.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ConfirmDeviceResponse {
     /// <p>Indicates whether the user confirmation is necessary to confirm the device response.</p>
     #[serde(rename = "UserConfirmationNecessary")]
@@ -938,6 +967,7 @@ pub struct ConfirmForgotPasswordRequest {
 
 /// <p>The response from the server that results from a user's request to retrieve a forgotten password.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ConfirmForgotPasswordResponse {}
 
 /// <p>Represents the request to confirm registration of a user.</p>
@@ -972,6 +1002,7 @@ pub struct ConfirmSignUpRequest {
 
 /// <p>Represents the response from the server for the registration confirmation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ConfirmSignUpResponse {}
 
 /// <p>Contextual user data type used for evaluating the risk of an unexpected event by Amazon Cognito advanced security.</p>
@@ -1018,6 +1049,7 @@ pub struct CreateGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateGroupResponse {
     /// <p>The group object for the group.</p>
     #[serde(rename = "Group")]
@@ -1050,6 +1082,7 @@ pub struct CreateIdentityProviderRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateIdentityProviderResponse {
     /// <p>The newly created identity provider object.</p>
     #[serde(rename = "IdentityProvider")]
@@ -1074,6 +1107,7 @@ pub struct CreateResourceServerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateResourceServerResponse {
     /// <p>The newly created resource server.</p>
     #[serde(rename = "ResourceServer")]
@@ -1096,6 +1130,7 @@ pub struct CreateUserImportJobRequest {
 
 /// <p>Represents the response from the server to the request to create the user import job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateUserImportJobResponse {
     /// <p>The job object that represents the user import job.</p>
     #[serde(rename = "UserImportJob")]
@@ -1168,6 +1203,7 @@ pub struct CreateUserPoolClientRequest {
 
 /// <p>Represents the response from the server to create a user pool client.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateUserPoolClientResponse {
     /// <p>The user pool client that was just created.</p>
     #[serde(rename = "UserPoolClient")]
@@ -1186,6 +1222,7 @@ pub struct CreateUserPoolDomainRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateUserPoolDomainResponse {}
 
 /// <p>Represents the request to create a user pool.</p>
@@ -1270,6 +1307,7 @@ pub struct CreateUserPoolRequest {
 
 /// <p>Represents the response from the server for the request to create a user pool.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateUserPoolResponse {
     /// <p>A container for the user pool details.</p>
     #[serde(rename = "UserPool")]
@@ -1320,6 +1358,7 @@ pub struct DeleteUserAttributesRequest {
 
 /// <p>Represents the response from the server to delete user attributes.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteUserAttributesResponse {}
 
 /// <p>Represents the request to delete a user pool client.</p>
@@ -1344,6 +1383,7 @@ pub struct DeleteUserPoolDomainRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteUserPoolDomainResponse {}
 
 /// <p>Represents the request to delete a user pool.</p>
@@ -1373,6 +1413,7 @@ pub struct DescribeIdentityProviderRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeIdentityProviderResponse {
     /// <p>The identity provider that was deleted.</p>
     #[serde(rename = "IdentityProvider")]
@@ -1390,6 +1431,7 @@ pub struct DescribeResourceServerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeResourceServerResponse {
     /// <p>The resource server.</p>
     #[serde(rename = "ResourceServer")]
@@ -1408,6 +1450,7 @@ pub struct DescribeRiskConfigurationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeRiskConfigurationResponse {
     /// <p>The risk configuration.</p>
     #[serde(rename = "RiskConfiguration")]
@@ -1427,6 +1470,7 @@ pub struct DescribeUserImportJobRequest {
 
 /// <p>Represents the response from the server to the request to describe the user import job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeUserImportJobResponse {
     /// <p>The job object that represents the user import job.</p>
     #[serde(rename = "UserImportJob")]
@@ -1447,6 +1491,7 @@ pub struct DescribeUserPoolClientRequest {
 
 /// <p>Represents the response from the server from a request to describe the user pool client.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeUserPoolClientResponse {
     /// <p>The user pool client from a server response to describe the user pool client.</p>
     #[serde(rename = "UserPoolClient")]
@@ -1462,6 +1507,7 @@ pub struct DescribeUserPoolDomainRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeUserPoolDomainResponse {
     /// <p>A domain description object containing information about the domain.</p>
     #[serde(rename = "DomainDescription")]
@@ -1479,6 +1525,7 @@ pub struct DescribeUserPoolRequest {
 
 /// <p>Represents the response to describe the user pool.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeUserPoolResponse {
     /// <p>The container of metadata returned by the server to describe the pool.</p>
     #[serde(rename = "UserPool")]
@@ -1514,6 +1561,7 @@ pub struct DeviceSecretVerifierConfigType {
 
 /// <p>The device type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeviceType {
     /// <p>The device attributes.</p>
     #[serde(rename = "DeviceAttributes")]
@@ -1539,6 +1587,7 @@ pub struct DeviceType {
 
 /// <p>A container for information about a domain.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DomainDescriptionType {
     /// <p>The AWS account ID for the user pool owner.</p>
     #[serde(rename = "AWSAccountId")]
@@ -1585,6 +1634,7 @@ pub struct EmailConfigurationType {
 
 /// <p>Specifies the user context data captured at the time of an event request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EventContextDataType {
     /// <p>The user's city.</p>
     #[serde(rename = "City")]
@@ -1610,6 +1660,7 @@ pub struct EventContextDataType {
 
 /// <p>Specifies the event feedback type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EventFeedbackType {
     /// <p>The event feedback date.</p>
     #[serde(rename = "FeedbackDate")]
@@ -1625,6 +1676,7 @@ pub struct EventFeedbackType {
 
 /// <p>The event risk type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EventRiskType {
     /// <p>The risk decision.</p>
     #[serde(rename = "RiskDecision")]
@@ -1673,6 +1725,7 @@ pub struct ForgotPasswordRequest {
 
 /// <p>Respresents the response from the server regarding the request to reset a password.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ForgotPasswordResponse {
     /// <p>The code delivery details returned by the server in response to the request to reset a password.</p>
     #[serde(rename = "CodeDeliveryDetails")]
@@ -1690,6 +1743,7 @@ pub struct GetCSVHeaderRequest {
 
 /// <p>Represents the response from the server to the request to get the header information for the .csv file for the user import job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetCSVHeaderResponse {
     /// <p>The header information for the .csv file for the user import job.</p>
     #[serde(rename = "CSVHeader")]
@@ -1715,6 +1769,7 @@ pub struct GetDeviceRequest {
 
 /// <p>Gets the device response.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDeviceResponse {
     /// <p>The device.</p>
     #[serde(rename = "Device")]
@@ -1732,6 +1787,7 @@ pub struct GetGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetGroupResponse {
     /// <p>The group object for the group.</p>
     #[serde(rename = "Group")]
@@ -1750,6 +1806,7 @@ pub struct GetIdentityProviderByIdentifierRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetIdentityProviderByIdentifierResponse {
     /// <p>The identity provider object.</p>
     #[serde(rename = "IdentityProvider")]
@@ -1766,6 +1823,7 @@ pub struct GetSigningCertificateRequest {
 
 /// <p>Response from Cognito for a signing certificate request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetSigningCertificateResponse {
     /// <p>The signing certificate.</p>
     #[serde(rename = "Certificate")]
@@ -1785,6 +1843,7 @@ pub struct GetUICustomizationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetUICustomizationResponse {
     /// <p>The UI customization information.</p>
     #[serde(rename = "UICustomization")]
@@ -1804,6 +1863,7 @@ pub struct GetUserAttributeVerificationCodeRequest {
 
 /// <p>The verification code response returned by the server response to get the user attribute verification code.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetUserAttributeVerificationCodeResponse {
     /// <p>The code delivery details returned by the server in response to the request to get the user attribute verification code.</p>
     #[serde(rename = "CodeDeliveryDetails")]
@@ -1819,6 +1879,7 @@ pub struct GetUserPoolMfaConfigRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetUserPoolMfaConfigResponse {
     /// <p>The multi-factor (MFA) configuration.</p>
     #[serde(rename = "MfaConfiguration")]
@@ -1844,6 +1905,7 @@ pub struct GetUserRequest {
 
 /// <p>Represents the response from the server from the request to get information about the user.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetUserResponse {
     /// <p>Specifies the options for MFA (e.g., email or phone number).</p>
     #[serde(rename = "MFAOptions")]
@@ -1875,10 +1937,12 @@ pub struct GlobalSignOutRequest {
 
 /// <p>The response to the request to sign out all devices.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GlobalSignOutResponse {}
 
 /// <p>The group type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GroupType {
     /// <p>The date the group was created.</p>
     #[serde(rename = "CreationDate")]
@@ -1925,6 +1989,7 @@ pub struct HttpHeader {
 
 /// <p>A container for information about an identity provider.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct IdentityProviderType {
     /// <p>A mapping of identity provider attributes to standard and custom user pool attributes.</p>
     #[serde(rename = "AttributeMapping")]
@@ -1989,6 +2054,7 @@ pub struct InitiateAuthRequest {
 
 /// <p>Initiates the authentication response.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InitiateAuthResponse {
     /// <p>The result of the authentication response. This is only returned if the caller does not need to pass another challenge. If the caller does need to pass another challenge before it gets tokens, <code>ChallengeName</code>, <code>ChallengeParameters</code>, and <code>Session</code> are returned.</p>
     #[serde(rename = "AuthenticationResult")]
@@ -2071,6 +2137,7 @@ pub struct ListDevicesRequest {
 
 /// <p>Represents the response to list devices.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListDevicesResponse {
     /// <p>The devices returned in the list devices response.</p>
     #[serde(rename = "Devices")]
@@ -2098,6 +2165,7 @@ pub struct ListGroupsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListGroupsResponse {
     /// <p>The group objects for the groups.</p>
     #[serde(rename = "Groups")]
@@ -2125,6 +2193,7 @@ pub struct ListIdentityProvidersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListIdentityProvidersResponse {
     /// <p>A pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -2151,6 +2220,7 @@ pub struct ListResourceServersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListResourceServersResponse {
     /// <p>A pagination token.</p>
     #[serde(rename = "NextToken")]
@@ -2178,6 +2248,7 @@ pub struct ListUserImportJobsRequest {
 
 /// <p>Represents the response from the server to the request to list the user import jobs.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListUserImportJobsResponse {
     /// <p>An identifier that can be used to return the next set of user import jobs in the list.</p>
     #[serde(rename = "PaginationToken")]
@@ -2207,6 +2278,7 @@ pub struct ListUserPoolClientsRequest {
 
 /// <p>Represents the response from the server that lists user pool clients.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListUserPoolClientsResponse {
     /// <p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>
     #[serde(rename = "NextToken")]
@@ -2232,6 +2304,7 @@ pub struct ListUserPoolsRequest {
 
 /// <p>Represents the response to list user pools.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListUserPoolsResponse {
     /// <p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>
     #[serde(rename = "NextToken")]
@@ -2262,6 +2335,7 @@ pub struct ListUsersInGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListUsersInGroupResponse {
     /// <p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>
     #[serde(rename = "NextToken")]
@@ -2299,6 +2373,7 @@ pub struct ListUsersRequest {
 
 /// <p>The response from the request to list users.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListUsersResponse {
     /// <p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>
     #[serde(rename = "PaginationToken")]
@@ -2342,6 +2417,7 @@ pub struct MessageTemplateType {
 
 /// <p>The new device metadata type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct NewDeviceMetadataType {
     /// <p>The device group key.</p>
     #[serde(rename = "DeviceGroupKey")]
@@ -2437,6 +2513,7 @@ pub struct PasswordPolicyType {
 
 /// <p>A container for identity provider details.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ProviderDescription {
     /// <p>The date the provider was added to the user pool.</p>
     #[serde(rename = "CreationDate")]
@@ -2498,6 +2575,7 @@ pub struct ResendConfirmationCodeRequest {
 
 /// <p>The response from the server when the Amazon Cognito Your User Pools service makes the request to resend a confirmation code.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResendConfirmationCodeResponse {
     /// <p>The code delivery details returned by the server in response to the request to resend the confirmation code.</p>
     #[serde(rename = "CodeDeliveryDetails")]
@@ -2518,6 +2596,7 @@ pub struct ResourceServerScopeType {
 
 /// <p>A container for information about a resource server for a user pool.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResourceServerType {
     /// <p>The identifier for the resource server.</p>
     #[serde(rename = "Identifier")]
@@ -2566,6 +2645,7 @@ pub struct RespondToAuthChallengeRequest {
 
 /// <p>The response to respond to the authentication challenge.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RespondToAuthChallengeResponse {
     /// <p>The result returned by the server in response to the request to respond to the authentication challenge.</p>
     #[serde(rename = "AuthenticationResult")]
@@ -2587,6 +2667,7 @@ pub struct RespondToAuthChallengeResponse {
 
 /// <p>The risk configuration type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RiskConfigurationType {
     /// <p>The account takeover risk configuration object including the <code>NotifyConfiguration</code> object and <code>Actions</code> to take in the case of an account takeover.</p>
     #[serde(rename = "AccountTakeoverRiskConfiguration")]
@@ -2699,6 +2780,7 @@ pub struct SetRiskConfigurationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SetRiskConfigurationResponse {
     /// <p>The risk configuration.</p>
     #[serde(rename = "RiskConfiguration")]
@@ -2729,6 +2811,7 @@ pub struct SetUICustomizationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SetUICustomizationResponse {
     /// <p>The UI customization information.</p>
     #[serde(rename = "UICustomization")]
@@ -2751,6 +2834,7 @@ pub struct SetUserMFAPreferenceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SetUserMFAPreferenceResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -2773,6 +2857,7 @@ pub struct SetUserPoolMfaConfigRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SetUserPoolMfaConfigResponse {
     /// <p>The MFA configuration.</p>
     #[serde(rename = "MfaConfiguration")]
@@ -2801,6 +2886,7 @@ pub struct SetUserSettingsRequest {
 
 /// <p>The response from the server for a set user settings request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SetUserSettingsResponse {}
 
 /// <p>Represents the request to register a user.</p>
@@ -2839,6 +2925,7 @@ pub struct SignUpRequest {
 
 /// <p>The response from the server for a registration request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SignUpResponse {
     /// <p>The code delivery details returned by the server response to the user registration request.</p>
     #[serde(rename = "CodeDeliveryDetails")]
@@ -2912,6 +2999,7 @@ pub struct StartUserImportJobRequest {
 
 /// <p>Represents the response from the server to the request to start the user import job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartUserImportJobResponse {
     /// <p>The job object that represents the user import job.</p>
     #[serde(rename = "UserImportJob")]
@@ -2932,6 +3020,7 @@ pub struct StopUserImportJobRequest {
 
 /// <p>Represents the response from the server to the request to stop the user import job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopUserImportJobResponse {
     /// <p>The job object that represents the user import job.</p>
     #[serde(rename = "UserImportJob")]
@@ -2954,6 +3043,7 @@ pub struct StringAttributeConstraintsType {
 
 /// <p>A container for the UI customization information for a user pool's built-in app UI.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UICustomizationType {
     /// <p>The CSS values in the UI customization.</p>
     #[serde(rename = "CSS")]
@@ -3005,6 +3095,7 @@ pub struct UpdateAuthEventFeedbackRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateAuthEventFeedbackResponse {}
 
 /// <p>Represents the request to update the device status.</p>
@@ -3024,6 +3115,7 @@ pub struct UpdateDeviceStatusRequest {
 
 /// <p>The response to the request to update the device status.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateDeviceStatusResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -3049,6 +3141,7 @@ pub struct UpdateGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateGroupResponse {
     /// <p>The group object for the group.</p>
     #[serde(rename = "Group")]
@@ -3079,6 +3172,7 @@ pub struct UpdateIdentityProviderRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateIdentityProviderResponse {
     /// <p>The identity provider object.</p>
     #[serde(rename = "IdentityProvider")]
@@ -3103,6 +3197,7 @@ pub struct UpdateResourceServerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateResourceServerResponse {
     /// <p>The resource server.</p>
     #[serde(rename = "ResourceServer")]
@@ -3122,6 +3217,7 @@ pub struct UpdateUserAttributesRequest {
 
 /// <p>Represents the response from the server for the request to update user attributes.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateUserAttributesResponse {
     /// <p>The code delivery details list from the server for the request to update user attributes.</p>
     #[serde(rename = "CodeDeliveryDetailsList")]
@@ -3194,6 +3290,7 @@ pub struct UpdateUserPoolClientRequest {
 
 /// <p>Represents the response from the server to the request to update the user pool client.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateUserPoolClientResponse {
     /// <p>The user pool client value from the response from the server when an update user pool client request is made.</p>
     #[serde(rename = "UserPoolClient")]
@@ -3271,6 +3368,7 @@ pub struct UpdateUserPoolRequest {
 
 /// <p>Represents the response from the server when you make a request to update the user pool.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateUserPoolResponse {}
 
 /// <p>Contextual data such as the user's device fingerprint, IP address, or location used for evaluating the risk of an unexpected event by Amazon Cognito advanced security.</p>
@@ -3284,6 +3382,7 @@ pub struct UserContextDataType {
 
 /// <p>The user import job type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UserImportJobType {
     /// <p>The role ARN for the Amazon CloudWatch Logging role for the user import job. For more information, see "Creating the CloudWatch Logs IAM Role" in the Amazon Cognito Developer Guide.</p>
     #[serde(rename = "CloudWatchLogsRoleArn")]
@@ -3349,6 +3448,7 @@ pub struct UserPoolAddOnsType {
 
 /// <p>The description of the user pool client.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UserPoolClientDescription {
     /// <p>The ID of the client associated with the user pool.</p>
     #[serde(rename = "ClientId")]
@@ -3366,6 +3466,7 @@ pub struct UserPoolClientDescription {
 
 /// <p>Contains information about a user pool client.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UserPoolClientType {
     /// <p>Set to <code>code</code> to initiate a code grant flow, which provides an authorization code as the response. This code can be exchanged for access tokens with the token endpoint.</p> <p>Set to <code>token</code> to specify that the client should get the access token (and, optionally, ID token, based on scopes) directly.</p>
     #[serde(rename = "AllowedOAuthFlows")]
@@ -3443,6 +3544,7 @@ pub struct UserPoolClientType {
 
 /// <p>A user pool description.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UserPoolDescriptionType {
     /// <p>The date the user pool description was created.</p>
     #[serde(rename = "CreationDate")]
@@ -3481,6 +3583,7 @@ pub struct UserPoolPolicyType {
 
 /// <p>A container for information about the user pool.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UserPoolType {
     /// <p>The configuration for <code>AdminCreateUser</code> requests.</p>
     #[serde(rename = "AdminCreateUserConfig")]
@@ -3598,6 +3701,7 @@ pub struct UserPoolType {
 
 /// <p>The user type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UserType {
     /// <p>A container with information about the user type attributes.</p>
     #[serde(rename = "Attributes")]
@@ -3678,6 +3782,7 @@ pub struct VerifySoftwareTokenRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VerifySoftwareTokenResponse {
     /// <p>The session which should be passed both ways in challenge-response calls to the service.</p>
     #[serde(rename = "Session")]
@@ -3705,6 +3810,7 @@ pub struct VerifyUserAttributeRequest {
 
 /// <p>A container representing the response from the server from the request to verify user attributes.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VerifyUserAttributeResponse {}
 
 /// Errors returned by AddCustomAttributes

--- a/rusoto/services/cognito-sync/src/generated.rs
+++ b/rusoto/services/cognito-sync/src/generated.rs
@@ -39,6 +39,7 @@ pub struct BulkPublishRequest {
 
 /// <p>The output for the BulkPublish operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BulkPublishResponse {
     /// <p>A name-spaced GUID (for example, us-east-1:23EC4050-6AEA-7089-A2DD-08002EXAMPLE) created by Amazon Cognito. GUID generation is unique within a region.</p>
     #[serde(rename = "IdentityPoolId")]
@@ -65,6 +66,7 @@ pub struct CognitoStreams {
 
 /// <p>A collection of data for an identity pool. An identity pool can have multiple datasets. A dataset is per identity and can be general or associated with a particular entity in an application (like a saved game). Datasets are automatically created if they don&#39;t exist. Data is synced by dataset, and a dataset can hold up to 1MB of key-value pairs.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Dataset {
     /// <p>Date on which the dataset was created.</p>
     #[serde(rename = "CreationDate")]
@@ -112,6 +114,7 @@ pub struct DeleteDatasetRequest {
 
 /// <p>Response to a successful DeleteDataset request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteDatasetResponse {
     /// <p>A collection of data for an identity pool. An identity pool can have multiple datasets. A dataset is per identity and can be general or associated with a particular entity in an application (like a saved game). Datasets are automatically created if they don&#39;t exist. Data is synced by dataset, and a dataset can hold up to 1MB of key-value pairs.</p>
     #[serde(rename = "Dataset")]
@@ -135,6 +138,7 @@ pub struct DescribeDatasetRequest {
 
 /// <p>Response to a successful DescribeDataset request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeDatasetResponse {
     /// <p>Meta data for a collection of data for an identity. An identity can have multiple datasets. A dataset can be general or associated with a particular entity in an application (like a saved game). Datasets are automatically created if they don&#39;t exist. Data is synced by dataset, and a dataset can hold up to 1MB of key-value pairs.</p>
     #[serde(rename = "Dataset")]
@@ -152,6 +156,7 @@ pub struct DescribeIdentityPoolUsageRequest {
 
 /// <p>Response to a successful DescribeIdentityPoolUsage request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeIdentityPoolUsageResponse {
     /// <p>Information about the usage of the identity pool.</p>
     #[serde(rename = "IdentityPoolUsage")]
@@ -172,6 +177,7 @@ pub struct DescribeIdentityUsageRequest {
 
 /// <p>The response to a successful DescribeIdentityUsage request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeIdentityUsageResponse {
     /// <p>Usage information for the identity.</p>
     #[serde(rename = "IdentityUsage")]
@@ -189,6 +195,7 @@ pub struct GetBulkPublishDetailsRequest {
 
 /// <p>The output for the GetBulkPublishDetails operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetBulkPublishDetailsResponse {
     /// <p>If BulkPublishStatus is SUCCEEDED, the time the last bulk publish operation completed.</p>
     #[serde(rename = "BulkPublishCompleteTime")]
@@ -222,6 +229,7 @@ pub struct GetCognitoEventsRequest {
 
 /// <p>The response from the GetCognitoEvents request</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetCognitoEventsResponse {
     /// <p>The Cognito Events returned from the GetCognitoEvents request</p>
     #[serde(rename = "Events")]
@@ -239,6 +247,7 @@ pub struct GetIdentityPoolConfigurationRequest {
 
 /// <p>The output for the GetIdentityPoolConfiguration operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetIdentityPoolConfigurationResponse {
     /// <p>Options to apply to this identity pool for Amazon Cognito streams.</p>
     #[serde(rename = "CognitoStreams")]
@@ -256,6 +265,7 @@ pub struct GetIdentityPoolConfigurationResponse {
 
 /// <p>Usage information for the identity pool.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct IdentityPoolUsage {
     /// <p>Data storage information for the identity pool.</p>
     #[serde(rename = "DataStorage")]
@@ -277,6 +287,7 @@ pub struct IdentityPoolUsage {
 
 /// <p>Usage information for the identity.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct IdentityUsage {
     /// <p>Total data storage for this identity.</p>
     #[serde(rename = "DataStorage")]
@@ -321,6 +332,7 @@ pub struct ListDatasetsRequest {
 
 /// <p>Returned for a successful ListDatasets request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListDatasetsResponse {
     /// <p>Number of datasets returned.</p>
     #[serde(rename = "Count")]
@@ -351,6 +363,7 @@ pub struct ListIdentityPoolUsageRequest {
 
 /// <p>Returned for a successful ListIdentityPoolUsage request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListIdentityPoolUsageResponse {
     /// <p>Total number of identities for the identity pool.</p>
     #[serde(rename = "Count")]
@@ -402,6 +415,7 @@ pub struct ListRecordsRequest {
 
 /// <p>Returned for a successful ListRecordsRequest.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListRecordsResponse {
     /// <p>Total number of records.</p>
     #[serde(rename = "Count")]
@@ -456,6 +470,7 @@ pub struct PushSync {
 
 /// <p>The basic data structure of a dataset.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Record {
     /// <p>The last modified date of the client device.</p>
     #[serde(rename = "DeviceLastModifiedDate")]
@@ -524,6 +539,7 @@ pub struct RegisterDeviceRequest {
 
 /// <p>Response to a RegisterDevice request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegisterDeviceResponse {
     /// <p>The unique ID generated for this device by Cognito.</p>
     #[serde(rename = "DeviceId")]
@@ -560,6 +576,7 @@ pub struct SetIdentityPoolConfigurationRequest {
 
 /// <p>The output for the SetIdentityPoolConfiguration operation</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SetIdentityPoolConfigurationResponse {
     /// <p>Options to apply to this identity pool for Amazon Cognito streams.</p>
     #[serde(rename = "CognitoStreams")]
@@ -594,6 +611,7 @@ pub struct SubscribeToDatasetRequest {
 
 /// <p>Response to a SubscribeToDataset request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SubscribeToDatasetResponse {}
 
 /// <p>A request to UnsubscribeFromDataset.</p>
@@ -615,6 +633,7 @@ pub struct UnsubscribeFromDatasetRequest {
 
 /// <p>Response to an UnsubscribeFromDataset request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UnsubscribeFromDatasetResponse {}
 
 /// <p>A request to post updates to records or add and delete records for a dataset and user.</p>
@@ -648,6 +667,7 @@ pub struct UpdateRecordsRequest {
 
 /// <p>Returned for a successful UpdateRecordsRequest.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateRecordsResponse {
     /// <p>A list of records that have been updated.</p>
     #[serde(rename = "Records")]

--- a/rusoto/services/comprehend/src/generated.rs
+++ b/rusoto/services/comprehend/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>The result of calling the operation. The operation returns one object for each document that is successfully processed by the operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchDetectDominantLanguageItemResult {
     /// <p>The zero-based index of the document in the input list.</p>
     #[serde(rename = "Index")]
@@ -49,6 +50,7 @@ pub struct BatchDetectDominantLanguageRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchDetectDominantLanguageResponse {
     /// <p>A list containing one object for each document that contained an error. The results are sorted in ascending order by the <code>Index</code> field and match the order of the documents in the input list. If there are no errors in the batch, the <code>ErrorList</code> is empty.</p>
     #[serde(rename = "ErrorList")]
@@ -60,6 +62,7 @@ pub struct BatchDetectDominantLanguageResponse {
 
 /// <p>The result of calling the operation. The operation returns one object for each document that is successfully processed by the operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchDetectEntitiesItemResult {
     /// <p>One or more <a>Entity</a> objects, one for each entity detected in the document.</p>
     #[serde(rename = "Entities")]
@@ -82,6 +85,7 @@ pub struct BatchDetectEntitiesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchDetectEntitiesResponse {
     /// <p>A list containing one object for each document that contained an error. The results are sorted in ascending order by the <code>Index</code> field and match the order of the documents in the input list. If there are no errors in the batch, the <code>ErrorList</code> is empty.</p>
     #[serde(rename = "ErrorList")]
@@ -93,6 +97,7 @@ pub struct BatchDetectEntitiesResponse {
 
 /// <p>The result of calling the operation. The operation returns one object for each document that is successfully processed by the operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchDetectKeyPhrasesItemResult {
     /// <p>The zero-based index of the document in the input list.</p>
     #[serde(rename = "Index")]
@@ -115,6 +120,7 @@ pub struct BatchDetectKeyPhrasesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchDetectKeyPhrasesResponse {
     /// <p>A list containing one object for each document that contained an error. The results are sorted in ascending order by the <code>Index</code> field and match the order of the documents in the input list. If there are no errors in the batch, the <code>ErrorList</code> is empty.</p>
     #[serde(rename = "ErrorList")]
@@ -126,6 +132,7 @@ pub struct BatchDetectKeyPhrasesResponse {
 
 /// <p>The result of calling the operation. The operation returns one object for each document that is successfully processed by the operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchDetectSentimentItemResult {
     /// <p>The zero-based index of the document in the input list.</p>
     #[serde(rename = "Index")]
@@ -152,6 +159,7 @@ pub struct BatchDetectSentimentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchDetectSentimentResponse {
     /// <p>A list containing one object for each document that contained an error. The results are sorted in ascending order by the <code>Index</code> field and match the order of the documents in the input list. If there are no errors in the batch, the <code>ErrorList</code> is empty.</p>
     #[serde(rename = "ErrorList")]
@@ -163,6 +171,7 @@ pub struct BatchDetectSentimentResponse {
 
 /// <p>The result of calling the operation. The operation returns one object that is successfully processed by the operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchDetectSyntaxItemResult {
     /// <p>The zero-based index of the document in the input list.</p>
     #[serde(rename = "Index")]
@@ -185,6 +194,7 @@ pub struct BatchDetectSyntaxRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchDetectSyntaxResponse {
     /// <p>A list containing one object for each document that contained an error. The results are sorted in ascending order by the <code>Index</code> field and match the order of the documents in the input list. If there are no errors in the batch, the <code>ErrorList</code> is empty.</p>
     #[serde(rename = "ErrorList")]
@@ -196,6 +206,7 @@ pub struct BatchDetectSyntaxResponse {
 
 /// <p>Describes an error that occurred while processing a document in a batch. The operation returns on <code>BatchItemError</code> object for each document that contained an error.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchItemError {
     /// <p>The numeric error code of the error.</p>
     #[serde(rename = "ErrorCode")]
@@ -219,6 +230,7 @@ pub struct DescribeDominantLanguageDetectionJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeDominantLanguageDetectionJobResponse {
     /// <p>An object that contains the properties associated with a dominant language detection job.</p>
     #[serde(rename = "DominantLanguageDetectionJobProperties")]
@@ -234,6 +246,7 @@ pub struct DescribeEntitiesDetectionJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEntitiesDetectionJobResponse {
     /// <p>An object that contains the properties associated with an entities detection job.</p>
     #[serde(rename = "EntitiesDetectionJobProperties")]
@@ -249,6 +262,7 @@ pub struct DescribeKeyPhrasesDetectionJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeKeyPhrasesDetectionJobResponse {
     /// <p>An object that contains the properties associated with a key phrases detection job. </p>
     #[serde(rename = "KeyPhrasesDetectionJobProperties")]
@@ -264,6 +278,7 @@ pub struct DescribeSentimentDetectionJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeSentimentDetectionJobResponse {
     /// <p>An object that contains the properties associated with a sentiment detection job.</p>
     #[serde(rename = "SentimentDetectionJobProperties")]
@@ -279,6 +294,7 @@ pub struct DescribeTopicsDetectionJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeTopicsDetectionJobResponse {
     /// <p>The list of properties for the requested job.</p>
     #[serde(rename = "TopicsDetectionJobProperties")]
@@ -294,6 +310,7 @@ pub struct DetectDominantLanguageRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DetectDominantLanguageResponse {
     /// <p>The languages that Amazon Comprehend detected in the input text. For each language, the response returns the RFC 5646 language code and the level of confidence that Amazon Comprehend has in the accuracy of its inference. For more information about RFC 5646, see <a href="https://tools.ietf.org/html/rfc5646">Tags for Identifying Languages</a> on the <i>IETF Tools</i> web site.</p>
     #[serde(rename = "Languages")]
@@ -312,6 +329,7 @@ pub struct DetectEntitiesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DetectEntitiesResponse {
     /// <p>A collection of entities identified in the input text. For each entity, the response provides the entity text, entity type, where the entity text begins and ends, and the level of confidence that Amazon Comprehend has in the detection. For a list of entity types, see <a>how-entities</a>. </p>
     #[serde(rename = "Entities")]
@@ -330,6 +348,7 @@ pub struct DetectKeyPhrasesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DetectKeyPhrasesResponse {
     /// <p>A collection of key phrases that Amazon Comprehend identified in the input text. For each key phrase, the response provides the text of the key phrase, where the key phrase begins and ends, and the level of confidence that Amazon Comprehend has in the accuracy of the detection. </p>
     #[serde(rename = "KeyPhrases")]
@@ -348,6 +367,7 @@ pub struct DetectSentimentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DetectSentimentResponse {
     /// <p>The inferred sentiment that Amazon Comprehend has the highest level of confidence in.</p>
     #[serde(rename = "Sentiment")]
@@ -370,6 +390,7 @@ pub struct DetectSyntaxRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DetectSyntaxResponse {
     /// <p>A collection of syntax tokens describing the text. For each token, the response provides the text, the token type, where the text begins and ends, and the level of confidence that Amazon Comprehend has that the token is correct. For a list of token types, see <a>how-syntax</a>.</p>
     #[serde(rename = "SyntaxTokens")]
@@ -379,6 +400,7 @@ pub struct DetectSyntaxResponse {
 
 /// <p>Returns the code for the dominant language in the input text and the level of confidence that Amazon Comprehend has in the accuracy of the detection.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DominantLanguage {
     /// <p>The RFC 5646 language code for the dominant language. For more information about RFC 5646, see <a href="https://tools.ietf.org/html/rfc5646">Tags for Identifying Languages</a> on the <i>IETF Tools</i> web site.</p>
     #[serde(rename = "LanguageCode")]
@@ -413,6 +435,7 @@ pub struct DominantLanguageDetectionJobFilter {
 
 /// <p>Provides information about a dominant language detection job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DominantLanguageDetectionJobProperties {
     /// <p>The Amazon Resource Name (ARN) that gives Amazon Comprehend read access to your input data.</p>
     #[serde(rename = "DataAccessRoleArn")]
@@ -475,6 +498,7 @@ pub struct EntitiesDetectionJobFilter {
 
 /// <p>Provides information about an entities detection job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EntitiesDetectionJobProperties {
     /// <p>The Amazon Resource Name (ARN) that gives Amazon Comprehend read access to your input data.</p>
     #[serde(rename = "DataAccessRoleArn")]
@@ -520,6 +544,7 @@ pub struct EntitiesDetectionJobProperties {
 
 /// <p>Provides information about an entity. </p> <p> </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Entity {
     /// <p>A character offset in the input text that shows where the entity begins (the first character is at position 0). The offset returns the position of each UTF-8 code point in the string. A <i>code point</i> is the abstract character from a particular graphical representation. For example, a multi-byte UTF-8 character maps to a single code point.</p>
     #[serde(rename = "BeginOffset")]
@@ -557,6 +582,7 @@ pub struct InputDataConfig {
 
 /// <p>Describes a key noun phrase.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct KeyPhrase {
     /// <p>A character offset in the input text that shows where the key phrase begins (the first character is at position 0). The offset returns the position of each UTF-8 code point in the string. A <i>code point</i> is the abstract character from a particular graphical representation. For example, a multi-byte UTF-8 character maps to a single code point.</p>
     #[serde(rename = "BeginOffset")]
@@ -599,6 +625,7 @@ pub struct KeyPhrasesDetectionJobFilter {
 
 /// <p>Provides information about a key phrases detection job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct KeyPhrasesDetectionJobProperties {
     /// <p>The Amazon Resource Name (ARN) that gives Amazon Comprehend read access to your input data.</p>
     #[serde(rename = "DataAccessRoleArn")]
@@ -659,6 +686,7 @@ pub struct ListDominantLanguageDetectionJobsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListDominantLanguageDetectionJobsResponse {
     /// <p>A list containing the properties of each job that is returned.</p>
     #[serde(rename = "DominantLanguageDetectionJobPropertiesList")]
@@ -688,6 +716,7 @@ pub struct ListEntitiesDetectionJobsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListEntitiesDetectionJobsResponse {
     /// <p>A list containing the properties of each job that is returned.</p>
     #[serde(rename = "EntitiesDetectionJobPropertiesList")]
@@ -716,6 +745,7 @@ pub struct ListKeyPhrasesDetectionJobsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListKeyPhrasesDetectionJobsResponse {
     /// <p>A list containing the properties of each job that is returned.</p>
     #[serde(rename = "KeyPhrasesDetectionJobPropertiesList")]
@@ -744,6 +774,7 @@ pub struct ListSentimentDetectionJobsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListSentimentDetectionJobsResponse {
     /// <p>Identifies the next page of results to return.</p>
     #[serde(rename = "NextToken")]
@@ -772,6 +803,7 @@ pub struct ListTopicsDetectionJobsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTopicsDetectionJobsResponse {
     /// <p>Identifies the next page of results to return.</p>
     #[serde(rename = "NextToken")]
@@ -793,6 +825,7 @@ pub struct OutputDataConfig {
 
 /// <p>Identifies the part of speech represented by the token and gives the confidence that Amazon Comprehend has that the part of speech was correctly identified. For more information about the parts of speech that Amazon Comprehend can identify, see <a>how-syntax</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PartOfSpeechTag {
     /// <p>The confidence that Amazon Comprehend has that the part of speech was correctly identified.</p>
     #[serde(rename = "Score")]
@@ -827,6 +860,7 @@ pub struct SentimentDetectionJobFilter {
 
 /// <p>Provides information about a sentiment detection job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SentimentDetectionJobProperties {
     /// <p>The Amazon Resource Name (ARN) that gives Amazon Comprehend read access to your input data.</p>
     #[serde(rename = "DataAccessRoleArn")]
@@ -872,6 +906,7 @@ pub struct SentimentDetectionJobProperties {
 
 /// <p>Describes the level of confidence that Amazon Comprehend has in the accuracy of its detection of sentiments.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SentimentScore {
     /// <p>The level of confidence that Amazon Comprehend has in the accuracy of its detection of the <code>MIXED</code> sentiment.</p>
     #[serde(rename = "Mixed")]
@@ -913,6 +948,7 @@ pub struct StartDominantLanguageDetectionJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartDominantLanguageDetectionJobResponse {
     /// <p>The identifier generated for the job. To get the status of a job, use this identifier with the operation.</p>
     #[serde(rename = "JobId")]
@@ -949,6 +985,7 @@ pub struct StartEntitiesDetectionJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartEntitiesDetectionJobResponse {
     /// <p>The identifier generated for the job. To get the status of job, use this identifier with the operation.</p>
     #[serde(rename = "JobId")]
@@ -985,6 +1022,7 @@ pub struct StartKeyPhrasesDetectionJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartKeyPhrasesDetectionJobResponse {
     /// <p>The identifier generated for the job. To get the status of a job, use this identifier with the operation.</p>
     #[serde(rename = "JobId")]
@@ -1021,6 +1059,7 @@ pub struct StartSentimentDetectionJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartSentimentDetectionJobResponse {
     /// <p>The identifier generated for the job. To get the status of a job, use this identifier with the operation.</p>
     #[serde(rename = "JobId")]
@@ -1058,6 +1097,7 @@ pub struct StartTopicsDetectionJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartTopicsDetectionJobResponse {
     /// <p>The identifier generated for the job. To get the status of the job, use this identifier with the <code>DescribeTopicDetectionJob</code> operation.</p>
     #[serde(rename = "JobId")]
@@ -1077,6 +1117,7 @@ pub struct StopDominantLanguageDetectionJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopDominantLanguageDetectionJobResponse {
     /// <p>The identifier of the dominant language detection job to stop.</p>
     #[serde(rename = "JobId")]
@@ -1096,6 +1137,7 @@ pub struct StopEntitiesDetectionJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopEntitiesDetectionJobResponse {
     /// <p>The identifier of the entities detection job to stop.</p>
     #[serde(rename = "JobId")]
@@ -1115,6 +1157,7 @@ pub struct StopKeyPhrasesDetectionJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopKeyPhrasesDetectionJobResponse {
     /// <p>The identifier of the key phrases detection job to stop.</p>
     #[serde(rename = "JobId")]
@@ -1134,6 +1177,7 @@ pub struct StopSentimentDetectionJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopSentimentDetectionJobResponse {
     /// <p>The identifier of the sentiment detection job to stop.</p>
     #[serde(rename = "JobId")]
@@ -1147,6 +1191,7 @@ pub struct StopSentimentDetectionJobResponse {
 
 /// <p>Represents a work in the input text that was recognized and assigned a part of speech. There is one syntax token record for each word in the source text.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SyntaxToken {
     /// <p>The zero-based offset from the beginning of the source text to the first character in the word.</p>
     #[serde(rename = "BeginOffset")]
@@ -1193,6 +1238,7 @@ pub struct TopicsDetectionJobFilter {
 
 /// <p>Provides information about a topic detection job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TopicsDetectionJobProperties {
     /// <p>The time that the topic detection job was completed.</p>
     #[serde(rename = "EndTime")]

--- a/rusoto/services/config/src/generated.rs
+++ b/rusoto/services/config/src/generated.rs
@@ -46,6 +46,7 @@ pub struct AccountAggregationSource {
 
 /// <p>Indicates whether an AWS Config rule is compliant based on account ID, region, compliance, and rule name.</p> <p>A rule is compliant if all of the resources that the rule evaluated comply with it. It is noncompliant if any of these resources do not comply.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AggregateComplianceByConfigRule {
     /// <p>The 12-digit account ID of the source account.</p>
     #[serde(rename = "AccountId")]
@@ -67,6 +68,7 @@ pub struct AggregateComplianceByConfigRule {
 
 /// <p>Returns the number of compliant and noncompliant rules for one or more accounts and regions in an aggregator.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AggregateComplianceCount {
     /// <p>The number of compliant and noncompliant AWS Config rules.</p>
     #[serde(rename = "ComplianceSummary")]
@@ -80,6 +82,7 @@ pub struct AggregateComplianceCount {
 
 /// <p>The details of an AWS Config evaluation for an account ID and region in an aggregator. Provides the AWS resource that was evaluated, the compliance of the resource, related time stamps, and supplementary information. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AggregateEvaluationResult {
     /// <p>The 12-digit account ID of the source account.</p>
     #[serde(rename = "AccountId")]
@@ -113,6 +116,7 @@ pub struct AggregateEvaluationResult {
 
 /// <p>The current sync status between the source and the aggregator account.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AggregatedSourceStatus {
     /// <p>The region authorized to collect aggregated data.</p>
     #[serde(rename = "AwsRegion")]
@@ -146,6 +150,7 @@ pub struct AggregatedSourceStatus {
 
 /// <p>An object that represents the authorizations granted to aggregator accounts and regions.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AggregationAuthorization {
     /// <p>The Amazon Resource Name (ARN) of the aggregation object.</p>
     #[serde(rename = "AggregationAuthorizationArn")]
@@ -167,6 +172,7 @@ pub struct AggregationAuthorization {
 
 /// <p>The detailed configuration of a specified resource.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BaseConfigurationItem {
     /// <p>The 12 digit AWS account ID associated with the resource.</p>
     #[serde(rename = "accountId")]
@@ -234,6 +240,7 @@ pub struct BatchGetResourceConfigRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchGetResourceConfigResponse {
     /// <p>A list that contains the current configuration of one or more resources.</p>
     #[serde(rename = "baseConfigurationItems")]
@@ -247,6 +254,7 @@ pub struct BatchGetResourceConfigResponse {
 
 /// <p>Indicates whether an AWS resource or AWS Config rule is compliant and provides the number of contributors that affect the compliance.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Compliance {
     /// <p>The number of AWS resources or AWS Config rules that cause a result of <code>NON_COMPLIANT</code>, up to a maximum number.</p>
     #[serde(rename = "ComplianceContributorCount")]
@@ -260,6 +268,7 @@ pub struct Compliance {
 
 /// <p>Indicates whether an AWS Config rule is compliant. A rule is compliant if all of the resources that the rule evaluated comply with it. A rule is noncompliant if any of these resources do not comply.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ComplianceByConfigRule {
     /// <p>Indicates whether the AWS Config rule is compliant.</p>
     #[serde(rename = "Compliance")]
@@ -273,6 +282,7 @@ pub struct ComplianceByConfigRule {
 
 /// <p>Indicates whether an AWS resource that is evaluated according to one or more AWS Config rules is compliant. A resource is compliant if it complies with all of the rules that evaluate it. A resource is noncompliant if it does not comply with one or more of these rules.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ComplianceByResource {
     /// <p>Indicates whether the AWS resource complies with all of the AWS Config rules that evaluated it.</p>
     #[serde(rename = "Compliance")]
@@ -290,6 +300,7 @@ pub struct ComplianceByResource {
 
 /// <p>The number of AWS resources or AWS Config rules responsible for the current compliance of the item, up to a maximum number.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ComplianceContributorCount {
     /// <p>Indicates whether the maximum count is reached.</p>
     #[serde(rename = "CapExceeded")]
@@ -303,6 +314,7 @@ pub struct ComplianceContributorCount {
 
 /// <p>The number of AWS Config rules or AWS resources that are compliant and noncompliant.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ComplianceSummary {
     /// <p>The time that AWS Config created the compliance summary.</p>
     #[serde(rename = "ComplianceSummaryTimestamp")]
@@ -320,6 +332,7 @@ pub struct ComplianceSummary {
 
 /// <p>The number of AWS resources of a specific type that are compliant or noncompliant, up to a maximum of 100 for each.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ComplianceSummaryByResourceType {
     /// <p>The number of AWS resources that are compliant or noncompliant, up to a maximum of 100 for each.</p>
     #[serde(rename = "ComplianceSummary")]
@@ -333,6 +346,7 @@ pub struct ComplianceSummaryByResourceType {
 
 /// <p>Provides status of the delivery of the snapshot or the configuration history to the specified Amazon S3 bucket. Also provides the status of notifications about the Amazon S3 delivery to the specified Amazon SNS topic.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ConfigExportDeliveryInfo {
     /// <p>The time of the last attempted delivery.</p>
     #[serde(rename = "lastAttemptTime")]
@@ -436,6 +450,7 @@ pub struct ConfigRuleComplianceSummaryFilters {
 
 /// <p>Status information for your AWS managed Config rules. The status includes information such as the last time the rule ran, the last time it failed, and the related error for the last failure.</p> <p>This action does not return status information about custom AWS Config rules.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ConfigRuleEvaluationStatus {
     /// <p>The Amazon Resource Name (ARN) of the AWS Config rule.</p>
     #[serde(rename = "ConfigRuleArn")]
@@ -494,6 +509,7 @@ pub struct ConfigSnapshotDeliveryProperties {
 
 /// <p>A list that contains the status of the delivery of the configuration stream notification to the Amazon SNS topic.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ConfigStreamDeliveryInfo {
     /// <p>The error code from the last attempted delivery.</p>
     #[serde(rename = "lastErrorCode")]
@@ -515,6 +531,7 @@ pub struct ConfigStreamDeliveryInfo {
 
 /// <p>The details about the configuration aggregator, including information about source accounts, regions, and metadata of the aggregator. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ConfigurationAggregator {
     /// <p>Provides a list of source accounts and regions to be aggregated.</p>
     #[serde(rename = "AccountAggregationSources")]
@@ -544,6 +561,7 @@ pub struct ConfigurationAggregator {
 
 /// <p>A list that contains detailed configurations of a specified resource.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ConfigurationItem {
     /// <p>The 12-digit AWS account ID associated with the resource.</p>
     #[serde(rename = "accountId")]
@@ -638,6 +656,7 @@ pub struct ConfigurationRecorder {
 
 /// <p>The current status of the configuration recorder.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ConfigurationRecorderStatus {
     /// <p>The error code indicating that the recording failed.</p>
     #[serde(rename = "lastErrorCode")]
@@ -724,6 +743,7 @@ pub struct DeleteEvaluationResultsRequest {
 
 /// <p>The output when you delete the evaluation results for the specified AWS Config rule.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteEvaluationResultsResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -753,6 +773,7 @@ pub struct DeliverConfigSnapshotRequest {
 
 /// <p>The output for the <a>DeliverConfigSnapshot</a> action, in JSON format.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeliverConfigSnapshotResponse {
     /// <p>The ID of the snapshot that is being created.</p>
     #[serde(rename = "configSnapshotId")]
@@ -787,6 +808,7 @@ pub struct DeliveryChannel {
 
 /// <p>The status of a specified delivery channel.</p> <p>Valid values: <code>Success</code> | <code>Failure</code> </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeliveryChannelStatus {
     /// <p>A list that contains the status of the delivery of the configuration history to the specified Amazon S3 bucket.</p>
     #[serde(rename = "configHistoryDeliveryInfo")]
@@ -826,6 +848,7 @@ pub struct DescribeAggregateComplianceByConfigRulesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAggregateComplianceByConfigRulesResponse {
     /// <p>Returns a list of AggregateComplianceByConfigRule object.</p>
     #[serde(rename = "AggregateComplianceByConfigRules")]
@@ -850,6 +873,7 @@ pub struct DescribeAggregationAuthorizationsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAggregationAuthorizationsResponse {
     /// <p>Returns a list of authorizations granted to various aggregator accounts and regions.</p>
     #[serde(rename = "AggregationAuthorizations")]
@@ -880,6 +904,7 @@ pub struct DescribeComplianceByConfigRuleRequest {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeComplianceByConfigRuleResponse {
     /// <p>Indicates whether each of the specified AWS Config rules is compliant.</p>
     #[serde(rename = "ComplianceByConfigRules")]
@@ -918,6 +943,7 @@ pub struct DescribeComplianceByResourceRequest {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeComplianceByResourceResponse {
     /// <p>Indicates whether the specified AWS resource complies with all of the AWS Config rules that evaluate it.</p>
     #[serde(rename = "ComplianceByResources")]
@@ -948,6 +974,7 @@ pub struct DescribeConfigRuleEvaluationStatusRequest {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeConfigRuleEvaluationStatusResponse {
     /// <p>Status information about your AWS managed Config rules.</p>
     #[serde(rename = "ConfigRulesEvaluationStatus")]
@@ -974,6 +1001,7 @@ pub struct DescribeConfigRulesRequest {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeConfigRulesResponse {
     /// <p>The details about your AWS Config rules.</p>
     #[serde(rename = "ConfigRules")]
@@ -1005,6 +1033,7 @@ pub struct DescribeConfigurationAggregatorSourcesStatusRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeConfigurationAggregatorSourcesStatusResponse {
     /// <p>Returns an AggregatedSourceStatus object. </p>
     #[serde(rename = "AggregatedSourceStatusList")]
@@ -1033,6 +1062,7 @@ pub struct DescribeConfigurationAggregatorsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeConfigurationAggregatorsResponse {
     /// <p>Returns a ConfigurationAggregators object.</p>
     #[serde(rename = "ConfigurationAggregators")]
@@ -1055,6 +1085,7 @@ pub struct DescribeConfigurationRecorderStatusRequest {
 
 /// <p>The output for the <a>DescribeConfigurationRecorderStatus</a> action, in JSON format.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeConfigurationRecorderStatusResponse {
     /// <p>A list that contains status of the specified recorders.</p>
     #[serde(rename = "ConfigurationRecordersStatus")]
@@ -1073,6 +1104,7 @@ pub struct DescribeConfigurationRecordersRequest {
 
 /// <p>The output for the <a>DescribeConfigurationRecorders</a> action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeConfigurationRecordersResponse {
     /// <p>A list that contains the descriptions of the specified configuration recorders.</p>
     #[serde(rename = "ConfigurationRecorders")]
@@ -1091,6 +1123,7 @@ pub struct DescribeDeliveryChannelStatusRequest {
 
 /// <p>The output for the <a>DescribeDeliveryChannelStatus</a> action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeDeliveryChannelStatusResponse {
     /// <p>A list that contains the status of a specified delivery channel.</p>
     #[serde(rename = "DeliveryChannelsStatus")]
@@ -1109,6 +1142,7 @@ pub struct DescribeDeliveryChannelsRequest {
 
 /// <p>The output for the <a>DescribeDeliveryChannels</a> action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeDeliveryChannelsResponse {
     /// <p>A list that contains the descriptions of the specified delivery channel.</p>
     #[serde(rename = "DeliveryChannels")]
@@ -1129,6 +1163,7 @@ pub struct DescribePendingAggregationRequestsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribePendingAggregationRequestsResponse {
     /// <p>The nextToken string returned on a previous page that you use to get the next page of results in a paginated response.</p>
     #[serde(rename = "NextToken")]
@@ -1153,6 +1188,7 @@ pub struct DescribeRetentionConfigurationsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeRetentionConfigurationsResponse {
     /// <p>The <code>nextToken</code> string returned on a previous page that you use to get the next page of results in a paginated response. </p>
     #[serde(rename = "NextToken")]
@@ -1187,6 +1223,7 @@ pub struct Evaluation {
 
 /// <p>The details of an AWS Config evaluation. Provides the AWS resource that was evaluated, the compliance of the resource, related time stamps, and supplementary information.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EvaluationResult {
     /// <p>Supplementary information about how the evaluation determined the compliance.</p>
     #[serde(rename = "Annotation")]
@@ -1216,6 +1253,7 @@ pub struct EvaluationResult {
 
 /// <p>Uniquely identifies an evaluation result.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EvaluationResultIdentifier {
     /// <p>Identifies an AWS Config rule used to evaluate an AWS resource, and provides the type and ID of the evaluated resource.</p>
     #[serde(rename = "EvaluationResultQualifier")]
@@ -1229,6 +1267,7 @@ pub struct EvaluationResultIdentifier {
 
 /// <p>Identifies an AWS Config rule that evaluated an AWS resource, and provides the type and ID of the resource that the rule evaluated.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EvaluationResultQualifier {
     /// <p>The name of the AWS Config rule that was used in the evaluation.</p>
     #[serde(rename = "ConfigRuleName")]
@@ -1273,6 +1312,7 @@ pub struct GetAggregateComplianceDetailsByConfigRuleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetAggregateComplianceDetailsByConfigRuleResponse {
     /// <p>Returns an AggregateEvaluationResults object.</p>
     #[serde(rename = "AggregateEvaluationResults")]
@@ -1308,6 +1348,7 @@ pub struct GetAggregateConfigRuleComplianceSummaryRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetAggregateConfigRuleComplianceSummaryResponse {
     /// <p>Returns a list of AggregateComplianceCounts object.</p>
     #[serde(rename = "AggregateComplianceCounts")]
@@ -1345,6 +1386,7 @@ pub struct GetComplianceDetailsByConfigRuleRequest {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetComplianceDetailsByConfigRuleResponse {
     /// <p>Indicates whether the AWS resource complies with the specified AWS Config rule.</p>
     #[serde(rename = "EvaluationResults")]
@@ -1377,6 +1419,7 @@ pub struct GetComplianceDetailsByResourceRequest {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetComplianceDetailsByResourceResponse {
     /// <p>Indicates whether the specified AWS resource complies each AWS Config rule.</p>
     #[serde(rename = "EvaluationResults")]
@@ -1390,6 +1433,7 @@ pub struct GetComplianceDetailsByResourceResponse {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetComplianceSummaryByConfigRuleResponse {
     /// <p>The number of AWS Config rules that are compliant and the number that are noncompliant, up to a maximum of 25 for each.</p>
     #[serde(rename = "ComplianceSummary")]
@@ -1408,6 +1452,7 @@ pub struct GetComplianceSummaryByResourceTypeRequest {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetComplianceSummaryByResourceTypeResponse {
     /// <p>The number of resources that are compliant and the number that are noncompliant. If one or more resource types were provided with the request, the numbers are returned for each resource type. The maximum number returned is 100.</p>
     #[serde(rename = "ComplianceSummariesByResourceType")]
@@ -1432,6 +1477,7 @@ pub struct GetDiscoveredResourceCountsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDiscoveredResourceCountsResponse {
     /// <p>The string that you use in a subsequent request to get the next page of results in a paginated response.</p>
     #[serde(rename = "nextToken")]
@@ -1480,6 +1526,7 @@ pub struct GetResourceConfigHistoryRequest {
 
 /// <p>The output for the <a>GetResourceConfigHistory</a> action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetResourceConfigHistoryResponse {
     /// <p>A list that contains the configuration history of one or more resources.</p>
     #[serde(rename = "configurationItems")]
@@ -1521,6 +1568,7 @@ pub struct ListDiscoveredResourcesRequest {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListDiscoveredResourcesResponse {
     /// <p>The string that you use in a subsequent request to get the next page of results in a paginated response.</p>
     #[serde(rename = "nextToken")]
@@ -1550,6 +1598,7 @@ pub struct OrganizationAggregationSource {
 
 /// <p>An object that represents the account ID and region of an aggregator account that is requesting authorization but is not yet authorized.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PendingAggregationRequest {
     /// <p>The 12-digit account ID of the account requesting to aggregate data.</p>
     #[serde(rename = "RequesterAccountId")]
@@ -1572,6 +1621,7 @@ pub struct PutAggregationAuthorizationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutAggregationAuthorizationResponse {
     /// <p>Returns an AggregationAuthorization object. </p>
     #[serde(rename = "AggregationAuthorization")]
@@ -1602,6 +1652,7 @@ pub struct PutConfigurationAggregatorRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutConfigurationAggregatorResponse {
     /// <p>Returns a ConfigurationAggregator object.</p>
     #[serde(rename = "ConfigurationAggregator")]
@@ -1643,6 +1694,7 @@ pub struct PutEvaluationsRequest {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutEvaluationsResponse {
     /// <p>Requests that failed because of a client or server error.</p>
     #[serde(rename = "FailedEvaluations")]
@@ -1658,6 +1710,7 @@ pub struct PutRetentionConfigurationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutRetentionConfigurationResponse {
     /// <p>Returns a retention configuration object.</p>
     #[serde(rename = "RetentionConfiguration")]
@@ -1684,6 +1737,7 @@ pub struct RecordingGroup {
 
 /// <p>The relationship of the related resource to the main resource.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Relationship {
     /// <p>The type of relationship with the related resource.</p>
     #[serde(rename = "relationshipName")]
@@ -1705,6 +1759,7 @@ pub struct Relationship {
 
 /// <p>An object that contains the resource type and the number of resources.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResourceCount {
     /// <p>The number of resources.</p>
     #[serde(rename = "count")]
@@ -1718,6 +1773,7 @@ pub struct ResourceCount {
 
 /// <p>The details that identify a resource that is discovered by AWS Config, including the resource type, ID, and (if available) the custom resource name.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResourceIdentifier {
     /// <p>The time that the resource was deleted.</p>
     #[serde(rename = "resourceDeletionTime")]
@@ -1750,6 +1806,7 @@ pub struct ResourceKey {
 
 /// <p>An object with the name of the retention configuration and the retention period in days. The object stores the configuration for data retention in AWS Config.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RetentionConfiguration {
     /// <p>The name of the retention configuration object.</p>
     #[serde(rename = "Name")]
@@ -1823,6 +1880,7 @@ pub struct StartConfigRulesEvaluationRequest {
 
 /// <p>The output when you start the evaluation for the specified AWS Config rule.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartConfigRulesEvaluationResponse {}
 
 /// <p>The input for the <a>StartConfigurationRecorder</a> action.</p>

--- a/rusoto/services/cur/src/generated.rs
+++ b/rusoto/services/cur/src/generated.rs
@@ -38,6 +38,7 @@ pub struct DeleteReportDefinitionRequest {
 
 /// <p>Response of DeleteReportDefinition</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteReportDefinitionResponse {
     #[serde(rename = "ResponseMessage")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -57,6 +58,7 @@ pub struct DescribeReportDefinitionsRequest {
 
 /// <p>Response of DescribeReportDefinitions</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeReportDefinitionsResponse {
     #[serde(rename = "NextToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -75,6 +77,7 @@ pub struct PutReportDefinitionRequest {
 
 /// <p>Response of PutReportDefinition</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutReportDefinitionResponse {}
 
 /// <p>The definition of AWS Cost and Usage Report. Customer can specify the report name, time unit, report format, compression format, S3 bucket and additional artifacts and schema elements in the definition.</p>

--- a/rusoto/services/datapipeline/src/generated.rs
+++ b/rusoto/services/datapipeline/src/generated.rs
@@ -46,6 +46,7 @@ pub struct ActivatePipelineInput {
 
 /// <p>Contains the output of ActivatePipeline.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActivatePipelineOutput {}
 
 /// <p>Contains the parameters for AddTags.</p>
@@ -61,6 +62,7 @@ pub struct AddTagsInput {
 
 /// <p>Contains the output of AddTags.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddTagsOutput {}
 
 /// <p>Contains the parameters for CreatePipeline.</p>
@@ -84,6 +86,7 @@ pub struct CreatePipelineInput {
 
 /// <p>Contains the output of CreatePipeline.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreatePipelineOutput {
     /// <p>The ID that AWS Data Pipeline assigns the newly created pipeline. For example, <code>df-06372391ZG65EXAMPLE</code>.</p>
     #[serde(rename = "pipelineId")]
@@ -104,6 +107,7 @@ pub struct DeactivatePipelineInput {
 
 /// <p>Contains the output of DeactivatePipeline.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeactivatePipelineOutput {}
 
 /// <p>Contains the parameters for DeletePipeline.</p>
@@ -135,6 +139,7 @@ pub struct DescribeObjectsInput {
 
 /// <p>Contains the output of DescribeObjects.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeObjectsOutput {
     /// <p>Indicates whether there are more results to return.</p>
     #[serde(rename = "hasMoreResults")]
@@ -159,6 +164,7 @@ pub struct DescribePipelinesInput {
 
 /// <p>Contains the output of DescribePipelines.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribePipelinesOutput {
     /// <p>An array of descriptions for the specified pipelines.</p>
     #[serde(rename = "pipelineDescriptionList")]
@@ -181,6 +187,7 @@ pub struct EvaluateExpressionInput {
 
 /// <p>Contains the output of EvaluateExpression.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EvaluateExpressionOutput {
     /// <p>The evaluated expression.</p>
     #[serde(rename = "evaluatedExpression")]
@@ -217,6 +224,7 @@ pub struct GetPipelineDefinitionInput {
 
 /// <p>Contains the output of GetPipelineDefinition.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetPipelineDefinitionOutput {
     /// <p>The parameter objects used in the pipeline definition.</p>
     #[serde(rename = "parameterObjects")]
@@ -256,6 +264,7 @@ pub struct ListPipelinesInput {
 
 /// <p>Contains the output of ListPipelines.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListPipelinesOutput {
     /// <p>Indicates whether there are more results that can be obtained by a subsequent call.</p>
     #[serde(rename = "hasMoreResults")]
@@ -318,6 +327,7 @@ pub struct ParameterValue {
 
 /// <p>Contains pipeline metadata.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PipelineDescription {
     /// <p>Description of the pipeline.</p>
     #[serde(rename = "description")]
@@ -340,6 +350,7 @@ pub struct PipelineDescription {
 
 /// <p>Contains the name and identifier of a pipeline.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PipelineIdName {
     /// <p>The ID of the pipeline that was assigned by AWS Data Pipeline. This is a string of the form <code>df-297EG78HU43EEXAMPLE</code>.</p>
     #[serde(rename = "id")]
@@ -383,6 +394,7 @@ pub struct PollForTaskInput {
 
 /// <p>Contains the output of PollForTask.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PollForTaskOutput {
     /// <p>The information needed to complete the task that is being assigned to the task runner. One of the fields returned in this object is <code>taskId</code>, which contains an identifier for the task being assigned. The calling task runner uses <code>taskId</code> in subsequent calls to <a>ReportTaskProgress</a> and <a>SetTaskStatus</a>.</p>
     #[serde(rename = "taskObject")]
@@ -411,6 +423,7 @@ pub struct PutPipelineDefinitionInput {
 
 /// <p>Contains the output of PutPipelineDefinition.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutPipelineDefinitionOutput {
     /// <p>Indicates whether there were validation errors, and the pipeline definition is stored but cannot be activated until you correct the pipeline and call <code>PutPipelineDefinition</code> to commit the corrected pipeline.</p>
     #[serde(rename = "errored")]
@@ -459,6 +472,7 @@ pub struct QueryObjectsInput {
 
 /// <p>Contains the output of QueryObjects.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct QueryObjectsOutput {
     /// <p>Indicates whether there are more results that can be obtained by a subsequent call.</p>
     #[serde(rename = "hasMoreResults")]
@@ -487,6 +501,7 @@ pub struct RemoveTagsInput {
 
 /// <p>Contains the output of RemoveTags.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RemoveTagsOutput {}
 
 /// <p>Contains the parameters for ReportTaskProgress.</p>
@@ -503,6 +518,7 @@ pub struct ReportTaskProgressInput {
 
 /// <p>Contains the output of ReportTaskProgress.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReportTaskProgressOutput {
     /// <p>If true, the calling task runner should cancel processing of the task. The task runner does not need to call <a>SetTaskStatus</a> for canceled tasks.</p>
     #[serde(rename = "canceled")]
@@ -527,6 +543,7 @@ pub struct ReportTaskRunnerHeartbeatInput {
 
 /// <p>Contains the output of ReportTaskRunnerHeartbeat.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReportTaskRunnerHeartbeatOutput {
     /// <p>Indicates whether the calling task runner should terminate.</p>
     #[serde(rename = "terminate")]
@@ -584,6 +601,7 @@ pub struct SetTaskStatusInput {
 
 /// <p>Contains the output of SetTaskStatus.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SetTaskStatusOutput {}
 
 /// <p>Tags are key/value pairs defined by a user and associated with a pipeline to control access. AWS Data Pipeline allows you to associate ten tags per pipeline. For more information, see <a href="http://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-control-access.html">Controlling User Access to Pipelines</a> in the <i>AWS Data Pipeline Developer Guide</i>.</p>
@@ -599,6 +617,7 @@ pub struct Tag {
 
 /// <p>Contains information about a pipeline task that is assigned to a task runner.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TaskObject {
     /// <p>The ID of the pipeline task attempt object. AWS Data Pipeline uses this value to track how many times a task is attempted.</p>
     #[serde(rename = "attemptId")]
@@ -639,6 +658,7 @@ pub struct ValidatePipelineDefinitionInput {
 
 /// <p>Contains the output of ValidatePipelineDefinition.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ValidatePipelineDefinitionOutput {
     /// <p>Indicates whether there were validation errors.</p>
     #[serde(rename = "errored")]
@@ -655,6 +675,7 @@ pub struct ValidatePipelineDefinitionOutput {
 
 /// <p>Defines a validation error. Validation errors prevent pipeline activation. The set of validation errors that can be returned are defined by AWS Data Pipeline.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ValidationError {
     /// <p>A description of the validation error.</p>
     #[serde(rename = "errors")]
@@ -668,6 +689,7 @@ pub struct ValidationError {
 
 /// <p>Defines a validation warning. Validation warnings do not prevent pipeline activation. The set of validation warnings that can be returned are defined by AWS Data Pipeline.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ValidationWarning {
     /// <p>The identifier of the object that contains the validation warning.</p>
     #[serde(rename = "id")]

--- a/rusoto/services/dax/src/generated.rs
+++ b/rusoto/services/dax/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Contains all of the attributes of a specific DAX cluster.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Cluster {
     /// <p>The number of nodes in the cluster that are active (i.e., capable of serving requests).</p>
     #[serde(rename = "ActiveNodes")]
@@ -146,6 +147,7 @@ pub struct CreateClusterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateClusterResponse {
     /// <p>A description of the DAX cluster that you have created.</p>
     #[serde(rename = "Cluster")]
@@ -165,6 +167,7 @@ pub struct CreateParameterGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateParameterGroupResponse {
     /// <p>Represents the output of a <i>CreateParameterGroup</i> action.</p>
     #[serde(rename = "ParameterGroup")]
@@ -187,6 +190,7 @@ pub struct CreateSubnetGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateSubnetGroupResponse {
     /// <p>Represents the output of a <i>CreateSubnetGroup</i> operation.</p>
     #[serde(rename = "SubnetGroup")]
@@ -213,6 +217,7 @@ pub struct DecreaseReplicationFactorRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DecreaseReplicationFactorResponse {
     /// <p>A description of the DAX cluster, after you have decreased its replication factor.</p>
     #[serde(rename = "Cluster")]
@@ -228,6 +233,7 @@ pub struct DeleteClusterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteClusterResponse {
     /// <p>A description of the DAX cluster that is being deleted.</p>
     #[serde(rename = "Cluster")]
@@ -243,6 +249,7 @@ pub struct DeleteParameterGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteParameterGroupResponse {
     /// <p>A user-specified message for this action (i.e., a reason for deleting the parameter group).</p>
     #[serde(rename = "DeletionMessage")]
@@ -258,6 +265,7 @@ pub struct DeleteSubnetGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteSubnetGroupResponse {
     /// <p>A user-specified message for this action (i.e., a reason for deleting the subnet group).</p>
     #[serde(rename = "DeletionMessage")]
@@ -282,6 +290,7 @@ pub struct DescribeClustersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeClustersResponse {
     /// <p>The descriptions of your DAX clusters, in response to a <i>DescribeClusters</i> request.</p>
     #[serde(rename = "Clusters")]
@@ -306,6 +315,7 @@ pub struct DescribeDefaultParametersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeDefaultParametersResponse {
     /// <p>Provides an identifier to allow retrieval of paginated results.</p>
     #[serde(rename = "NextToken")]
@@ -350,6 +360,7 @@ pub struct DescribeEventsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEventsResponse {
     /// <p>An array of events. Each element in the array represents one event.</p>
     #[serde(rename = "Events")]
@@ -378,6 +389,7 @@ pub struct DescribeParameterGroupsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeParameterGroupsResponse {
     /// <p>Provides an identifier to allow retrieval of paginated results.</p>
     #[serde(rename = "NextToken")]
@@ -409,6 +421,7 @@ pub struct DescribeParametersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeParametersResponse {
     /// <p>Provides an identifier to allow retrieval of paginated results.</p>
     #[serde(rename = "NextToken")]
@@ -437,6 +450,7 @@ pub struct DescribeSubnetGroupsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeSubnetGroupsResponse {
     /// <p>Provides an identifier to allow retrieval of paginated results.</p>
     #[serde(rename = "NextToken")]
@@ -450,6 +464,7 @@ pub struct DescribeSubnetGroupsResponse {
 
 /// <p>Represents the information required for client programs to connect to the configuration endpoint for a DAX cluster, or to an individual node within the cluster.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Endpoint {
     /// <p>The DNS hostname of the endpoint.</p>
     #[serde(rename = "Address")]
@@ -463,6 +478,7 @@ pub struct Endpoint {
 
 /// <p>Represents a single occurrence of something interesting within the system. Some examples of events are creating a DAX cluster, adding or removing a node, or rebooting a node.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Event {
     /// <p>The date and time when the event occurred.</p>
     #[serde(rename = "Date")]
@@ -497,6 +513,7 @@ pub struct IncreaseReplicationFactorRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct IncreaseReplicationFactorResponse {
     /// <p>A description of the DAX cluster. with its new replication factor.</p>
     #[serde(rename = "Cluster")]
@@ -516,6 +533,7 @@ pub struct ListTagsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagsResponse {
     /// <p>If this value is present, there are additional results to be displayed. To retrieve them, call <code>ListTags</code> again, with <code>NextToken</code> set to this value.</p>
     #[serde(rename = "NextToken")]
@@ -529,6 +547,7 @@ pub struct ListTagsResponse {
 
 /// <p>Represents an individual node within a DAX cluster.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Node {
     /// <p>The Availability Zone (AZ) in which the node has been deployed.</p>
     #[serde(rename = "AvailabilityZone")]
@@ -558,6 +577,7 @@ pub struct Node {
 
 /// <p>Represents a parameter value that is applicable to a particular node type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct NodeTypeSpecificValue {
     /// <p>A node type to which the parameter value applies.</p>
     #[serde(rename = "NodeType")]
@@ -571,6 +591,7 @@ pub struct NodeTypeSpecificValue {
 
 /// <p>Describes a notification topic and its status. Notification topics are used for publishing DAX events to subscribers using Amazon Simple Notification Service (SNS).</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct NotificationConfiguration {
     /// <p>The Amazon Resource Name (ARN) that identifies the topic. </p>
     #[serde(rename = "TopicArn")]
@@ -584,6 +605,7 @@ pub struct NotificationConfiguration {
 
 /// <p>Describes an individual setting that controls some aspect of DAX behavior.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Parameter {
     /// <p>A range of values within which the parameter can be set.</p>
     #[serde(rename = "AllowedValues")]
@@ -629,6 +651,7 @@ pub struct Parameter {
 
 /// <p>A named set of parameters that are applied to all of the nodes in a DAX cluster.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ParameterGroup {
     /// <p>A description of the parameter group.</p>
     #[serde(rename = "Description")]
@@ -642,6 +665,7 @@ pub struct ParameterGroup {
 
 /// <p>The status of a parameter group.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ParameterGroupStatus {
     /// <p>The node IDs of one or more nodes to be rebooted.</p>
     #[serde(rename = "NodeIdsToReboot")]
@@ -681,6 +705,7 @@ pub struct RebootNodeRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RebootNodeResponse {
     /// <p>A description of the DAX cluster after a node has been rebooted.</p>
     #[serde(rename = "Cluster")]
@@ -690,6 +715,7 @@ pub struct RebootNodeResponse {
 
 /// <p>An individual VPC security group and its status.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SecurityGroupMembership {
     /// <p>The unique ID for this security group.</p>
     #[serde(rename = "SecurityGroupIdentifier")]
@@ -703,6 +729,7 @@ pub struct SecurityGroupMembership {
 
 /// <p>Represents the subnet associated with a DAX cluster. This parameter refers to subnets defined in Amazon Virtual Private Cloud (Amazon VPC) and used with DAX.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Subnet {
     /// <p>The Availability Zone (AZ) for subnet subnet.</p>
     #[serde(rename = "SubnetAvailabilityZone")]
@@ -716,6 +743,7 @@ pub struct Subnet {
 
 /// <p><p>Represents the output of one of the following actions:</p> <ul> <li> <p> <i>CreateSubnetGroup</i> </p> </li> <li> <p> <i>ModifySubnetGroup</i> </p> </li> </ul></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SubnetGroup {
     /// <p>The description of the subnet group.</p>
     #[serde(rename = "Description")]
@@ -759,6 +787,7 @@ pub struct TagResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TagResourceResponse {
     /// <p>The list of tags that are associated with the DAX resource.</p>
     #[serde(rename = "Tags")]
@@ -777,6 +806,7 @@ pub struct UntagResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UntagResourceResponse {
     /// <p>The tag keys that have been removed from the cluster.</p>
     #[serde(rename = "Tags")]
@@ -816,6 +846,7 @@ pub struct UpdateClusterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateClusterResponse {
     /// <p>A description of the DAX cluster, after it has been modified.</p>
     #[serde(rename = "Cluster")]
@@ -834,6 +865,7 @@ pub struct UpdateParameterGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateParameterGroupResponse {
     /// <p>The parameter group that has been modified.</p>
     #[serde(rename = "ParameterGroup")]
@@ -857,6 +889,7 @@ pub struct UpdateSubnetGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateSubnetGroupResponse {
     /// <p>The subnet group that has been modified.</p>
     #[serde(rename = "SubnetGroup")]

--- a/rusoto/services/devicefarm/src/generated.rs
+++ b/rusoto/services/devicefarm/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>A container for account-level settings within AWS Device Farm.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AccountSettings {
     /// <p>The AWS account number specified in the <code>AccountSettings</code> container.</p>
     #[serde(rename = "awsAccountNumber")]
@@ -67,6 +68,7 @@ pub struct AccountSettings {
 
 /// <p>Represents the output of a test. Examples of artifacts include logs and screenshots.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Artifact {
     /// <p>The artifact's ARN.</p>
     #[serde(rename = "arn")]
@@ -92,6 +94,7 @@ pub struct Artifact {
 
 /// <p>Represents the amount of CPU that an app is using on a physical device.</p> <p>Note that this does not represent system-wide CPU usage.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CPU {
     /// <p>The CPU's architecture, for example x86 or ARM.</p>
     #[serde(rename = "architecture")]
@@ -109,6 +112,7 @@ pub struct CPU {
 
 /// <p>Represents entity counters.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Counters {
     /// <p>The number of errored entities.</p>
     #[serde(rename = "errored")]
@@ -160,6 +164,7 @@ pub struct CreateDevicePoolRequest {
 
 /// <p>Represents the result of a create device pool request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDevicePoolResult {
     /// <p>The newly created device pool.</p>
     #[serde(rename = "devicePool")]
@@ -191,6 +196,7 @@ pub struct CreateInstanceProfileRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateInstanceProfileResult {
     /// <p>An object containing information about your instance profile.</p>
     #[serde(rename = "instanceProfile")]
@@ -249,6 +255,7 @@ pub struct CreateNetworkProfileRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateNetworkProfileResult {
     /// <p>The network profile that is returned by the create network profile request.</p>
     #[serde(rename = "networkProfile")]
@@ -270,6 +277,7 @@ pub struct CreateProjectRequest {
 
 /// <p>Represents the result of a create project request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateProjectResult {
     /// <p>The newly created project.</p>
     #[serde(rename = "project")]
@@ -343,6 +351,7 @@ pub struct CreateRemoteAccessSessionRequest {
 
 /// <p>Represents the server response from a request to create a remote access session.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateRemoteAccessSessionResult {
     /// <p>A container that describes the remote access session when the request to create a remote access session is sent.</p>
     #[serde(rename = "remoteAccessSession")]
@@ -370,6 +379,7 @@ pub struct CreateUploadRequest {
 
 /// <p>Represents the result of a create upload request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateUploadResult {
     /// <p>The newly created upload.</p>
     #[serde(rename = "upload")]
@@ -395,6 +405,7 @@ pub struct CreateVPCEConfigurationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateVPCEConfigurationResult {
     /// <p>An object containing information about your VPC endpoint configuration.</p>
     #[serde(rename = "vpceConfiguration")]
@@ -429,6 +440,7 @@ pub struct DeleteDevicePoolRequest {
 
 /// <p>Represents the result of a delete device pool request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteDevicePoolResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -439,6 +451,7 @@ pub struct DeleteInstanceProfileRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteInstanceProfileResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -449,6 +462,7 @@ pub struct DeleteNetworkProfileRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteNetworkProfileResult {}
 
 /// <p>Represents a request to the delete project operation.</p>
@@ -461,6 +475,7 @@ pub struct DeleteProjectRequest {
 
 /// <p>Represents the result of a delete project request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteProjectResult {}
 
 /// <p>Represents the request to delete the specified remote access session.</p>
@@ -473,6 +488,7 @@ pub struct DeleteRemoteAccessSessionRequest {
 
 /// <p>The response from the server when a request is made to delete the remote access session.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteRemoteAccessSessionResult {}
 
 /// <p>Represents a request to the delete run operation.</p>
@@ -485,6 +501,7 @@ pub struct DeleteRunRequest {
 
 /// <p>Represents the result of a delete run request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteRunResult {}
 
 /// <p>Represents a request to the delete upload operation.</p>
@@ -497,6 +514,7 @@ pub struct DeleteUploadRequest {
 
 /// <p>Represents the result of a delete upload request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteUploadResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -507,10 +525,12 @@ pub struct DeleteVPCEConfigurationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteVPCEConfigurationResult {}
 
 /// <p>Represents a device type that an app is tested against.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Device {
     /// <p>The device's ARN.</p>
     #[serde(rename = "arn")]
@@ -596,6 +616,7 @@ pub struct Device {
 
 /// <p>Represents the device instance.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeviceInstance {
     /// <p>The Amazon Resource Name (ARN) of the device instance.</p>
     #[serde(rename = "arn")]
@@ -625,6 +646,7 @@ pub struct DeviceInstance {
 
 /// <p>Represents the total (metered or unmetered) minutes used by the resource to run tests. Contains the sum of minutes consumed by all children.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeviceMinutes {
     /// <p>When specified, represents only the sum of metered minutes used by the resource to run tests.</p>
     #[serde(rename = "metered")]
@@ -642,6 +664,7 @@ pub struct DeviceMinutes {
 
 /// <p>Represents a collection of device types.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DevicePool {
     /// <p>The device pool's ARN.</p>
     #[serde(rename = "arn")]
@@ -667,6 +690,7 @@ pub struct DevicePool {
 
 /// <p>Represents a device pool compatibility result.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DevicePoolCompatibilityResult {
     /// <p>Whether the result was compatible with the device pool.</p>
     #[serde(rename = "compatible")]
@@ -709,6 +733,7 @@ pub struct GetAccountSettingsRequest {}
 
 /// <p>Represents the account settings return values from the <code>GetAccountSettings</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetAccountSettingsResult {
     /// <p>The account settings.</p>
     #[serde(rename = "accountSettings")]
@@ -724,6 +749,7 @@ pub struct GetDeviceInstanceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDeviceInstanceResult {
     /// <p>An object containing information about your device instance.</p>
     #[serde(rename = "deviceInstance")]
@@ -757,6 +783,7 @@ pub struct GetDevicePoolCompatibilityRequest {
 
 /// <p>Represents the result of describe device pool compatibility request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDevicePoolCompatibilityResult {
     /// <p>Information about compatible devices.</p>
     #[serde(rename = "compatibleDevices")]
@@ -778,6 +805,7 @@ pub struct GetDevicePoolRequest {
 
 /// <p>Represents the result of a get device pool request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDevicePoolResult {
     /// <p>An object containing information about the requested device pool.</p>
     #[serde(rename = "devicePool")]
@@ -795,6 +823,7 @@ pub struct GetDeviceRequest {
 
 /// <p>Represents the result of a get device request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDeviceResult {
     /// <p>An object containing information about the requested device.</p>
     #[serde(rename = "device")]
@@ -810,6 +839,7 @@ pub struct GetInstanceProfileRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetInstanceProfileResult {
     /// <p>An object containing information about your instance profile.</p>
     #[serde(rename = "instanceProfile")]
@@ -827,6 +857,7 @@ pub struct GetJobRequest {
 
 /// <p>Represents the result of a get job request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetJobResult {
     /// <p>An object containing information about the requested job.</p>
     #[serde(rename = "job")]
@@ -842,6 +873,7 @@ pub struct GetNetworkProfileRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetNetworkProfileResult {
     /// <p>The network profile.</p>
     #[serde(rename = "networkProfile")]
@@ -860,6 +892,7 @@ pub struct GetOfferingStatusRequest {
 
 /// <p>Returns the status result for a device offering.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetOfferingStatusResult {
     /// <p>When specified, gets the offering status for the current period.</p>
     #[serde(rename = "current")]
@@ -885,6 +918,7 @@ pub struct GetProjectRequest {
 
 /// <p>Represents the result of a get project request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetProjectResult {
     /// <p>The project you wish to get information about.</p>
     #[serde(rename = "project")]
@@ -902,6 +936,7 @@ pub struct GetRemoteAccessSessionRequest {
 
 /// <p>Represents the response from the server that lists detailed information about the remote access session.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetRemoteAccessSessionResult {
     /// <p>A container that lists detailed information about the remote access session.</p>
     #[serde(rename = "remoteAccessSession")]
@@ -919,6 +954,7 @@ pub struct GetRunRequest {
 
 /// <p>Represents the result of a get run request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetRunResult {
     /// <p>The run you wish to get results from.</p>
     #[serde(rename = "run")]
@@ -936,6 +972,7 @@ pub struct GetSuiteRequest {
 
 /// <p>Represents the result of a get suite request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetSuiteResult {
     /// <p>A collection of one or more tests.</p>
     #[serde(rename = "suite")]
@@ -953,6 +990,7 @@ pub struct GetTestRequest {
 
 /// <p>Represents the result of a get test request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetTestResult {
     /// <p>A test condition that is evaluated.</p>
     #[serde(rename = "test")]
@@ -970,6 +1008,7 @@ pub struct GetUploadRequest {
 
 /// <p>Represents the result of a get upload request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetUploadResult {
     /// <p>An app or a set of one or more tests to upload or that have been uploaded.</p>
     #[serde(rename = "upload")]
@@ -985,6 +1024,7 @@ pub struct GetVPCEConfigurationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetVPCEConfigurationResult {
     /// <p>An object containing information about your VPC endpoint configuration.</p>
     #[serde(rename = "vpceConfiguration")]
@@ -994,6 +1034,7 @@ pub struct GetVPCEConfigurationResult {
 
 /// <p>Represents information about incompatibility.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct IncompatibilityMessage {
     /// <p>A message about the incompatibility.</p>
     #[serde(rename = "message")]
@@ -1018,6 +1059,7 @@ pub struct InstallToRemoteAccessSessionRequest {
 
 /// <p>Represents the response from the server after AWS Device Farm makes a request to install to a remote access session.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstallToRemoteAccessSessionResult {
     /// <p>An app to upload or that has been uploaded.</p>
     #[serde(rename = "appUpload")]
@@ -1027,6 +1069,7 @@ pub struct InstallToRemoteAccessSessionResult {
 
 /// <p>Represents the instance profile.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceProfile {
     /// <p>The Amazon Resource Name (ARN) of the instance profile.</p>
     #[serde(rename = "arn")]
@@ -1056,6 +1099,7 @@ pub struct InstanceProfile {
 
 /// <p>Represents a device.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Job {
     /// <p>The job's ARN.</p>
     #[serde(rename = "arn")]
@@ -1128,6 +1172,7 @@ pub struct ListArtifactsRequest {
 
 /// <p>Represents the result of a list artifacts operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListArtifactsResult {
     /// <p>Information about the artifacts.</p>
     #[serde(rename = "artifacts")]
@@ -1152,6 +1197,7 @@ pub struct ListDeviceInstancesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListDeviceInstancesResult {
     /// <p>An object containing information about your device instances.</p>
     #[serde(rename = "deviceInstances")]
@@ -1181,6 +1227,7 @@ pub struct ListDevicePoolsRequest {
 
 /// <p>Represents the result of a list device pools request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListDevicePoolsResult {
     /// <p>Information about the device pools.</p>
     #[serde(rename = "devicePools")]
@@ -1207,6 +1254,7 @@ pub struct ListDevicesRequest {
 
 /// <p>Represents the result of a list devices operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListDevicesResult {
     /// <p>Information about the devices.</p>
     #[serde(rename = "devices")]
@@ -1231,6 +1279,7 @@ pub struct ListInstanceProfilesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListInstanceProfilesResult {
     /// <p>An object containing information about your instance profiles.</p>
     #[serde(rename = "instanceProfiles")]
@@ -1256,6 +1305,7 @@ pub struct ListJobsRequest {
 
 /// <p>Represents the result of a list jobs request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListJobsResult {
     /// <p>Information about the jobs.</p>
     #[serde(rename = "jobs")]
@@ -1283,6 +1333,7 @@ pub struct ListNetworkProfilesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListNetworkProfilesResult {
     /// <p>A list of the available network profiles.</p>
     #[serde(rename = "networkProfiles")]
@@ -1303,6 +1354,7 @@ pub struct ListOfferingPromotionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListOfferingPromotionsResult {
     /// <p>An identifier to be used in the next call to this operation, to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1325,6 +1377,7 @@ pub struct ListOfferingTransactionsRequest {
 
 /// <p>Returns the transaction log of the specified offerings.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListOfferingTransactionsResult {
     /// <p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1347,6 +1400,7 @@ pub struct ListOfferingsRequest {
 
 /// <p>Represents the return values of the list of offerings.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListOfferingsResult {
     /// <p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1373,6 +1427,7 @@ pub struct ListProjectsRequest {
 
 /// <p>Represents the result of a list projects request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListProjectsResult {
     /// <p>If the number of items that are returned is significantly large, this is an identifier that is also returned, which can be used in a subsequent call to this operation to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1398,6 +1453,7 @@ pub struct ListRemoteAccessSessionsRequest {
 
 /// <p>Represents the response from the server after AWS Device Farm makes a request to return information about the remote access session.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListRemoteAccessSessionsResult {
     /// <p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1423,6 +1479,7 @@ pub struct ListRunsRequest {
 
 /// <p>Represents the result of a list runs request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListRunsResult {
     /// <p>If the number of items that are returned is significantly large, this is an identifier that is also returned, which can be used in a subsequent call to this operation to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1448,6 +1505,7 @@ pub struct ListSamplesRequest {
 
 /// <p>Represents the result of a list samples request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListSamplesResult {
     /// <p>If the number of items that are returned is significantly large, this is an identifier that is also returned, which can be used in a subsequent call to this operation to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1473,6 +1531,7 @@ pub struct ListSuitesRequest {
 
 /// <p>Represents the result of a list suites request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListSuitesResult {
     /// <p>If the number of items that are returned is significantly large, this is an identifier that is also returned, which can be used in a subsequent call to this operation to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1498,6 +1557,7 @@ pub struct ListTestsRequest {
 
 /// <p>Represents the result of a list tests request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTestsResult {
     /// <p>If the number of items that are returned is significantly large, this is an identifier that is also returned, which can be used in a subsequent call to this operation to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1523,6 +1583,7 @@ pub struct ListUniqueProblemsRequest {
 
 /// <p>Represents the result of a list unique problems request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListUniqueProblemsResult {
     /// <p>If the number of items that are returned is significantly large, this is an identifier that is also returned, which can be used in a subsequent call to this operation to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1548,6 +1609,7 @@ pub struct ListUploadsRequest {
 
 /// <p>Represents the result of a list uploads request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListUploadsResult {
     /// <p>If the number of items that are returned is significantly large, this is an identifier that is also returned, which can be used in a subsequent call to this operation to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1572,6 +1634,7 @@ pub struct ListVPCEConfigurationsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListVPCEConfigurationsResult {
     /// <p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>
     #[serde(rename = "nextToken")]
@@ -1596,6 +1659,7 @@ pub struct Location {
 
 /// <p>A number representing the monetary amount for an offering or transaction.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MonetaryAmount {
     /// <p>The numerical amount of an offering or transaction.</p>
     #[serde(rename = "amount")]
@@ -1609,6 +1673,7 @@ pub struct MonetaryAmount {
 
 /// <p>An array of settings that describes characteristics of a network profile.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct NetworkProfile {
     /// <p>The Amazon Resource Name (ARN) of the network profile.</p>
     #[serde(rename = "arn")]
@@ -1662,6 +1727,7 @@ pub struct NetworkProfile {
 
 /// <p>Represents the metadata of a device offering.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Offering {
     /// <p>A string describing the offering.</p>
     #[serde(rename = "description")]
@@ -1687,6 +1753,7 @@ pub struct Offering {
 
 /// <p>Represents information about an offering promotion.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct OfferingPromotion {
     /// <p>A string describing the offering promotion.</p>
     #[serde(rename = "description")]
@@ -1700,6 +1767,7 @@ pub struct OfferingPromotion {
 
 /// <p>The status of the offering.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct OfferingStatus {
     /// <p>The date on which the offering is effective.</p>
     #[serde(rename = "effectiveOn")]
@@ -1721,6 +1789,7 @@ pub struct OfferingStatus {
 
 /// <p>Represents the metadata of an offering transaction.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct OfferingTransaction {
     /// <p>The cost of an offering transaction.</p>
     #[serde(rename = "cost")]
@@ -1746,6 +1815,7 @@ pub struct OfferingTransaction {
 
 /// <p>Represents a specific warning or failure.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Problem {
     /// <p>Information about the associated device.</p>
     #[serde(rename = "device")]
@@ -1779,6 +1849,7 @@ pub struct Problem {
 
 /// <p>Information about a problem detail.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ProblemDetail {
     /// <p>The problem detail's ARN.</p>
     #[serde(rename = "arn")]
@@ -1792,6 +1863,7 @@ pub struct ProblemDetail {
 
 /// <p>Represents an operating-system neutral workspace for running and managing tests.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Project {
     /// <p>The project's ARN.</p>
     #[serde(rename = "arn")]
@@ -1830,6 +1902,7 @@ pub struct PurchaseOfferingRequest {
 
 /// <p>The result of the purchase offering (e.g., success or failure).</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PurchaseOfferingResult {
     /// <p>Represents the offering transaction for the purchase result.</p>
     #[serde(rename = "offeringTransaction")]
@@ -1860,6 +1933,7 @@ pub struct Radios {
 
 /// <p>Specifies whether charges for devices will be recurring.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RecurringCharge {
     /// <p>The cost of the recurring charge.</p>
     #[serde(rename = "cost")]
@@ -1873,6 +1947,7 @@ pub struct RecurringCharge {
 
 /// <p>Represents information about the remote access session.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RemoteAccessSession {
     /// <p>The Amazon Resource Name (ARN) of the remote access session.</p>
     #[serde(rename = "arn")]
@@ -1975,6 +2050,7 @@ pub struct RenewOfferingRequest {
 
 /// <p>The result of a renewal offering.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RenewOfferingResult {
     /// <p>Represents the status of the offering transaction for the renewal.</p>
     #[serde(rename = "offeringTransaction")]
@@ -1984,6 +2060,7 @@ pub struct RenewOfferingResult {
 
 /// <p>Represents the screen resolution of a device in height and width, expressed in pixels.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Resolution {
     /// <p>The screen resolution's height, expressed in pixels.</p>
     #[serde(rename = "height")]
@@ -2014,6 +2091,7 @@ pub struct Rule {
 
 /// <p>Represents a test run on a set of devices with a given app package, test parameters, etc.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Run {
     /// <p>An app to upload or that has been uploaded.</p>
     #[serde(rename = "appUpload")]
@@ -2135,6 +2213,7 @@ pub struct Run {
 
 /// <p>Represents a sample of performance data.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Sample {
     /// <p>The sample's ARN.</p>
     #[serde(rename = "arn")]
@@ -2223,6 +2302,7 @@ pub struct ScheduleRunRequest {
 
 /// <p>Represents the result of a schedule run request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ScheduleRunResult {
     /// <p>Information about the scheduled run.</p>
     #[serde(rename = "run")]
@@ -2260,6 +2340,7 @@ pub struct StopRemoteAccessSessionRequest {
 
 /// <p>Represents the response from the server that describes the remote access session when AWS Device Farm stops the session.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopRemoteAccessSessionResult {
     /// <p>A container representing the metadata from the service about the remote access session you are stopping.</p>
     #[serde(rename = "remoteAccessSession")]
@@ -2277,6 +2358,7 @@ pub struct StopRunRequest {
 
 /// <p>Represents the results of your stop run attempt.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopRunResult {
     /// <p>The run that was stopped.</p>
     #[serde(rename = "run")]
@@ -2286,6 +2368,7 @@ pub struct StopRunResult {
 
 /// <p>Represents a collection of one or more tests.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Suite {
     /// <p>The suite's ARN.</p>
     #[serde(rename = "arn")]
@@ -2335,6 +2418,7 @@ pub struct Suite {
 
 /// <p>Represents a condition that is evaluated.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Test {
     /// <p>The test's ARN.</p>
     #[serde(rename = "arn")]
@@ -2384,6 +2468,7 @@ pub struct Test {
 
 /// <p>Represents information about free trial device minutes for an AWS account.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TrialMinutes {
     /// <p>The number of free trial minutes remaining in the account.</p>
     #[serde(rename = "remaining")]
@@ -2397,6 +2482,7 @@ pub struct TrialMinutes {
 
 /// <p>A collection of one or more problems, grouped by their result.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UniqueProblem {
     /// <p>A message about the unique problems' result.</p>
     #[serde(rename = "message")]
@@ -2424,6 +2510,7 @@ pub struct UpdateDeviceInstanceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateDeviceInstanceResult {
     /// <p>An object containing information about your device instance.</p>
     #[serde(rename = "deviceInstance")]
@@ -2453,6 +2540,7 @@ pub struct UpdateDevicePoolRequest {
 
 /// <p>Represents the result of an update device pool request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateDevicePoolResult {
     /// <p>The device pool you just updated.</p>
     #[serde(rename = "devicePool")]
@@ -2488,6 +2576,7 @@ pub struct UpdateInstanceProfileRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateInstanceProfileResult {
     /// <p>An object containing information about your instance profile.</p>
     #[serde(rename = "instanceProfile")]
@@ -2547,6 +2636,7 @@ pub struct UpdateNetworkProfileRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateNetworkProfileResult {
     /// <p>A list of the available network profiles.</p>
     #[serde(rename = "networkProfile")]
@@ -2572,6 +2662,7 @@ pub struct UpdateProjectRequest {
 
 /// <p>Represents the result of an update project request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateProjectResult {
     /// <p>The project you wish to update.</p>
     #[serde(rename = "project")]
@@ -2603,6 +2694,7 @@ pub struct UpdateVPCEConfigurationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateVPCEConfigurationResult {
     /// <p>An object containing information about your VPC endpoint configuration.</p>
     #[serde(rename = "vpceConfiguration")]
@@ -2612,6 +2704,7 @@ pub struct UpdateVPCEConfigurationResult {
 
 /// <p>An app or a set of one or more tests to upload or that have been uploaded.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Upload {
     /// <p>The upload's ARN.</p>
     #[serde(rename = "arn")]
@@ -2653,6 +2746,7 @@ pub struct Upload {
 
 /// <p>Represents an Amazon Virtual Private Cloud (VPC) endpoint configuration.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VPCEConfiguration {
     /// <p>The Amazon Resource Name (ARN) of the VPC endpoint configuration.</p>
     #[serde(rename = "arn")]

--- a/rusoto/services/directconnect/src/generated.rs
+++ b/rusoto/services/directconnect/src/generated.rs
@@ -131,6 +131,7 @@ pub struct AssociateVirtualInterfaceRequest {
 
 /// <p>A structure containing information about a BGP peer.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BGPPeer {
     #[serde(rename = "addressFamily")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -168,6 +169,7 @@ pub struct ConfirmConnectionRequest {
 
 /// <p>The response received when ConfirmConnection is called.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ConfirmConnectionResponse {
     #[serde(rename = "connectionState")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -191,6 +193,7 @@ pub struct ConfirmPrivateVirtualInterfaceRequest {
 
 /// <p>The response received when ConfirmPrivateVirtualInterface is called.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ConfirmPrivateVirtualInterfaceResponse {
     #[serde(rename = "virtualInterfaceState")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -206,6 +209,7 @@ pub struct ConfirmPublicVirtualInterfaceRequest {
 
 /// <p>The response received when ConfirmPublicVirtualInterface is called.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ConfirmPublicVirtualInterfaceResponse {
     #[serde(rename = "virtualInterfaceState")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -214,6 +218,7 @@ pub struct ConfirmPublicVirtualInterfaceResponse {
 
 /// <p>A connection represents the physical network connection between the AWS Direct Connect location and the customer.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Connection {
     /// <p>Deprecated in favor of awsDeviceV2.</p> <p>The Direct Connection endpoint which the physical connection terminates on.</p>
     #[serde(rename = "awsDevice")]
@@ -264,6 +269,7 @@ pub struct Connection {
 
 /// <p>A structure containing a list of connections.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Connections {
     /// <p>A list of connections.</p>
     #[serde(rename = "connections")]
@@ -286,6 +292,7 @@ pub struct CreateBGPPeerRequest {
 
 /// <p>The response received when CreateBGPPeer is called.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateBGPPeerResponse {
     #[serde(rename = "virtualInterface")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -319,6 +326,7 @@ pub struct CreateDirectConnectGatewayAssociationRequest {
 
 /// <p>Container for the response from the CreateDirectConnectGatewayAssociation API call</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDirectConnectGatewayAssociationResult {
     /// <p>The direct connect gateway association to be created.</p>
     #[serde(rename = "directConnectGatewayAssociation")]
@@ -340,6 +348,7 @@ pub struct CreateDirectConnectGatewayRequest {
 
 /// <p>Container for the response from the CreateDirectConnectGateway API call</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDirectConnectGatewayResult {
     /// <p>The direct connect gateway to be created.</p>
     #[serde(rename = "directConnectGateway")]
@@ -422,6 +431,7 @@ pub struct DeleteBGPPeerRequest {
 
 /// <p>The response received when DeleteBGPPeer is called.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteBGPPeerResponse {
     #[serde(rename = "virtualInterface")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -448,6 +458,7 @@ pub struct DeleteDirectConnectGatewayAssociationRequest {
 
 /// <p>Container for the response from the DeleteDirectConnectGatewayAssociation API call</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteDirectConnectGatewayAssociationResult {
     /// <p>The direct connect gateway association to be deleted.</p>
     #[serde(rename = "directConnectGatewayAssociation")]
@@ -465,6 +476,7 @@ pub struct DeleteDirectConnectGatewayRequest {
 
 /// <p>Container for the response from the DeleteDirectConnectGateway API call</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteDirectConnectGatewayResult {
     /// <p>The direct connect gateway to be deleted.</p>
     #[serde(rename = "directConnectGateway")]
@@ -481,6 +493,7 @@ pub struct DeleteInterconnectRequest {
 
 /// <p>The response received when DeleteInterconnect is called.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteInterconnectResponse {
     #[serde(rename = "interconnectState")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -504,6 +517,7 @@ pub struct DeleteVirtualInterfaceRequest {
 
 /// <p>The response received when DeleteVirtualInterface is called.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteVirtualInterfaceResponse {
     #[serde(rename = "virtualInterfaceState")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -526,6 +540,7 @@ pub struct DescribeConnectionLoaRequest {
 
 /// <p>The response received when DescribeConnectionLoa is called.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeConnectionLoaResponse {
     #[serde(rename = "loa")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -571,6 +586,7 @@ pub struct DescribeDirectConnectGatewayAssociationsRequest {
 
 /// <p>Container for the response from the DescribeDirectConnectGatewayAssociations API call</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeDirectConnectGatewayAssociationsResult {
     /// <p>Information about the direct connect gateway associations.</p>
     #[serde(rename = "directConnectGatewayAssociations")]
@@ -604,6 +620,7 @@ pub struct DescribeDirectConnectGatewayAttachmentsRequest {
 
 /// <p>Container for the response from the DescribeDirectConnectGatewayAttachments API call</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeDirectConnectGatewayAttachmentsResult {
     /// <p>Information about the direct connect gateway attachments.</p>
     #[serde(rename = "directConnectGatewayAttachments")]
@@ -633,6 +650,7 @@ pub struct DescribeDirectConnectGatewaysRequest {
 
 /// <p>Container for the response from the DescribeDirectConnectGateways API call</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeDirectConnectGatewaysResult {
     /// <p>Information about the direct connect gateways.</p>
     #[serde(rename = "directConnectGateways")]
@@ -667,6 +685,7 @@ pub struct DescribeInterconnectLoaRequest {
 
 /// <p>The response received when DescribeInterconnectLoa is called.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeInterconnectLoaResponse {
     #[serde(rename = "loa")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -716,6 +735,7 @@ pub struct DescribeTagsRequest {
 
 /// <p>The response received when DescribeTags is called.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeTagsResponse {
     /// <p>Information about the tags.</p>
     #[serde(rename = "resourceTags")]
@@ -736,6 +756,7 @@ pub struct DescribeVirtualInterfacesRequest {
 
 /// <p>A direct connect gateway is an intermediate object that enables you to connect virtual interfaces and virtual private gateways.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DirectConnectGateway {
     /// <p>The autonomous system number (ASN) for the Amazon side of the connection.</p>
     #[serde(rename = "amazonSideAsn")]
@@ -761,6 +782,7 @@ pub struct DirectConnectGateway {
 
 /// <p>The association between a direct connect gateway and virtual private gateway.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DirectConnectGatewayAssociation {
     #[serde(rename = "associationState")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -785,6 +807,7 @@ pub struct DirectConnectGatewayAssociation {
 
 /// <p>The association between a direct connect gateway and virtual interface.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DirectConnectGatewayAttachment {
     #[serde(rename = "attachmentState")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -820,6 +843,7 @@ pub struct DisassociateConnectionFromLagRequest {
 
 /// <p>An interconnect is a connection that can host other connections.</p> <p>Like a standard AWS Direct Connect connection, an interconnect represents the physical connection between an AWS Direct Connect partner's network and a specific Direct Connect location. An AWS Direct Connect partner who owns an interconnect can provision hosted connections on the interconnect for their end customers, thereby providing the end customers with connectivity to AWS services.</p> <p>The resources of the interconnect, including bandwidth and VLAN numbers, are shared by all of the hosted connections on the interconnect, and the owner of the interconnect determines how these resources are assigned.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Interconnect {
     /// <p>Deprecated in favor of awsDeviceV2.</p> <p>The Direct Connection endpoint which the physical connection terminates on.</p>
     #[serde(rename = "awsDevice")]
@@ -858,6 +882,7 @@ pub struct Interconnect {
 
 /// <p>A structure containing a list of interconnects.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Interconnects {
     /// <p>A list of interconnects.</p>
     #[serde(rename = "interconnects")]
@@ -867,6 +892,7 @@ pub struct Interconnects {
 
 /// <p>Describes a link aggregation group (LAG). A LAG is a connection that uses the Link Aggregation Control Protocol (LACP) to logically aggregate a bundle of physical connections. Like an interconnect, it can host other connections. All connections in a LAG must terminate on the same physical AWS Direct Connect endpoint, and must be the same bandwidth.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Lag {
     /// <p><p>Indicates whether the LAG can host other connections.</p> <note> <p>This is intended for use by AWS Direct Connect partners only.</p> </note></p>
     #[serde(rename = "allowsHostedConnections")]
@@ -920,6 +946,7 @@ pub struct Lag {
 
 /// <p>A structure containing a list of LAGs.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Lags {
     /// <p>A list of LAGs.</p>
     #[serde(rename = "lags")]
@@ -929,6 +956,7 @@ pub struct Lags {
 
 /// <p>A structure containing the Letter of Authorization - Connecting Facility Assignment (LOA-CFA) for a connection.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Loa {
     #[serde(rename = "loaContent")]
     #[serde(
@@ -944,6 +972,7 @@ pub struct Loa {
 
 /// <p>An AWS Direct Connect location where connections and interconnects can be requested.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Location {
     /// <p>The code used to indicate the AWS Direct Connect location.</p>
     #[serde(rename = "locationCode")]
@@ -961,6 +990,7 @@ pub struct Location {
 
 /// <p>A location is a network facility where AWS Direct Connect routers are available to be connected. Generally, these are colocation hubs where many network providers have equipment, and where cross connects can be delivered. Locations include a name and facility code, and must be provided when creating a connection.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Locations {
     /// <p>A list of colocation hubs where network providers have equipment. Most regions have multiple locations available.</p>
     #[serde(rename = "locations")]
@@ -1094,6 +1124,7 @@ pub struct NewPublicVirtualInterfaceAllocation {
 
 /// <p>The tags associated with a Direct Connect resource.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResourceTag {
     /// <p>The Amazon Resource Name (ARN) of the Direct Connect resource.</p>
     #[serde(rename = "resourceArn")]
@@ -1139,6 +1170,7 @@ pub struct TagResourceRequest {
 
 /// <p>The response received when TagResource is called.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TagResourceResponse {}
 
 /// <p>Container for the parameters to the UntagResource operation.</p>
@@ -1154,6 +1186,7 @@ pub struct UntagResourceRequest {
 
 /// <p>The response received when UntagResource is called.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UntagResourceResponse {}
 
 /// <p>Container for the parameters to the UpdateLag operation.</p>
@@ -1174,6 +1207,7 @@ pub struct UpdateLagRequest {
 
 /// <p>You can create one or more AWS Direct Connect private virtual interfaces linking to your virtual private gateway.</p> <p>Virtual private gateways can be managed using the Amazon Virtual Private Cloud (Amazon VPC) console or the <a href="http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-CreateVpnGateway.html">Amazon EC2 CreateVpnGateway action</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VirtualGateway {
     #[serde(rename = "virtualGatewayId")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1185,6 +1219,7 @@ pub struct VirtualGateway {
 
 /// <p>A structure containing a list of virtual private gateways.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VirtualGateways {
     /// <p>A list of virtual private gateways.</p>
     #[serde(rename = "virtualGateways")]
@@ -1194,6 +1229,7 @@ pub struct VirtualGateways {
 
 /// <p>A virtual interface (VLAN) transmits the traffic between the AWS Direct Connect location and the customer.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VirtualInterface {
     #[serde(rename = "addressFamily")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1267,6 +1303,7 @@ pub struct VirtualInterface {
 
 /// <p>A structure containing a list of virtual interfaces.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VirtualInterfaces {
     /// <p>A list of virtual interfaces.</p>
     #[serde(rename = "virtualInterfaces")]

--- a/rusoto/services/discovery/src/generated.rs
+++ b/rusoto/services/discovery/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Information about agents or connectors that were instructed to start collecting data. Information includes the agent/connector ID, a description of the operation, and whether the agent/connector configuration was updated.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AgentConfigurationStatus {
     /// <p>The agent/connector ID.</p>
     #[serde(rename = "agentId")]
@@ -47,6 +48,7 @@ pub struct AgentConfigurationStatus {
 
 /// <p>Information about agents or connectors associated with the user’s AWS account. Information includes agent or connector IDs, IP addresses, media access control (MAC) addresses, agent or connector health, hostname where the agent or connector resides, and agent version for each agent.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AgentInfo {
     /// <p>The agent or connector ID.</p>
     #[serde(rename = "agentId")]
@@ -92,6 +94,7 @@ pub struct AgentInfo {
 
 /// <p>Network details about the host where the agent/connector resides.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AgentNetworkInfo {
     /// <p>The IP address for the host where the agent/connector resides.</p>
     #[serde(rename = "ipAddress")]
@@ -114,10 +117,12 @@ pub struct AssociateConfigurationItemsToApplicationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociateConfigurationItemsToApplicationResponse {}
 
 /// <p>Tags for a configuration item. Tags are metadata that help you categorize IT assets.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ConfigurationTag {
     /// <p>The configuration ID for the item to tag. You can specify a list of keys and values.</p>
     #[serde(rename = "configurationId")]
@@ -153,6 +158,7 @@ pub struct CreateApplicationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateApplicationResponse {
     /// <p>Configuration ID of an application to be created.</p>
     #[serde(rename = "configurationId")]
@@ -171,10 +177,12 @@ pub struct CreateTagsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateTagsResponse {}
 
 /// <p>Inventory data for installed discovery agents.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CustomerAgentInfo {
     /// <p>Number of active discovery agents.</p>
     #[serde(rename = "activeAgents")]
@@ -201,6 +209,7 @@ pub struct CustomerAgentInfo {
 
 /// <p>Inventory data for installed discovery connectors.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CustomerConnectorInfo {
     /// <p>Number of active discovery connectors.</p>
     #[serde(rename = "activeConnectors")]
@@ -233,6 +242,7 @@ pub struct DeleteApplicationsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteApplicationsResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -247,6 +257,7 @@ pub struct DeleteTagsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteTagsResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -270,6 +281,7 @@ pub struct DescribeAgentsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAgentsResponse {
     /// <p>Lists agents or the Connector by ID or lists all agents/Connectors associated with your user account if you did not specify an agent/Connector ID. The output includes agent/Connector IDs, IP addresses, media access control (MAC) addresses, agent/Connector health, host name where the agent/Connector resides, and the version number of each agent/Connector.</p>
     #[serde(rename = "agentsInfo")]
@@ -289,6 +301,7 @@ pub struct DescribeConfigurationsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeConfigurationsResponse {
     /// <p>A key in the response map. The value is an array of data.</p>
     #[serde(rename = "configurations")]
@@ -313,6 +326,7 @@ pub struct DescribeExportConfigurationsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeExportConfigurationsResponse {
     /// <p>Returns export details. When the status is complete, the response includes a URL for an Amazon S3 bucket where you can view the data in a CSV file.</p>
     #[serde(rename = "exportsInfo")]
@@ -345,6 +359,7 @@ pub struct DescribeExportTasksRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeExportTasksResponse {
     /// <p>Contains one or more sets of export request details. When the status of a request is <code>SUCCEEDED</code>, the response includes a URL for an Amazon S3 bucket where you can view the data in a CSV file.</p>
     #[serde(rename = "exportsInfo")]
@@ -373,6 +388,7 @@ pub struct DescribeTagsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeTagsResponse {
     /// <p>The call returns a token. Use this token to get the next set of results.</p>
     #[serde(rename = "nextToken")]
@@ -395,9 +411,11 @@ pub struct DisassociateConfigurationItemsFromApplicationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisassociateConfigurationItemsFromApplicationResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ExportConfigurationsResponse {
     /// <p>A unique identifier that you can use to query the export status.</p>
     #[serde(rename = "exportId")]
@@ -421,6 +439,7 @@ pub struct ExportFilter {
 
 /// <p>Information regarding the export status of discovered data. The value is an array of objects.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ExportInfo {
     /// <p>A URL for an Amazon S3 bucket where you can review the exported data. The URL is displayed only if the export succeeded.</p>
     #[serde(rename = "configurationsDownloadUrl")]
@@ -470,6 +489,7 @@ pub struct Filter {
 pub struct GetDiscoverySummaryRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDiscoverySummaryResponse {
     /// <p>Details about discovered agents, including agent status and health.</p>
     #[serde(rename = "agentSummary")]
@@ -521,6 +541,7 @@ pub struct ListConfigurationsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListConfigurationsResponse {
     /// <p>Returns configuration details, including the configuration ID, attribute names, and attribute values.</p>
     #[serde(rename = "configurations")]
@@ -556,6 +577,7 @@ pub struct ListServerNeighborsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListServerNeighborsResponse {
     /// <p>Count of distinct servers that are one hop away from the given server.</p>
     #[serde(rename = "knownDependencyCount")]
@@ -572,6 +594,7 @@ pub struct ListServerNeighborsResponse {
 
 /// <p>Details about neighboring servers.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct NeighborConnectionDetail {
     /// <p>The number of open network connections with the neighboring server.</p>
     #[serde(rename = "connectionsCount")]
@@ -612,6 +635,7 @@ pub struct StartDataCollectionByAgentIdsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartDataCollectionByAgentIdsResponse {
     /// <p>Information about agents or the connector that were instructed to start collecting data. Information includes the agent/connector ID, a description of the operation performed, and whether the agent/connector configuration was updated.</p>
     #[serde(rename = "agentsConfigurationStatus")]
@@ -640,6 +664,7 @@ pub struct StartExportTaskRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartExportTaskResponse {
     /// <p>A unique identifier used to query the status of an export request.</p>
     #[serde(rename = "exportId")]
@@ -655,6 +680,7 @@ pub struct StopDataCollectionByAgentIdsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopDataCollectionByAgentIdsResponse {
     /// <p>Information about the agents or connector that were instructed to stop collecting data. Information includes the agent/connector ID, a description of the operation performed, and whether the agent/connector configuration was updated.</p>
     #[serde(rename = "agentsConfigurationStatus")]
@@ -700,6 +726,7 @@ pub struct UpdateApplicationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateApplicationResponse {}
 
 /// Errors returned by AssociateConfigurationItemsToApplication

--- a/rusoto/services/dms/src/generated.rs
+++ b/rusoto/services/dms/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Describes a quota for an AWS account, for example, the number of replication instances allowed.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AccountQuota {
     /// <p>The name of the AWS DMS quota for this AWS account.</p>
     #[serde(rename = "AccountQuotaName")]
@@ -58,10 +59,12 @@ pub struct AddTagsToResourceMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddTagsToResourceResponse {}
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AvailabilityZone {
     /// <p>The name of the availability zone.</p>
     #[serde(rename = "Name")]
@@ -71,6 +74,7 @@ pub struct AvailabilityZone {
 
 /// <p>The SSL certificate that can be used to encrypt connections between the endpoints and the replication instance.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Certificate {
     /// <p>The Amazon Resource Name (ARN) for the certificate.</p>
     #[serde(rename = "CertificateArn")]
@@ -120,6 +124,7 @@ pub struct Certificate {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Connection {
     /// <p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>
     #[serde(rename = "EndpointArn")]
@@ -227,6 +232,7 @@ pub struct CreateEndpointMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateEndpointResponse {
     /// <p>The endpoint that was created.</p>
     #[serde(rename = "Endpoint")]
@@ -267,6 +273,7 @@ pub struct CreateEventSubscriptionMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateEventSubscriptionResponse {
     /// <p>The event subscription that was created.</p>
     #[serde(rename = "EventSubscription")]
@@ -331,6 +338,7 @@ pub struct CreateReplicationInstanceMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateReplicationInstanceResponse {
     /// <p>The replication instance that was created.</p>
     #[serde(rename = "ReplicationInstance")]
@@ -358,6 +366,7 @@ pub struct CreateReplicationSubnetGroupMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateReplicationSubnetGroupResponse {
     /// <p>The replication subnet group that was created.</p>
     #[serde(rename = "ReplicationSubnetGroup")]
@@ -410,6 +419,7 @@ pub struct CreateReplicationTaskMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateReplicationTaskResponse {
     /// <p>The replication task that was created.</p>
     #[serde(rename = "ReplicationTask")]
@@ -425,6 +435,7 @@ pub struct DeleteCertificateMessage {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteCertificateResponse {
     /// <p>The Secure Sockets Layer (SSL) certificate.</p>
     #[serde(rename = "Certificate")]
@@ -442,6 +453,7 @@ pub struct DeleteEndpointMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteEndpointResponse {
     /// <p>The endpoint that was deleted.</p>
     #[serde(rename = "Endpoint")]
@@ -459,6 +471,7 @@ pub struct DeleteEventSubscriptionMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteEventSubscriptionResponse {
     /// <p>The event subscription that was deleted.</p>
     #[serde(rename = "EventSubscription")]
@@ -476,6 +489,7 @@ pub struct DeleteReplicationInstanceMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteReplicationInstanceResponse {
     /// <p>The replication instance that was deleted.</p>
     #[serde(rename = "ReplicationInstance")]
@@ -493,6 +507,7 @@ pub struct DeleteReplicationSubnetGroupMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteReplicationSubnetGroupResponse {}
 
 /// <p><p/></p>
@@ -505,6 +520,7 @@ pub struct DeleteReplicationTaskMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteReplicationTaskResponse {
     /// <p>The deleted replication task.</p>
     #[serde(rename = "ReplicationTask")]
@@ -518,6 +534,7 @@ pub struct DescribeAccountAttributesMessage {}
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAccountAttributesResponse {
     /// <p>Account quota information.</p>
     #[serde(rename = "AccountQuotas")]
@@ -542,6 +559,7 @@ pub struct DescribeCertificatesMessage {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeCertificatesResponse {
     /// <p>The Secure Sockets Layer (SSL) certificates associated with the replication instance.</p>
     #[serde(rename = "Certificates")]
@@ -572,6 +590,7 @@ pub struct DescribeConnectionsMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeConnectionsResponse {
     /// <p>A description of the connections.</p>
     #[serde(rename = "Connections")]
@@ -602,6 +621,7 @@ pub struct DescribeEndpointTypesMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEndpointTypesResponse {
     /// <p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>
     #[serde(rename = "Marker")]
@@ -632,6 +652,7 @@ pub struct DescribeEndpointsMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEndpointsResponse {
     /// <p>Endpoint description.</p>
     #[serde(rename = "Endpoints")]
@@ -658,6 +679,7 @@ pub struct DescribeEventCategoriesMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEventCategoriesResponse {
     /// <p>A list of event categories.</p>
     #[serde(rename = "EventCategoryGroupList")]
@@ -688,6 +710,7 @@ pub struct DescribeEventSubscriptionsMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEventSubscriptionsResponse {
     /// <p>A list of event subscriptions.</p>
     #[serde(rename = "EventSubscriptionsList")]
@@ -742,6 +765,7 @@ pub struct DescribeEventsMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEventsResponse {
     /// <p>The events described.</p>
     #[serde(rename = "Events")]
@@ -768,6 +792,7 @@ pub struct DescribeOrderableReplicationInstancesMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeOrderableReplicationInstancesResponse {
     /// <p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>
     #[serde(rename = "Marker")]
@@ -789,6 +814,7 @@ pub struct DescribeRefreshSchemasStatusMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeRefreshSchemasStatusResponse {
     /// <p>The status of the schema.</p>
     #[serde(rename = "RefreshSchemasStatus")]
@@ -812,6 +838,7 @@ pub struct DescribeReplicationInstanceTaskLogsMessage {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeReplicationInstanceTaskLogsResponse {
     /// <p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>.</p>
     #[serde(rename = "Marker")]
@@ -846,6 +873,7 @@ pub struct DescribeReplicationInstancesMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeReplicationInstancesResponse {
     /// <p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>
     #[serde(rename = "Marker")]
@@ -876,6 +904,7 @@ pub struct DescribeReplicationSubnetGroupsMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeReplicationSubnetGroupsResponse {
     /// <p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>
     #[serde(rename = "Marker")]
@@ -906,6 +935,7 @@ pub struct DescribeReplicationTaskAssessmentResultsMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeReplicationTaskAssessmentResultsResponse {
     /// <p>- The Amazon S3 bucket where the task assessment report is located. </p>
     #[serde(rename = "BucketName")]
@@ -940,6 +970,7 @@ pub struct DescribeReplicationTasksMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeReplicationTasksResponse {
     /// <p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>
     #[serde(rename = "Marker")]
@@ -969,6 +1000,7 @@ pub struct DescribeSchemasMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeSchemasResponse {
     /// <p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>
     #[serde(rename = "Marker")]
@@ -1002,6 +1034,7 @@ pub struct DescribeTableStatisticsMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeTableStatisticsResponse {
     /// <p> An optional pagination token provided by a previous request. If this parameter is specified, the response includes only records beyond the marker, up to the value specified by <code>MaxRecords</code>. </p>
     #[serde(rename = "Marker")]
@@ -1040,6 +1073,7 @@ pub struct DynamoDbSettings {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Endpoint {
     /// <p>The Amazon Resource Name (ARN) used for SSL connection to the endpoint.</p>
     #[serde(rename = "CertificateArn")]
@@ -1129,6 +1163,7 @@ pub struct Endpoint {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Event {
     /// <p>The date of the event.</p>
     #[serde(rename = "Date")]
@@ -1154,6 +1189,7 @@ pub struct Event {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EventCategoryGroup {
     /// <p> A list of event categories for a <code>SourceType</code> that you want to subscribe to. </p>
     #[serde(rename = "EventCategories")]
@@ -1167,6 +1203,7 @@ pub struct EventCategoryGroup {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EventSubscription {
     /// <p>The AWS DMS event notification subscription Id.</p>
     #[serde(rename = "CustSubscriptionId")]
@@ -1241,6 +1278,7 @@ pub struct ImportCertificateMessage {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ImportCertificateResponse {
     /// <p>The certificate to be uploaded.</p>
     #[serde(rename = "Certificate")]
@@ -1258,6 +1296,7 @@ pub struct ListTagsForResourceMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagsForResourceResponse {
     /// <p>A list of tags for the resource.</p>
     #[serde(rename = "TagList")]
@@ -1343,6 +1382,7 @@ pub struct ModifyEndpointMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ModifyEndpointResponse {
     /// <p>The modified endpoint.</p>
     #[serde(rename = "Endpoint")]
@@ -1376,6 +1416,7 @@ pub struct ModifyEventSubscriptionMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ModifyEventSubscriptionResponse {
     /// <p>The modified event subscription.</p>
     #[serde(rename = "EventSubscription")]
@@ -1433,6 +1474,7 @@ pub struct ModifyReplicationInstanceMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ModifyReplicationInstanceResponse {
     /// <p>The modified replication instance.</p>
     #[serde(rename = "ReplicationInstance")]
@@ -1457,6 +1499,7 @@ pub struct ModifyReplicationSubnetGroupMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ModifyReplicationSubnetGroupResponse {
     /// <p>The modified replication subnet group.</p>
     #[serde(rename = "ReplicationSubnetGroup")]
@@ -1502,6 +1545,7 @@ pub struct ModifyReplicationTaskMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ModifyReplicationTaskResponse {
     /// <p>The replication task that was modified.</p>
     #[serde(rename = "ReplicationTask")]
@@ -1564,6 +1608,7 @@ pub struct MongoDbSettings {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct OrderableReplicationInstance {
     /// <p>The default amount of storage (in gigabytes) that is allocated for the replication instance.</p>
     #[serde(rename = "DefaultAllocatedStorage")]
@@ -1607,6 +1652,7 @@ pub struct RebootReplicationInstanceMessage {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RebootReplicationInstanceResponse {
     /// <p>The replication instance that is being rebooted. </p>
     #[serde(rename = "ReplicationInstance")]
@@ -1627,6 +1673,7 @@ pub struct RefreshSchemasMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RefreshSchemasResponse {
     /// <p>The status of the refreshed schema.</p>
     #[serde(rename = "RefreshSchemasStatus")]
@@ -1636,6 +1683,7 @@ pub struct RefreshSchemasResponse {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RefreshSchemasStatus {
     /// <p>The Amazon Resource Name (ARN) string that uniquely identifies the endpoint.</p>
     #[serde(rename = "EndpointArn")]
@@ -1674,6 +1722,7 @@ pub struct ReloadTablesMessage {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReloadTablesResponse {
     /// <p>The Amazon Resource Name (ARN) of the replication task. </p>
     #[serde(rename = "ReplicationTaskArn")]
@@ -1694,10 +1743,12 @@ pub struct RemoveTagsFromResourceMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RemoveTagsFromResourceResponse {}
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReplicationInstance {
     /// <p>The amount of storage (in gigabytes) that is allocated for the replication instance.</p>
     #[serde(rename = "AllocatedStorage")]
@@ -1783,6 +1834,7 @@ pub struct ReplicationInstance {
 
 /// <p>Contains metadata for a replication instance task log.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReplicationInstanceTaskLog {
     /// <p>The size, in bytes, of the replication task log.</p>
     #[serde(rename = "ReplicationInstanceTaskLogSize")]
@@ -1800,6 +1852,7 @@ pub struct ReplicationInstanceTaskLog {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReplicationPendingModifiedValues {
     /// <p>The amount of storage (in gigabytes) that is allocated for the replication instance.</p>
     #[serde(rename = "AllocatedStorage")]
@@ -1821,6 +1874,7 @@ pub struct ReplicationPendingModifiedValues {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReplicationSubnetGroup {
     /// <p>The description of the replication subnet group.</p>
     #[serde(rename = "ReplicationSubnetGroupDescription")]
@@ -1846,6 +1900,7 @@ pub struct ReplicationSubnetGroup {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReplicationTask {
     /// <p>Indicates when you want a change data capture (CDC) operation to start. Use either CdcStartPosition or CdcStartTime to specify when you want a CDC operation to start. Specifying both values results in an error.</p> <p> The value can be in date, checkpoint, or LSN/SCN format.</p> <p>Date Example: --cdc-start-position “2018-03-08T12:12:12”</p> <p>Checkpoint Example: --cdc-start-position "checkpoint:V1#27#mysql-bin-changelog.157832:1975:-1:2002:677883278264080:mysql-bin-changelog.157832:1876#0#0#*#0#93"</p> <p>LSN Example: --cdc-start-position “mysql-bin-changelog.000024:373”</p>
     #[serde(rename = "CdcStartPosition")]
@@ -1919,6 +1974,7 @@ pub struct ReplicationTask {
 
 /// <p> The task assessment report in JSON format. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReplicationTaskAssessmentResult {
     /// <p> The task assessment results in JSON format. </p>
     #[serde(rename = "AssessmentResults")]
@@ -1952,6 +2008,7 @@ pub struct ReplicationTaskAssessmentResult {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReplicationTaskStats {
     /// <p>The elapsed time of the task, in milliseconds.</p>
     #[serde(rename = "ElapsedTimeMillis")]
@@ -2022,6 +2079,7 @@ pub struct StartReplicationTaskAssessmentMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartReplicationTaskAssessmentResponse {
     /// <p> The assessed replication task. </p>
     #[serde(rename = "ReplicationTask")]
@@ -2054,6 +2112,7 @@ pub struct StartReplicationTaskMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartReplicationTaskResponse {
     /// <p>The replication task started.</p>
     #[serde(rename = "ReplicationTask")]
@@ -2071,6 +2130,7 @@ pub struct StopReplicationTaskMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopReplicationTaskResponse {
     /// <p>The replication task stopped.</p>
     #[serde(rename = "ReplicationTask")]
@@ -2080,6 +2140,7 @@ pub struct StopReplicationTaskResponse {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Subnet {
     /// <p>The Availability Zone of the subnet.</p>
     #[serde(rename = "SubnetAvailabilityZone")]
@@ -2097,6 +2158,7 @@ pub struct Subnet {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SupportedEndpointType {
     /// <p>The type of endpoint.</p>
     #[serde(rename = "EndpointType")]
@@ -2118,6 +2180,7 @@ pub struct SupportedEndpointType {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TableStatistics {
     /// <p>The Data Definition Language (DDL) used to build and modify the structure of your tables.</p>
     #[serde(rename = "Ddls")]
@@ -2224,6 +2287,7 @@ pub struct TestConnectionMessage {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TestConnectionResponse {
     /// <p>The connection tested.</p>
     #[serde(rename = "Connection")]
@@ -2233,6 +2297,7 @@ pub struct TestConnectionResponse {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VpcSecurityGroupMembership {
     /// <p>The status of the VPC security group.</p>
     #[serde(rename = "Status")]

--- a/rusoto/services/ds/src/generated.rs
+++ b/rusoto/services/ds/src/generated.rs
@@ -43,6 +43,7 @@ pub struct AddIpRoutesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddIpRoutesResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -56,6 +57,7 @@ pub struct AddTagsToResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddTagsToResourceResult {}
 
 /// <p>Represents a named directory attribute.</p>
@@ -82,10 +84,12 @@ pub struct CancelSchemaExtensionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CancelSchemaExtensionResult {}
 
 /// <p>Contains information about a computer account in a directory.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Computer {
     /// <p>An array of <a>Attribute</a> objects containing the LDAP attributes that belong to the computer account.</p>
     #[serde(rename = "ComputerAttributes")]
@@ -103,6 +107,7 @@ pub struct Computer {
 
 /// <p>Points to a remote domain with which you are setting up a trust relationship. Conditional forwarders are required in order to set up a trust relationship with another domain.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ConditionalForwarder {
     /// <p>The IP addresses of the remote DNS server associated with RemoteDomainName. This is the IP address of the DNS server that your conditional forwarder points to.</p>
     #[serde(rename = "DnsIpAddrs")]
@@ -145,6 +150,7 @@ pub struct ConnectDirectoryRequest {
 
 /// <p>Contains the results of the <a>ConnectDirectory</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ConnectDirectoryResult {
     /// <p>The identifier of the new directory.</p>
     #[serde(rename = "DirectoryId")]
@@ -165,6 +171,7 @@ pub struct CreateAliasRequest {
 
 /// <p>Contains the results of the <a>CreateAlias</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateAliasResult {
     /// <p>The alias for the directory.</p>
     #[serde(rename = "Alias")]
@@ -200,6 +207,7 @@ pub struct CreateComputerRequest {
 
 /// <p>Contains the results for the <a>CreateComputer</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateComputerResult {
     /// <p>A <a>Computer</a> object that represents the computer account.</p>
     #[serde(rename = "Computer")]
@@ -223,6 +231,7 @@ pub struct CreateConditionalForwarderRequest {
 
 /// <p>The result of a CreateConditinalForwarder request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateConditionalForwarderResult {}
 
 /// <p>Contains the inputs for the <a>CreateDirectory</a> operation. </p>
@@ -253,6 +262,7 @@ pub struct CreateDirectoryRequest {
 
 /// <p>Contains the results of the <a>CreateDirectory</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDirectoryResult {
     /// <p>The identifier of the directory that was created.</p>
     #[serde(rename = "DirectoryId")]
@@ -288,6 +298,7 @@ pub struct CreateMicrosoftADRequest {
 
 /// <p>Result of a CreateMicrosoftAD request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateMicrosoftADResult {
     /// <p>The identifier of the directory that was created.</p>
     #[serde(rename = "DirectoryId")]
@@ -309,6 +320,7 @@ pub struct CreateSnapshotRequest {
 
 /// <p>Contains the results of the <a>CreateSnapshot</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateSnapshotResult {
     /// <p>The identifier of the snapshot that was created.</p>
     #[serde(rename = "SnapshotId")]
@@ -343,6 +355,7 @@ pub struct CreateTrustRequest {
 
 /// <p>The result of a CreateTrust request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateTrustResult {
     /// <p>A unique identifier for the trust relationship that was created.</p>
     #[serde(rename = "TrustId")]
@@ -363,6 +376,7 @@ pub struct DeleteConditionalForwarderRequest {
 
 /// <p>The result of a DeleteConditionalForwarder request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteConditionalForwarderResult {}
 
 /// <p>Contains the inputs for the <a>DeleteDirectory</a> operation.</p>
@@ -375,6 +389,7 @@ pub struct DeleteDirectoryRequest {
 
 /// <p>Contains the results of the <a>DeleteDirectory</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteDirectoryResult {
     /// <p>The directory identifier.</p>
     #[serde(rename = "DirectoryId")]
@@ -392,6 +407,7 @@ pub struct DeleteSnapshotRequest {
 
 /// <p>Contains the results of the <a>DeleteSnapshot</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteSnapshotResult {
     /// <p>The identifier of the directory snapshot that was deleted.</p>
     #[serde(rename = "SnapshotId")]
@@ -413,6 +429,7 @@ pub struct DeleteTrustRequest {
 
 /// <p>The result of a DeleteTrust request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteTrustResult {
     /// <p>The Trust ID of the trust relationship that was deleted.</p>
     #[serde(rename = "TrustId")]
@@ -433,6 +450,7 @@ pub struct DeregisterEventTopicRequest {
 
 /// <p>The result of a DeregisterEventTopic request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeregisterEventTopicResult {}
 
 /// <p>Describes a conditional forwarder.</p>
@@ -449,6 +467,7 @@ pub struct DescribeConditionalForwardersRequest {
 
 /// <p>The result of a DescribeConditionalForwarder request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeConditionalForwardersResult {
     /// <p>The list of conditional forwarders that have been created.</p>
     #[serde(rename = "ConditionalForwarders")]
@@ -475,6 +494,7 @@ pub struct DescribeDirectoriesRequest {
 
 /// <p>Contains the results of the <a>DescribeDirectories</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeDirectoriesResult {
     /// <p>The list of <a>DirectoryDescription</a> objects that were retrieved.</p> <p>It is possible that this list contains less than the number of items specified in the <i>Limit</i> member of the request. This occurs if there are less than the requested number of items left to retrieve, or if the limitations of the operation have been exceeded.</p>
     #[serde(rename = "DirectoryDescriptions")]
@@ -506,6 +526,7 @@ pub struct DescribeDomainControllersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeDomainControllersResult {
     /// <p>List of the <a>DomainController</a> objects that were retrieved.</p>
     #[serde(rename = "DomainControllers")]
@@ -532,6 +553,7 @@ pub struct DescribeEventTopicsRequest {
 
 /// <p>The result of a DescribeEventTopic request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEventTopicsResult {
     /// <p>A list of SNS topic names that receive status messages from the specified Directory ID.</p>
     #[serde(rename = "EventTopics")]
@@ -562,6 +584,7 @@ pub struct DescribeSnapshotsRequest {
 
 /// <p>Contains the results of the <a>DescribeSnapshots</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeSnapshotsResult {
     /// <p>If not null, more results are available. Pass this value in the <i>NextToken</i> member of a subsequent call to <a>DescribeSnapshots</a>.</p>
     #[serde(rename = "NextToken")]
@@ -596,6 +619,7 @@ pub struct DescribeTrustsRequest {
 
 /// <p>The result of a DescribeTrust request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeTrustsResult {
     /// <p>If not null, more results are available. Pass this value for the <i>NextToken</i> parameter in a subsequent call to <a>DescribeTrusts</a> to retrieve the next set of items.</p>
     #[serde(rename = "NextToken")]
@@ -626,6 +650,7 @@ pub struct DirectoryConnectSettings {
 
 /// <p>Contains information about an AD Connector directory.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DirectoryConnectSettingsDescription {
     /// <p>A list of the Availability Zones that the directory is in.</p>
     #[serde(rename = "AvailabilityZones")]
@@ -655,6 +680,7 @@ pub struct DirectoryConnectSettingsDescription {
 
 /// <p>Contains information about an AWS Directory Service directory.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DirectoryDescription {
     /// <p>The access URL for the directory, such as <code>http://&lt;alias&gt;.awsapps.com</code>. If no alias has been created for the directory, <code>&lt;alias&gt;</code> is the directory identifier, such as <code>d-XXXXXXXXXX</code>.</p>
     #[serde(rename = "AccessUrl")]
@@ -740,6 +766,7 @@ pub struct DirectoryDescription {
 
 /// <p>Contains directory limit information for a region.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DirectoryLimits {
     /// <p>The current number of cloud directories in the region.</p>
     #[serde(rename = "CloudOnlyDirectoriesCurrentCount")]
@@ -792,6 +819,7 @@ pub struct DirectoryVpcSettings {
 
 /// <p>Contains information about the directory.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DirectoryVpcSettingsDescription {
     /// <p>The list of Availability Zones that the directory is in.</p>
     #[serde(rename = "AvailabilityZones")]
@@ -821,6 +849,7 @@ pub struct DisableRadiusRequest {
 
 /// <p>Contains the results of the <a>DisableRadius</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisableRadiusResult {}
 
 /// <p>Contains the inputs for the <a>DisableSso</a> operation.</p>
@@ -841,10 +870,12 @@ pub struct DisableSsoRequest {
 
 /// <p>Contains the results of the <a>DisableSso</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisableSsoResult {}
 
 /// <p>Contains information about the domain controllers for a specified directory.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DomainController {
     /// <p>The Availability Zone where the domain controller is located.</p>
     #[serde(rename = "AvailabilityZone")]
@@ -901,6 +932,7 @@ pub struct EnableRadiusRequest {
 
 /// <p>Contains the results of the <a>EnableRadius</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EnableRadiusResult {}
 
 /// <p>Contains the inputs for the <a>EnableSso</a> operation.</p>
@@ -921,10 +953,12 @@ pub struct EnableSsoRequest {
 
 /// <p>Contains the results of the <a>EnableSso</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EnableSsoResult {}
 
 /// <p>Information about SNS topic and AWS Directory Service directory associations.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EventTopic {
     /// <p>The date and time of when you associated your directory with the SNS topic.</p>
     #[serde(rename = "CreatedDateTime")]
@@ -954,6 +988,7 @@ pub struct GetDirectoryLimitsRequest {}
 
 /// <p>Contains the results of the <a>GetDirectoryLimits</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDirectoryLimitsResult {
     /// <p>A <a>DirectoryLimits</a> object that contains the directory limits for the current region.</p>
     #[serde(rename = "DirectoryLimits")]
@@ -971,6 +1006,7 @@ pub struct GetSnapshotLimitsRequest {
 
 /// <p>Contains the results of the <a>GetSnapshotLimits</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetSnapshotLimitsResult {
     /// <p>A <a>SnapshotLimits</a> object that contains the manual snapshot limits for the specified directory.</p>
     #[serde(rename = "SnapshotLimits")]
@@ -993,6 +1029,7 @@ pub struct IpRoute {
 
 /// <p>Information about one or more IP address blocks.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct IpRouteInfo {
     /// <p>The date and time the address block was added to the directory.</p>
     #[serde(rename = "AddedDateTime")]
@@ -1036,6 +1073,7 @@ pub struct ListIpRoutesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListIpRoutesResult {
     /// <p>A list of <a>IpRoute</a>s.</p>
     #[serde(rename = "IpRoutesInfo")]
@@ -1063,6 +1101,7 @@ pub struct ListSchemaExtensionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListSchemaExtensionsResult {
     /// <p>If not null, more results are available. Pass this value for the <code>NextToken</code> parameter in a subsequent call to <code>ListSchemaExtensions</code> to retrieve the next set of items.</p>
     #[serde(rename = "NextToken")]
@@ -1090,6 +1129,7 @@ pub struct ListTagsForResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagsForResourceResult {
     /// <p>Reserved for future use.</p>
     #[serde(rename = "NextToken")]
@@ -1151,6 +1191,7 @@ pub struct RegisterEventTopicRequest {
 
 /// <p>The result of a RegisterEventTopic request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegisterEventTopicResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1164,6 +1205,7 @@ pub struct RemoveIpRoutesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RemoveIpRoutesResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1177,6 +1219,7 @@ pub struct RemoveTagsFromResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RemoveTagsFromResourceResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1193,6 +1236,7 @@ pub struct ResetUserPasswordRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResetUserPasswordResult {}
 
 /// <p>An object representing the inputs for the <a>RestoreFromSnapshot</a> operation.</p>
@@ -1205,10 +1249,12 @@ pub struct RestoreFromSnapshotRequest {
 
 /// <p>Contains the results of the <a>RestoreFromSnapshot</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RestoreFromSnapshotResult {}
 
 /// <p>Information about a schema extension.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SchemaExtensionInfo {
     /// <p>A description of the schema extension.</p>
     #[serde(rename = "Description")]
@@ -1242,6 +1288,7 @@ pub struct SchemaExtensionInfo {
 
 /// <p>Describes a directory snapshot.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Snapshot {
     /// <p>The directory identifier.</p>
     #[serde(rename = "DirectoryId")]
@@ -1271,6 +1318,7 @@ pub struct Snapshot {
 
 /// <p>Contains manual snapshot limit information for a directory.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SnapshotLimits {
     /// <p>The current number of manual snapshots of the directory.</p>
     #[serde(rename = "ManualSnapshotsCurrentCount")]
@@ -1303,6 +1351,7 @@ pub struct StartSchemaExtensionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartSchemaExtensionResult {
     /// <p>The identifier of the schema extension that will be applied.</p>
     #[serde(rename = "SchemaExtensionId")]
@@ -1323,6 +1372,7 @@ pub struct Tag {
 
 /// <p>Describes a trust relationship between an Microsoft AD in the AWS cloud and an external domain.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Trust {
     /// <p>The date and time that the trust relationship was created.</p>
     #[serde(rename = "CreatedDateTime")]
@@ -1382,6 +1432,7 @@ pub struct UpdateConditionalForwarderRequest {
 
 /// <p>The result of an UpdateConditionalForwarder request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateConditionalForwarderResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1395,6 +1446,7 @@ pub struct UpdateNumberOfDomainControllersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateNumberOfDomainControllersResult {}
 
 /// <p>Contains the inputs for the <a>UpdateRadius</a> operation.</p>
@@ -1410,6 +1462,7 @@ pub struct UpdateRadiusRequest {
 
 /// <p>Contains the results of the <a>UpdateRadius</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateRadiusResult {}
 
 /// <p>Initiates the verification of an existing trust relationship between a Microsoft AD in the AWS cloud and an external domain.</p>
@@ -1422,6 +1475,7 @@ pub struct VerifyTrustRequest {
 
 /// <p>Result of a VerifyTrust request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VerifyTrustResult {
     /// <p>The unique Trust ID of the trust relationship that was verified.</p>
     #[serde(rename = "TrustId")]

--- a/rusoto/services/dynamodb/src/generated.rs
+++ b/rusoto/services/dynamodb/src/generated.rs
@@ -103,6 +103,7 @@ pub struct AttributeValueUpdate {
 
 /// <p>Represents the properties of the scaling policy.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AutoScalingPolicyDescription {
     /// <p>The name of the scaling policy.</p>
     #[serde(rename = "PolicyName")]
@@ -130,6 +131,7 @@ pub struct AutoScalingPolicyUpdate {
 
 /// <p>Represents the autoscaling settings for a global table or global secondary index.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AutoScalingSettingsDescription {
     /// <p>Disabled autoscaling for this global table or global secondary index.</p>
     #[serde(rename = "AutoScalingDisabled")]
@@ -180,6 +182,7 @@ pub struct AutoScalingSettingsUpdate {
 
 /// <p>Represents the properties of a target tracking scaling policy.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AutoScalingTargetTrackingScalingPolicyConfigurationDescription {
     /// <p>Indicates whether scale in by the target tracking policy is disabled. If the value is true, scale in is disabled and the target tracking policy won't remove capacity from the scalable resource. Otherwise, scale in is enabled and the target tracking policy can remove capacity from the scalable resource. The default value is false.</p>
     #[serde(rename = "DisableScaleIn")]
@@ -220,6 +223,7 @@ pub struct AutoScalingTargetTrackingScalingPolicyConfigurationUpdate {
 
 /// <p>Contains the description of the backup created for the table.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BackupDescription {
     /// <p>Contains the details of the backup created for the table. </p>
     #[serde(rename = "BackupDetails")]
@@ -237,6 +241,7 @@ pub struct BackupDescription {
 
 /// <p>Contains the details of the backup created for the table.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BackupDetails {
     /// <p>ARN associated with the backup.</p>
     #[serde(rename = "BackupArn")]
@@ -258,6 +263,7 @@ pub struct BackupDetails {
 
 /// <p>Contains details for the backup.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BackupSummary {
     /// <p>ARN associated with the backup.</p>
     #[serde(rename = "BackupArn")]
@@ -306,6 +312,7 @@ pub struct BatchGetItemInput {
 
 /// <p>Represents the output of a <code>BatchGetItem</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchGetItemOutput {
     /// <p><p>The read capacity units consumed by the entire <code>BatchGetItem</code> operation.</p> <p>Each element consists of:</p> <ul> <li> <p> <code>TableName</code> - The table that consumed the provisioned throughput.</p> </li> <li> <p> <code>CapacityUnits</code> - The total number of capacity units consumed.</p> </li> </ul></p>
     #[serde(rename = "ConsumedCapacity")]
@@ -343,6 +350,7 @@ pub struct BatchWriteItemInput {
 
 /// <p>Represents the output of a <code>BatchWriteItem</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchWriteItemOutput {
     /// <p><p>The capacity units consumed by the entire <code>BatchWriteItem</code> operation.</p> <p>Each element consists of:</p> <ul> <li> <p> <code>TableName</code> - The table that consumed the provisioned throughput.</p> </li> <li> <p> <code>CapacityUnits</code> - The total number of capacity units consumed.</p> </li> </ul></p>
     #[serde(rename = "ConsumedCapacity")]
@@ -361,6 +369,7 @@ pub struct BatchWriteItemOutput {
 
 /// <p>Represents the amount of provisioned throughput capacity consumed on a table or an index.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Capacity {
     /// <p>The total number of capacity units consumed on a table or an index.</p>
     #[serde(rename = "CapacityUnits")]
@@ -382,6 +391,7 @@ pub struct Condition {
 
 /// <p>The capacity units consumed by an operation. The data returned includes the total provisioned throughput consumed, along with statistics for the table and any indexes involved in the operation. <code>ConsumedCapacity</code> is only returned if the request asked for it. For more information, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html">Provisioned Throughput</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ConsumedCapacity {
     /// <p>The total number of capacity units consumed by the operation.</p>
     #[serde(rename = "CapacityUnits")]
@@ -407,6 +417,7 @@ pub struct ConsumedCapacity {
 
 /// <p>Represents the continuous backups and point in time recovery settings on the table.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ContinuousBackupsDescription {
     /// <p> <code>ContinuousBackupsStatus</code> can be one of the following states : ENABLED, DISABLED</p>
     #[serde(rename = "ContinuousBackupsStatus")]
@@ -428,6 +439,7 @@ pub struct CreateBackupInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateBackupOutput {
     /// <p>Contains the details of the backup created for the table.</p>
     #[serde(rename = "BackupDetails")]
@@ -463,6 +475,7 @@ pub struct CreateGlobalTableInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateGlobalTableOutput {
     /// <p>Contains the details of the global table.</p>
     #[serde(rename = "GlobalTableDescription")]
@@ -513,6 +526,7 @@ pub struct CreateTableInput {
 
 /// <p>Represents the output of a <code>CreateTable</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateTableOutput {
     /// <p>Represents the properties of the table.</p>
     #[serde(rename = "TableDescription")]
@@ -528,6 +542,7 @@ pub struct DeleteBackupInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteBackupOutput {
     /// <p>Contains the description of the backup created for the table.</p>
     #[serde(rename = "BackupDescription")]
@@ -587,6 +602,7 @@ pub struct DeleteItemInput {
 
 /// <p>Represents the output of a <code>DeleteItem</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteItemOutput {
     /// <p>A map of attribute names to <code>AttributeValue</code> objects, representing the item as it appeared before the <code>DeleteItem</code> operation. This map appears in the response only if <code>ReturnValues</code> was specified as <code>ALL_OLD</code> in the request.</p>
     #[serde(rename = "Attributes")]
@@ -628,6 +644,7 @@ pub struct DeleteTableInput {
 
 /// <p>Represents the output of a <code>DeleteTable</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteTableOutput {
     /// <p>Represents the properties of a table.</p>
     #[serde(rename = "TableDescription")]
@@ -643,6 +660,7 @@ pub struct DescribeBackupInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeBackupOutput {
     /// <p>Contains the description of the backup created for the table.</p>
     #[serde(rename = "BackupDescription")]
@@ -658,6 +676,7 @@ pub struct DescribeContinuousBackupsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeContinuousBackupsOutput {
     /// <p>Represents the continuous backups and point in time recovery settings on the table.</p>
     #[serde(rename = "ContinuousBackupsDescription")]
@@ -673,6 +692,7 @@ pub struct DescribeGlobalTableInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeGlobalTableOutput {
     /// <p>Contains the details of the global table.</p>
     #[serde(rename = "GlobalTableDescription")]
@@ -688,6 +708,7 @@ pub struct DescribeGlobalTableSettingsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeGlobalTableSettingsOutput {
     /// <p>The name of the global table.</p>
     #[serde(rename = "GlobalTableName")]
@@ -705,6 +726,7 @@ pub struct DescribeLimitsInput {}
 
 /// <p>Represents the output of a <code>DescribeLimits</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeLimitsOutput {
     /// <p>The maximum total read capacity units that your account allows you to provision across all of your tables in this region.</p>
     #[serde(rename = "AccountMaxReadCapacityUnits")]
@@ -734,6 +756,7 @@ pub struct DescribeTableInput {
 
 /// <p>Represents the output of a <code>DescribeTable</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeTableOutput {
     /// <p>The properties of the table.</p>
     #[serde(rename = "Table")]
@@ -749,6 +772,7 @@ pub struct DescribeTimeToLiveInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeTimeToLiveOutput {
     /// <p><p/></p>
     #[serde(rename = "TimeToLiveDescription")]
@@ -809,6 +833,7 @@ pub struct GetItemInput {
 
 /// <p>Represents the output of a <code>GetItem</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetItemOutput {
     /// <p>The capacity units consumed by the <code>GetItem</code> operation. The data returned includes the total provisioned throughput consumed, along with statistics for the table and any indexes involved in the operation. <code>ConsumedCapacity</code> is only returned if the <code>ReturnConsumedCapacity</code> parameter was specified. For more information, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html">Provisioned Throughput</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
     #[serde(rename = "ConsumedCapacity")]
@@ -839,6 +864,7 @@ pub struct GlobalSecondaryIndex {
 
 /// <p>Represents the properties of a global secondary index.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GlobalSecondaryIndexDescription {
     /// <p><p>Indicates whether the index is currently backfilling. <i>Backfilling</i> is the process of reading items from the table and determining whether they can be added to the index. (Not all items will qualify: For example, a partition key cannot have any duplicate values.) If an item can be added to the index, DynamoDB will do so. After all items have been processed, the backfilling operation is complete and <code>Backfilling</code> is false.</p> <note> <p>For indexes that were created during a <code>CreateTable</code> operation, the <code>Backfilling</code> attribute does not appear in the <code>DescribeTable</code> output.</p> </note></p>
     #[serde(rename = "Backfilling")]
@@ -880,6 +906,7 @@ pub struct GlobalSecondaryIndexDescription {
 
 /// <p>Represents the properties of a global secondary index for the table when the backup was created.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GlobalSecondaryIndexInfo {
     /// <p>The name of the global secondary index.</p>
     #[serde(rename = "IndexName")]
@@ -918,6 +945,7 @@ pub struct GlobalSecondaryIndexUpdate {
 
 /// <p>Represents the properties of a global table.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GlobalTable {
     /// <p>The global table name.</p>
     #[serde(rename = "GlobalTableName")]
@@ -931,6 +959,7 @@ pub struct GlobalTable {
 
 /// <p>Contains details about the global table.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GlobalTableDescription {
     /// <p>The creation time of the global table.</p>
     #[serde(rename = "CreationDateTime")]
@@ -972,6 +1001,7 @@ pub struct GlobalTableGlobalSecondaryIndexSettingsUpdate {
 
 /// <p>Information about item collections, if any, that were affected by the operation. <code>ItemCollectionMetrics</code> is only returned if the request asked for it. If the table does not have any local secondary indexes, this information is not returned in the response.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ItemCollectionMetrics {
     /// <p>The partition key value of the item collection. This value is the same as the partition key value of the item.</p>
     #[serde(rename = "ItemCollectionKey")]
@@ -1043,6 +1073,7 @@ pub struct ListBackupsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListBackupsOutput {
     /// <p>List of <code>BackupSummary</code> objects.</p>
     #[serde(rename = "BackupSummaries")]
@@ -1071,6 +1102,7 @@ pub struct ListGlobalTablesInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListGlobalTablesOutput {
     /// <p>List of global table names.</p>
     #[serde(rename = "GlobalTables")]
@@ -1097,6 +1129,7 @@ pub struct ListTablesInput {
 
 /// <p>Represents the output of a <code>ListTables</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTablesOutput {
     /// <p>The name of the last table in the current page of results. Use this value as the <code>ExclusiveStartTableName</code> in a new request to obtain the next page of results, until all the table names are returned.</p> <p>If you do not receive a <code>LastEvaluatedTableName</code> value in the response, this means that there are no more table names to be retrieved.</p>
     #[serde(rename = "LastEvaluatedTableName")]
@@ -1120,6 +1153,7 @@ pub struct ListTagsOfResourceInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagsOfResourceOutput {
     /// <p>If this value is returned, there are additional results to be displayed. To retrieve them, call ListTagsOfResource again, with NextToken set to this value.</p>
     #[serde(rename = "NextToken")]
@@ -1147,6 +1181,7 @@ pub struct LocalSecondaryIndex {
 
 /// <p>Represents the properties of a local secondary index.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LocalSecondaryIndexDescription {
     /// <p>The Amazon Resource Name (ARN) that uniquely identifies the index.</p>
     #[serde(rename = "IndexArn")]
@@ -1176,6 +1211,7 @@ pub struct LocalSecondaryIndexDescription {
 
 /// <p>Represents the properties of a local secondary index for the table when the backup was created.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LocalSecondaryIndexInfo {
     /// <p>Represents the name of the local secondary index.</p>
     #[serde(rename = "IndexName")]
@@ -1193,6 +1229,7 @@ pub struct LocalSecondaryIndexInfo {
 
 /// <p>The description of the point in time settings applied to the table.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PointInTimeRecoveryDescription {
     /// <p>Specifies the earliest point in time you can restore your table to. It You can restore your table to any point in time during the last 35 days. </p>
     #[serde(rename = "EarliestRestorableDateTime")]
@@ -1242,6 +1279,7 @@ pub struct ProvisionedThroughput {
 
 /// <p>Represents the provisioned throughput settings for the table, consisting of read and write capacity units, along with data about increases and decreases.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ProvisionedThroughputDescription {
     /// <p>The date and time of the last provisioned throughput decrease for this table.</p>
     #[serde(rename = "LastDecreaseDateTime")]
@@ -1309,6 +1347,7 @@ pub struct PutItemInput {
 
 /// <p>Represents the output of a <code>PutItem</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutItemOutput {
     /// <p>The attribute values as they appeared before the <code>PutItem</code> operation, but only if <code>ReturnValues</code> is specified as <code>ALL_OLD</code> in the request. Each element consists of an attribute name and an attribute value.</p>
     #[serde(rename = "Attributes")]
@@ -1405,6 +1444,7 @@ pub struct QueryInput {
 
 /// <p>Represents the output of a <code>Query</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct QueryOutput {
     /// <p>The capacity units consumed by the <code>Query</code> operation. The data returned includes the total provisioned throughput consumed, along with statistics for the table and any indexes involved in the operation. <code>ConsumedCapacity</code> is only returned if the <code>ReturnConsumedCapacity</code> parameter was specified For more information, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html">Provisioned Throughput</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
     #[serde(rename = "ConsumedCapacity")]
@@ -1439,6 +1479,7 @@ pub struct Replica {
 
 /// <p>Contains the details of the replica.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReplicaDescription {
     /// <p>The name of the region.</p>
     #[serde(rename = "RegionName")]
@@ -1448,6 +1489,7 @@ pub struct ReplicaDescription {
 
 /// <p>Represents the properties of a global secondary index.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReplicaGlobalSecondaryIndexSettingsDescription {
     /// <p>The name of the global secondary index. The name must be unique among all other indexes on this table.</p>
     #[serde(rename = "IndexName")]
@@ -1492,6 +1534,7 @@ pub struct ReplicaGlobalSecondaryIndexSettingsUpdate {
 
 /// <p>Represents the properties of a replica.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReplicaSettingsDescription {
     /// <p>The region name of the replica.</p>
     #[serde(rename = "RegionName")]
@@ -1562,6 +1605,7 @@ pub struct ReplicaUpdate {
 
 /// <p>Contains details for the restore.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RestoreSummary {
     /// <p>Point in time or source backup time.</p>
     #[serde(rename = "RestoreDateTime")]
@@ -1590,6 +1634,7 @@ pub struct RestoreTableFromBackupInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RestoreTableFromBackupOutput {
     /// <p>The description of the table created from an existing backup.</p>
     #[serde(rename = "TableDescription")]
@@ -1616,6 +1661,7 @@ pub struct RestoreTableToPointInTimeInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RestoreTableToPointInTimeOutput {
     /// <p>Represents the properties of a table.</p>
     #[serde(rename = "TableDescription")]
@@ -1625,6 +1671,7 @@ pub struct RestoreTableToPointInTimeOutput {
 
 /// <p>The description of the server-side encryption status on the specified table.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SSEDescription {
     /// <p>The KMS master key ARN used for the KMS encryption.</p>
     #[serde(rename = "KMSMasterKeyArn")]
@@ -1717,6 +1764,7 @@ pub struct ScanInput {
 
 /// <p>Represents the output of a <code>Scan</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ScanOutput {
     /// <p>The capacity units consumed by the <code>Scan</code> operation. The data returned includes the total provisioned throughput consumed, along with statistics for the table and any indexes involved in the operation. <code>ConsumedCapacity</code> is only returned if the <code>ReturnConsumedCapacity</code> parameter was specified. For more information, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html">Provisioned Throughput</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
     #[serde(rename = "ConsumedCapacity")]
@@ -1742,6 +1790,7 @@ pub struct ScanOutput {
 
 /// <p>Contains the details of the table when the backup was created. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SourceTableDetails {
     /// <p>Number of items in the table. Please note this is an approximate value. </p>
     #[serde(rename = "ItemCount")]
@@ -1774,6 +1823,7 @@ pub struct SourceTableDetails {
 
 /// <p>Contains the details of the features enabled on the table when the backup was created. For example, LSIs, GSIs, streams, TTL. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SourceTableFeatureDetails {
     /// <p>Represents the GSI properties for the table when the backup was created. It includes the IndexName, KeySchema, Projection and ProvisionedThroughput for the GSIs on the table at the time of backup. </p>
     #[serde(rename = "GlobalSecondaryIndexes")]
@@ -1812,6 +1862,7 @@ pub struct StreamSpecification {
 
 /// <p>Represents the properties of a table.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TableDescription {
     /// <p><p>An array of <code>AttributeDefinition</code> objects. Each of these objects describes one attribute in the table and index key schema.</p> <p>Each <code>AttributeDefinition</code> object in this array is composed of:</p> <ul> <li> <p> <code>AttributeName</code> - The name of the attribute.</p> </li> <li> <p> <code>AttributeType</code> - The data type for the attribute.</p> </li> </ul></p>
     #[serde(rename = "AttributeDefinitions")]
@@ -1906,6 +1957,7 @@ pub struct TagResourceInput {
 
 /// <p>The description of the Time to Live (TTL) status on the specified table. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TimeToLiveDescription {
     /// <p> The name of the Time to Live attribute for items in the table.</p>
     #[serde(rename = "AttributeName")]
@@ -1949,6 +2001,7 @@ pub struct UpdateContinuousBackupsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateContinuousBackupsOutput {
     /// <p>Represents the continuous backups and point in time recovery settings on the table.</p>
     #[serde(rename = "ContinuousBackupsDescription")]
@@ -1978,6 +2031,7 @@ pub struct UpdateGlobalTableInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateGlobalTableOutput {
     /// <p>Contains the details of the global table.</p>
     #[serde(rename = "GlobalTableDescription")]
@@ -2011,6 +2065,7 @@ pub struct UpdateGlobalTableSettingsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateGlobalTableSettingsOutput {
     /// <p>The name of the global table.</p>
     #[serde(rename = "GlobalTableName")]
@@ -2074,6 +2129,7 @@ pub struct UpdateItemInput {
 
 /// <p>Represents the output of an <code>UpdateItem</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateItemOutput {
     /// <p>A map of attribute values as they appear before or after the <code>UpdateItem</code> operation, as determined by the <code>ReturnValues</code> parameter.</p> <p>The <code>Attributes</code> map is only present if <code>ReturnValues</code> was specified as something other than <code>NONE</code> in the request. Each element represents one attribute.</p>
     #[serde(rename = "Attributes")]
@@ -2115,6 +2171,7 @@ pub struct UpdateTableInput {
 
 /// <p>Represents the output of an <code>UpdateTable</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateTableOutput {
     /// <p>Represents the properties of the table.</p>
     #[serde(rename = "TableDescription")]
@@ -2134,6 +2191,7 @@ pub struct UpdateTimeToLiveInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateTimeToLiveOutput {
     /// <p>Represents the output of an <code>UpdateTimeToLive</code> operation.</p>
     #[serde(rename = "TimeToLiveSpecification")]

--- a/rusoto/services/dynamodbstreams/src/generated.rs
+++ b/rusoto/services/dynamodbstreams/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Represents the data for an attribute. You can set one, and only one, of the elements.</p> <p>Each attribute in an item is a name-value pair. An attribute can be single-valued or multi-valued set. For example, a book item can have title and authors attributes. Each book has one title but can have many authors. The multi-valued attribute is a set; duplicate values are not allowed.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AttributeValue {
     /// <p>A Binary data type.</p>
     #[serde(rename = "B")]
@@ -95,6 +96,7 @@ pub struct DescribeStreamInput {
 
 /// <p>Represents the output of a <code>DescribeStream</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeStreamOutput {
     /// <p>A complete description of the stream, including its creation date and time, the DynamoDB table associated with the stream, the shard IDs within the stream, and the beginning and ending sequence numbers of stream records within the shards.</p>
     #[serde(rename = "StreamDescription")]
@@ -116,6 +118,7 @@ pub struct GetRecordsInput {
 
 /// <p>Represents the output of a <code>GetRecords</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetRecordsOutput {
     /// <p>The next position in the shard from which to start sequentially reading stream records. If set to <code>null</code>, the shard has been closed and the requested iterator will not return any more data.</p>
     #[serde(rename = "NextShardIterator")]
@@ -147,6 +150,7 @@ pub struct GetShardIteratorInput {
 
 /// <p>Represents the output of a <code>GetShardIterator</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetShardIteratorOutput {
     /// <p>The position in the shard from which to start reading stream records sequentially. A shard iterator specifies this position using the sequence number of a stream record in a shard.</p>
     #[serde(rename = "ShardIterator")]
@@ -156,6 +160,7 @@ pub struct GetShardIteratorOutput {
 
 /// <p>Contains details about the type of identity that made the request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Identity {
     /// <p>A unique identifier for the entity that made the call. For Time To Live, the principalId is "dynamodb.amazonaws.com".</p>
     #[serde(rename = "PrincipalId")]
@@ -169,6 +174,7 @@ pub struct Identity {
 
 /// <p><p>Represents <i>a single element</i> of a key schema. A key schema specifies the attributes that make up the primary key of a table, or the key attributes of an index.</p> <p>A <code>KeySchemaElement</code> represents exactly one attribute of the primary key. For example, a simple primary key (partition key) would be represented by one <code>KeySchemaElement</code>. A composite primary key (partition key and sort key) would require one <code>KeySchemaElement</code> for the partition key, and another <code>KeySchemaElement</code> for the sort key.</p> <note> <p>The partition key of an item is also known as its <i>hash attribute</i>. The term &quot;hash attribute&quot; derives from DynamoDB&#39;s usage of an internal hash function to evenly distribute data items across partitions, based on their partition key values.</p> <p>The sort key of an item is also known as its <i>range attribute</i>. The term &quot;range attribute&quot; derives from the way DynamoDB stores items with the same partition key physically close together, in sorted order by the sort key value.</p> </note></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct KeySchemaElement {
     /// <p>The name of a key attribute.</p>
     #[serde(rename = "AttributeName")]
@@ -197,6 +203,7 @@ pub struct ListStreamsInput {
 
 /// <p>Represents the output of a <code>ListStreams</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListStreamsOutput {
     /// <p>The stream ARN of the item where the operation stopped, inclusive of the previous result set. Use this value to start a new operation, excluding this value in the new request.</p> <p>If <code>LastEvaluatedStreamArn</code> is empty, then the "last page" of results has been processed and there is no more data to be retrieved.</p> <p>If <code>LastEvaluatedStreamArn</code> is not empty, it does not necessarily mean that there is more data in the result set. The only way to know when you have reached the end of the result set is when <code>LastEvaluatedStreamArn</code> is empty.</p>
     #[serde(rename = "LastEvaluatedStreamArn")]
@@ -210,6 +217,7 @@ pub struct ListStreamsOutput {
 
 /// <p>A description of a unique event within a stream.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Record {
     /// <p>The region in which the <code>GetRecords</code> request was received.</p>
     #[serde(rename = "awsRegion")]
@@ -243,6 +251,7 @@ pub struct Record {
 
 /// <p>The beginning and ending sequence numbers for the stream records contained within a shard.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SequenceNumberRange {
     /// <p>The last sequence number.</p>
     #[serde(rename = "EndingSequenceNumber")]
@@ -256,6 +265,7 @@ pub struct SequenceNumberRange {
 
 /// <p>A uniquely identified group of stream records within a stream.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Shard {
     /// <p>The shard ID of the current shard's parent.</p>
     #[serde(rename = "ParentShardId")]
@@ -273,6 +283,7 @@ pub struct Shard {
 
 /// <p>Represents all of the data describing a particular stream.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Stream {
     /// <p>The Amazon Resource Name (ARN) for the stream.</p>
     #[serde(rename = "StreamArn")]
@@ -290,6 +301,7 @@ pub struct Stream {
 
 /// <p>Represents all of the data describing a particular stream.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StreamDescription {
     /// <p>The date and time when the request to create this stream was issued.</p>
     #[serde(rename = "CreationRequestDateTime")]
@@ -331,6 +343,7 @@ pub struct StreamDescription {
 
 /// <p>A description of a single data modification that was performed on an item in a DynamoDB table.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StreamRecord {
     /// <p>The approximate date and time when the stream record was created, in <a href="http://www.epochconverter.com/">UNIX epoch time</a> format.</p>
     #[serde(rename = "ApproximateCreationDateTime")]

--- a/rusoto/services/ecr/src/generated.rs
+++ b/rusoto/services/ecr/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>An object representing authorization data for an Amazon ECR registry.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AuthorizationData {
     /// <p>A base64-encoded string that contains authorization data for the specified Amazon ECR registry. When the string is decoded, it is presented in the format <code>user:password</code> for private registry authentication using <code>docker login</code>.</p>
     #[serde(rename = "authorizationToken")]
@@ -60,6 +61,7 @@ pub struct BatchCheckLayerAvailabilityRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchCheckLayerAvailabilityResponse {
     /// <p>Any failures associated with the call.</p>
     #[serde(rename = "failures")]
@@ -87,6 +89,7 @@ pub struct BatchDeleteImageRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchDeleteImageResponse {
     /// <p>Any failures associated with the call.</p>
     #[serde(rename = "failures")]
@@ -117,6 +120,7 @@ pub struct BatchGetImageRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchGetImageResponse {
     /// <p>Any failures associated with the call.</p>
     #[serde(rename = "failures")]
@@ -146,6 +150,7 @@ pub struct CompleteLayerUploadRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CompleteLayerUploadResponse {
     /// <p>The <code>sha256</code> digest of the image layer.</p>
     #[serde(rename = "layerDigest")]
@@ -173,6 +178,7 @@ pub struct CreateRepositoryRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateRepositoryResponse {
     /// <p>The repository that was created.</p>
     #[serde(rename = "repository")]
@@ -192,6 +198,7 @@ pub struct DeleteLifecyclePolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteLifecyclePolicyResponse {
     /// <p>The time stamp of the last time that the lifecycle policy was run.</p>
     #[serde(rename = "lastEvaluatedAt")]
@@ -223,6 +230,7 @@ pub struct DeleteRepositoryPolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteRepositoryPolicyResponse {
     /// <p>The JSON repository policy that was deleted from the repository.</p>
     #[serde(rename = "policyText")]
@@ -254,6 +262,7 @@ pub struct DeleteRepositoryRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteRepositoryResponse {
     /// <p>The repository that was deleted.</p>
     #[serde(rename = "repository")]
@@ -298,6 +307,7 @@ pub struct DescribeImagesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeImagesResponse {
     /// <p>A list of <a>ImageDetail</a> objects that contain data about the image.</p>
     #[serde(rename = "imageDetails")]
@@ -330,6 +340,7 @@ pub struct DescribeRepositoriesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeRepositoriesResponse {
     /// <p>The <code>nextToken</code> value to include in a future <code>DescribeRepositories</code> request. When the results of a <code>DescribeRepositories</code> request exceed <code>maxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>
     #[serde(rename = "nextToken")]
@@ -350,6 +361,7 @@ pub struct GetAuthorizationTokenRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetAuthorizationTokenResponse {
     /// <p>A list of authorization token data objects that correspond to the <code>registryIds</code> values in the request.</p>
     #[serde(rename = "authorizationData")]
@@ -372,6 +384,7 @@ pub struct GetDownloadUrlForLayerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDownloadUrlForLayerResponse {
     /// <p>The pre-signed Amazon S3 download URL for the requested layer.</p>
     #[serde(rename = "downloadUrl")]
@@ -411,6 +424,7 @@ pub struct GetLifecyclePolicyPreviewRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetLifecyclePolicyPreviewResponse {
     /// <p>The JSON lifecycle policy text.</p>
     #[serde(rename = "lifecyclePolicyText")]
@@ -454,6 +468,7 @@ pub struct GetLifecyclePolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetLifecyclePolicyResponse {
     /// <p>The time stamp of the last time that the lifecycle policy was run.</p>
     #[serde(rename = "lastEvaluatedAt")]
@@ -485,6 +500,7 @@ pub struct GetRepositoryPolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetRepositoryPolicyResponse {
     /// <p>The JSON repository policy text associated with the repository.</p>
     #[serde(rename = "policyText")]
@@ -502,6 +518,7 @@ pub struct GetRepositoryPolicyResponse {
 
 /// <p>An object representing an Amazon ECR image.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Image {
     /// <p>An object containing the image tag and image digest associated with an image.</p>
     #[serde(rename = "imageId")]
@@ -523,6 +540,7 @@ pub struct Image {
 
 /// <p>An object that describes an image returned by a <a>DescribeImages</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ImageDetail {
     /// <p>The <code>sha256</code> digest of the image manifest.</p>
     #[serde(rename = "imageDigest")]
@@ -552,6 +570,7 @@ pub struct ImageDetail {
 
 /// <p>An object representing an Amazon ECR image failure.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ImageFailure {
     /// <p>The code associated with the failure.</p>
     #[serde(rename = "failureCode")]
@@ -592,6 +611,7 @@ pub struct InitiateLayerUploadRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InitiateLayerUploadResponse {
     /// <p>The size, in bytes, that Amazon ECR expects future layer part uploads to be.</p>
     #[serde(rename = "partSize")]
@@ -605,6 +625,7 @@ pub struct InitiateLayerUploadResponse {
 
 /// <p>An object representing an Amazon ECR image layer.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Layer {
     /// <p>The availability status of the image layer.</p>
     #[serde(rename = "layerAvailability")]
@@ -626,6 +647,7 @@ pub struct Layer {
 
 /// <p>An object representing an Amazon ECR image layer failure.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LayerFailure {
     /// <p>The failure code associated with the failure.</p>
     #[serde(rename = "failureCode")]
@@ -652,6 +674,7 @@ pub struct LifecyclePolicyPreviewFilter {
 
 /// <p>The result of the lifecycle policy preview.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LifecyclePolicyPreviewResult {
     /// <p>The type of action to be taken.</p>
     #[serde(rename = "action")]
@@ -677,6 +700,7 @@ pub struct LifecyclePolicyPreviewResult {
 
 /// <p>The summary of the lifecycle policy preview request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LifecyclePolicyPreviewSummary {
     /// <p>The number of expiring images.</p>
     #[serde(rename = "expiringImageTotalCount")]
@@ -686,6 +710,7 @@ pub struct LifecyclePolicyPreviewSummary {
 
 /// <p>The type of action to be taken.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LifecyclePolicyRuleAction {
     /// <p>The type of action to be taken.</p>
     #[serde(rename = "type")]
@@ -726,6 +751,7 @@ pub struct ListImagesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListImagesResponse {
     /// <p>The list of image IDs for the requested repository.</p>
     #[serde(rename = "imageIds")]
@@ -756,6 +782,7 @@ pub struct PutImageRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutImageResponse {
     /// <p>Details of the image uploaded.</p>
     #[serde(rename = "image")]
@@ -778,6 +805,7 @@ pub struct PutLifecyclePolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutLifecyclePolicyResponse {
     /// <p>The JSON repository policy text.</p>
     #[serde(rename = "lifecyclePolicyText")]
@@ -795,6 +823,7 @@ pub struct PutLifecyclePolicyResponse {
 
 /// <p>An object representing a repository.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Repository {
     /// <p>The date and time, in JavaScript date format, when the repository was created.</p>
     #[serde(rename = "createdAt")]
@@ -837,6 +866,7 @@ pub struct SetRepositoryPolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SetRepositoryPolicyResponse {
     /// <p>The JSON repository policy text applied to the repository.</p>
     #[serde(rename = "policyText")]
@@ -868,6 +898,7 @@ pub struct StartLifecyclePolicyPreviewRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartLifecyclePolicyPreviewResponse {
     /// <p>The JSON repository policy text.</p>
     #[serde(rename = "lifecyclePolicyText")]
@@ -916,6 +947,7 @@ pub struct UploadLayerPartRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UploadLayerPartResponse {
     /// <p>The integer value of the last byte received in the request.</p>
     #[serde(rename = "lastByteReceived")]

--- a/rusoto/services/ecs/src/generated.rs
+++ b/rusoto/services/ecs/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>An object representing a container instance or task attachment.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Attachment {
     /// <p>Details of the attachment. For elastic network interfaces, this includes the network interface ID, the MAC address, the subnet ID, and the private IPv4 address.</p>
     #[serde(rename = "details")]
@@ -98,6 +99,7 @@ pub struct AwsVpcConfiguration {
 
 /// <p>A regional grouping of one or more container instances on which you can run task requests. Each account receives a default cluster the first time you use the Amazon ECS service, but you may also create other clusters. Clusters may contain more than one instance type simultaneously.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Cluster {
     /// <p>The number of services that are running on the cluster in an <code>ACTIVE</code> state. You can view these services with <a>ListServices</a>.</p>
     #[serde(rename = "activeServicesCount")]
@@ -135,6 +137,7 @@ pub struct Cluster {
 
 /// <p>A Docker container that is part of a task.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Container {
     /// <p>The Amazon Resource Name (ARN) of the container.</p>
     #[serde(rename = "containerArn")]
@@ -297,6 +300,7 @@ pub struct ContainerDefinition {
 
 /// <p>An EC2 instance that is running the Amazon ECS agent and has been registered with a cluster.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ContainerInstance {
     /// <p>This parameter returns <code>true</code> if the agent is connected to Amazon ECS. Registered instances with an agent that may be unhealthy or stopped return <code>false</code>. Only instances connected to an agent can accept placement requests.</p>
     #[serde(rename = "agentConnected")]
@@ -419,6 +423,7 @@ pub struct CreateClusterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateClusterResponse {
     /// <p>The full description of your new cluster.</p>
     #[serde(rename = "cluster")]
@@ -493,6 +498,7 @@ pub struct CreateServiceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateServiceResponse {
     /// <p>The full description of your service following the create call.</p>
     #[serde(rename = "service")]
@@ -512,6 +518,7 @@ pub struct DeleteAttributesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteAttributesResponse {
     /// <p>A list of attribute objects that were successfully deleted from your resource.</p>
     #[serde(rename = "attributes")]
@@ -527,6 +534,7 @@ pub struct DeleteClusterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteClusterResponse {
     /// <p>The full description of the deleted cluster.</p>
     #[serde(rename = "cluster")]
@@ -550,6 +558,7 @@ pub struct DeleteServiceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteServiceResponse {
     /// <p>The full description of the deleted service.</p>
     #[serde(rename = "service")]
@@ -559,6 +568,7 @@ pub struct DeleteServiceResponse {
 
 /// <p>The details of an Amazon ECS service deployment.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Deployment {
     /// <p>The Unix time stamp for when the service was created.</p>
     #[serde(rename = "createdAt")]
@@ -635,6 +645,7 @@ pub struct DeregisterContainerInstanceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeregisterContainerInstanceResponse {
     /// <p>The container instance that was deregistered.</p>
     #[serde(rename = "containerInstance")]
@@ -650,6 +661,7 @@ pub struct DeregisterTaskDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeregisterTaskDefinitionResponse {
     /// <p>The full description of the deregistered task.</p>
     #[serde(rename = "taskDefinition")]
@@ -670,6 +682,7 @@ pub struct DescribeClustersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeClustersResponse {
     /// <p>The list of clusters.</p>
     #[serde(rename = "clusters")]
@@ -693,6 +706,7 @@ pub struct DescribeContainerInstancesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeContainerInstancesResponse {
     /// <p>The list of container instances.</p>
     #[serde(rename = "containerInstances")]
@@ -716,6 +730,7 @@ pub struct DescribeServicesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeServicesResponse {
     /// <p>Any failures associated with the call.</p>
     #[serde(rename = "failures")]
@@ -735,6 +750,7 @@ pub struct DescribeTaskDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeTaskDefinitionResponse {
     /// <p>The full task definition description.</p>
     #[serde(rename = "taskDefinition")]
@@ -754,6 +770,7 @@ pub struct DescribeTasksRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeTasksResponse {
     /// <p>Any failures associated with the call.</p>
     #[serde(rename = "failures")]
@@ -794,6 +811,7 @@ pub struct DiscoverPollEndpointRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DiscoverPollEndpointResponse {
     /// <p>The endpoint for the Amazon ECS agent to poll.</p>
     #[serde(rename = "endpoint")]
@@ -807,6 +825,7 @@ pub struct DiscoverPollEndpointResponse {
 
 /// <p>A failed resource.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Failure {
     /// <p>The Amazon Resource Name (ARN) of the failed resource.</p>
     #[serde(rename = "arn")]
@@ -941,6 +960,7 @@ pub struct ListAttributesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAttributesResponse {
     /// <p>A list of attribute objects that meet the criteria of the request.</p>
     #[serde(rename = "attributes")]
@@ -965,6 +985,7 @@ pub struct ListClustersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListClustersResponse {
     /// <p>The list of full Amazon Resource Name (ARN) entries for each cluster associated with your account.</p>
     #[serde(rename = "clusterArns")]
@@ -1001,6 +1022,7 @@ pub struct ListContainerInstancesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListContainerInstancesResponse {
     /// <p>The list of container instances with full ARN entries for each container instance associated with the specified cluster.</p>
     #[serde(rename = "containerInstanceArns")]
@@ -1037,6 +1059,7 @@ pub struct ListServicesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListServicesResponse {
     /// <p>The <code>nextToken</code> value to include in a future <code>ListServices</code> request. When the results of a <code>ListServices</code> request exceed <code>maxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>
     #[serde(rename = "nextToken")]
@@ -1069,6 +1092,7 @@ pub struct ListTaskDefinitionFamiliesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTaskDefinitionFamiliesResponse {
     /// <p>The list of task definition family names that match the <code>ListTaskDefinitionFamilies</code> request.</p>
     #[serde(rename = "families")]
@@ -1105,6 +1129,7 @@ pub struct ListTaskDefinitionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTaskDefinitionsResponse {
     /// <p>The <code>nextToken</code> value to include in a future <code>ListTaskDefinitions</code> request. When the results of a <code>ListTaskDefinitions</code> request exceed <code>maxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>
     #[serde(rename = "nextToken")]
@@ -1157,6 +1182,7 @@ pub struct ListTasksRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTasksResponse {
     /// <p>The <code>nextToken</code> value to include in a future <code>ListTasks</code> request. When the results of a <code>ListTasks</code> request exceed <code>maxResults</code>, this value can be used to retrieve the next page of results. This value is <code>null</code> when there are no more results to return.</p>
     #[serde(rename = "nextToken")]
@@ -1250,6 +1276,7 @@ pub struct NetworkConfiguration {
 
 /// <p>An object representing the elastic network interface for tasks that use the <code>awsvpc</code> network mode.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct NetworkInterface {
     /// <p>The attachment ID for the network interface.</p>
     #[serde(rename = "attachmentId")]
@@ -1320,6 +1347,7 @@ pub struct PutAttributesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutAttributesResponse {
     /// <p>The attributes applied to your resource.</p>
     #[serde(rename = "attributes")]
@@ -1360,6 +1388,7 @@ pub struct RegisterContainerInstanceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegisterContainerInstanceResponse {
     /// <p>The container instance that was registered.</p>
     #[serde(rename = "containerInstance")]
@@ -1410,6 +1439,7 @@ pub struct RegisterTaskDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegisterTaskDefinitionResponse {
     /// <p>The full description of the registered task definition.</p>
     #[serde(rename = "taskDefinition")]
@@ -1502,6 +1532,7 @@ pub struct RunTaskRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RunTaskResponse {
     /// <p>Any failures associated with the call.</p>
     #[serde(rename = "failures")]
@@ -1515,6 +1546,7 @@ pub struct RunTaskResponse {
 
 /// <p>Details on a service within a cluster</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Service {
     /// <p>The Amazon Resource Name (ARN) of the cluster that hosts the service.</p>
     #[serde(rename = "clusterArn")]
@@ -1608,6 +1640,7 @@ pub struct Service {
 
 /// <p>Details on an event associated with a service.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ServiceEvent {
     /// <p>The Unix time stamp for when the event was triggered.</p>
     #[serde(rename = "createdAt")]
@@ -1675,6 +1708,7 @@ pub struct StartTaskRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartTaskResponse {
     /// <p>Any failures associated with the call.</p>
     #[serde(rename = "failures")]
@@ -1702,6 +1736,7 @@ pub struct StopTaskRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopTaskResponse {
     /// <p>The task that was stopped.</p>
     #[serde(rename = "task")]
@@ -1742,6 +1777,7 @@ pub struct SubmitContainerStateChangeRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SubmitContainerStateChangeResponse {
     /// <p>Acknowledgement of the state change.</p>
     #[serde(rename = "acknowledgment")]
@@ -1790,6 +1826,7 @@ pub struct SubmitTaskStateChangeRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SubmitTaskStateChangeResponse {
     /// <p>Acknowledgement of the state change.</p>
     #[serde(rename = "acknowledgment")]
@@ -1799,6 +1836,7 @@ pub struct SubmitTaskStateChangeResponse {
 
 /// <p>Details on a task in a cluster.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Task {
     /// <p>The elastic network adapter associated with the task if the task uses the <code>awsvpc</code> network mode.</p>
     #[serde(rename = "attachments")]
@@ -1912,6 +1950,7 @@ pub struct Task {
 
 /// <p>Details of a task definition.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TaskDefinition {
     /// <p>The launch type to use with your task. For more information, see <a href="http://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html">Amazon ECS Launch Types</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>
     #[serde(rename = "compatibilities")]
@@ -2046,6 +2085,7 @@ pub struct UpdateContainerAgentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateContainerAgentResponse {
     /// <p>The container instance for which the container agent was updated.</p>
     #[serde(rename = "containerInstance")]
@@ -2068,6 +2108,7 @@ pub struct UpdateContainerInstancesStateRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateContainerInstancesStateResponse {
     /// <p>The list of container instances.</p>
     #[serde(rename = "containerInstances")]
@@ -2119,6 +2160,7 @@ pub struct UpdateServiceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateServiceResponse {
     /// <p>The full description of your service following the update call.</p>
     #[serde(rename = "service")]

--- a/rusoto/services/efs/src/generated.rs
+++ b/rusoto/services/efs/src/generated.rs
@@ -135,6 +135,7 @@ pub struct DescribeFileSystemsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeFileSystemsResponse {
     /// <p>Array of file system descriptions.</p>
     #[serde(rename = "FileSystems")]
@@ -159,6 +160,7 @@ pub struct DescribeMountTargetSecurityGroupsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeMountTargetSecurityGroupsResponse {
     /// <p>Array of security groups.</p>
     #[serde(rename = "SecurityGroups")]
@@ -188,6 +190,7 @@ pub struct DescribeMountTargetsRequest {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeMountTargetsResponse {
     /// <p>If the request included the <code>Marker</code>, the response returns that value in this field.</p>
     #[serde(rename = "Marker")]
@@ -221,6 +224,7 @@ pub struct DescribeTagsRequest {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeTagsResponse {
     /// <p>If the request included a <code>Marker</code>, the response returns that value in this field.</p>
     #[serde(rename = "Marker")]
@@ -237,6 +241,7 @@ pub struct DescribeTagsResponse {
 
 /// <p>Description of the file system.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FileSystemDescription {
     /// <p>Time that the file system was created, in seconds (since 1970-01-01T00:00:00Z).</p>
     #[serde(rename = "CreationTime")]
@@ -286,6 +291,7 @@ pub struct FileSystemDescription {
 
 /// <p>Latest known metered size (in bytes) of data stored in the file system, in its <code>Value</code> field, and the time at which that size was determined in its <code>Timestamp</code> field. Note that the value does not represent the size of a consistent snapshot of the file system, but it is eventually consistent when there are no writes to the file system. That is, the value will represent the actual size only if the file system is not modified for a period longer than a couple of hours. Otherwise, the value is not necessarily the exact size the file system was at any instant in time.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FileSystemSize {
     /// <p>Time at which the size of data, returned in the <code>Value</code> field, was determined. The value is the integer number of seconds since 1970-01-01T00:00:00Z.</p>
     #[serde(rename = "Timestamp")]
@@ -310,6 +316,7 @@ pub struct ModifyMountTargetSecurityGroupsRequest {
 
 /// <p>Provides a description of a mount target.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MountTargetDescription {
     /// <p>ID of the file system for which the mount target is intended.</p>
     #[serde(rename = "FileSystemId")]

--- a/rusoto/services/eks/src/generated.rs
+++ b/rusoto/services/eks/src/generated.rs
@@ -31,6 +31,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>An object representing the <code>certificate-authority-data</code> for your cluster.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Certificate {
     /// <p>The base64 encoded certificate data required to communicate with your cluster. Add this to the <code>certificate-authority-data</code> section of the <code>kubeconfig</code> file for your cluster.</p>
     #[serde(rename = "data")]
@@ -40,6 +41,7 @@ pub struct Certificate {
 
 /// <p>An object representing an Amazon EKS cluster.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Cluster {
     /// <p>The Amazon Resource Name (ARN) of the cluster.</p>
     #[serde(rename = "arn")]
@@ -105,6 +107,7 @@ pub struct CreateClusterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateClusterResponse {
     /// <p>The full description of your new cluster.</p>
     #[serde(rename = "cluster")]
@@ -120,6 +123,7 @@ pub struct DeleteClusterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteClusterResponse {
     /// <p>The full description of the cluster to delete.</p>
     #[serde(rename = "cluster")]
@@ -135,6 +139,7 @@ pub struct DescribeClusterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeClusterResponse {
     /// <p>The full description of your specified cluster.</p>
     #[serde(rename = "cluster")]
@@ -155,6 +160,7 @@ pub struct ListClustersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListClustersResponse {
     /// <p>A list of all of the clusters for your account in the specified region.</p>
     #[serde(rename = "clusters")]
@@ -180,6 +186,7 @@ pub struct VpcConfigRequest {
 
 /// <p>An object representing an Amazon EKS cluster VPC configuration response.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VpcConfigResponse {
     /// <p>The security groups associated with the cross-account elastic network interfaces that are used to allow communication between your worker nodes and the Kubernetes control plane.</p>
     #[serde(rename = "securityGroupIds")]

--- a/rusoto/services/elastictranscoder/src/generated.rs
+++ b/rusoto/services/elastictranscoder/src/generated.rs
@@ -122,6 +122,7 @@ pub struct CancelJobRequest {
 
 /// <p>The response body contains a JSON object. If the job is successfully canceled, the value of <code>Success</code> is <code>true</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CancelJobResponse {}
 
 /// <p>The file format of the output captions. If you leave this value blank, Elastic Transcoder returns an error.</p>
@@ -290,6 +291,7 @@ pub struct CreateJobRequest {
 
 /// <p>The CreateJobResponse structure.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateJobResponse {
     /// <p>A section of the response body that provides information about the job that is created.</p>
     #[serde(rename = "Job")]
@@ -333,6 +335,7 @@ pub struct CreatePipelineRequest {
 
 /// <p>When you create a pipeline, Elastic Transcoder returns the values that you specified in the request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreatePipelineResponse {
     /// <p>A section of the response body that provides information about the pipeline that is created.</p>
     #[serde(rename = "Pipeline")]
@@ -373,6 +376,7 @@ pub struct CreatePresetRequest {
 
 /// <p>The <code>CreatePresetResponse</code> structure.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreatePresetResponse {
     /// <p>A section of the response body that provides information about the preset that is created.</p>
     #[serde(rename = "Preset")]
@@ -394,6 +398,7 @@ pub struct DeletePipelineRequest {
 
 /// <p>The <code>DeletePipelineResponse</code> structure.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeletePipelineResponse {}
 
 /// <p>The <code>DeletePresetRequest</code> structure.</p>
@@ -406,6 +411,7 @@ pub struct DeletePresetRequest {
 
 /// <p>The <code>DeletePresetResponse</code> structure.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeletePresetResponse {}
 
 /// <p>The detected properties of the input file. Elastic Transcoder identifies these values from the input file.</p>
@@ -498,6 +504,7 @@ pub struct InputCaptions {
 
 /// <p>A section of the response body that provides information about the job that is created.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Job {
     /// <p>The Amazon Resource Name (ARN) for the job.</p>
     #[serde(rename = "Arn")]
@@ -609,6 +616,7 @@ pub struct JobInput {
 
 /// <p><important> <p>Outputs recommended instead.</p> </important> <p>If you specified one output for a job, information about that output. If you specified multiple outputs for a job, the <code>Output</code> object lists information about the first output. This duplicates the information that is listed for the first output in the <code>Outputs</code> object.</p></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct JobOutput {
     /// <p>The album art to be associated with the output file, if any.</p>
     #[serde(rename = "AlbumArt")]
@@ -727,6 +735,7 @@ pub struct ListJobsByPipelineRequest {
 
 /// <p>The <code>ListJobsByPipelineResponse</code> structure.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListJobsByPipelineResponse {
     /// <p>An array of <code>Job</code> objects that are in the specified pipeline.</p>
     #[serde(rename = "Jobs")]
@@ -756,6 +765,7 @@ pub struct ListJobsByStatusRequest {
 
 /// <p> The <code>ListJobsByStatusResponse</code> structure. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListJobsByStatusResponse {
     /// <p>An array of <code>Job</code> objects that have the specified status.</p>
     #[serde(rename = "Jobs")]
@@ -782,6 +792,7 @@ pub struct ListPipelinesRequest {
 
 /// <p>A list of the pipelines associated with the current AWS account.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListPipelinesResponse {
     /// <p>A value that you use to access the second and subsequent pages of results, if any. When the pipelines fit on one page or when you've reached the last page of results, the value of <code>NextPageToken</code> is <code>null</code>.</p>
     #[serde(rename = "NextPageToken")]
@@ -808,6 +819,7 @@ pub struct ListPresetsRequest {
 
 /// <p>The <code>ListPresetsResponse</code> structure.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListPresetsResponse {
     /// <p>A value that you use to access the second and subsequent pages of results, if any. When the presets fit on one page or when you've reached the last page of results, the value of <code>NextPageToken</code> is <code>null</code>.</p>
     #[serde(rename = "NextPageToken")]
@@ -859,6 +871,7 @@ pub struct Permission {
 
 /// <p>The pipeline (queue) that is used to manage jobs.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Pipeline {
     /// <p>The Amazon Resource Name (ARN) for the pipeline.</p>
     #[serde(rename = "Arn")]
@@ -954,6 +967,7 @@ pub struct PlayReadyDrm {
 
 /// <p> Use Only for Fragmented MP4 or MPEG-TS Outputs. If you specify a preset for which the value of Container is <code>fmp4</code> (Fragmented MP4) or <code>ts</code> (MPEG-TS), Playlists contains information about the master playlists that you want Elastic Transcoder to create. We recommend that you create only one master playlist per output format. The maximum number of master playlists in a job is 30. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Playlist {
     /// <p>The format of the output playlist. Valid formats include <code>HLSv3</code>, <code>HLSv4</code>, and <code>Smooth</code>.</p>
     #[serde(rename = "Format")]
@@ -987,6 +1001,7 @@ pub struct Playlist {
 
 /// <p>Presets are templates that contain most of the settings for transcoding media files from one format to another. Elastic Transcoder includes some default presets for common formats, for example, several iPod and iPhone versions. You can also create your own presets for formats that aren't included among the default presets. You specify which preset you want to use when you create a job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Preset {
     /// <p>The Amazon Resource Name (ARN) for the preset.</p>
     #[serde(rename = "Arn")]
@@ -1081,6 +1096,7 @@ pub struct ReadJobRequest {
 
 /// <p>The <code>ReadJobResponse</code> structure.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReadJobResponse {
     /// <p>A section of the response body that provides information about the job.</p>
     #[serde(rename = "Job")]
@@ -1098,6 +1114,7 @@ pub struct ReadPipelineRequest {
 
 /// <p>The <code>ReadPipelineResponse</code> structure.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReadPipelineResponse {
     /// <p>A section of the response body that provides information about the pipeline.</p>
     #[serde(rename = "Pipeline")]
@@ -1119,6 +1136,7 @@ pub struct ReadPresetRequest {
 
 /// <p>The <code>ReadPresetResponse</code> structure.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReadPresetResponse {
     /// <p>A section of the response body that provides information about the preset.</p>
     #[serde(rename = "Preset")]
@@ -1145,6 +1163,7 @@ pub struct TestRoleRequest {
 
 /// <p>The <code>TestRoleResponse</code> structure.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TestRoleResponse {
     /// <p>If the <code>Success</code> element contains <code>false</code>, this value is an array of one or more error messages that were generated during the test process.</p>
     #[serde(rename = "Messages")]
@@ -1208,6 +1227,7 @@ pub struct TimeSpan {
 
 /// <p>Details about the timing of a job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Timing {
     /// <p>The time the job finished transcoding, in epoch milliseconds.</p>
     #[serde(rename = "FinishTimeMillis")]
@@ -1236,6 +1256,7 @@ pub struct UpdatePipelineNotificationsRequest {
 
 /// <p>The <code>UpdatePipelineNotificationsResponse</code> structure.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdatePipelineNotificationsResponse {
     /// <p>A section of the response body that provides information about the pipeline associated with this notification.</p>
     #[serde(rename = "Pipeline")]
@@ -1281,6 +1302,7 @@ pub struct UpdatePipelineRequest {
 
 /// <p>When you update a pipeline, Elastic Transcoder returns the values that you specified in the request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdatePipelineResponse {
     /// <p>The pipeline updated by this <code>UpdatePipelineResponse</code> call.</p>
     #[serde(rename = "Pipeline")]
@@ -1305,6 +1327,7 @@ pub struct UpdatePipelineStatusRequest {
 
 /// <p>When you update status for a pipeline, Elastic Transcoder returns the values that you specified in the request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdatePipelineStatusResponse {
     /// <p>A section of the response body that provides information about the pipeline.</p>
     #[serde(rename = "Pipeline")]
@@ -1379,6 +1402,7 @@ pub struct VideoParameters {
 
 /// <p>Elastic Transcoder returns a warning if the resources used by your pipeline are not in the same region as the pipeline.</p> <p>Using resources in the same region, such as your Amazon S3 buckets, Amazon SNS notification topics, and AWS KMS key, reduces processing time and prevents cross-regional charges.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Warning {
     /// <p>The code of the cross-regional warning.</p>
     #[serde(rename = "Code")]

--- a/rusoto/services/emr/src/generated.rs
+++ b/rusoto/services/emr/src/generated.rs
@@ -39,6 +39,7 @@ pub struct AddInstanceFleetInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddInstanceFleetOutput {
     /// <p>The unique identifier of the cluster.</p>
     #[serde(rename = "ClusterId")]
@@ -63,6 +64,7 @@ pub struct AddInstanceGroupsInput {
 
 /// <p>Output from an AddInstanceGroups call.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddInstanceGroupsOutput {
     /// <p>Instance group IDs of the newly created instance groups.</p>
     #[serde(rename = "InstanceGroupIds")]
@@ -87,6 +89,7 @@ pub struct AddJobFlowStepsInput {
 
 /// <p> The output for the <a>AddJobFlowSteps</a> operation. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddJobFlowStepsOutput {
     /// <p>The identifiers of the list of steps added to the job flow.</p>
     #[serde(rename = "StepIds")]
@@ -107,6 +110,7 @@ pub struct AddTagsInput {
 
 /// <p>This output indicates the result of adding tags to a resource.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddTagsOutput {}
 
 /// <p><p>An application is any Amazon or third-party software that you can add to the cluster. This structure contains a list of strings that indicates the software to use with the cluster and accepts a user argument list. Amazon EMR accepts and forwards the argument list to the corresponding installation script as bootstrap action argument. For more information, see <a href="http://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-mapr.html">Using the MapR Distribution for Hadoop</a>. Currently supported values are:</p> <ul> <li> <p>&quot;mapr-m3&quot; - launch the cluster using MapR M3 Edition.</p> </li> <li> <p>&quot;mapr-m5&quot; - launch the cluster using MapR M5 Edition.</p> </li> <li> <p>&quot;mapr&quot; with the user arguments specifying &quot;--edition,m3&quot; or &quot;--edition,m5&quot; - launch the cluster using MapR M3 or M5 Edition, respectively.</p> </li> </ul> <note> <p>In Amazon EMR releases 4.x and later, the only accepted parameter is the application name. To pass arguments to applications, you supply a configuration for each application.</p> </note></p>
@@ -143,6 +147,7 @@ pub struct AutoScalingPolicy {
 
 /// <p>An automatic scaling policy for a core instance group or task instance group in an Amazon EMR cluster. The automatic scaling policy defines how an instance group dynamically adds and terminates EC2 instances in response to the value of a CloudWatch metric. See <a>PutAutoScalingPolicy</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AutoScalingPolicyDescription {
     /// <p>The upper and lower EC2 instance limits for an automatic scaling policy. Automatic scaling activity will not cause an instance group to grow above or below these limits.</p>
     #[serde(rename = "Constraints")]
@@ -160,6 +165,7 @@ pub struct AutoScalingPolicyDescription {
 
 /// <p>The reason for an <a>AutoScalingPolicyStatus</a> change.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AutoScalingPolicyStateChangeReason {
     /// <p>The code indicating the reason for the change in status.<code>USER_REQUEST</code> indicates that the scaling policy status was changed by a user. <code>PROVISION_FAILURE</code> indicates that the status change was because the policy failed to provision. <code>CLEANUP_FAILURE</code> indicates an error.</p>
     #[serde(rename = "Code")]
@@ -173,6 +179,7 @@ pub struct AutoScalingPolicyStateChangeReason {
 
 /// <p>The status of an automatic scaling policy. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AutoScalingPolicyStatus {
     /// <p>Indicates the status of the automatic scaling policy.</p>
     #[serde(rename = "State")]
@@ -197,6 +204,7 @@ pub struct BootstrapActionConfig {
 
 /// <p>Reports the configuration of a bootstrap action in a cluster (job flow).</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BootstrapActionDetail {
     /// <p>A description of the bootstrap action.</p>
     #[serde(rename = "BootstrapActionConfig")]
@@ -206,6 +214,7 @@ pub struct BootstrapActionDetail {
 
 /// <p>Specification of the status of a CancelSteps request. Available only in Amazon EMR version 4.8.0 and later, excluding version 5.0.0.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CancelStepsInfo {
     /// <p>The reason for the failure if the CancelSteps request fails.</p>
     #[serde(rename = "Reason")]
@@ -236,6 +245,7 @@ pub struct CancelStepsInput {
 
 /// <p> The output for the <a>CancelSteps</a> operation. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CancelStepsOutput {
     /// <p>A list of <a>CancelStepsInfo</a>, which shows the status of specified cancel requests for each <code>StepID</code> specified.</p>
     #[serde(rename = "CancelStepsInfoList")]
@@ -282,6 +292,7 @@ pub struct CloudWatchAlarmDefinition {
 
 /// <p>The detailed description of the cluster.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Cluster {
     /// <p>The applications installed on this cluster.</p>
     #[serde(rename = "Applications")]
@@ -387,6 +398,7 @@ pub struct Cluster {
 
 /// <p>The reason that the cluster changed to its current state.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ClusterStateChangeReason {
     /// <p>The programmatic code for the state change reason.</p>
     #[serde(rename = "Code")]
@@ -400,6 +412,7 @@ pub struct ClusterStateChangeReason {
 
 /// <p>The detailed status of the cluster.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ClusterStatus {
     /// <p>The current state of the cluster.</p>
     #[serde(rename = "State")]
@@ -417,6 +430,7 @@ pub struct ClusterStatus {
 
 /// <p>The summary description of the cluster.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ClusterSummary {
     /// <p>The unique identifier for the cluster.</p>
     #[serde(rename = "Id")]
@@ -438,6 +452,7 @@ pub struct ClusterSummary {
 
 /// <p>Represents the timeline of the cluster's lifecycle.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ClusterTimeline {
     /// <p>The creation date and time of the cluster.</p>
     #[serde(rename = "CreationDateTime")]
@@ -455,6 +470,7 @@ pub struct ClusterTimeline {
 
 /// <p>An entity describing an executable that runs on a cluster.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Command {
     /// <p>Arguments for Amazon EMR to pass to the command for execution.</p>
     #[serde(rename = "Args")]
@@ -498,6 +514,7 @@ pub struct CreateSecurityConfigurationInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateSecurityConfigurationOutput {
     /// <p>The date and time the security configuration was created.</p>
     #[serde(rename = "CreationDateTime")]
@@ -515,6 +532,7 @@ pub struct DeleteSecurityConfigurationInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteSecurityConfigurationOutput {}
 
 /// <p>This input determines which cluster to describe.</p>
@@ -527,6 +545,7 @@ pub struct DescribeClusterInput {
 
 /// <p>This output contains the description of the cluster.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeClusterOutput {
     /// <p>This output contains the details for the requested cluster.</p>
     #[serde(rename = "Cluster")]
@@ -557,6 +576,7 @@ pub struct DescribeJobFlowsInput {
 
 /// <p> The output for the <a>DescribeJobFlows</a> operation. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeJobFlowsOutput {
     /// <p>A list of job flows matching the parameters supplied.</p>
     #[serde(rename = "JobFlows")]
@@ -572,6 +592,7 @@ pub struct DescribeSecurityConfigurationInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeSecurityConfigurationOutput {
     /// <p>The date and time the security configuration was created</p>
     #[serde(rename = "CreationDateTime")]
@@ -600,6 +621,7 @@ pub struct DescribeStepInput {
 
 /// <p>This output contains the description of the cluster step.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeStepOutput {
     /// <p>The step details for the requested step identifier.</p>
     #[serde(rename = "Step")]
@@ -609,6 +631,7 @@ pub struct DescribeStepOutput {
 
 /// <p>Configuration of requested EBS block device associated with the instance group.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EbsBlockDevice {
     /// <p>The device name that is exposed to the instance, such as /dev/sdh.</p>
     #[serde(rename = "Device")]
@@ -647,6 +670,7 @@ pub struct EbsConfiguration {
 
 /// <p>EBS block device that's attached to an EC2 instance.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EbsVolume {
     /// <p>The device name that is exposed to the instance, such as /dev/sdh.</p>
     #[serde(rename = "Device")]
@@ -660,6 +684,7 @@ pub struct EbsVolume {
 
 /// <p>Provides information about the EC2 instances in a cluster grouped by category. For example, key name, subnet ID, IAM instance profile, and so on.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Ec2InstanceAttributes {
     /// <p>A list of additional Amazon EC2 security group IDs for the master node.</p>
     #[serde(rename = "AdditionalMasterSecurityGroups")]
@@ -709,6 +734,7 @@ pub struct Ec2InstanceAttributes {
 
 /// <p>The details of the step failure. The service attempts to detect the root cause for many common failures.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FailureDetails {
     /// <p>The path to the log file where the step failure root cause was originally recorded.</p>
     #[serde(rename = "LogFile")]
@@ -746,6 +772,7 @@ pub struct HadoopJarStepConfig {
 
 /// <p>A cluster step consisting of a JAR file whose main function will be executed. The main function submits a job for Hadoop to execute and waits for the job to finish or fail.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct HadoopStepConfig {
     /// <p>The list of command line arguments to pass to the JAR file's main function for execution.</p>
     #[serde(rename = "Args")]
@@ -767,6 +794,7 @@ pub struct HadoopStepConfig {
 
 /// <p>Represents an EC2 instance provisioned as part of cluster.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Instance {
     /// <p>The list of EBS volumes that are attached to this instance.</p>
     #[serde(rename = "EbsVolumes")]
@@ -820,6 +848,7 @@ pub struct Instance {
 
 /// <p><p>Describes an instance fleet, which is a group of EC2 instances that host a particular node type (master, core, or task) in an Amazon EMR cluster. Instance fleets can consist of a mix of instance types and On-Demand and Spot instances, which are provisioned to meet a defined target capacity. </p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceFleet {
     /// <p>The unique identifier of the instance fleet.</p>
     #[serde(rename = "Id")]
@@ -917,6 +946,7 @@ pub struct InstanceFleetProvisioningSpecifications {
 
 /// <p><p>Provides status change reason details for the instance fleet.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceFleetStateChangeReason {
     /// <p>A code corresponding to the reason the state change occurred.</p>
     #[serde(rename = "Code")]
@@ -930,6 +960,7 @@ pub struct InstanceFleetStateChangeReason {
 
 /// <p><p>The status of the instance fleet.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceFleetStatus {
     /// <p><p>A code representing the instance fleet status.</p> <ul> <li> <p> <code>PROVISIONING</code>—The instance fleet is provisioning EC2 resources and is not yet ready to run jobs.</p> </li> <li> <p> <code>BOOTSTRAPPING</code>—EC2 instances and other resources have been provisioned and the bootstrap actions specified for the instances are underway.</p> </li> <li> <p> <code>RUNNING</code>—EC2 instances and other resources are running. They are either executing jobs or waiting to execute jobs.</p> </li> <li> <p> <code>RESIZING</code>—A resize operation is underway. EC2 instances are either being added or removed.</p> </li> <li> <p> <code>SUSPENDED</code>—A resize operation could not complete. Existing EC2 instances are running, but instances can&#39;t be added or removed.</p> </li> <li> <p> <code>TERMINATING</code>—The instance fleet is terminating EC2 instances.</p> </li> <li> <p> <code>TERMINATED</code>—The instance fleet is no longer active, and all EC2 instances have been terminated.</p> </li> </ul></p>
     #[serde(rename = "State")]
@@ -947,6 +978,7 @@ pub struct InstanceFleetStatus {
 
 /// <p><p>Provides historical timestamps for the instance fleet, including the time of creation, the time it became ready to run jobs, and the time of termination.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceFleetTimeline {
     /// <p>The time and date the instance fleet was created.</p>
     #[serde(rename = "CreationDateTime")]
@@ -964,6 +996,7 @@ pub struct InstanceFleetTimeline {
 
 /// <p>This entity represents an instance group, which is a group of instances that have common purpose. For example, CORE instance group is used for HDFS.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceGroup {
     /// <p>An automatic scaling policy for a core instance group or task instance group in an Amazon EMR cluster. The automatic scaling policy defines how an instance group dynamically adds and terminates EC2 instances in response to the value of a CloudWatch metric. See PutAutoScalingPolicy.</p>
     #[serde(rename = "AutoScalingPolicy")]
@@ -1063,6 +1096,7 @@ pub struct InstanceGroupConfig {
 
 /// <p>Detailed information about an instance group.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceGroupDetail {
     /// <p>The maximum Spot price your are willing to pay for EC2 instances.</p> <p>An optional, nullable field that applies if the <code>MarketType</code> for the instance group is specified as <code>SPOT</code>. Specified in USD. If the value is NULL and <code>SPOT</code> is specified, the maximum Spot price is set equal to the On-Demand price.</p>
     #[serde(rename = "BidPrice")]
@@ -1137,6 +1171,7 @@ pub struct InstanceGroupModifyConfig {
 
 /// <p>The status change reason details for the instance group.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceGroupStateChangeReason {
     /// <p>The programmable code for the state change reason.</p>
     #[serde(rename = "Code")]
@@ -1150,6 +1185,7 @@ pub struct InstanceGroupStateChangeReason {
 
 /// <p>The details of the instance group status.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceGroupStatus {
     /// <p>The current state of the instance group.</p>
     #[serde(rename = "State")]
@@ -1167,6 +1203,7 @@ pub struct InstanceGroupStatus {
 
 /// <p>The timeline of the instance group lifecycle.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceGroupTimeline {
     /// <p>The creation date and time of the instance group.</p>
     #[serde(rename = "CreationDateTime")]
@@ -1201,6 +1238,7 @@ pub struct InstanceResizePolicy {
 
 /// <p>The details of the status change reason for the instance.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceStateChangeReason {
     /// <p>The programmable code for the state change reason.</p>
     #[serde(rename = "Code")]
@@ -1214,6 +1252,7 @@ pub struct InstanceStateChangeReason {
 
 /// <p>The instance status details.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceStatus {
     /// <p>The current state of the instance.</p>
     #[serde(rename = "State")]
@@ -1231,6 +1270,7 @@ pub struct InstanceStatus {
 
 /// <p>The timeline of the instance lifecycle.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceTimeline {
     /// <p>The creation date and time of the instance.</p>
     #[serde(rename = "CreationDateTime")]
@@ -1276,6 +1316,7 @@ pub struct InstanceTypeConfig {
 
 /// <p><p>The configuration specification for each instance type in an instance fleet.</p> <note> <p>The instance fleet configuration is available only in Amazon EMR versions 4.8.0 and later, excluding 5.0.x versions.</p> </note></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceTypeSpecification {
     /// <p>The bid price for each EC2 Spot instance type as defined by <code>InstanceType</code>. Expressed in USD.</p>
     #[serde(rename = "BidPrice")]
@@ -1309,6 +1350,7 @@ pub struct InstanceTypeSpecification {
 
 /// <p>A description of a cluster (job flow).</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct JobFlowDetail {
     /// <p>Applies only to Amazon EMR AMI versions 3.x and 2.x. For Amazon EMR releases 4.0 and later, <code>ReleaseLabel</code> is used. To specify a custom AMI, use <code>CustomAmiID</code>.</p>
     #[serde(rename = "AmiVersion")]
@@ -1366,6 +1408,7 @@ pub struct JobFlowDetail {
 
 /// <p>Describes the status of the cluster (job flow).</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct JobFlowExecutionStatusDetail {
     /// <p>The creation date and time of the job flow.</p>
     #[serde(rename = "CreationDateTime")]
@@ -1466,6 +1509,7 @@ pub struct JobFlowInstancesConfig {
 
 /// <p>Specify the type of Amazon EC2 instances that the cluster (job flow) runs on.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct JobFlowInstancesDetail {
     /// <p>The name of an Amazon EC2 key pair that can be used to ssh to the master node.</p>
     #[serde(rename = "Ec2KeyName")]
@@ -1568,6 +1612,7 @@ pub struct ListBootstrapActionsInput {
 
 /// <p>This output contains the bootstrap actions detail.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListBootstrapActionsOutput {
     /// <p>The bootstrap actions associated with the cluster.</p>
     #[serde(rename = "BootstrapActions")]
@@ -1602,6 +1647,7 @@ pub struct ListClustersInput {
 
 /// <p>This contains a ClusterSummaryList with the cluster details; for example, the cluster IDs, names, and status.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListClustersOutput {
     /// <p>The list of clusters for the account based on the given filters.</p>
     #[serde(rename = "Clusters")]
@@ -1625,6 +1671,7 @@ pub struct ListInstanceFleetsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListInstanceFleetsOutput {
     /// <p>The list of instance fleets for the cluster and given filters.</p>
     #[serde(rename = "InstanceFleets")]
@@ -1650,6 +1697,7 @@ pub struct ListInstanceGroupsInput {
 
 /// <p>This input determines which instance groups to retrieve.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListInstanceGroupsOutput {
     /// <p>The list of instance groups for the cluster and given filters.</p>
     #[serde(rename = "InstanceGroups")]
@@ -1695,6 +1743,7 @@ pub struct ListInstancesInput {
 
 /// <p>This output contains the list of instances.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListInstancesOutput {
     /// <p>The list of instances for the cluster and given filters.</p>
     #[serde(rename = "Instances")]
@@ -1715,6 +1764,7 @@ pub struct ListSecurityConfigurationsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListSecurityConfigurationsOutput {
     /// <p>A pagination token that indicates the next set of results to retrieve. Include the marker in the next ListSecurityConfiguration call to retrieve the next page of results, if required.</p>
     #[serde(rename = "Marker")]
@@ -1748,6 +1798,7 @@ pub struct ListStepsInput {
 
 /// <p>This output contains the list of steps returned in reverse order. This means that the last step is the first element in the list.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListStepsOutput {
     /// <p>The pagination token that indicates the next set of results to retrieve.</p>
     #[serde(rename = "Marker")]
@@ -1822,6 +1873,7 @@ pub struct PutAutoScalingPolicyInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutAutoScalingPolicyOutput {
     /// <p>The automatic scaling policy definition.</p>
     #[serde(rename = "AutoScalingPolicy")]
@@ -1848,6 +1900,7 @@ pub struct RemoveAutoScalingPolicyInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RemoveAutoScalingPolicyOutput {}
 
 /// <p>This input identifies a cluster and a list of tags to remove.</p>
@@ -1863,6 +1916,7 @@ pub struct RemoveTagsInput {
 
 /// <p>This output indicates the result of removing tags from a resource.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RemoveTagsOutput {}
 
 /// <p> Input to the <a>RunJobFlow</a> operation. </p>
@@ -1962,6 +2016,7 @@ pub struct RunJobFlowInput {
 
 /// <p> The result of the <a>RunJobFlow</a> operation. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RunJobFlowOutput {
     /// <p>An unique identifier for the job flow.</p>
     #[serde(rename = "JobFlowId")]
@@ -2032,6 +2087,7 @@ pub struct ScriptBootstrapActionConfig {
 
 /// <p>The creation date and time, and name, of a security configuration.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SecurityConfigurationSummary {
     /// <p>The date and time the security configuration was created.</p>
     #[serde(rename = "CreationDateTime")]
@@ -2111,6 +2167,7 @@ pub struct SpotProvisioningSpecification {
 
 /// <p>This represents a step in a cluster.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Step {
     /// <p>This specifies what action to take when the cluster step fails. Possible values are TERMINATE_CLUSTER, CANCEL_AND_WAIT, and CONTINUE.</p>
     #[serde(rename = "ActionOnFailure")]
@@ -2151,6 +2208,7 @@ pub struct StepConfig {
 
 /// <p>Combines the execution state and configuration of a step.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StepDetail {
     /// <p>The description of the step status.</p>
     #[serde(rename = "ExecutionStatusDetail")]
@@ -2162,6 +2220,7 @@ pub struct StepDetail {
 
 /// <p>The execution state of a step.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StepExecutionStatusDetail {
     /// <p>The creation date and time of the step.</p>
     #[serde(rename = "CreationDateTime")]
@@ -2185,6 +2244,7 @@ pub struct StepExecutionStatusDetail {
 
 /// <p>The details of the step state change reason.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StepStateChangeReason {
     /// <p>The programmable code for the state change reason. Note: Currently, the service provides no code for the state change.</p>
     #[serde(rename = "Code")]
@@ -2198,6 +2258,7 @@ pub struct StepStateChangeReason {
 
 /// <p>The execution status details of the cluster step.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StepStatus {
     /// <p>The details for the step failure including reason, message, and log file path where the root cause was identified.</p>
     #[serde(rename = "FailureDetails")]
@@ -2219,6 +2280,7 @@ pub struct StepStatus {
 
 /// <p>The summary of the cluster step.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StepSummary {
     /// <p>This specifies what action to take when the cluster step fails. Possible values are TERMINATE_CLUSTER, CANCEL_AND_WAIT, and CONTINUE.</p>
     #[serde(rename = "ActionOnFailure")]
@@ -2244,6 +2306,7 @@ pub struct StepSummary {
 
 /// <p>The timeline of the cluster step lifecycle.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StepTimeline {
     /// <p>The date and time when the cluster step was created.</p>
     #[serde(rename = "CreationDateTime")]

--- a/rusoto/services/events/src/generated.rs
+++ b/rusoto/services/events/src/generated.rs
@@ -76,6 +76,7 @@ pub struct DeleteRuleRequest {
 pub struct DescribeEventBusRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEventBusResponse {
     /// <p>The Amazon Resource Name (ARN) of the account permitted to write events to the current account.</p>
     #[serde(rename = "Arn")]
@@ -99,6 +100,7 @@ pub struct DescribeRuleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeRuleResponse {
     /// <p>The Amazon Resource Name (ARN) of the rule.</p>
     #[serde(rename = "Arn")]
@@ -192,6 +194,7 @@ pub struct ListRuleNamesByTargetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListRuleNamesByTargetResponse {
     /// <p>Indicates whether there are additional results to retrieve. If there are no more results, the value is null.</p>
     #[serde(rename = "NextToken")]
@@ -220,6 +223,7 @@ pub struct ListRulesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListRulesResponse {
     /// <p>Indicates whether there are additional results to retrieve. If there are no more results, the value is null.</p>
     #[serde(rename = "NextToken")]
@@ -247,6 +251,7 @@ pub struct ListTargetsByRuleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTargetsByRuleResponse {
     /// <p>Indicates whether there are additional results to retrieve. If there are no more results, the value is null.</p>
     #[serde(rename = "NextToken")]
@@ -291,6 +296,7 @@ pub struct PutEventsRequestEntry {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutEventsResponse {
     /// <p>The successfully and unsuccessfully ingested events results. If the ingestion was successful, the entry has the event ID in it. Otherwise, you can use the error code and error message to identify the problem with the entry.</p>
     #[serde(rename = "Entries")]
@@ -304,6 +310,7 @@ pub struct PutEventsResponse {
 
 /// <p>Represents an event that failed to be submitted.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutEventsResultEntry {
     /// <p>The error code that indicates why the event submission failed.</p>
     #[serde(rename = "ErrorCode")]
@@ -360,6 +367,7 @@ pub struct PutRuleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutRuleResponse {
     /// <p>The Amazon Resource Name (ARN) of the rule.</p>
     #[serde(rename = "RuleArn")]
@@ -378,6 +386,7 @@ pub struct PutTargetsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutTargetsResponse {
     /// <p>The failed target entries.</p>
     #[serde(rename = "FailedEntries")]
@@ -391,6 +400,7 @@ pub struct PutTargetsResponse {
 
 /// <p>Represents a target that failed to be added to a rule.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutTargetsResultEntry {
     /// <p>The error code that indicates why the target addition failed. If the value is <code>ConcurrentModificationException</code>, too many requests were made at the same time.</p>
     #[serde(rename = "ErrorCode")]
@@ -424,6 +434,7 @@ pub struct RemoveTargetsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RemoveTargetsResponse {
     /// <p>The failed target entries.</p>
     #[serde(rename = "FailedEntries")]
@@ -437,6 +448,7 @@ pub struct RemoveTargetsResponse {
 
 /// <p>Represents a target that failed to be removed from a rule.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RemoveTargetsResultEntry {
     /// <p>The error code that indicates why the target removal failed. If the value is <code>ConcurrentModificationException</code>, too many requests were made at the same time.</p>
     #[serde(rename = "ErrorCode")]
@@ -454,6 +466,7 @@ pub struct RemoveTargetsResultEntry {
 
 /// <p>Contains information about a rule in Amazon CloudWatch Events.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Rule {
     /// <p>The Amazon Resource Name (ARN) of the rule.</p>
     #[serde(rename = "Arn")]
@@ -571,6 +584,7 @@ pub struct TestEventPatternRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TestEventPatternResponse {
     /// <p>Indicates whether the event matches the event pattern.</p>
     #[serde(rename = "Result")]

--- a/rusoto/services/firehose/src/generated.rs
+++ b/rusoto/services/firehose/src/generated.rs
@@ -106,6 +106,7 @@ pub struct CreateDeliveryStreamInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDeliveryStreamOutput {
     /// <p>The ARN of the delivery stream.</p>
     #[serde(rename = "DeliveryStreamARN")]
@@ -142,10 +143,12 @@ pub struct DeleteDeliveryStreamInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteDeliveryStreamOutput {}
 
 /// <p>Contains information about a delivery stream.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeliveryStreamDescription {
     /// <p>The date and time that the delivery stream was created.</p>
     #[serde(rename = "CreateTimestamp")]
@@ -198,6 +201,7 @@ pub struct DescribeDeliveryStreamInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeDeliveryStreamOutput {
     /// <p>Information about the delivery stream.</p>
     #[serde(rename = "DeliveryStreamDescription")]
@@ -219,6 +223,7 @@ pub struct Deserializer {
 
 /// <p>Describes the destination for a delivery stream.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DestinationDescription {
     /// <p>The ID of the destination.</p>
     #[serde(rename = "DestinationId")]
@@ -304,6 +309,7 @@ pub struct ElasticsearchDestinationConfiguration {
 
 /// <p>The destination description in Amazon ES.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ElasticsearchDestinationDescription {
     /// <p>The buffering options.</p>
     #[serde(rename = "BufferingHints")]
@@ -467,6 +473,7 @@ pub struct ExtendedS3DestinationConfiguration {
 
 /// <p>Describes a destination in Amazon S3.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ExtendedS3DestinationDescription {
     /// <p>The ARN of the S3 bucket. For more information, see <a href="https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>
     #[serde(rename = "BucketARN")]
@@ -597,6 +604,7 @@ pub struct KinesisStreamSourceConfiguration {
 
 /// <p>Details about a Kinesis data stream used as the source for a Kinesis Data Firehose delivery stream.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct KinesisStreamSourceDescription {
     /// <p>Kinesis Data Firehose starts retrieving records from the Kinesis data stream starting with this time stamp.</p>
     #[serde(rename = "DeliveryStartTimestamp")]
@@ -629,6 +637,7 @@ pub struct ListDeliveryStreamsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListDeliveryStreamsOutput {
     /// <p>The names of the delivery streams.</p>
     #[serde(rename = "DeliveryStreamNames")]
@@ -654,6 +663,7 @@ pub struct ListTagsForDeliveryStreamInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagsForDeliveryStreamOutput {
     /// <p>If this is <code>true</code> in the response, more tags are available. To list the remaining tags, set <code>ExclusiveStartTagKey</code> to the key of the last tag returned and call <code>ListTagsForDeliveryStream</code> again.</p>
     #[serde(rename = "HasMoreTags")]
@@ -810,6 +820,7 @@ pub struct PutRecordBatchInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutRecordBatchOutput {
     /// <p>The number of records that might have failed processing.</p>
     #[serde(rename = "FailedPutCount")]
@@ -821,6 +832,7 @@ pub struct PutRecordBatchOutput {
 
 /// <p>Contains the result for an individual record from a <a>PutRecordBatch</a> request. If the record is successfully added to your delivery stream, it receives a record ID. If the record fails to be added to your delivery stream, the result includes an error code and an error message.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutRecordBatchResponseEntry {
     /// <p>The error code for an individual record result.</p>
     #[serde(rename = "ErrorCode")]
@@ -847,6 +859,7 @@ pub struct PutRecordInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutRecordOutput {
     /// <p>The ID of the record.</p>
     #[serde(rename = "RecordId")]
@@ -911,6 +924,7 @@ pub struct RedshiftDestinationConfiguration {
 
 /// <p>Describes a destination in Amazon Redshift.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RedshiftDestinationDescription {
     /// <p>The Amazon CloudWatch logging options for your delivery stream.</p>
     #[serde(rename = "CloudWatchLoggingOptions")]
@@ -1040,6 +1054,7 @@ pub struct S3DestinationConfiguration {
 
 /// <p>Describes a destination in Amazon S3.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct S3DestinationDescription {
     /// <p>The ARN of the S3 bucket. For more information, see <a href="https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html">Amazon Resource Names (ARNs) and AWS Service Namespaces</a>.</p>
     #[serde(rename = "BucketARN")]
@@ -1143,6 +1158,7 @@ pub struct Serializer {
 
 /// <p>Details about a Kinesis data stream used as the source for a Kinesis Data Firehose delivery stream.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SourceDescription {
     /// <p>The <a>KinesisStreamSourceDescription</a> value for the source Kinesis data stream.</p>
     #[serde(rename = "KinesisStreamSourceDescription")]
@@ -1189,6 +1205,7 @@ pub struct SplunkDestinationConfiguration {
 
 /// <p>Describes a destination in Splunk.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SplunkDestinationDescription {
     /// <p>The Amazon CloudWatch logging options for your delivery stream.</p>
     #[serde(rename = "CloudWatchLoggingOptions")]
@@ -1301,6 +1318,7 @@ pub struct TagDeliveryStreamInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TagDeliveryStreamOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1314,6 +1332,7 @@ pub struct UntagDeliveryStreamInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UntagDeliveryStreamOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1346,6 +1365,7 @@ pub struct UpdateDestinationInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateDestinationOutput {}
 
 /// Errors returned by CreateDeliveryStream

--- a/rusoto/services/fms/src/generated.rs
+++ b/rusoto/services/fms/src/generated.rs
@@ -37,6 +37,7 @@ pub struct AssociateAdminAccountRequest {
 
 /// <p>Details of the resource that is not protected by the policy.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ComplianceViolator {
     /// <p>The resource ID.</p>
     #[serde(rename = "ResourceId")]
@@ -67,6 +68,7 @@ pub struct DisassociateAdminAccountRequest {}
 
 /// <p>Describes the compliance status for the account. An account is considered non-compliant if it includes resources that are not protected by the specified policy.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EvaluationResult {
     /// <p>Describes an AWS account's compliance with the AWS Firewall Manager policy.</p>
     #[serde(rename = "ComplianceStatus")]
@@ -86,6 +88,7 @@ pub struct EvaluationResult {
 pub struct GetAdminAccountRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetAdminAccountResponse {
     /// <p>The AWS account that is set as the AWS Firewall Manager administrator.</p>
     #[serde(rename = "AdminAccount")]
@@ -104,6 +107,7 @@ pub struct GetComplianceDetailRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetComplianceDetailResponse {
     /// <p>Information about the resources and the policy that you specified in the <code>GetComplianceDetail</code> request.</p>
     #[serde(rename = "PolicyComplianceDetail")]
@@ -115,6 +119,7 @@ pub struct GetComplianceDetailResponse {
 pub struct GetNotificationChannelRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetNotificationChannelResponse {
     /// <p>The IAM role that is used by AWS Firewall Manager to record activity to SNS.</p>
     #[serde(rename = "SnsRoleName")]
@@ -134,6 +139,7 @@ pub struct GetPolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetPolicyResponse {
     /// <p>Information about the specified AWS Firewall Manager policy.</p>
     #[serde(rename = "Policy")]
@@ -161,6 +167,7 @@ pub struct ListComplianceStatusRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListComplianceStatusResponse {
     /// <p>If you have more <code>PolicyComplianceStatus</code> objects than the number that you specified for <code>MaxResults</code> in the request, the response includes a <code>NextToken</code> value. To list more <code>PolicyComplianceStatus</code> objects, submit another <code>ListComplianceStatus</code> request, and specify the <code>NextToken</code> value from the response in the <code>NextToken</code> value in the next request.</p>
     #[serde(rename = "NextToken")]
@@ -185,6 +192,7 @@ pub struct ListPoliciesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListPoliciesResponse {
     /// <p>If you have more <code>PolicySummary</code> objects than the number that you specified for <code>MaxResults</code> in the request, the response includes a <code>NextToken</code> value. To list more <code>PolicySummary</code> objects, submit another <code>ListPolicies</code> request, and specify the <code>NextToken</code> value from the response in the <code>NextToken</code> value in the next request.</p>
     #[serde(rename = "NextToken")]
@@ -230,6 +238,7 @@ pub struct Policy {
 
 /// <p>Describes the non-compliant resources in a member account for a specific AWS Firewall Manager policy. A maximum of 100 entries are displayed. If more than 100 resources are non-compliant, <code>EvaluationLimitExceeded</code> is set to <code>True</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PolicyComplianceDetail {
     /// <p>Indicates if over 100 resources are non-compliant with the AWS Firewall Manager policy.</p>
     #[serde(rename = "EvaluationLimitExceeded")]
@@ -259,6 +268,7 @@ pub struct PolicyComplianceDetail {
 
 /// <p>Indicates whether the account is compliant with the specified policy. An account is considered non-compliant if it includes resources that are not protected by the policy.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PolicyComplianceStatus {
     /// <p>An array of <code>EvaluationResult</code> objects.</p>
     #[serde(rename = "EvaluationResults")]
@@ -288,6 +298,7 @@ pub struct PolicyComplianceStatus {
 
 /// <p>Details of the AWS Firewall Manager policy. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PolicySummary {
     /// <p>The Amazon Resource Name (ARN) of the specified policy.</p>
     #[serde(rename = "PolicyArn")]
@@ -333,6 +344,7 @@ pub struct PutPolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutPolicyResponse {
     /// <p>The details of the AWS Firewall Manager policy that was created.</p>
     #[serde(rename = "Policy")]

--- a/rusoto/services/gamelift/src/generated.rs
+++ b/rusoto/services/gamelift/src/generated.rs
@@ -43,10 +43,12 @@ pub struct AcceptMatchInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AcceptMatchOutput {}
 
 /// <p><p>Properties describing a fleet alias.</p> <p>Alias-related operations include:</p> <ul> <li> <p> <a>CreateAlias</a> </p> </li> <li> <p> <a>ListAliases</a> </p> </li> <li> <p> <a>DescribeAlias</a> </p> </li> <li> <p> <a>UpdateAlias</a> </p> </li> <li> <p> <a>DeleteAlias</a> </p> </li> <li> <p> <a>ResolveAlias</a> </p> </li> </ul></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Alias {
     /// <p>Unique identifier for an alias; alias ARNs are unique across all regions.</p>
     #[serde(rename = "AliasArn")]
@@ -101,6 +103,7 @@ pub struct AttributeValue {
 
 /// <p>Temporary access credentials used for uploading game build files to Amazon GameLift. They are valid for a limited time. If they expire before you upload your game build, get a new set by calling <a>RequestUploadCredentials</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AwsCredentials {
     /// <p>Temporary key allowing access to the Amazon GameLift S3 account.</p>
     #[serde(rename = "AccessKeyId")]
@@ -118,6 +121,7 @@ pub struct AwsCredentials {
 
 /// <p><p>Properties describing a game build.</p> <p>Build-related operations include:</p> <ul> <li> <p> <a>CreateBuild</a> </p> </li> <li> <p> <a>ListBuilds</a> </p> </li> <li> <p> <a>DescribeBuild</a> </p> </li> <li> <p> <a>UpdateBuild</a> </p> </li> <li> <p> <a>DeleteBuild</a> </p> </li> </ul></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Build {
     /// <p>Unique identifier for a build.</p>
     #[serde(rename = "BuildId")]
@@ -166,6 +170,7 @@ pub struct CreateAliasInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateAliasOutput {
     /// <p>Object that describes the newly created alias record.</p>
     #[serde(rename = "Alias")]
@@ -196,6 +201,7 @@ pub struct CreateBuildInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateBuildOutput {
     /// <p>The newly created build record, including a unique build ID and status. </p>
     #[serde(rename = "Build")]
@@ -275,6 +281,7 @@ pub struct CreateFleetInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateFleetOutput {
     /// <p>Properties for the newly created fleet.</p>
     #[serde(rename = "FleetAttributes")]
@@ -324,6 +331,7 @@ pub struct CreateGameSessionInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateGameSessionOutput {
     /// <p>Object that describes the newly created game session record.</p>
     #[serde(rename = "GameSession")]
@@ -353,6 +361,7 @@ pub struct CreateGameSessionQueueInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateGameSessionQueueOutput {
     /// <p>Object that describes the newly created game session queue.</p>
     #[serde(rename = "GameSessionQueue")]
@@ -410,6 +419,7 @@ pub struct CreateMatchmakingConfigurationInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateMatchmakingConfigurationOutput {
     /// <p>Object that describes the newly created matchmaking configuration.</p>
     #[serde(rename = "Configuration")]
@@ -430,6 +440,7 @@ pub struct CreateMatchmakingRuleSetInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateMatchmakingRuleSetOutput {
     /// <p>Object that describes the newly created matchmaking rule set.</p>
     #[serde(rename = "RuleSet")]
@@ -453,6 +464,7 @@ pub struct CreatePlayerSessionInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreatePlayerSessionOutput {
     /// <p>Object that describes the newly created player session record.</p>
     #[serde(rename = "PlayerSession")]
@@ -477,6 +489,7 @@ pub struct CreatePlayerSessionsInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreatePlayerSessionsOutput {
     /// <p>Collection of player session objects created for the added players.</p>
     #[serde(rename = "PlayerSessions")]
@@ -497,6 +510,7 @@ pub struct CreateVpcPeeringAuthorizationInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateVpcPeeringAuthorizationOutput {
     /// <p>Details on the requested VPC peering authorization, including expiration.</p>
     #[serde(rename = "VpcPeeringAuthorization")]
@@ -519,6 +533,7 @@ pub struct CreateVpcPeeringConnectionInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateVpcPeeringConnectionOutput {}
 
 /// <p>Represents the input for a request action.</p>
@@ -554,6 +569,7 @@ pub struct DeleteGameSessionQueueInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteGameSessionQueueOutput {}
 
 /// <p>Represents the input for a request action.</p>
@@ -565,6 +581,7 @@ pub struct DeleteMatchmakingConfigurationInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteMatchmakingConfigurationOutput {}
 
 /// <p>Represents the input for a request action.</p>
@@ -590,6 +607,7 @@ pub struct DeleteVpcPeeringAuthorizationInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteVpcPeeringAuthorizationOutput {}
 
 /// <p>Represents the input for a request action.</p>
@@ -604,6 +622,7 @@ pub struct DeleteVpcPeeringConnectionInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteVpcPeeringConnectionOutput {}
 
 /// <p>Represents the input for a request action.</p>
@@ -616,6 +635,7 @@ pub struct DescribeAliasInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAliasOutput {
     /// <p>Object that contains the requested alias.</p>
     #[serde(rename = "Alias")]
@@ -633,6 +653,7 @@ pub struct DescribeBuildInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeBuildOutput {
     /// <p>Set of properties describing the requested build.</p>
     #[serde(rename = "Build")]
@@ -651,6 +672,7 @@ pub struct DescribeEC2InstanceLimitsInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEC2InstanceLimitsOutput {
     /// <p>Object that contains the maximum number of instances for the specified instance type.</p>
     #[serde(rename = "EC2InstanceLimits")]
@@ -677,6 +699,7 @@ pub struct DescribeFleetAttributesInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeFleetAttributesOutput {
     /// <p>Collection of objects containing attribute metadata for each requested fleet ID.</p>
     #[serde(rename = "FleetAttributes")]
@@ -707,6 +730,7 @@ pub struct DescribeFleetCapacityInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeFleetCapacityOutput {
     /// <p>Collection of objects containing capacity information for each requested fleet ID. Leave this parameter empty to retrieve capacity information for all fleets.</p>
     #[serde(rename = "FleetCapacity")]
@@ -744,6 +768,7 @@ pub struct DescribeFleetEventsInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeFleetEventsOutput {
     /// <p>Collection of objects containing event log entries for the specified fleet.</p>
     #[serde(rename = "Events")]
@@ -765,6 +790,7 @@ pub struct DescribeFleetPortSettingsInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeFleetPortSettingsOutput {
     /// <p>Object that contains port settings for the requested fleet ID.</p>
     #[serde(rename = "InboundPermissions")]
@@ -791,6 +817,7 @@ pub struct DescribeFleetUtilizationInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeFleetUtilizationOutput {
     /// <p>Collection of objects containing utilization information for each requested fleet ID.</p>
     #[serde(rename = "FleetUtilization")]
@@ -833,6 +860,7 @@ pub struct DescribeGameSessionDetailsInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeGameSessionDetailsOutput {
     /// <p>Collection of objects containing game session properties and the protection policy currently in force for each session matching the request.</p>
     #[serde(rename = "GameSessionDetails")]
@@ -854,6 +882,7 @@ pub struct DescribeGameSessionPlacementInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeGameSessionPlacementOutput {
     /// <p>Object that describes the requested game session placement.</p>
     #[serde(rename = "GameSessionPlacement")]
@@ -880,6 +909,7 @@ pub struct DescribeGameSessionQueuesInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeGameSessionQueuesOutput {
     /// <p>Collection of objects that describes the requested game session queues.</p>
     #[serde(rename = "GameSessionQueues")]
@@ -922,6 +952,7 @@ pub struct DescribeGameSessionsInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeGameSessionsOutput {
     /// <p>Collection of objects containing game session properties for each session matching the request.</p>
     #[serde(rename = "GameSessions")]
@@ -955,6 +986,7 @@ pub struct DescribeInstancesInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeInstancesOutput {
     /// <p>Collection of objects containing properties for each instance returned.</p>
     #[serde(rename = "Instances")]
@@ -989,6 +1021,7 @@ pub struct DescribeMatchmakingConfigurationsInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeMatchmakingConfigurationsOutput {
     /// <p>Collection of requested matchmaking configuration objects.</p>
     #[serde(rename = "Configurations")]
@@ -1010,6 +1043,7 @@ pub struct DescribeMatchmakingInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeMatchmakingOutput {
     /// <p>Collection of existing matchmaking ticket objects matching the request.</p>
     #[serde(rename = "TicketList")]
@@ -1036,6 +1070,7 @@ pub struct DescribeMatchmakingRuleSetsInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeMatchmakingRuleSetsOutput {
     /// <p>Token that indicates where to resume retrieving results on the next call to this action. If no token is returned, these results represent the end of the list.</p>
     #[serde(rename = "NextToken")]
@@ -1077,6 +1112,7 @@ pub struct DescribePlayerSessionsInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribePlayerSessionsOutput {
     /// <p>Token that indicates where to resume retrieving results on the next call to this action. If no token is returned, these results represent the end of the list.</p>
     #[serde(rename = "NextToken")]
@@ -1098,6 +1134,7 @@ pub struct DescribeRuntimeConfigurationInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeRuntimeConfigurationOutput {
     /// <p>Instructions describing how server processes should be launched and maintained on each instance in the fleet.</p>
     #[serde(rename = "RuntimeConfiguration")]
@@ -1127,6 +1164,7 @@ pub struct DescribeScalingPoliciesInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeScalingPoliciesOutput {
     /// <p>Token that indicates where to resume retrieving results on the next call to this action. If no token is returned, these results represent the end of the list.</p>
     #[serde(rename = "NextToken")]
@@ -1142,6 +1180,7 @@ pub struct DescribeScalingPoliciesOutput {
 pub struct DescribeVpcPeeringAuthorizationsInput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeVpcPeeringAuthorizationsOutput {
     /// <p>Collection of objects that describe all valid VPC peering operations for the current AWS account.</p>
     #[serde(rename = "VpcPeeringAuthorizations")]
@@ -1160,6 +1199,7 @@ pub struct DescribeVpcPeeringConnectionsInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeVpcPeeringConnectionsOutput {
     /// <p>Collection of VPC peering connection records that match the request.</p>
     #[serde(rename = "VpcPeeringConnections")]
@@ -1182,6 +1222,7 @@ pub struct DesiredPlayerSession {
 
 /// <p><p>Current status of fleet capacity. The number of active instances should match or be in the process of matching the number of desired instances. Pending and terminating counts are non-zero only if fleet capacity is adjusting to an <a>UpdateFleetCapacity</a> request, or if access to resources is temporarily affected.</p> <p>Fleet-related operations include:</p> <ul> <li> <p> <a>CreateFleet</a> </p> </li> <li> <p> <a>ListFleets</a> </p> </li> <li> <p> <a>DeleteFleet</a> </p> </li> <li> <p>Describe fleets:</p> <ul> <li> <p> <a>DescribeFleetAttributes</a> </p> </li> <li> <p> <a>DescribeFleetCapacity</a> </p> </li> <li> <p> <a>DescribeFleetPortSettings</a> </p> </li> <li> <p> <a>DescribeFleetUtilization</a> </p> </li> <li> <p> <a>DescribeRuntimeConfiguration</a> </p> </li> <li> <p> <a>DescribeEC2InstanceLimits</a> </p> </li> <li> <p> <a>DescribeFleetEvents</a> </p> </li> </ul> </li> <li> <p>Update fleets:</p> <ul> <li> <p> <a>UpdateFleetAttributes</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetPortSettings</a> </p> </li> <li> <p> <a>UpdateRuntimeConfiguration</a> </p> </li> </ul> </li> <li> <p>Manage fleet actions:</p> <ul> <li> <p> <a>StartFleetActions</a> </p> </li> <li> <p> <a>StopFleetActions</a> </p> </li> </ul> </li> </ul></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EC2InstanceCounts {
     /// <p>Actual number of active instances in the fleet.</p>
     #[serde(rename = "ACTIVE")]
@@ -1215,6 +1256,7 @@ pub struct EC2InstanceCounts {
 
 /// <p>Maximum number of instances allowed based on the Amazon Elastic Compute Cloud (Amazon EC2) instance type. Instance limits can be retrieved by calling <a>DescribeEC2InstanceLimits</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EC2InstanceLimit {
     /// <p>Number of instances of the specified type that are currently in use by this AWS account.</p>
     #[serde(rename = "CurrentInstances")]
@@ -1232,6 +1274,7 @@ pub struct EC2InstanceLimit {
 
 /// <p>Log entry describing an event that involves Amazon GameLift resources (such as a fleet). In addition to tracking activity, event codes and messages can provide additional information for troubleshooting and debugging problems.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Event {
     /// <p><p>Type of event being logged. The following events are currently in use:</p> <p> <b>Fleet creation events:</b> </p> <ul> <li> <p>FLEET<em>CREATED -- A fleet record was successfully created with a status of <code>NEW</code>. Event messaging includes the fleet ID.</p> </li> <li> <p>FLEET</em>STATE<em>DOWNLOADING -- Fleet status changed from <code>NEW</code> to <code>DOWNLOADING</code>. The compressed build has started downloading to a fleet instance for installation.</p> </li> <li> <p> FLEET</em>BINARY<em>DOWNLOAD</em>FAILED -- The build failed to download to the fleet instance.</p> </li> <li> <p>FLEET<em>CREATION</em>EXTRACTING<em>BUILD – The game server build was successfully downloaded to an instance, and the build files are now being extracted from the uploaded build and saved to an instance. Failure at this stage prevents a fleet from moving to <code>ACTIVE</code> status. Logs for this stage display a list of the files that are extracted and saved on the instance. Access the logs by using the URL in <i>PreSignedLogUrl</i>.</p> </li> <li> <p>FLEET</em>CREATION<em>RUNNING</em>INSTALLER – The game server build files were successfully extracted, and the Amazon GameLift is now running the build&#39;s install script (if one is included). Failure in this stage prevents a fleet from moving to <code>ACTIVE</code> status. Logs for this stage list the installation steps and whether or not the install completed successfully. Access the logs by using the URL in <i>PreSignedLogUrl</i>. </p> </li> <li> <p>FLEET<em>CREATION</em>VALIDATING<em>RUNTIME</em>CONFIG -- The build process was successful, and the Amazon GameLift is now verifying that the game server launch paths, which are specified in the fleet&#39;s run-time configuration, exist. If any listed launch path exists, Amazon GameLift tries to launch a game server process and waits for the process to report ready. Failures in this stage prevent a fleet from moving to <code>ACTIVE</code> status. Logs for this stage list the launch paths in the run-time configuration and indicate whether each is found. Access the logs by using the URL in <i>PreSignedLogUrl</i>. </p> </li> <li> <p>FLEET<em>STATE</em>VALIDATING -- Fleet status changed from <code>DOWNLOADING</code> to <code>VALIDATING</code>.</p> </li> <li> <p> FLEET<em>VALIDATION</em>LAUNCH<em>PATH</em>NOT<em>FOUND -- Validation of the run-time configuration failed because the executable specified in a launch path does not exist on the instance.</p> </li> <li> <p>FLEET</em>STATE<em>BUILDING -- Fleet status changed from <code>VALIDATING</code> to <code>BUILDING</code>.</p> </li> <li> <p>FLEET</em>VALIDATION<em>EXECUTABLE</em>RUNTIME<em>FAILURE -- Validation of the run-time configuration failed because the executable specified in a launch path failed to run on the fleet instance.</p> </li> <li> <p>FLEET</em>STATE<em>ACTIVATING -- Fleet status changed from <code>BUILDING</code> to <code>ACTIVATING</code>. </p> </li> <li> <p> FLEET</em>ACTIVATION<em>FAILED - The fleet failed to successfully complete one of the steps in the fleet activation process. This event code indicates that the game build was successfully downloaded to a fleet instance, built, and validated, but was not able to start a server process. A possible reason for failure is that the game server is not reporting &quot;process ready&quot; to the Amazon GameLift service.</p> </li> <li> <p>FLEET</em>STATE<em>ACTIVE -- The fleet&#39;s status changed from <code>ACTIVATING</code> to <code>ACTIVE</code>. The fleet is now ready to host game sessions.</p> </li> </ul> <p> <b>VPC peering events:</b> </p> <ul> <li> <p>FLEET</em>VPC<em>PEERING</em>SUCCEEDED -- A VPC peering connection has been established between the VPC for an Amazon GameLift fleet and a VPC in your AWS account.</p> </li> <li> <p>FLEET<em>VPC</em>PEERING<em>FAILED -- A requested VPC peering connection has failed. Event details and status information (see <a>DescribeVpcPeeringConnections</a>) provide additional detail. A common reason for peering failure is that the two VPCs have overlapping CIDR blocks of IPv4 addresses. To resolve this, change the CIDR block for the VPC in your AWS account. For more information on VPC peering failures, see <a href="http://docs.aws.amazon.com/AmazonVPC/latest/PeeringGuide/invalid-peering-configurations.html">http://docs.aws.amazon.com/AmazonVPC/latest/PeeringGuide/invalid-peering-configurations.html</a> </p> </li> <li> <p>FLEET</em>VPC<em>PEERING</em>DELETED -- A VPC peering connection has been successfully deleted.</p> </li> </ul> <p> <b>Spot instance events:</b> </p> <ul> <li> <p> INSTANCE<em>INTERRUPTED -- A spot instance was interrupted by EC2 with a two-minute notification.</p> </li> </ul> <p> <b>Other fleet events:</b> </p> <ul> <li> <p>FLEET</em>SCALING<em>EVENT -- A change was made to the fleet&#39;s capacity settings (desired instances, minimum/maximum scaling limits). Event messaging includes the new capacity settings.</p> </li> <li> <p>FLEET</em>NEW<em>GAME</em>SESSION<em>PROTECTION</em>POLICY<em>UPDATED -- A change was made to the fleet&#39;s game session protection policy setting. Event messaging includes both the old and new policy setting. </p> </li> <li> <p>FLEET</em>DELETED -- A request to delete a fleet was initiated.</p> </li> <li> <p> GENERIC_EVENT -- An unspecified event has occurred.</p> </li> </ul></p>
     #[serde(rename = "EventCode")]
@@ -1261,6 +1304,7 @@ pub struct Event {
 
 /// <p><p>General properties describing a fleet.</p> <p>Fleet-related operations include:</p> <ul> <li> <p> <a>CreateFleet</a> </p> </li> <li> <p> <a>ListFleets</a> </p> </li> <li> <p> <a>DeleteFleet</a> </p> </li> <li> <p>Describe fleets:</p> <ul> <li> <p> <a>DescribeFleetAttributes</a> </p> </li> <li> <p> <a>DescribeFleetCapacity</a> </p> </li> <li> <p> <a>DescribeFleetPortSettings</a> </p> </li> <li> <p> <a>DescribeFleetUtilization</a> </p> </li> <li> <p> <a>DescribeRuntimeConfiguration</a> </p> </li> <li> <p> <a>DescribeEC2InstanceLimits</a> </p> </li> <li> <p> <a>DescribeFleetEvents</a> </p> </li> </ul> </li> <li> <p>Update fleets:</p> <ul> <li> <p> <a>UpdateFleetAttributes</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetPortSettings</a> </p> </li> <li> <p> <a>UpdateRuntimeConfiguration</a> </p> </li> </ul> </li> <li> <p>Manage fleet actions:</p> <ul> <li> <p> <a>StartFleetActions</a> </p> </li> <li> <p> <a>StopFleetActions</a> </p> </li> </ul> </li> </ul></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FleetAttributes {
     /// <p>Unique identifier for a build.</p>
     #[serde(rename = "BuildId")]
@@ -1338,6 +1382,7 @@ pub struct FleetAttributes {
 
 /// <p><p>Information about the fleet&#39;s capacity. Fleet capacity is measured in EC2 instances. By default, new fleets have a capacity of one instance, but can be updated as needed. The maximum number of instances for a fleet is determined by the fleet&#39;s instance type.</p> <p>Fleet-related operations include:</p> <ul> <li> <p> <a>CreateFleet</a> </p> </li> <li> <p> <a>ListFleets</a> </p> </li> <li> <p> <a>DeleteFleet</a> </p> </li> <li> <p>Describe fleets:</p> <ul> <li> <p> <a>DescribeFleetAttributes</a> </p> </li> <li> <p> <a>DescribeFleetCapacity</a> </p> </li> <li> <p> <a>DescribeFleetPortSettings</a> </p> </li> <li> <p> <a>DescribeFleetUtilization</a> </p> </li> <li> <p> <a>DescribeRuntimeConfiguration</a> </p> </li> <li> <p> <a>DescribeEC2InstanceLimits</a> </p> </li> <li> <p> <a>DescribeFleetEvents</a> </p> </li> </ul> </li> <li> <p>Update fleets:</p> <ul> <li> <p> <a>UpdateFleetAttributes</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetPortSettings</a> </p> </li> <li> <p> <a>UpdateRuntimeConfiguration</a> </p> </li> </ul> </li> <li> <p>Manage fleet actions:</p> <ul> <li> <p> <a>StartFleetActions</a> </p> </li> <li> <p> <a>StopFleetActions</a> </p> </li> </ul> </li> </ul></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FleetCapacity {
     /// <p>Unique identifier for a fleet.</p>
     #[serde(rename = "FleetId")]
@@ -1355,6 +1400,7 @@ pub struct FleetCapacity {
 
 /// <p><p>Current status of fleet utilization, including the number of game and player sessions being hosted.</p> <p>Fleet-related operations include:</p> <ul> <li> <p> <a>CreateFleet</a> </p> </li> <li> <p> <a>ListFleets</a> </p> </li> <li> <p> <a>DeleteFleet</a> </p> </li> <li> <p>Describe fleets:</p> <ul> <li> <p> <a>DescribeFleetAttributes</a> </p> </li> <li> <p> <a>DescribeFleetCapacity</a> </p> </li> <li> <p> <a>DescribeFleetPortSettings</a> </p> </li> <li> <p> <a>DescribeFleetUtilization</a> </p> </li> <li> <p> <a>DescribeRuntimeConfiguration</a> </p> </li> <li> <p> <a>DescribeEC2InstanceLimits</a> </p> </li> <li> <p> <a>DescribeFleetEvents</a> </p> </li> </ul> </li> <li> <p>Update fleets:</p> <ul> <li> <p> <a>UpdateFleetAttributes</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetPortSettings</a> </p> </li> <li> <p> <a>UpdateRuntimeConfiguration</a> </p> </li> </ul> </li> <li> <p>Manage fleet actions:</p> <ul> <li> <p> <a>StartFleetActions</a> </p> </li> <li> <p> <a>StopFleetActions</a> </p> </li> </ul> </li> </ul></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FleetUtilization {
     /// <p>Number of active game sessions currently being hosted on all instances in the fleet.</p>
     #[serde(rename = "ActiveGameSessionCount")]
@@ -1391,6 +1437,7 @@ pub struct GameProperty {
 
 /// <p><p>Properties describing a game session.</p> <p>A game session in ACTIVE status can host players. When a game session ends, its status is set to <code>TERMINATED</code>. </p> <p>Once the session ends, the game session object is retained for 30 days. This means you can reuse idempotency token values after this time. Game session logs are retained for 14 days.</p> <p>Game-session-related operations include:</p> <ul> <li> <p> <a>CreateGameSession</a> </p> </li> <li> <p> <a>DescribeGameSessions</a> </p> </li> <li> <p> <a>DescribeGameSessionDetails</a> </p> </li> <li> <p> <a>SearchGameSessions</a> </p> </li> <li> <p> <a>UpdateGameSession</a> </p> </li> <li> <p> <a>GetGameSessionLogUrl</a> </p> </li> <li> <p>Game session placements</p> <ul> <li> <p> <a>StartGameSessionPlacement</a> </p> </li> <li> <p> <a>DescribeGameSessionPlacement</a> </p> </li> <li> <p> <a>StopGameSessionPlacement</a> </p> </li> </ul> </li> </ul></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GameSession {
     /// <p>Time stamp indicating when this data object was created. Format is a number expressed in Unix time as milliseconds (for example "1469498468.057").</p>
     #[serde(rename = "CreationTime")]
@@ -1460,6 +1507,7 @@ pub struct GameSession {
 
 /// <p>Connection information for the new game session that is created with matchmaking. (with <a>StartMatchmaking</a>). Once a match is set, the FlexMatch engine places the match and creates a new game session for it. This information, including the game session endpoint and player sessions for each player in the original matchmaking request, is added to the <a>MatchmakingTicket</a>, which can be retrieved by calling <a>DescribeMatchmaking</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GameSessionConnectionInfo {
     /// <p>Amazon Resource Name (<a href="http://docs.aws.amazon.com/AmazonS3/latest/dev/s3-arn-format.html">ARN</a>) that is assigned to a game session and uniquely identifies it.</p>
     #[serde(rename = "GameSessionArn")]
@@ -1481,6 +1529,7 @@ pub struct GameSessionConnectionInfo {
 
 /// <p>A game session's properties plus the protection policy currently in force.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GameSessionDetail {
     /// <p>Object that describes a game session.</p>
     #[serde(rename = "GameSession")]
@@ -1494,6 +1543,7 @@ pub struct GameSessionDetail {
 
 /// <p><p>Object that describes a <a>StartGameSessionPlacement</a> request. This object includes the full details of the original request plus the current status and start/end time stamps.</p> <p>Game session placement-related operations include:</p> <ul> <li> <p> <a>StartGameSessionPlacement</a> </p> </li> <li> <p> <a>DescribeGameSessionPlacement</a> </p> </li> <li> <p> <a>StopGameSessionPlacement</a> </p> </li> </ul></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GameSessionPlacement {
     /// <p>Time stamp indicating when this request was completed, canceled, or timed out.</p>
     #[serde(rename = "EndTime")]
@@ -1567,6 +1617,7 @@ pub struct GameSessionPlacement {
 
 /// <p><p>Configuration of a queue that is used to process game session placement requests. The queue configuration identifies several game features:</p> <ul> <li> <p>The destinations where a new game session can potentially be hosted. Amazon GameLift tries these destinations in an order based on either the queue&#39;s default order or player latency information, if provided in a placement request. With latency information, Amazon GameLift can place game sessions where the majority of players are reporting the lowest possible latency. </p> </li> <li> <p>The length of time that placement requests can wait in the queue before timing out. </p> </li> <li> <p>A set of optional latency policies that protect individual players from high latencies, preventing game sessions from being placed where any individual player is reporting latency higher than a policy&#39;s maximum.</p> </li> </ul> <p>Queue-related operations include:</p> <ul> <li> <p> <a>CreateGameSessionQueue</a> </p> </li> <li> <p> <a>DescribeGameSessionQueues</a> </p> </li> <li> <p> <a>UpdateGameSessionQueue</a> </p> </li> <li> <p> <a>DeleteGameSessionQueue</a> </p> </li> </ul></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GameSessionQueue {
     /// <p>List of fleets that can be used to fulfill game session placement requests in the queue. Fleets are identified by either a fleet ARN or a fleet alias ARN. Destinations are listed in default preference order.</p>
     #[serde(rename = "Destinations")]
@@ -1609,6 +1660,7 @@ pub struct GetGameSessionLogUrlInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetGameSessionLogUrlOutput {
     /// <p>Location of the requested game session logs, available for download.</p>
     #[serde(rename = "PreSignedUrl")]
@@ -1629,6 +1681,7 @@ pub struct GetInstanceAccessInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetInstanceAccessOutput {
     /// <p>Object that contains connection information for a fleet instance, including IP address and access credentials.</p>
     #[serde(rename = "InstanceAccess")]
@@ -1638,6 +1691,7 @@ pub struct GetInstanceAccessOutput {
 
 /// <p>Properties that describe an instance of a virtual computing resource that hosts one or more game servers. A fleet may contain zero or more instances.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Instance {
     /// <p>Time stamp indicating when this data object was created. Format is a number expressed in Unix time as milliseconds (for example "1469498468.057").</p>
     #[serde(rename = "CreationTime")]
@@ -1671,6 +1725,7 @@ pub struct Instance {
 
 /// <p>Information required to remotely connect to a fleet instance. Access is requested by calling <a>GetInstanceAccess</a>. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceAccess {
     /// <p>Credentials required to access the instance.</p>
     #[serde(rename = "Credentials")]
@@ -1696,6 +1751,7 @@ pub struct InstanceAccess {
 
 /// <p>Set of credentials required to remotely access a fleet instance. Access credentials are requested by calling <a>GetInstanceAccess</a> and returned in an <a>InstanceAccess</a> object.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceCredentials {
     /// <p>Secret string. For Windows instances, the secret is a password for use with Windows Remote Desktop. For Linux instances, it is a private key (which must be saved as a <code>.pem</code> file) for use with SSH.</p>
     #[serde(rename = "Secret")]
@@ -1747,6 +1803,7 @@ pub struct ListAliasesInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAliasesOutput {
     /// <p>Collection of alias records that match the list request.</p>
     #[serde(rename = "Aliases")]
@@ -1777,6 +1834,7 @@ pub struct ListBuildsInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListBuildsOutput {
     /// <p>Collection of build records that match the request.</p>
     #[serde(rename = "Builds")]
@@ -1807,6 +1865,7 @@ pub struct ListFleetsInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListFleetsOutput {
     /// <p>Set of fleet IDs matching the list request. You can retrieve additional information about all returned fleets by passing this result set to a call to <a>DescribeFleetAttributes</a>, <a>DescribeFleetCapacity</a>, or <a>DescribeFleetUtilization</a>.</p>
     #[serde(rename = "FleetIds")]
@@ -1820,6 +1879,7 @@ pub struct ListFleetsOutput {
 
 /// <p>Represents a new player session that is created as a result of a successful FlexMatch match. A successful match automatically creates new player sessions for every player ID in the original matchmaking request. </p> <p>When players connect to the match's game session, they must include both player ID and player session ID in order to claim their assigned player slot.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MatchedPlayerSession {
     /// <p>Unique identifier for a player </p>
     #[serde(rename = "PlayerId")]
@@ -1833,6 +1893,7 @@ pub struct MatchedPlayerSession {
 
 /// <p>Guidelines for use with FlexMatch to match players into games. All matchmaking requests must specify a matchmaking configuration.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MatchmakingConfiguration {
     /// <p>Flag that determines whether or not a match that was created with this configuration must be accepted by the matched players. To require acceptance, set to TRUE.</p>
     #[serde(rename = "AcceptanceRequired")]
@@ -1890,6 +1951,7 @@ pub struct MatchmakingConfiguration {
 
 /// <p><p>Set of rule statements, used with FlexMatch, that determine how to build a certain kind of player match. Each rule set describes a type of group to be created and defines the parameters for acceptable player matches. Rule sets are used in <a>MatchmakingConfiguration</a> objects.</p> <p>A rule set may define the following elements for a match. For detailed information and examples showing how to construct a rule set, see <a href="http://docs.aws.amazon.com/gamelift/latest/developerguide/match-rulesets.html">Build a FlexMatch Rule Set</a>. </p> <ul> <li> <p>Teams -- Required. A rule set must define one or multiple teams for the match and set minimum and maximum team sizes. For example, a rule set might describe a 4x4 match that requires all eight slots to be filled. </p> </li> <li> <p>Player attributes -- Optional. These attributes specify a set of player characteristics to evaluate when looking for a match. Matchmaking requests that use a rule set with player attributes must provide the corresponding attribute values. For example, an attribute might specify a player&#39;s skill or level.</p> </li> <li> <p>Rules -- Optional. Rules define how to evaluate potential players for a match based on player attributes. A rule might specify minimum requirements for individual players, teams, or entire matches. For example, a rule might require each player to meet a certain skill level, each team to have at least one player in a certain role, or the match to have a minimum average skill level. or may describe an entire group--such as all teams must be evenly matched or have at least one player in a certain role. </p> </li> <li> <p>Expansions -- Optional. Expansions allow you to relax the rules after a period of time when no acceptable matches are found. This feature lets you balance getting players into games in a reasonable amount of time instead of making them wait indefinitely for the best possible match. For example, you might use an expansion to increase the maximum skill variance between players after 30 seconds.</p> </li> </ul></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MatchmakingRuleSet {
     /// <p>Time stamp indicating when this data object was created. Format is a number expressed in Unix time as milliseconds (for example "1469498468.057").</p>
     #[serde(rename = "CreationTime")]
@@ -1906,6 +1968,7 @@ pub struct MatchmakingRuleSet {
 
 /// <p>Ticket generated to track the progress of a matchmaking request. Each ticket is uniquely identified by a ticket ID, supplied by the requester, when creating a matchmaking request with <a>StartMatchmaking</a>. Tickets can be retrieved by calling <a>DescribeMatchmaking</a> with the ticket ID.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MatchmakingTicket {
     /// <p>Name of the <a>MatchmakingConfiguration</a> that is used with this ticket. Matchmaking configurations determine how players are grouped into a match and how a new game session is created for the match.</p>
     #[serde(rename = "ConfigurationName")]
@@ -1951,6 +2014,7 @@ pub struct MatchmakingTicket {
 
 /// <p><p>Information about a player session that was created as part of a <a>StartGameSessionPlacement</a> request. This object contains only the player ID and player session ID. To retrieve full details on a player session, call <a>DescribePlayerSessions</a> with the player session ID.</p> <p>Player-session-related operations include:</p> <ul> <li> <p> <a>CreatePlayerSession</a> </p> </li> <li> <p> <a>CreatePlayerSessions</a> </p> </li> <li> <p> <a>DescribePlayerSessions</a> </p> </li> <li> <p>Game session placements</p> <ul> <li> <p> <a>StartGameSessionPlacement</a> </p> </li> <li> <p> <a>DescribeGameSessionPlacement</a> </p> </li> <li> <p> <a>StopGameSessionPlacement</a> </p> </li> </ul> </li> </ul></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PlacedPlayerSession {
     /// <p>Unique identifier for a player that is associated with this player session.</p>
     #[serde(rename = "PlayerId")]
@@ -2015,6 +2079,7 @@ pub struct PlayerLatencyPolicy {
 
 /// <p><p>Properties describing a player session. Player session objects are created either by creating a player session for a specific game session, or as part of a game session placement. A player session represents either a player reservation for a game session (status <code>RESERVED</code>) or actual player activity in a game session (status <code>ACTIVE</code>). A player session object (including player data) is automatically passed to a game session when the player connects to the game session and is validated.</p> <p>When a player disconnects, the player session status changes to <code>COMPLETED</code>. Once the session ends, the player session object is retained for 30 days and then removed.</p> <p>Player-session-related operations include:</p> <ul> <li> <p> <a>CreatePlayerSession</a> </p> </li> <li> <p> <a>CreatePlayerSessions</a> </p> </li> <li> <p> <a>DescribePlayerSessions</a> </p> </li> <li> <p>Game session placements</p> <ul> <li> <p> <a>StartGameSessionPlacement</a> </p> </li> <li> <p> <a>DescribeGameSessionPlacement</a> </p> </li> <li> <p> <a>StopGameSessionPlacement</a> </p> </li> </ul> </li> </ul></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PlayerSession {
     /// <p>Time stamp indicating when this data object was created. Format is a number expressed in Unix time as milliseconds (for example "1469498468.057").</p>
     #[serde(rename = "CreationTime")]
@@ -2102,6 +2167,7 @@ pub struct PutScalingPolicyInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutScalingPolicyOutput {
     /// <p>Descriptive label that is associated with a scaling policy. Policy names do not need to be unique.</p>
     #[serde(rename = "Name")]
@@ -2119,6 +2185,7 @@ pub struct RequestUploadCredentialsInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RequestUploadCredentialsOutput {
     /// <p>Amazon S3 path and key, identifying where the game build files are stored.</p>
     #[serde(rename = "StorageLocation")]
@@ -2140,6 +2207,7 @@ pub struct ResolveAliasInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResolveAliasOutput {
     /// <p>Fleet identifier that is associated with the requested alias.</p>
     #[serde(rename = "FleetId")]
@@ -2213,6 +2281,7 @@ pub struct S3Location {
 
 /// <p><p>Rule that controls how a fleet is scaled. Scaling policies are uniquely identified by the combination of name and fleet ID.</p> <p>Operations related to fleet capacity scaling include:</p> <ul> <li> <p> <a>DescribeFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>DescribeEC2InstanceLimits</a> </p> </li> <li> <p>Manage scaling policies:</p> <ul> <li> <p> <a>PutScalingPolicy</a> (auto-scaling)</p> </li> <li> <p> <a>DescribeScalingPolicies</a> (auto-scaling)</p> </li> <li> <p> <a>DeleteScalingPolicy</a> (auto-scaling)</p> </li> </ul> </li> <li> <p>Manage fleet actions:</p> <ul> <li> <p> <a>StartFleetActions</a> </p> </li> <li> <p> <a>StopFleetActions</a> </p> </li> </ul> </li> </ul></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ScalingPolicy {
     /// <p>Comparison operator to use when measuring a metric against the threshold value.</p>
     #[serde(rename = "ComparisonOperator")]
@@ -2291,6 +2360,7 @@ pub struct SearchGameSessionsInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SearchGameSessionsOutput {
     /// <p>Collection of objects containing game session properties for each session matching the request.</p>
     #[serde(rename = "GameSessions")]
@@ -2328,6 +2398,7 @@ pub struct StartFleetActionsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartFleetActionsOutput {}
 
 /// <p>Represents the input for a request action.</p>
@@ -2366,6 +2437,7 @@ pub struct StartGameSessionPlacementInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartGameSessionPlacementOutput {
     /// <p>Object that describes the newly created game session placement. This object includes all the information provided in the request, as well as start/end time stamps and placement status. </p>
     #[serde(rename = "GameSessionPlacement")]
@@ -2393,6 +2465,7 @@ pub struct StartMatchBackfillInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartMatchBackfillOutput {
     /// <p>Ticket representing the backfill matchmaking request. This object includes the information in the request, ticket status, and match results as generated during the matchmaking process.</p>
     #[serde(rename = "MatchmakingTicket")]
@@ -2417,6 +2490,7 @@ pub struct StartMatchmakingInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartMatchmakingOutput {
     /// <p>Ticket representing the matchmaking request. This object include the information included in the request, ticket status, and match results as generated during the matchmaking process.</p>
     #[serde(rename = "MatchmakingTicket")]
@@ -2435,6 +2509,7 @@ pub struct StopFleetActionsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopFleetActionsOutput {}
 
 /// <p>Represents the input for a request action.</p>
@@ -2447,6 +2522,7 @@ pub struct StopGameSessionPlacementInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopGameSessionPlacementOutput {
     /// <p>Object that describes the canceled game session placement, with <code>CANCELLED</code> status and an end time stamp. </p>
     #[serde(rename = "GameSessionPlacement")]
@@ -2463,6 +2539,7 @@ pub struct StopMatchmakingInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopMatchmakingOutput {}
 
 /// <p><p>Settings for a target-based scaling policy (see <a>ScalingPolicy</a>. A target-based policy tracks a particular fleet metric specifies a target value for the metric. As player usage changes, the policy triggers Amazon GameLift to adjust capacity so that the metric returns to the target value. The target configuration specifies settings as needed for the target based policy, including the target value. </p> <p>Operations related to fleet capacity scaling include:</p> <ul> <li> <p> <a>DescribeFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>DescribeEC2InstanceLimits</a> </p> </li> <li> <p>Manage scaling policies:</p> <ul> <li> <p> <a>PutScalingPolicy</a> (auto-scaling)</p> </li> <li> <p> <a>DescribeScalingPolicies</a> (auto-scaling)</p> </li> <li> <p> <a>DeleteScalingPolicy</a> (auto-scaling)</p> </li> </ul> </li> <li> <p>Manage fleet actions:</p> <ul> <li> <p> <a>StartFleetActions</a> </p> </li> <li> <p> <a>StopFleetActions</a> </p> </li> </ul> </li> </ul></p>
@@ -2495,6 +2572,7 @@ pub struct UpdateAliasInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateAliasOutput {
     /// <p>Object that contains the updated alias configuration.</p>
     #[serde(rename = "Alias")]
@@ -2520,6 +2598,7 @@ pub struct UpdateBuildInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateBuildOutput {
     /// <p>Object that contains the updated build record.</p>
     #[serde(rename = "Build")]
@@ -2557,6 +2636,7 @@ pub struct UpdateFleetAttributesInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateFleetAttributesOutput {
     /// <p>Unique identifier for a fleet that was updated.</p>
     #[serde(rename = "FleetId")]
@@ -2586,6 +2666,7 @@ pub struct UpdateFleetCapacityInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateFleetCapacityOutput {
     /// <p>Unique identifier for a fleet that was updated.</p>
     #[serde(rename = "FleetId")]
@@ -2611,6 +2692,7 @@ pub struct UpdateFleetPortSettingsInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateFleetPortSettingsOutput {
     /// <p>Unique identifier for a fleet that was updated.</p>
     #[serde(rename = "FleetId")]
@@ -2644,6 +2726,7 @@ pub struct UpdateGameSessionInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateGameSessionOutput {
     /// <p>Object that contains the updated game session metadata.</p>
     #[serde(rename = "GameSession")]
@@ -2673,6 +2756,7 @@ pub struct UpdateGameSessionQueueInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateGameSessionQueueOutput {
     /// <p>Object that describes the newly updated game session queue.</p>
     #[serde(rename = "GameSessionQueue")]
@@ -2734,6 +2818,7 @@ pub struct UpdateMatchmakingConfigurationInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateMatchmakingConfigurationOutput {
     /// <p>Object that describes the updated matchmaking configuration.</p>
     #[serde(rename = "Configuration")]
@@ -2754,6 +2839,7 @@ pub struct UpdateRuntimeConfigurationInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateRuntimeConfigurationOutput {
     /// <p>The run-time configuration currently in force. If the update was successful, this object matches the one in the request.</p>
     #[serde(rename = "RuntimeConfiguration")]
@@ -2771,6 +2857,7 @@ pub struct ValidateMatchmakingRuleSetInput {
 
 /// <p>Represents the returned data in response to a request action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ValidateMatchmakingRuleSetOutput {
     /// <p>Response indicating whether or not the rule set is valid.</p>
     #[serde(rename = "Valid")]
@@ -2780,6 +2867,7 @@ pub struct ValidateMatchmakingRuleSetOutput {
 
 /// <p><p>Represents an authorization for a VPC peering connection between the VPC for an Amazon GameLift fleet and another VPC on an account you have access to. This authorization must exist and be valid for the peering connection to be established. Authorizations are valid for 24 hours after they are issued.</p> <p>VPC peering connection operations include:</p> <ul> <li> <p> <a>CreateVpcPeeringAuthorization</a> </p> </li> <li> <p> <a>DescribeVpcPeeringAuthorizations</a> </p> </li> <li> <p> <a>DeleteVpcPeeringAuthorization</a> </p> </li> <li> <p> <a>CreateVpcPeeringConnection</a> </p> </li> <li> <p> <a>DescribeVpcPeeringConnections</a> </p> </li> <li> <p> <a>DeleteVpcPeeringConnection</a> </p> </li> </ul></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VpcPeeringAuthorization {
     /// <p>Time stamp indicating when this authorization was issued. Format is a number expressed in Unix time as milliseconds (for example "1469498468.057").</p>
     #[serde(rename = "CreationTime")]
@@ -2805,6 +2893,7 @@ pub struct VpcPeeringAuthorization {
 
 /// <p><p>Represents a peering connection between a VPC on one of your AWS accounts and the VPC for your Amazon GameLift fleets. This record may be for an active peering connection or a pending connection that has not yet been established.</p> <p>VPC peering connection operations include:</p> <ul> <li> <p> <a>CreateVpcPeeringAuthorization</a> </p> </li> <li> <p> <a>DescribeVpcPeeringAuthorizations</a> </p> </li> <li> <p> <a>DeleteVpcPeeringAuthorization</a> </p> </li> <li> <p> <a>CreateVpcPeeringConnection</a> </p> </li> <li> <p> <a>DescribeVpcPeeringConnections</a> </p> </li> <li> <p> <a>DeleteVpcPeeringConnection</a> </p> </li> </ul></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VpcPeeringConnection {
     /// <p>Unique identifier for a fleet. This ID determines the ID of the Amazon GameLift VPC for your fleet.</p>
     #[serde(rename = "FleetId")]
@@ -2834,6 +2923,7 @@ pub struct VpcPeeringConnection {
 
 /// <p>Represents status information for a VPC peering connection. Status is associated with a <a>VpcPeeringConnection</a> object. Status codes and messages are provided from EC2 (see <a href="http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_VpcPeeringConnectionStateReason.html">VpcPeeringConnectionStateReason</a>). Connection status information is also communicated as a fleet <a>Event</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VpcPeeringConnectionStatus {
     /// <p>Code indicating the status of a VPC peering connection.</p>
     #[serde(rename = "Code")]

--- a/rusoto/services/glacier/src/generated.rs
+++ b/rusoto/services/glacier/src/generated.rs
@@ -71,6 +71,7 @@ pub struct AddTagsToVaultInput {
 
 /// <p>Contains the Amazon Glacier response to your request.</p> <p>For information about the underlying REST API, see <a href="http://docs.aws.amazon.com/amazonglacier/latest/dev/api-archive-post.html">Upload Archive</a>. For conceptual information, see <a href="http://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html">Working with Archives in Amazon Glacier</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ArchiveCreationOutput {
     /// <p>The ID of the archive. This value is also included as part of the location.</p>
     #[serde(rename = "archiveId")]
@@ -189,6 +190,7 @@ pub struct CreateVaultInput {
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateVaultOutput {
     /// <p>The URI of the vault that was created.</p>
     #[serde(rename = "location")]
@@ -292,6 +294,7 @@ pub struct DescribeVaultInput {
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeVaultOutput {
     /// <p>The Universal Coordinated Time (UTC) date when the vault was created. This value should be a string in the ISO 8601 date format, for example <code>2012-03-20T17:03:43.221Z</code>.</p>
     #[serde(rename = "CreationDate")]
@@ -346,6 +349,7 @@ pub struct GetDataRetrievalPolicyInput {
 
 /// <p>Contains the Amazon Glacier response to the <code>GetDataRetrievalPolicy</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDataRetrievalPolicyOutput {
     /// <p>Contains the returned data retrieval policy in JSON format.</p>
     #[serde(rename = "Policy")]
@@ -403,6 +407,7 @@ pub struct GetVaultAccessPolicyInput {
 
 /// <p>Output for GetVaultAccessPolicy.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetVaultAccessPolicyOutput {
     /// <p>Contains the returned vault access policy as a JSON string.</p>
     #[serde(rename = "policy")]
@@ -423,6 +428,7 @@ pub struct GetVaultLockInput {
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetVaultLockOutput {
     /// <p>The UTC date and time at which the vault lock was put into the <code>InProgress</code> state.</p>
     #[serde(rename = "CreationDate")]
@@ -455,6 +461,7 @@ pub struct GetVaultNotificationsInput {
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetVaultNotificationsOutput {
     /// <p>Returns the notification configuration set on the vault.</p>
     #[serde(rename = "vaultNotificationConfig")]
@@ -464,6 +471,7 @@ pub struct GetVaultNotificationsOutput {
 
 /// <p>Contains the description of an Amazon Glacier job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GlacierJobDescription {
     /// <p>The job type. This value is either <code>ArchiveRetrieval</code>, <code>InventoryRetrieval</code>, or <code>Select</code>. </p>
     #[serde(rename = "Action")]
@@ -605,6 +613,7 @@ pub struct InitiateJobInput {
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InitiateJobOutput {
     /// <p>The ID of the job.</p>
     #[serde(rename = "jobId")]
@@ -641,6 +650,7 @@ pub struct InitiateMultipartUploadInput {
 
 /// <p>The Amazon Glacier response to your request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InitiateMultipartUploadOutput {
     /// <p>The relative URI path of the multipart upload ID Amazon Glacier created.</p>
     #[serde(rename = "location")]
@@ -669,6 +679,7 @@ pub struct InitiateVaultLockInput {
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InitiateVaultLockOutput {
     /// <p>The lock ID, which is used to complete the vault locking process.</p>
     #[serde(rename = "lockId")]
@@ -687,6 +698,7 @@ pub struct InputSerialization {
 
 /// <p>Describes the options for a range inventory retrieval job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InventoryRetrievalJobDescription {
     /// <p>The end of the date range in UTC for vault inventory retrieval that includes archives created before this date. This value should be a string in the ISO 8601 date format, for example <code>2013-03-20T17:03:43Z</code>.</p>
     #[serde(rename = "EndDate")]
@@ -805,6 +817,7 @@ pub struct ListJobsInput {
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListJobsOutput {
     /// <p>A list of job objects. Each job object contains metadata describing the job.</p>
     #[serde(rename = "JobList")]
@@ -837,6 +850,7 @@ pub struct ListMultipartUploadsInput {
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListMultipartUploadsOutput {
     /// <p>An opaque string that represents where to continue pagination of the results. You use the marker in a new List Multipart Uploads request to obtain more uploads in the list. If there are no more uploads, this value is <code>null</code>.</p>
     #[serde(rename = "Marker")]
@@ -872,6 +886,7 @@ pub struct ListPartsInput {
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListPartsOutput {
     /// <p>The description of the archive that was specified in the Initiate Multipart Upload request.</p>
     #[serde(rename = "ArchiveDescription")]
@@ -911,6 +926,7 @@ pub struct ListProvisionedCapacityInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListProvisionedCapacityOutput {
     /// <p>The response body contains the following JSON fields.</p>
     #[serde(rename = "ProvisionedCapacityList")]
@@ -931,6 +947,7 @@ pub struct ListTagsForVaultInput {
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagsForVaultOutput {
     /// <p>The tags attached to the vault. Each tag is composed of a key and a value.</p>
     #[serde(rename = "Tags")]
@@ -956,6 +973,7 @@ pub struct ListVaultsInput {
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListVaultsOutput {
     /// <p>The vault ARN at which to continue pagination of the results. You use the marker in another List Vaults request to obtain more vaults in the list.</p>
     #[serde(rename = "Marker")]
@@ -987,6 +1005,7 @@ pub struct OutputSerialization {
 
 /// <p>A list of the part sizes of the multipart upload.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PartListElement {
     /// <p>The byte range of a part, inclusive of the upper value of the range.</p>
     #[serde(rename = "RangeInBytes")]
@@ -1000,6 +1019,7 @@ pub struct PartListElement {
 
 /// <p>The definition for a provisioned capacity unit.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ProvisionedCapacityDescription {
     /// <p>The ID that identifies the provisioned capacity unit.</p>
     #[serde(rename = "CapacityId")]
@@ -1023,6 +1043,7 @@ pub struct PurchaseProvisionedCapacityInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PurchaseProvisionedCapacityOutput {
     /// <p>The ID that identifies the provisioned capacity unit.</p>
     #[serde(rename = "capacityId")]
@@ -1174,6 +1195,7 @@ pub struct UploadArchiveInput {
 
 /// <p>A list of in-progress multipart uploads for a vault.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UploadListElement {
     /// <p>The description of the archive that was specified in the Initiate Multipart Upload request.</p>
     #[serde(rename = "ArchiveDescription")]
@@ -1229,6 +1251,7 @@ pub struct UploadMultipartPartInput {
 
 /// <p>Contains the Amazon Glacier response to your request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UploadMultipartPartOutput {
     /// <p>The SHA256 tree hash that Amazon Glacier computed for the uploaded part.</p>
     #[serde(rename = "checksum")]

--- a/rusoto/services/glue/src/generated.rs
+++ b/rusoto/services/glue/src/generated.rs
@@ -67,6 +67,7 @@ pub struct BatchCreatePartitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchCreatePartitionResponse {
     /// <p>Errors encountered when trying to create the requested partitions.</p>
     #[serde(rename = "Errors")]
@@ -86,6 +87,7 @@ pub struct BatchDeleteConnectionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchDeleteConnectionResponse {
     /// <p>A map of the names of connections that were not successfully deleted to error details.</p>
     #[serde(rename = "Errors")]
@@ -115,6 +117,7 @@ pub struct BatchDeletePartitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchDeletePartitionResponse {
     /// <p>Errors encountered when trying to delete the requested partitions.</p>
     #[serde(rename = "Errors")]
@@ -137,6 +140,7 @@ pub struct BatchDeleteTableRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchDeleteTableResponse {
     /// <p>A list of errors encountered in attempting to delete the specified tables.</p>
     #[serde(rename = "Errors")]
@@ -162,6 +166,7 @@ pub struct BatchDeleteTableVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchDeleteTableVersionResponse {
     /// <p>A list of errors encountered while trying to delete the specified table versions.</p>
     #[serde(rename = "Errors")]
@@ -187,6 +192,7 @@ pub struct BatchGetPartitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchGetPartitionResponse {
     /// <p>A list of the requested partitions.</p>
     #[serde(rename = "Partitions")]
@@ -200,6 +206,7 @@ pub struct BatchGetPartitionResponse {
 
 /// <p>Records an error that occurred when attempting to stop a specified job run.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchStopJobRunError {
     /// <p>Specifies details about the error that was encountered.</p>
     #[serde(rename = "ErrorDetail")]
@@ -226,6 +233,7 @@ pub struct BatchStopJobRunRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchStopJobRunResponse {
     /// <p>A list of the errors that were encountered in tryng to stop JobRuns, including the JobRunId for which each error was encountered and details about the error.</p>
     #[serde(rename = "Errors")]
@@ -239,6 +247,7 @@ pub struct BatchStopJobRunResponse {
 
 /// <p>Records a successful request to stop a specified JobRun.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchStopJobRunSuccessfulSubmission {
     /// <p>The name of the job definition used in the job run that was stopped.</p>
     #[serde(rename = "JobName")]
@@ -263,6 +272,7 @@ pub struct CatalogEntry {
 
 /// <p>A structure containing migration status information.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CatalogImportStatus {
     /// <p>True if the migration has completed, or False otherwise.</p>
     #[serde(rename = "ImportCompleted")]
@@ -280,6 +290,7 @@ pub struct CatalogImportStatus {
 
 /// <p>Classifiers are triggered during a crawl task. A classifier checks whether a given file is in a format it can handle, and if it is, the classifier creates a schema in the form of a <code>StructType</code> object that matches that data format.</p> <p>You can use the standard classifiers that AWS Glue supplies, or you can write your own classifiers to best categorize your data sources and specify the appropriate schemas to use for them. A classifier can be a <code>grok</code> classifier, an <code>XML</code> classifier, or a <code>JSON</code> classifier, as specified in one of the fields in the <code>Classifier</code> object.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Classifier {
     /// <p>A <code>GrokClassifier</code> object.</p>
     #[serde(rename = "GrokClassifier")]
@@ -378,6 +389,7 @@ pub struct Condition {
 
 /// <p>Defines a connection to a data source.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Connection {
     /// <p>A list of key-value pairs used as parameters for this connection.</p>
     #[serde(rename = "ConnectionProperties")]
@@ -454,6 +466,7 @@ pub struct ConnectionsList {
 
 /// <p>Specifies a crawler program that examines a data source and uses classifiers to try to determine its schema. If successful, the crawler records metadata concerning the data source in the AWS Glue Data Catalog.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Crawler {
     /// <p>A list of custom classifiers associated with the crawler.</p>
     #[serde(rename = "Classifiers")]
@@ -523,6 +536,7 @@ pub struct Crawler {
 
 /// <p>Metrics for a specified crawler.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CrawlerMetrics {
     /// <p>The name of the crawler.</p>
     #[serde(rename = "CrawlerName")]
@@ -592,6 +606,7 @@ pub struct CreateClassifierRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateClassifierResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -606,6 +621,7 @@ pub struct CreateConnectionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateConnectionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -649,6 +665,7 @@ pub struct CreateCrawlerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateCrawlerResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -663,6 +680,7 @@ pub struct CreateDatabaseRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDatabaseResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -704,6 +722,7 @@ pub struct CreateDevEndpointRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDevEndpointResponse {
     /// <p>The AWS availability zone where this DevEndpoint is located.</p>
     #[serde(rename = "AvailabilityZone")]
@@ -831,6 +850,7 @@ pub struct CreateJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateJobResponse {
     /// <p>The unique name that was provided for this job definition.</p>
     #[serde(rename = "Name")]
@@ -867,6 +887,7 @@ pub struct CreatePartitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreatePartitionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -886,6 +907,7 @@ pub struct CreateScriptRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateScriptResponse {
     /// <p>The Python script generated from the DAG.</p>
     #[serde(rename = "PythonScript")]
@@ -912,6 +934,7 @@ pub struct CreateTableRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateTableResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -944,6 +967,7 @@ pub struct CreateTriggerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateTriggerResponse {
     /// <p>The name of the trigger.</p>
     #[serde(rename = "Name")]
@@ -966,6 +990,7 @@ pub struct CreateUserDefinedFunctionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateUserDefinedFunctionResponse {}
 
 /// <p>Specifies an XML classifier for <code>CreateClassifier</code> to create.</p>
@@ -985,6 +1010,7 @@ pub struct CreateXMLClassifierRequest {
 
 /// <p>The <code>Database</code> object represents a logical grouping of tables that may reside in a Hive metastore or an RDBMS.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Database {
     /// <p>The time at which the metadata database was created in the catalog.</p>
     #[serde(rename = "CreateTime")]
@@ -1035,6 +1061,7 @@ pub struct DeleteClassifierRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteClassifierResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1049,6 +1076,7 @@ pub struct DeleteConnectionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteConnectionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1059,6 +1087,7 @@ pub struct DeleteCrawlerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteCrawlerResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1073,6 +1102,7 @@ pub struct DeleteDatabaseRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteDatabaseResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1083,6 +1113,7 @@ pub struct DeleteDevEndpointRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteDevEndpointResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1093,6 +1124,7 @@ pub struct DeleteJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteJobResponse {
     /// <p>The name of the job definition that was deleted.</p>
     #[serde(rename = "JobName")]
@@ -1118,6 +1150,7 @@ pub struct DeletePartitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeletePartitionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1135,6 +1168,7 @@ pub struct DeleteTableRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteTableResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1155,6 +1189,7 @@ pub struct DeleteTableVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteTableVersionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1165,6 +1200,7 @@ pub struct DeleteTriggerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteTriggerResponse {
     /// <p>The name of the trigger that was deleted.</p>
     #[serde(rename = "Name")]
@@ -1187,10 +1223,12 @@ pub struct DeleteUserDefinedFunctionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteUserDefinedFunctionResponse {}
 
 /// <p>A development endpoint where a developer can remotely debug ETL scripts.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DevEndpoint {
     /// <p>The AWS availability zone where this DevEndpoint is located.</p>
     #[serde(rename = "AvailabilityZone")]
@@ -1298,6 +1336,7 @@ pub struct DynamoDBTarget {
 
 /// <p>Contains details about an error.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ErrorDetail {
     /// <p>The code associated with this error.</p>
     #[serde(rename = "ErrorCode")]
@@ -1327,6 +1366,7 @@ pub struct GetCatalogImportStatusRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetCatalogImportStatusResponse {
     /// <p>The status of the specified catalog migration.</p>
     #[serde(rename = "ImportStatus")]
@@ -1342,6 +1382,7 @@ pub struct GetClassifierRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetClassifierResponse {
     /// <p>The requested classifier.</p>
     #[serde(rename = "Classifier")]
@@ -1362,6 +1403,7 @@ pub struct GetClassifiersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetClassifiersResponse {
     /// <p>The requested list of classifier objects.</p>
     #[serde(rename = "Classifiers")]
@@ -1385,6 +1427,7 @@ pub struct GetConnectionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetConnectionResponse {
     /// <p>The requested connection definition.</p>
     #[serde(rename = "Connection")]
@@ -1426,6 +1469,7 @@ pub struct GetConnectionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetConnectionsResponse {
     /// <p>A list of requested connection definitions.</p>
     #[serde(rename = "ConnectionList")]
@@ -1454,6 +1498,7 @@ pub struct GetCrawlerMetricsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetCrawlerMetricsResponse {
     /// <p>A list of metrics for the specified crawler.</p>
     #[serde(rename = "CrawlerMetricsList")]
@@ -1473,6 +1518,7 @@ pub struct GetCrawlerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetCrawlerResponse {
     /// <p>The metadata for the specified crawler.</p>
     #[serde(rename = "Crawler")]
@@ -1493,6 +1539,7 @@ pub struct GetCrawlersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetCrawlersResponse {
     /// <p>A list of crawler metadata.</p>
     #[serde(rename = "Crawlers")]
@@ -1516,6 +1563,7 @@ pub struct GetDatabaseRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDatabaseResponse {
     /// <p>The definition of the specified database in the catalog.</p>
     #[serde(rename = "Database")]
@@ -1540,6 +1588,7 @@ pub struct GetDatabasesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDatabasesResponse {
     /// <p>A list of <code>Database</code> objects from the specified catalog.</p>
     #[serde(rename = "DatabaseList")]
@@ -1559,6 +1608,7 @@ pub struct GetDataflowGraphRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDataflowGraphResponse {
     /// <p>A list of the edges in the resulting DAG.</p>
     #[serde(rename = "DagEdges")]
@@ -1578,6 +1628,7 @@ pub struct GetDevEndpointRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDevEndpointResponse {
     /// <p>A DevEndpoint definition.</p>
     #[serde(rename = "DevEndpoint")]
@@ -1598,6 +1649,7 @@ pub struct GetDevEndpointsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDevEndpointsResponse {
     /// <p>A list of DevEndpoint definitions.</p>
     #[serde(rename = "DevEndpoints")]
@@ -1617,6 +1669,7 @@ pub struct GetJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetJobResponse {
     /// <p>The requested job definition.</p>
     #[serde(rename = "Job")]
@@ -1639,6 +1692,7 @@ pub struct GetJobRunRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetJobRunResponse {
     /// <p>The requested job-run metadata.</p>
     #[serde(rename = "JobRun")]
@@ -1662,6 +1716,7 @@ pub struct GetJobRunsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetJobRunsResponse {
     /// <p>A list of job-run metatdata objects.</p>
     #[serde(rename = "JobRuns")]
@@ -1686,6 +1741,7 @@ pub struct GetJobsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetJobsResponse {
     /// <p>A list of job definitions.</p>
     #[serde(rename = "Jobs")]
@@ -1713,6 +1769,7 @@ pub struct GetMappingRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetMappingResponse {
     /// <p>A list of mappings to the specified targets.</p>
     #[serde(rename = "Mapping")]
@@ -1737,6 +1794,7 @@ pub struct GetPartitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetPartitionResponse {
     /// <p>The requested information, in the form of a <code>Partition</code> object.</p>
     #[serde(rename = "Partition")]
@@ -1775,6 +1833,7 @@ pub struct GetPartitionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetPartitionsResponse {
     /// <p>A continuation token, if the returned list of partitions does not does not include the last one.</p>
     #[serde(rename = "NextToken")]
@@ -1809,6 +1868,7 @@ pub struct GetPlanRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetPlanResponse {
     /// <p>A Python script to perform the mapping.</p>
     #[serde(rename = "PythonScript")]
@@ -1835,6 +1895,7 @@ pub struct GetTableRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetTableResponse {
     /// <p>The <code>Table</code> object that defines the specified table.</p>
     #[serde(rename = "Table")]
@@ -1861,6 +1922,7 @@ pub struct GetTableVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetTableVersionResponse {
     /// <p>The requested table version.</p>
     #[serde(rename = "TableVersion")]
@@ -1891,6 +1953,7 @@ pub struct GetTableVersionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetTableVersionsResponse {
     /// <p>A continuation token, if the list of available versions does not include the last one.</p>
     #[serde(rename = "NextToken")]
@@ -1926,6 +1989,7 @@ pub struct GetTablesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetTablesResponse {
     /// <p>A continuation token, present if the current list segment is not the last.</p>
     #[serde(rename = "NextToken")]
@@ -1945,6 +2009,7 @@ pub struct GetTriggerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetTriggerResponse {
     /// <p>The requested trigger definition.</p>
     #[serde(rename = "Trigger")]
@@ -1969,6 +2034,7 @@ pub struct GetTriggersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetTriggersResponse {
     /// <p>A continuation token, if not all the requested triggers have yet been returned.</p>
     #[serde(rename = "NextToken")]
@@ -1995,6 +2061,7 @@ pub struct GetUserDefinedFunctionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetUserDefinedFunctionResponse {
     /// <p>The requested function definition.</p>
     #[serde(rename = "UserDefinedFunction")]
@@ -2025,6 +2092,7 @@ pub struct GetUserDefinedFunctionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetUserDefinedFunctionsResponse {
     /// <p>A continuation token, if the list of functions returned does not include the last requested function.</p>
     #[serde(rename = "NextToken")]
@@ -2038,6 +2106,7 @@ pub struct GetUserDefinedFunctionsResponse {
 
 /// <p>A classifier that uses <code>grok</code> patterns.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GrokClassifier {
     /// <p>An identifier of the data format that the classifier matches, such as Twitter, JSON, Omniture logs, and so on.</p>
     #[serde(rename = "Classification")]
@@ -2075,6 +2144,7 @@ pub struct ImportCatalogToGlueRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ImportCatalogToGlueResponse {}
 
 /// <p>Specifies a JDBC data store to crawl.</p>
@@ -2096,6 +2166,7 @@ pub struct JdbcTarget {
 
 /// <p>Specifies a job definition.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Job {
     /// <p>The number of AWS Glue data processing units (DPUs) allocated to runs of this job. From 2 to 100 DPUs can be allocated; the default is 10. A DPU is a relative measure of processing power that consists of 4 vCPUs of compute capacity and 16 GB of memory. For more information, see the <a href="https://aws.amazon.com/glue/pricing/">AWS Glue pricing page</a>.</p>
     #[serde(rename = "AllocatedCapacity")]
@@ -2157,6 +2228,7 @@ pub struct Job {
 
 /// <p>Defines a point which a job can resume processing.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct JobBookmarkEntry {
     /// <p>The attempt ID number.</p>
     #[serde(rename = "Attempt")]
@@ -2195,6 +2267,7 @@ pub struct JobCommand {
 
 /// <p>Contains information about a job run.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct JobRun {
     /// <p>The number of AWS Glue data processing units (DPUs) allocated to this JobRun. From 2 to 100 DPUs can be allocated; the default is 10. A DPU is a relative measure of processing power that consists of 4 vCPUs of compute capacity and 16 GB of memory. For more information, see the <a href="https://aws.amazon.com/glue/pricing/">AWS Glue pricing page</a>.</p>
     #[serde(rename = "AllocatedCapacity")]
@@ -2313,6 +2386,7 @@ pub struct JobUpdate {
 
 /// <p>A classifier for <code>JSON</code> content.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct JsonClassifier {
     /// <p>The time this classifier was registered.</p>
     #[serde(rename = "CreationTime")]
@@ -2336,6 +2410,7 @@ pub struct JsonClassifier {
 
 /// <p>Status and error information about the most recent crawl.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LastCrawlInfo {
     /// <p>If an error occurred, the error information about the last crawl.</p>
     #[serde(rename = "ErrorMessage")]
@@ -2431,6 +2506,7 @@ pub struct Order {
 
 /// <p>Represents a slice of table data.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Partition {
     /// <p>The time at which the partition was created.</p>
     #[serde(rename = "CreationTime")]
@@ -2468,6 +2544,7 @@ pub struct Partition {
 
 /// <p>Contains information about a partition error.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PartitionError {
     /// <p>Details about the partition error.</p>
     #[serde(rename = "ErrorDetail")]
@@ -2531,6 +2608,7 @@ pub struct PhysicalConnectionRequirements {
 
 /// <p>A job run that was used in the predicate of a conditional trigger that triggered this job run.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Predecessor {
     /// <p>The name of the job definition used by the predecessor job run.</p>
     #[serde(rename = "JobName")]
@@ -2563,6 +2641,7 @@ pub struct ResetJobBookmarkRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResetJobBookmarkResponse {
     /// <p>The reset bookmark entry.</p>
     #[serde(rename = "JobBookmarkEntry")]
@@ -2598,6 +2677,7 @@ pub struct S3Target {
 
 /// <p>A scheduling object using a <code>cron</code> statement to schedule an event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Schedule {
     /// <p>A <code>cron</code> expression used to specify the schedule (see <a href="http://docs.aws.amazon.com/glue/latest/dg/monitor-data-warehouse-schedule.html">Time-Based Schedules for Jobs and Crawlers</a>. For example, to run something every day at 12:15 UTC, you would specify: <code>cron(15 12 * * ? *)</code>.</p>
     #[serde(rename = "ScheduleExpression")]
@@ -2675,6 +2755,7 @@ pub struct StartCrawlerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartCrawlerResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -2685,6 +2766,7 @@ pub struct StartCrawlerScheduleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartCrawlerScheduleResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -2715,6 +2797,7 @@ pub struct StartJobRunRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartJobRunResponse {
     /// <p>The ID assigned to this job run.</p>
     #[serde(rename = "JobRunId")]
@@ -2730,6 +2813,7 @@ pub struct StartTriggerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartTriggerResponse {
     /// <p>The name of the trigger that was started.</p>
     #[serde(rename = "Name")]
@@ -2745,6 +2829,7 @@ pub struct StopCrawlerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopCrawlerResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -2755,6 +2840,7 @@ pub struct StopCrawlerScheduleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopCrawlerScheduleResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -2765,6 +2851,7 @@ pub struct StopTriggerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopTriggerResponse {
     /// <p>The name of the trigger that was stopped.</p>
     #[serde(rename = "Name")]
@@ -2827,6 +2914,7 @@ pub struct StorageDescriptor {
 
 /// <p>Represents a collection of related data organized in columns and rows.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Table {
     /// <p>Time when the table definition was created in the Data Catalog.</p>
     #[serde(rename = "CreateTime")]
@@ -2895,6 +2983,7 @@ pub struct Table {
 
 /// <p>An error record for table operations.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TableError {
     /// <p>Detail about the error.</p>
     #[serde(rename = "ErrorDetail")]
@@ -2960,6 +3049,7 @@ pub struct TableInput {
 
 /// <p>Specifies a version of a table.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TableVersion {
     /// <p>The table in question</p>
     #[serde(rename = "Table")]
@@ -2973,6 +3063,7 @@ pub struct TableVersion {
 
 /// <p>An error record for table-version operations.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TableVersionError {
     /// <p>Detail about the error.</p>
     #[serde(rename = "ErrorDetail")]
@@ -2990,6 +3081,7 @@ pub struct TableVersionError {
 
 /// <p>Information about a specific trigger.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Trigger {
     /// <p>The actions initiated by this trigger.</p>
     #[serde(rename = "Actions")]
@@ -3067,6 +3159,7 @@ pub struct UpdateClassifierRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateClassifierResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -3084,6 +3177,7 @@ pub struct UpdateConnectionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateConnectionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -3130,6 +3224,7 @@ pub struct UpdateCrawlerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateCrawlerResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -3144,6 +3239,7 @@ pub struct UpdateCrawlerScheduleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateCrawlerScheduleResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -3161,6 +3257,7 @@ pub struct UpdateDatabaseRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateDatabaseResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -3191,6 +3288,7 @@ pub struct UpdateDevEndpointRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateDevEndpointResponse {}
 
 /// <p>Specifies a grok classifier to update when passed to <code>UpdateClassifier</code>.</p>
@@ -3224,6 +3322,7 @@ pub struct UpdateJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateJobResponse {
     /// <p>Returns the name of the updated job definition.</p>
     #[serde(rename = "JobName")]
@@ -3264,6 +3363,7 @@ pub struct UpdatePartitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdatePartitionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -3285,6 +3385,7 @@ pub struct UpdateTableRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateTableResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -3298,6 +3399,7 @@ pub struct UpdateTriggerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateTriggerResponse {
     /// <p>The resulting trigger definition.</p>
     #[serde(rename = "Trigger")]
@@ -3323,6 +3425,7 @@ pub struct UpdateUserDefinedFunctionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateUserDefinedFunctionResponse {}
 
 /// <p>Specifies an XML classifier to be updated.</p>
@@ -3343,6 +3446,7 @@ pub struct UpdateXMLClassifierRequest {
 
 /// <p>Represents the equivalent of a Hive user-defined function (<code>UDF</code>) definition.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UserDefinedFunction {
     /// <p>The Java class that contains the function code.</p>
     #[serde(rename = "ClassName")]
@@ -3397,6 +3501,7 @@ pub struct UserDefinedFunctionInput {
 
 /// <p>A classifier for <code>XML</code> content.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct XMLClassifier {
     /// <p>An identifier of the data format that the classifier matches.</p>
     #[serde(rename = "Classification")]

--- a/rusoto/services/greengrass/src/generated.rs
+++ b/rusoto/services/greengrass/src/generated.rs
@@ -41,6 +41,7 @@ pub struct AssociateRoleToGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociateRoleToGroupResponse {
     /// <p>The time, in milliseconds since the epoch, when the role ARN was associated with the group.</p>
     #[serde(rename = "AssociatedAt")]
@@ -57,6 +58,7 @@ pub struct AssociateServiceRoleToAccountRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociateServiceRoleToAccountResponse {
     /// <p>The time when the service role was associated with the account.</p>
     #[serde(rename = "AssociatedAt")]
@@ -133,6 +135,7 @@ pub struct CreateCoreDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateCoreDefinitionResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -180,6 +183,7 @@ pub struct CreateCoreDefinitionVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateCoreDefinitionVersionResponse {
     /// <p>The ARN of the version.</p>
     #[serde(rename = "Arn")]
@@ -223,6 +227,7 @@ pub struct CreateDeploymentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDeploymentResponse {
     /// <p>The ARN of the deployment.</p>
     #[serde(rename = "DeploymentArn")]
@@ -251,6 +256,7 @@ pub struct CreateDeviceDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDeviceDefinitionResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -298,6 +304,7 @@ pub struct CreateDeviceDefinitionVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDeviceDefinitionVersionResponse {
     /// <p>The ARN of the version.</p>
     #[serde(rename = "Arn")]
@@ -334,6 +341,7 @@ pub struct CreateFunctionDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateFunctionDefinitionResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -382,6 +390,7 @@ pub struct CreateFunctionDefinitionVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateFunctionDefinitionVersionResponse {
     /// <p>The ARN of the version.</p>
     #[serde(rename = "Arn")]
@@ -413,6 +422,7 @@ pub struct CreateGroupCertificateAuthorityRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateGroupCertificateAuthorityResponse {
     /// <p>The ARN of the group certificate authority.</p>
     #[serde(rename = "GroupCertificateAuthorityArn")]
@@ -437,6 +447,7 @@ pub struct CreateGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateGroupResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -504,6 +515,7 @@ pub struct CreateGroupVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateGroupVersionResponse {
     /// <p>The ARN of the version.</p>
     #[serde(rename = "Arn")]
@@ -540,6 +552,7 @@ pub struct CreateLoggerDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateLoggerDefinitionResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -587,6 +600,7 @@ pub struct CreateLoggerDefinitionVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateLoggerDefinitionVersionResponse {
     /// <p>The ARN of the version.</p>
     #[serde(rename = "Arn")]
@@ -623,6 +637,7 @@ pub struct CreateResourceDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateResourceDefinitionResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -670,6 +685,7 @@ pub struct CreateResourceDefinitionVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateResourceDefinitionVersionResponse {
     /// <p>The ARN of the version.</p>
     #[serde(rename = "Arn")]
@@ -716,6 +732,7 @@ pub struct CreateSoftwareUpdateJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateSoftwareUpdateJobResponse {
     /// <p>The IoT Job ARN corresponding to this update.</p>
     #[serde(rename = "IotJobArn")]
@@ -744,6 +761,7 @@ pub struct CreateSubscriptionDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateSubscriptionDefinitionResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -791,6 +809,7 @@ pub struct CreateSubscriptionDefinitionVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateSubscriptionDefinitionVersionResponse {
     /// <p>The ARN of the version.</p>
     #[serde(rename = "Arn")]
@@ -812,6 +831,7 @@ pub struct CreateSubscriptionDefinitionVersionResponse {
 
 /// <p>Information about a definition.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DefinitionInformation {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -851,6 +871,7 @@ pub struct DeleteCoreDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteCoreDefinitionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -861,6 +882,7 @@ pub struct DeleteDeviceDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteDeviceDefinitionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -871,6 +893,7 @@ pub struct DeleteFunctionDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteFunctionDefinitionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -881,6 +904,7 @@ pub struct DeleteGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteGroupResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -891,6 +915,7 @@ pub struct DeleteLoggerDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteLoggerDefinitionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -901,6 +926,7 @@ pub struct DeleteResourceDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteResourceDefinitionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -911,10 +937,12 @@ pub struct DeleteSubscriptionDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteSubscriptionDefinitionResponse {}
 
 /// <p>Information about a deployment.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Deployment {
     /// <p>The time, in milliseconds since the epoch, when the deployment was created.</p>
     #[serde(rename = "CreatedAt")]
@@ -976,6 +1004,7 @@ pub struct DisassociateRoleFromGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisassociateRoleFromGroupResponse {
     /// <p>The time, in milliseconds since the epoch, when the role was disassociated from the group.</p>
     #[serde(rename = "DisassociatedAt")]
@@ -987,6 +1016,7 @@ pub struct DisassociateRoleFromGroupResponse {
 pub struct DisassociateServiceRoleFromAccountRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisassociateServiceRoleFromAccountResponse {
     /// <p>The time when the service role was disassociated from the account.</p>
     #[serde(rename = "DisassociatedAt")]
@@ -1000,6 +1030,7 @@ pub struct Empty {}
 
 /// <p>Details about the error.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ErrorDetail {
     /// <p>A detailed error code.</p>
     #[serde(rename = "DetailedErrorCode")]
@@ -1104,6 +1135,7 @@ pub struct GetAssociatedRoleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetAssociatedRoleResponse {
     /// <p>The time when the role was associated with the group.</p>
     #[serde(rename = "AssociatedAt")]
@@ -1123,6 +1155,7 @@ pub struct GetConnectivityInfoRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetConnectivityInfoResponse {
     /// <p>Connectivity info list.</p>
     #[serde(rename = "ConnectivityInfo")]
@@ -1142,6 +1175,7 @@ pub struct GetCoreDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetCoreDefinitionResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -1184,6 +1218,7 @@ pub struct GetCoreDefinitionVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetCoreDefinitionVersionResponse {
     /// <p>The ARN of the core definition version.</p>
     #[serde(rename = "Arn")]
@@ -1218,6 +1253,7 @@ pub struct GetDeploymentStatusRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDeploymentStatusResponse {
     /// <p>The status of the deployment.</p>
     #[serde(rename = "DeploymentStatus")]
@@ -1249,6 +1285,7 @@ pub struct GetDeviceDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDeviceDefinitionResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -1291,6 +1328,7 @@ pub struct GetDeviceDefinitionVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDeviceDefinitionVersionResponse {
     /// <p>The ARN of the device definition version.</p>
     #[serde(rename = "Arn")]
@@ -1322,6 +1360,7 @@ pub struct GetFunctionDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetFunctionDefinitionResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -1364,6 +1403,7 @@ pub struct GetFunctionDefinitionVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetFunctionDefinitionVersionResponse {
     /// <p>The ARN of the function definition version.</p>
     #[serde(rename = "Arn")]
@@ -1398,6 +1438,7 @@ pub struct GetGroupCertificateAuthorityRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetGroupCertificateAuthorityResponse {
     /// <p>The ARN of the certificate authority for the group.</p>
     #[serde(rename = "GroupCertificateAuthorityArn")]
@@ -1421,6 +1462,7 @@ pub struct GetGroupCertificateConfigurationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetGroupCertificateConfigurationResponse {
     /// <p>The amount of time remaining before the certificate authority expires, in milliseconds.</p>
     #[serde(rename = "CertificateAuthorityExpiryInMilliseconds")]
@@ -1444,6 +1486,7 @@ pub struct GetGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetGroupResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -1486,6 +1529,7 @@ pub struct GetGroupVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetGroupVersionResponse {
     /// <p>The ARN of the group version.</p>
     #[serde(rename = "Arn")]
@@ -1517,6 +1561,7 @@ pub struct GetLoggerDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetLoggerDefinitionResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -1559,6 +1604,7 @@ pub struct GetLoggerDefinitionVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetLoggerDefinitionVersionResponse {
     /// <p>The ARN of the logger definition version.</p>
     #[serde(rename = "Arn")]
@@ -1590,6 +1636,7 @@ pub struct GetResourceDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetResourceDefinitionResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -1632,6 +1679,7 @@ pub struct GetResourceDefinitionVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetResourceDefinitionVersionResponse {
     /// <p>Arn of the resource definition version.</p>
     #[serde(rename = "Arn")]
@@ -1659,6 +1707,7 @@ pub struct GetResourceDefinitionVersionResponse {
 pub struct GetServiceRoleForAccountRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetServiceRoleForAccountResponse {
     /// <p>The time when the service role was associated with the account.</p>
     #[serde(rename = "AssociatedAt")]
@@ -1678,6 +1727,7 @@ pub struct GetSubscriptionDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetSubscriptionDefinitionResponse {
     /// <p>The ARN of the definition.</p>
     #[serde(rename = "Arn")]
@@ -1720,6 +1770,7 @@ pub struct GetSubscriptionDefinitionVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetSubscriptionDefinitionVersionResponse {
     /// <p>The ARN of the subscription definition version.</p>
     #[serde(rename = "Arn")]
@@ -1745,6 +1796,7 @@ pub struct GetSubscriptionDefinitionVersionResponse {
 
 /// <p>Information about a certificate authority for a group.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GroupCertificateAuthorityProperties {
     /// <p>The ARN of the certificate authority for the group.</p>
     #[serde(rename = "GroupCertificateAuthorityArn")]
@@ -1769,6 +1821,7 @@ pub struct GroupCertificateConfiguration {
 
 /// <p>Information about a group.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GroupInformation {
     /// <p>The ARN of the group.</p>
     #[serde(rename = "Arn")]
@@ -1858,6 +1911,7 @@ pub struct ListCoreDefinitionVersionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListCoreDefinitionVersionsResponse {
     /// <p>The token for the next set of results, or &#39;&#39;null&#39;&#39; if there are no additional results.</p>
     #[serde(rename = "NextToken")]
@@ -1882,6 +1936,7 @@ pub struct ListCoreDefinitionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListCoreDefinitionsResponse {
     /// <p>Information about a definition.</p>
     #[serde(rename = "Definitions")]
@@ -1918,6 +1973,7 @@ pub struct ListDeploymentsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListDeploymentsResponse {
     /// <p>A list of deployments for the requested groups.</p>
     #[serde(rename = "Deployments")]
@@ -1945,6 +2001,7 @@ pub struct ListDeviceDefinitionVersionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListDeviceDefinitionVersionsResponse {
     /// <p>The token for the next set of results, or &#39;&#39;null&#39;&#39; if there are no additional results.</p>
     #[serde(rename = "NextToken")]
@@ -1969,6 +2026,7 @@ pub struct ListDeviceDefinitionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListDeviceDefinitionsResponse {
     /// <p>Information about a definition.</p>
     #[serde(rename = "Definitions")]
@@ -1996,6 +2054,7 @@ pub struct ListFunctionDefinitionVersionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListFunctionDefinitionVersionsResponse {
     /// <p>The token for the next set of results, or &#39;&#39;null&#39;&#39; if there are no additional results.</p>
     #[serde(rename = "NextToken")]
@@ -2020,6 +2079,7 @@ pub struct ListFunctionDefinitionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListFunctionDefinitionsResponse {
     /// <p>Information about a definition.</p>
     #[serde(rename = "Definitions")]
@@ -2039,6 +2099,7 @@ pub struct ListGroupCertificateAuthoritiesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListGroupCertificateAuthoritiesResponse {
     /// <p>A list of certificate authorities associated with the group.</p>
     #[serde(rename = "GroupCertificateAuthorities")]
@@ -2062,6 +2123,7 @@ pub struct ListGroupVersionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListGroupVersionsResponse {
     /// <p>The token for the next set of results, or &#39;&#39;null&#39;&#39; if there are no additional results.</p>
     #[serde(rename = "NextToken")]
@@ -2086,6 +2148,7 @@ pub struct ListGroupsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListGroupsResponse {
     /// <p>Information about a group.</p>
     #[serde(rename = "Groups")]
@@ -2113,6 +2176,7 @@ pub struct ListLoggerDefinitionVersionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListLoggerDefinitionVersionsResponse {
     /// <p>The token for the next set of results, or &#39;&#39;null&#39;&#39; if there are no additional results.</p>
     #[serde(rename = "NextToken")]
@@ -2137,6 +2201,7 @@ pub struct ListLoggerDefinitionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListLoggerDefinitionsResponse {
     /// <p>Information about a definition.</p>
     #[serde(rename = "Definitions")]
@@ -2164,6 +2229,7 @@ pub struct ListResourceDefinitionVersionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListResourceDefinitionVersionsResponse {
     /// <p>The token for the next set of results, or &#39;&#39;null&#39;&#39; if there are no additional results.</p>
     #[serde(rename = "NextToken")]
@@ -2188,6 +2254,7 @@ pub struct ListResourceDefinitionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListResourceDefinitionsResponse {
     /// <p>Information about a definition.</p>
     #[serde(rename = "Definitions")]
@@ -2215,6 +2282,7 @@ pub struct ListSubscriptionDefinitionVersionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListSubscriptionDefinitionVersionsResponse {
     /// <p>The token for the next set of results, or &#39;&#39;null&#39;&#39; if there are no additional results.</p>
     #[serde(rename = "NextToken")]
@@ -2239,6 +2307,7 @@ pub struct ListSubscriptionDefinitionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListSubscriptionDefinitionsResponse {
     /// <p>Information about a definition.</p>
     #[serde(rename = "Definitions")]
@@ -2340,6 +2409,7 @@ pub struct ResetDeploymentsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResetDeploymentsResponse {
     /// <p>The ARN of the deployment.</p>
     #[serde(rename = "DeploymentArn")]
@@ -2481,6 +2551,7 @@ pub struct UpdateConnectivityInfoRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateConnectivityInfoResponse {
     /// <p>A message about the connectivity info update request.</p>
     #[serde(rename = "Message")]
@@ -2504,6 +2575,7 @@ pub struct UpdateCoreDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateCoreDefinitionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -2518,6 +2590,7 @@ pub struct UpdateDeviceDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateDeviceDefinitionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -2532,6 +2605,7 @@ pub struct UpdateFunctionDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateFunctionDefinitionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -2546,6 +2620,7 @@ pub struct UpdateGroupCertificateConfigurationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateGroupCertificateConfigurationResponse {
     /// <p>The amount of time remaining before the certificate authority expires, in milliseconds.</p>
     #[serde(rename = "CertificateAuthorityExpiryInMilliseconds")]
@@ -2573,6 +2648,7 @@ pub struct UpdateGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateGroupResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -2587,6 +2663,7 @@ pub struct UpdateLoggerDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateLoggerDefinitionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -2601,6 +2678,7 @@ pub struct UpdateResourceDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateResourceDefinitionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -2615,10 +2693,12 @@ pub struct UpdateSubscriptionDefinitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateSubscriptionDefinitionResponse {}
 
 /// <p>Information about a version.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VersionInformation {
     /// <p>The ARN of the version.</p>
     #[serde(rename = "Arn")]

--- a/rusoto/services/guardduty/src/generated.rs
+++ b/rusoto/services/guardduty/src/generated.rs
@@ -46,10 +46,12 @@ pub struct AcceptInvitationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AcceptInvitationResponse {}
 
 /// <p>The IAM access key details (IAM user information) of a user that engaged in the activity that prompted GuardDuty to generate a finding.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AccessKeyDetails {
     /// <p>Access key ID of the user.</p>
     #[serde(rename = "AccessKeyId")]
@@ -82,6 +84,7 @@ pub struct AccountDetail {
 
 /// <p>Information about the activity described in a finding.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Action {
     /// <p>GuardDuty Finding activity type.</p>
     #[serde(rename = "ActionType")]
@@ -118,10 +121,12 @@ pub struct ArchiveFindingsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ArchiveFindingsResponse {}
 
 /// <p>Information about the AWS<em>API</em>CALL action described in this finding.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AwsApiCallAction {
     /// <p>AWS API name.</p>
     #[serde(rename = "Api")]
@@ -147,6 +152,7 @@ pub struct AwsApiCallAction {
 
 /// <p>City information of the remote IP address.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct City {
     /// <p>City name of the remote IP address.</p>
     #[serde(rename = "CityName")]
@@ -185,6 +191,7 @@ pub struct Condition {
 
 /// <p>Country information of the remote IP address.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Country {
     /// <p>Country code of the remote IP address.</p>
     #[serde(rename = "CountryCode")]
@@ -206,6 +213,7 @@ pub struct CreateDetectorRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDetectorResponse {
     /// <p>The unique ID of the created detector.</p>
     #[serde(rename = "DetectorId")]
@@ -246,6 +254,7 @@ pub struct CreateFilterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateFilterResponse {
     /// <p>The name of the successfully created filter.</p>
     #[serde(rename = "Name")]
@@ -278,6 +287,7 @@ pub struct CreateIPSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateIPSetResponse {
     #[serde(rename = "IpSetId")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -297,6 +307,7 @@ pub struct CreateMembersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateMembersResponse {
     /// <p>A list of objects containing the unprocessed account and a result string explaining why it was unprocessed.</p>
     #[serde(rename = "UnprocessedAccounts")]
@@ -317,6 +328,7 @@ pub struct CreateSampleFindingsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateSampleFindingsResponse {}
 
 /// <p>CreateThreatIntelSet request body.</p>
@@ -344,6 +356,7 @@ pub struct CreateThreatIntelSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateThreatIntelSetResponse {
     #[serde(rename = "ThreatIntelSetId")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -360,6 +373,7 @@ pub struct DeclineInvitationsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeclineInvitationsResponse {
     /// <p>A list of objects containing the unprocessed account and a result string explaining why it was unprocessed.</p>
     #[serde(rename = "UnprocessedAccounts")]
@@ -375,6 +389,7 @@ pub struct DeleteDetectorRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteDetectorResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -388,6 +403,7 @@ pub struct DeleteFilterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteFilterResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -401,6 +417,7 @@ pub struct DeleteIPSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteIPSetResponse {}
 
 /// <p>DeleteInvitations request body.</p>
@@ -413,6 +430,7 @@ pub struct DeleteInvitationsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteInvitationsResponse {
     /// <p>A list of objects containing the unprocessed account and a result string explaining why it was unprocessed.</p>
     #[serde(rename = "UnprocessedAccounts")]
@@ -433,6 +451,7 @@ pub struct DeleteMembersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteMembersResponse {
     /// <p>A list of objects containing the unprocessed account and a result string explaining why it was unprocessed.</p>
     #[serde(rename = "UnprocessedAccounts")]
@@ -451,6 +470,7 @@ pub struct DeleteThreatIntelSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteThreatIntelSetResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -461,6 +481,7 @@ pub struct DisassociateFromMasterAccountRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisassociateFromMasterAccountResponse {}
 
 /// <p>DisassociateMembers request body.</p>
@@ -476,6 +497,7 @@ pub struct DisassociateMembersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisassociateMembersResponse {
     /// <p>A list of objects containing the unprocessed account and a result string explaining why it was unprocessed.</p>
     #[serde(rename = "UnprocessedAccounts")]
@@ -485,6 +507,7 @@ pub struct DisassociateMembersResponse {
 
 /// <p>Information about the DNS_REQUEST action described in this finding.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DnsRequestAction {
     /// <p>Domain information for the DNS request.</p>
     #[serde(rename = "Domain")]
@@ -494,6 +517,7 @@ pub struct DnsRequestAction {
 
 /// <p>Domain information for the AWS API call.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DomainDetails {}
 
 /// <p>Error response object.</p>
@@ -507,6 +531,7 @@ pub struct ErrorResponse {
 
 /// <p>Representation of a abnormal or suspicious activity.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Finding {
     /// <p>AWS account ID where the activity occurred that prompted GuardDuty to generate a finding.</p>
     #[serde(rename = "AccountId")]
@@ -571,6 +596,7 @@ pub struct FindingCriteria {
 
 /// <p>Finding statistics object.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FindingStatistics {
     /// <p>Represents a map of severity to count statistic for a set of findings</p>
     #[serde(rename = "CountBySeverity")]
@@ -580,6 +606,7 @@ pub struct FindingStatistics {
 
 /// <p>Location information of the remote IP address.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GeoLocation {
     /// <p>Latitude information of remote IP address.</p>
     #[serde(rename = "Lat")]
@@ -599,6 +626,7 @@ pub struct GetDetectorRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDetectorResponse {
     #[serde(rename = "CreatedAt")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -625,6 +653,7 @@ pub struct GetFilterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetFilterResponse {
     /// <p>Specifies the action that is to be applied to the findings that match the filter.</p>
     #[serde(rename = "Action")]
@@ -665,6 +694,7 @@ pub struct GetFindingsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetFindingsResponse {
     #[serde(rename = "Findings")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -688,6 +718,7 @@ pub struct GetFindingsStatisticsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetFindingsStatisticsResponse {
     /// <p>Finding statistics object.</p>
     #[serde(rename = "FindingStatistics")]
@@ -706,6 +737,7 @@ pub struct GetIPSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetIPSetResponse {
     /// <p>The format of the file that contains the IPSet.</p>
     #[serde(rename = "Format")]
@@ -729,6 +761,7 @@ pub struct GetIPSetResponse {
 pub struct GetInvitationsCountRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetInvitationsCountResponse {
     /// <p>The number of received invitations.</p>
     #[serde(rename = "InvitationsCount")]
@@ -744,6 +777,7 @@ pub struct GetMasterAccountRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetMasterAccountResponse {
     #[serde(rename = "Master")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -763,6 +797,7 @@ pub struct GetMembersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetMembersResponse {
     #[serde(rename = "Members")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -784,6 +819,7 @@ pub struct GetThreatIntelSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetThreatIntelSetResponse {
     /// <p>The format of the threatIntelSet.</p>
     #[serde(rename = "Format")]
@@ -805,6 +841,7 @@ pub struct GetThreatIntelSetResponse {
 
 /// <p>The profile information of the EC2 instance.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct IamInstanceProfile {
     /// <p>AWS EC2 instance profile ARN.</p>
     #[serde(rename = "Arn")]
@@ -818,6 +855,7 @@ pub struct IamInstanceProfile {
 
 /// <p>The information about the EC2 instance associated with the activity that prompted GuardDuty to generate a finding.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceDetails {
     /// <p>The availability zone of the EC2 instance.</p>
     #[serde(rename = "AvailabilityZone")]
@@ -870,6 +908,7 @@ pub struct InstanceDetails {
 
 /// <p>Invitation from an AWS account to become the current account&#39;s master.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Invitation {
     /// <p>Inviter account ID</p>
     #[serde(rename = "AccountId")]
@@ -910,6 +949,7 @@ pub struct InviteMembersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InviteMembersResponse {
     /// <p>A list of objects containing the unprocessed account and a result string explaining why it was unprocessed.</p>
     #[serde(rename = "UnprocessedAccounts")]
@@ -930,6 +970,7 @@ pub struct ListDetectorsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListDetectorsResponse {
     #[serde(rename = "DetectorIds")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -955,6 +996,7 @@ pub struct ListFiltersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListFiltersResponse {
     #[serde(rename = "FilterNames")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -989,6 +1031,7 @@ pub struct ListFindingsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListFindingsResponse {
     #[serde(rename = "FindingIds")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1014,6 +1057,7 @@ pub struct ListIPSetsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListIPSetsResponse {
     #[serde(rename = "IpSetIds")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1036,6 +1080,7 @@ pub struct ListInvitationsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListInvitationsResponse {
     #[serde(rename = "Invitations")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1065,6 +1110,7 @@ pub struct ListMembersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListMembersResponse {
     #[serde(rename = "Members")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1090,6 +1136,7 @@ pub struct ListThreatIntelSetsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListThreatIntelSetsResponse {
     #[serde(rename = "NextToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1101,6 +1148,7 @@ pub struct ListThreatIntelSetsResponse {
 
 /// <p>Local port information of the connection.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LocalPortDetails {
     /// <p>Port number of the local connection.</p>
     #[serde(rename = "Port")]
@@ -1114,6 +1162,7 @@ pub struct LocalPortDetails {
 
 /// <p>Contains details about the master account.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Master {
     /// <p>Master account ID</p>
     #[serde(rename = "AccountId")]
@@ -1135,6 +1184,7 @@ pub struct Master {
 
 /// <p>Contains details about the member account.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Member {
     #[serde(rename = "AccountId")]
     pub account_id: String,
@@ -1159,6 +1209,7 @@ pub struct Member {
 
 /// <p>Information about the NETWORK_CONNECTION action described in this finding.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct NetworkConnectionAction {
     /// <p>Network connection blocked information.</p>
     #[serde(rename = "Blocked")]
@@ -1188,6 +1239,7 @@ pub struct NetworkConnectionAction {
 
 /// <p>The network interface information of the EC2 instance.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct NetworkInterface {
     /// <p>A list of EC2 instance IPv6 address information.</p>
     #[serde(rename = "Ipv6Addresses")]
@@ -1233,6 +1285,7 @@ pub struct NetworkInterface {
 
 /// <p>ISP Organization information of the remote IP address.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Organization {
     /// <p>Autonomous system number of the internet provider of the remote IP address.</p>
     #[serde(rename = "Asn")]
@@ -1254,6 +1307,7 @@ pub struct Organization {
 
 /// <p>Information about the PORT_PROBE action described in this finding.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PortProbeAction {
     /// <p>Port probe blocked information.</p>
     #[serde(rename = "Blocked")]
@@ -1267,6 +1321,7 @@ pub struct PortProbeAction {
 
 /// <p>Details about the port probe finding.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PortProbeDetail {
     /// <p>Local port information of the connection.</p>
     #[serde(rename = "LocalPortDetails")]
@@ -1280,6 +1335,7 @@ pub struct PortProbeDetail {
 
 /// <p>Other private IP address information of the EC2 instance.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PrivateIpAddressDetails {
     /// <p>Private DNS name of the EC2 instance.</p>
     #[serde(rename = "PrivateDnsName")]
@@ -1293,6 +1349,7 @@ pub struct PrivateIpAddressDetails {
 
 /// <p>The product code of the EC2 instance.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ProductCode {
     /// <p>Product code information.</p>
     #[serde(rename = "Code")]
@@ -1306,6 +1363,7 @@ pub struct ProductCode {
 
 /// <p>Remote IP information of the connection.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RemoteIpDetails {
     /// <p>City information of the remote IP address.</p>
     #[serde(rename = "City")]
@@ -1331,6 +1389,7 @@ pub struct RemoteIpDetails {
 
 /// <p>Remote port information of the connection.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RemotePortDetails {
     /// <p>Port number of the remote connection.</p>
     #[serde(rename = "Port")]
@@ -1344,6 +1403,7 @@ pub struct RemotePortDetails {
 
 /// <p>The AWS resource associated with the activity that prompted GuardDuty to generate a finding.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Resource {
     #[serde(rename = "AccessKeyDetails")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1359,6 +1419,7 @@ pub struct Resource {
 
 /// <p>Security groups associated with the EC2 instance.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SecurityGroup {
     /// <p>EC2 instance&#39;s security group ID.</p>
     #[serde(rename = "GroupId")]
@@ -1372,6 +1433,7 @@ pub struct SecurityGroup {
 
 /// <p>Additional information assigned to the generated finding by GuardDuty.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Service {
     /// <p>Information about the activity described in a finding.</p>
     #[serde(rename = "Action")]
@@ -1437,6 +1499,7 @@ pub struct StartMonitoringMembersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartMonitoringMembersResponse {
     /// <p>A list of objects containing the unprocessed account and a result string explaining why it was unprocessed.</p>
     #[serde(rename = "UnprocessedAccounts")]
@@ -1457,6 +1520,7 @@ pub struct StopMonitoringMembersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopMonitoringMembersResponse {
     /// <p>A list of objects containing the unprocessed account and a result string explaining why it was unprocessed.</p>
     #[serde(rename = "UnprocessedAccounts")]
@@ -1466,6 +1530,7 @@ pub struct StopMonitoringMembersResponse {
 
 /// <p>A tag of the EC2 instance.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Tag {
     /// <p>EC2 instance tag key.</p>
     #[serde(rename = "Key")]
@@ -1490,10 +1555,12 @@ pub struct UnarchiveFindingsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UnarchiveFindingsResponse {}
 
 /// <p>An object containing the unprocessed account and a result string explaining why it was unprocessed.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UnprocessedAccount {
     /// <p>AWS Account ID.</p>
     #[serde(rename = "AccountId")]
@@ -1516,6 +1583,7 @@ pub struct UpdateDetectorRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateDetectorResponse {}
 
 /// <p>UpdateFilterRequest request body.</p>
@@ -1546,6 +1614,7 @@ pub struct UpdateFilterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateFilterResponse {
     /// <p>The name of the filter.</p>
     #[serde(rename = "Name")]
@@ -1574,6 +1643,7 @@ pub struct UpdateFindingsFeedbackRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateFindingsFeedbackResponse {}
 
 /// <p>UpdateIPSet request body.</p>
@@ -1600,6 +1670,7 @@ pub struct UpdateIPSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateIPSetResponse {}
 
 /// <p>UpdateThreatIntelSet request body.</p>
@@ -1626,6 +1697,7 @@ pub struct UpdateThreatIntelSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateThreatIntelSetResponse {}
 
 /// Errors returned by AcceptInvitation

--- a/rusoto/services/health/src/generated.rs
+++ b/rusoto/services/health/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Information about an entity that is affected by a Health event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AffectedEntity {
     /// <p>The 12-digit AWS account number that contains the affected entity.</p>
     #[serde(rename = "awsAccountId")]
@@ -94,6 +95,7 @@ pub struct DescribeAffectedEntitiesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAffectedEntitiesResponse {
     /// <p>The entities that match the filter criteria.</p>
     #[serde(rename = "entities")]
@@ -114,6 +116,7 @@ pub struct DescribeEntityAggregatesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEntityAggregatesResponse {
     /// <p>The number of entities that are affected by each of the specified events.</p>
     #[serde(rename = "entityAggregates")]
@@ -141,6 +144,7 @@ pub struct DescribeEventAggregatesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEventAggregatesResponse {
     /// <p>The number of events in each category that meet the optional filter criteria.</p>
     #[serde(rename = "eventAggregates")]
@@ -164,6 +168,7 @@ pub struct DescribeEventDetailsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEventDetailsResponse {
     /// <p>Error messages for any events that could not be retrieved.</p>
     #[serde(rename = "failedSet")]
@@ -196,6 +201,7 @@ pub struct DescribeEventTypesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEventTypesResponse {
     /// <p>A list of event types that match the filter criteria. Event types have a category (<code>issue</code>, <code>accountNotification</code>, or <code>scheduledChange</code>), a service (for example, <code>EC2</code>, <code>RDS</code>, <code>DATAPIPELINE</code>, <code>BILLING</code>), and a code (in the format <code>AWS_<i>SERVICE</i>_<i>DESCRIPTION</i> </code>; for example, <code>AWS_EC2_SYSTEM_MAINTENANCE_EVENT</code>).</p>
     #[serde(rename = "eventTypes")]
@@ -228,6 +234,7 @@ pub struct DescribeEventsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEventsResponse {
     /// <p>The events that match the specified filter criteria.</p>
     #[serde(rename = "events")]
@@ -241,6 +248,7 @@ pub struct DescribeEventsResponse {
 
 /// <p>The number of entities that are affected by one or more events. Returned by the <a>DescribeEntityAggregates</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EntityAggregate {
     /// <p>The number entities that match the criteria for the specified events.</p>
     #[serde(rename = "count")]
@@ -282,6 +290,7 @@ pub struct EntityFilter {
 
 /// <p>Summary information about an event, returned by the <a>DescribeEvents</a> operation. The <a>DescribeEventDetails</a> operation also returns this information, as well as the <a>EventDescription</a> and additional event metadata.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Event {
     /// <p>The unique identifier for the event. Format: <code>arn:aws:health:<i>event-region</i>::event/<i>EVENT_TYPE_PLUS_ID</i> </code>. Example: <code>arn:aws:health:us-east-1::event/AWS_EC2_MAINTENANCE_5331</code> </p>
     #[serde(rename = "arn")]
@@ -327,6 +336,7 @@ pub struct Event {
 
 /// <p>The number of events of each issue type. Returned by the <a>DescribeEventAggregates</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EventAggregate {
     /// <p>The issue type for the associated count.</p>
     #[serde(rename = "aggregateValue")]
@@ -340,6 +350,7 @@ pub struct EventAggregate {
 
 /// <p>Detailed information about an event. A combination of an <a>Event</a> object, an <a>EventDescription</a> object, and additional metadata about the event. Returned by the <a>DescribeEventDetails</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EventDetails {
     /// <p>Summary information about the event.</p>
     #[serde(rename = "event")]
@@ -357,6 +368,7 @@ pub struct EventDetails {
 
 /// <p>Error information returned when a <a>DescribeEventDetails</a> operation cannot find a specified event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EventDetailsErrorItem {
     /// <p>A message that describes the error.</p>
     #[serde(rename = "errorMessage")]

--- a/rusoto/services/inspector/src/generated.rs
+++ b/rusoto/services/inspector/src/generated.rs
@@ -39,6 +39,7 @@ pub struct AddAttributesToFindingsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddAttributesToFindingsResponse {
     /// <p>Attribute details that cannot be described. An error code is provided for each failed item.</p>
     #[serde(rename = "failedItems")]
@@ -67,6 +68,7 @@ pub struct AgentFilter {
 
 /// <p>Used as a response element in the <a>PreviewAgents</a> action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AgentPreview {
     /// <p>The health status of the Amazon Inspector Agent.</p>
     #[serde(rename = "agentHealth")]
@@ -103,6 +105,7 @@ pub struct AgentPreview {
 
 /// <p>A snapshot of an Amazon Inspector assessment run that contains the findings of the assessment run .</p> <p>Used as the response element in the <a>DescribeAssessmentRuns</a> action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssessmentRun {
     /// <p>The ARN of the assessment run.</p>
     #[serde(rename = "arn")]
@@ -155,6 +158,7 @@ pub struct AssessmentRun {
 
 /// <p>Contains information about an Amazon Inspector agent. This data type is used as a response element in the <a>ListAssessmentRunAgents</a> action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssessmentRunAgent {
     /// <p>The current health state of the agent.</p>
     #[serde(rename = "agentHealth")]
@@ -216,6 +220,7 @@ pub struct AssessmentRunFilter {
 
 /// <p>Used as one of the elements of the <a>AssessmentRun</a> data type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssessmentRunNotification {
     /// <p>The date of the notification.</p>
     #[serde(rename = "date")]
@@ -242,6 +247,7 @@ pub struct AssessmentRunNotification {
 
 /// <p>Used as one of the elements of the <a>AssessmentRun</a> data type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssessmentRunStateChange {
     /// <p>The assessment run state.</p>
     #[serde(rename = "state")]
@@ -253,6 +259,7 @@ pub struct AssessmentRunStateChange {
 
 /// <p>Contains information about an Amazon Inspector application. This data type is used as the response element in the <a>DescribeAssessmentTargets</a> action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssessmentTarget {
     /// <p>The ARN that specifies the Amazon Inspector assessment target.</p>
     #[serde(rename = "arn")]
@@ -283,6 +290,7 @@ pub struct AssessmentTargetFilter {
 
 /// <p>Contains information about an Amazon Inspector assessment template. This data type is used as the response element in the <a>DescribeAssessmentTemplates</a> action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssessmentTemplate {
     /// <p>The ARN of the assessment template.</p>
     #[serde(rename = "arn")]
@@ -333,6 +341,7 @@ pub struct AssessmentTemplateFilter {
 
 /// <p>A collection of attributes of the host from which the finding is generated.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssetAttributes {
     /// <p>The ID of the agent that is installed on the EC2 instance where the finding is generated.</p>
     #[serde(rename = "agentId")]
@@ -383,6 +392,7 @@ pub struct CreateAssessmentTargetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateAssessmentTargetResponse {
     /// <p>The ARN that specifies the assessment target that is created.</p>
     #[serde(rename = "assessmentTargetArn")]
@@ -410,6 +420,7 @@ pub struct CreateAssessmentTemplateRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateAssessmentTemplateResponse {
     /// <p>The ARN that specifies the assessment template that is created.</p>
     #[serde(rename = "assessmentTemplateArn")]
@@ -424,6 +435,7 @@ pub struct CreateExclusionsPreviewRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateExclusionsPreviewResponse {
     /// <p>Specifies the unique identifier of the requested exclusions preview. You can use the unique identifier to retrieve the exclusions preview when running the GetExclusionsPreview API.</p>
     #[serde(rename = "previewToken")]
@@ -438,6 +450,7 @@ pub struct CreateResourceGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateResourceGroupResponse {
     /// <p>The ARN that specifies the resource group that is created.</p>
     #[serde(rename = "resourceGroupArn")]
@@ -473,6 +486,7 @@ pub struct DescribeAssessmentRunsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAssessmentRunsResponse {
     /// <p>Information about the assessment run.</p>
     #[serde(rename = "assessmentRuns")]
@@ -490,6 +504,7 @@ pub struct DescribeAssessmentTargetsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAssessmentTargetsResponse {
     /// <p>Information about the assessment targets.</p>
     #[serde(rename = "assessmentTargets")]
@@ -506,6 +521,7 @@ pub struct DescribeAssessmentTemplatesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAssessmentTemplatesResponse {
     /// <p>Information about the assessment templates.</p>
     #[serde(rename = "assessmentTemplates")]
@@ -516,6 +532,7 @@ pub struct DescribeAssessmentTemplatesResponse {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeCrossAccountAccessRoleResponse {
     /// <p>The date when the cross-account access role was registered.</p>
     #[serde(rename = "registeredAt")]
@@ -540,6 +557,7 @@ pub struct DescribeExclusionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeExclusionsResponse {
     /// <p>Information about the exclusions.</p>
     #[serde(rename = "exclusions")]
@@ -561,6 +579,7 @@ pub struct DescribeFindingsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeFindingsResponse {
     /// <p>Finding details that cannot be described. An error code is provided for each failed item.</p>
     #[serde(rename = "failedItems")]
@@ -578,6 +597,7 @@ pub struct DescribeResourceGroupsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeResourceGroupsResponse {
     /// <p>Resource group details that cannot be described. An error code is provided for each failed item.</p>
     #[serde(rename = "failedItems")]
@@ -599,6 +619,7 @@ pub struct DescribeRulesPackagesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeRulesPackagesResponse {
     /// <p>Rules package details that cannot be described. An error code is provided for each failed item.</p>
     #[serde(rename = "failedItems")]
@@ -623,6 +644,7 @@ pub struct DurationRange {
 
 /// <p>This data type is used in the <a>Subscription</a> data type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EventSubscription {
     /// <p>The event for which Amazon Simple Notification Service (SNS) notifications are sent.</p>
     #[serde(rename = "event")]
@@ -634,6 +656,7 @@ pub struct EventSubscription {
 
 /// <p>Contains information about what was excluded from an assessment run.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Exclusion {
     /// <p>The ARN that specifies the exclusion.</p>
     #[serde(rename = "arn")]
@@ -658,6 +681,7 @@ pub struct Exclusion {
 
 /// <p>Contains information about what is excluded from an assessment run given the current state of the assessment template.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ExclusionPreview {
     /// <p>The system-defined attributes for the exclusion preview.</p>
     #[serde(rename = "attributes")]
@@ -679,6 +703,7 @@ pub struct ExclusionPreview {
 
 /// <p>Includes details about the failed items.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FailedItemDetails {
     /// <p>The status code of a failed item.</p>
     #[serde(rename = "failureCode")]
@@ -690,6 +715,7 @@ pub struct FailedItemDetails {
 
 /// <p>Contains information about an Amazon Inspector finding. This data type is used as the response element in the <a>DescribeFindings</a> action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Finding {
     /// <p>The ARN that specifies the finding.</p>
     #[serde(rename = "arn")]
@@ -811,6 +837,7 @@ pub struct GetAssessmentReportRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetAssessmentReportResponse {
     /// <p>Specifies the status of the request to generate an assessment report. </p>
     #[serde(rename = "status")]
@@ -844,6 +871,7 @@ pub struct GetExclusionsPreviewRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetExclusionsPreviewResponse {
     /// <p>Information about the exclusions included in the preview.</p>
     #[serde(rename = "exclusionPreviews")]
@@ -866,6 +894,7 @@ pub struct GetTelemetryMetadataRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetTelemetryMetadataResponse {
     /// <p>Telemetry details.</p>
     #[serde(rename = "telemetryMetadata")]
@@ -874,6 +903,7 @@ pub struct GetTelemetryMetadataResponse {
 
 /// <p>This data type is used in the <a>Finding</a> data type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InspectorServiceAttributes {
     /// <p>The ARN of the assessment run during which the finding is generated.</p>
     #[serde(rename = "assessmentRunArn")]
@@ -908,6 +938,7 @@ pub struct ListAssessmentRunAgentsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAssessmentRunAgentsResponse {
     /// <p>A list of ARNs that specifies the agents returned by the action.</p>
     #[serde(rename = "assessmentRunAgents")]
@@ -939,6 +970,7 @@ pub struct ListAssessmentRunsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAssessmentRunsResponse {
     /// <p>A list of ARNs that specifies the assessment runs that are returned by the action.</p>
     #[serde(rename = "assessmentRunArns")]
@@ -966,6 +998,7 @@ pub struct ListAssessmentTargetsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAssessmentTargetsResponse {
     /// <p>A list of ARNs that specifies the assessment targets that are returned by the action.</p>
     #[serde(rename = "assessmentTargetArns")]
@@ -997,6 +1030,7 @@ pub struct ListAssessmentTemplatesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAssessmentTemplatesResponse {
     /// <p>A list of ARNs that specifies the assessment templates returned by the action.</p>
     #[serde(rename = "assessmentTemplateArns")]
@@ -1024,6 +1058,7 @@ pub struct ListEventSubscriptionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListEventSubscriptionsResponse {
     /// <p> When a response is generated, if there is more data to be listed, this parameter is present in the response and contains the value to use for the <b>nextToken</b> parameter in a subsequent pagination request. If there is no more data to be listed, this parameter is set to null.</p>
     #[serde(rename = "nextToken")]
@@ -1050,6 +1085,7 @@ pub struct ListExclusionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListExclusionsResponse {
     /// <p>A list of exclusions' ARNs returned by the action.</p>
     #[serde(rename = "exclusionArns")]
@@ -1081,6 +1117,7 @@ pub struct ListFindingsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListFindingsResponse {
     /// <p>A list of ARNs that specifies the findings returned by the action.</p>
     #[serde(rename = "findingArns")]
@@ -1104,6 +1141,7 @@ pub struct ListRulesPackagesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListRulesPackagesResponse {
     /// <p> When a response is generated, if there is more data to be listed, this parameter is present in the response and contains the value to use for the <b>nextToken</b> parameter in a subsequent pagination request. If there is no more data to be listed, this parameter is set to null.</p>
     #[serde(rename = "nextToken")]
@@ -1122,6 +1160,7 @@ pub struct ListTagsForResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagsForResourceResponse {
     /// <p>A collection of key and value pairs.</p>
     #[serde(rename = "tags")]
@@ -1144,6 +1183,7 @@ pub struct PreviewAgentsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PreviewAgentsResponse {
     /// <p>The resulting list of agents.</p>
     #[serde(rename = "agentPreviews")]
@@ -1172,6 +1212,7 @@ pub struct RemoveAttributesFromFindingsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RemoveAttributesFromFindingsResponse {
     /// <p>Attributes details that cannot be described. An error code is provided for each failed item.</p>
     #[serde(rename = "failedItems")]
@@ -1180,6 +1221,7 @@ pub struct RemoveAttributesFromFindingsResponse {
 
 /// <p>Contains information about a resource group. The resource group defines a set of tags that, when queried, identify the AWS resources that make up the assessment target. This data type is used as the response element in the <a>DescribeResourceGroups</a> action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResourceGroup {
     /// <p>The ARN of the resource group.</p>
     #[serde(rename = "arn")]
@@ -1206,6 +1248,7 @@ pub struct ResourceGroupTag {
 
 /// <p>Contains information about an Amazon Inspector rules package. This data type is used as the response element in the <a>DescribeRulesPackages</a> action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RulesPackage {
     /// <p>The ARN of the rules package.</p>
     #[serde(rename = "arn")]
@@ -1227,6 +1270,7 @@ pub struct RulesPackage {
 
 /// <p>This data type contains key-value pairs that identify various Amazon resources.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Scope {
     /// <p>The type of the scope.</p>
     #[serde(rename = "key")]
@@ -1261,6 +1305,7 @@ pub struct StartAssessmentRunRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartAssessmentRunResponse {
     /// <p>The ARN of the assessment run that has been started.</p>
     #[serde(rename = "assessmentRunArn")]
@@ -1293,6 +1338,7 @@ pub struct SubscribeToEventRequest {
 
 /// <p>This data type is used as a response element in the <a>ListEventSubscriptions</a> action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Subscription {
     /// <p>The list of existing event subscriptions.</p>
     #[serde(rename = "eventSubscriptions")]
@@ -1319,6 +1365,7 @@ pub struct Tag {
 
 /// <p>The metadata about the Amazon Inspector application data metrics collected by the agent. This data type is used as the response element in the <a>GetTelemetryMetadata</a> action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TelemetryMetadata {
     /// <p>The count of messages that the agent sends to the Amazon Inspector service.</p>
     #[serde(rename = "count")]

--- a/rusoto/services/iot/src/generated.rs
+++ b/rusoto/services/iot/src/generated.rs
@@ -108,6 +108,7 @@ pub struct Action {
 
 /// <p>Information about an active Device Defender security profile behavior violation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActiveViolation {
     /// <p>The behavior which is being violated.</p>
     #[serde(rename = "behavior")]
@@ -160,6 +161,7 @@ pub struct AddThingToThingGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddThingToThingGroupResponse {}
 
 /// <p>A structure containing the alert target ARN and the role ARN.</p>
@@ -175,6 +177,7 @@ pub struct AlertTarget {
 
 /// <p>Contains information that allowed the authorization.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Allowed {
     /// <p>A list of policies that allowed the authentication.</p>
     #[serde(rename = "policies")]
@@ -197,6 +200,7 @@ pub struct AssociateTargetsWithJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociateTargetsWithJobResponse {
     /// <p>A short text description of the job.</p>
     #[serde(rename = "description")]
@@ -244,6 +248,7 @@ pub struct AttachSecurityProfileRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AttachSecurityProfileResponse {}
 
 /// <p>The input for the AttachThingPrincipal operation.</p>
@@ -259,6 +264,7 @@ pub struct AttachThingPrincipalRequest {
 
 /// <p>The output from the AttachThingPrincipal operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AttachThingPrincipalResponse {}
 
 /// <p>The attribute payload.</p>
@@ -285,6 +291,7 @@ pub struct AuditCheckConfiguration {
 
 /// <p>Information about the audit check.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AuditCheckDetails {
     /// <p>True if the check completed and found all resources compliant.</p>
     #[serde(rename = "checkCompliant")]
@@ -314,6 +321,7 @@ pub struct AuditCheckDetails {
 
 /// <p>The findings (results) of the audit.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AuditFinding {
     /// <p>The audit check that generated this result.</p>
     #[serde(rename = "checkName")]
@@ -372,6 +380,7 @@ pub struct AuditNotificationTarget {
 
 /// <p>The audits that were performed.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AuditTaskMetadata {
     /// <p>The ID of this audit.</p>
     #[serde(rename = "taskId")]
@@ -402,6 +411,7 @@ pub struct AuthInfo {
 
 /// <p>The authorizer result.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AuthResult {
     /// <p>The policies and statements that allowed the specified action.</p>
     #[serde(rename = "allowed")]
@@ -427,6 +437,7 @@ pub struct AuthResult {
 
 /// <p>The authorizer description.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AuthorizerDescription {
     /// <p>The authorizer ARN.</p>
     #[serde(rename = "authorizerArn")]
@@ -464,6 +475,7 @@ pub struct AuthorizerDescription {
 
 /// <p>The authorizer summary.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AuthorizerSummary {
     /// <p>The authorizer ARN.</p>
     #[serde(rename = "authorizerArn")]
@@ -510,6 +522,7 @@ pub struct BehaviorCriteria {
 
 /// <p>A CA certificate.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CACertificate {
     /// <p>The ARN of the CA certificate.</p>
     #[serde(rename = "certificateArn")]
@@ -531,6 +544,7 @@ pub struct CACertificate {
 
 /// <p>Describes a CA certificate.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CACertificateDescription {
     /// <p>Whether the CA certificate configured for auto registration of device certificates. Valid values are "ENABLE" and "DISABLE"</p>
     #[serde(rename = "autoRegistrationStatus")]
@@ -586,6 +600,7 @@ pub struct CancelAuditTaskRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CancelAuditTaskResponse {}
 
 /// <p>The input for the CancelCertificateTransfer operation.</p>
@@ -634,6 +649,7 @@ pub struct CancelJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CancelJobResponse {
     /// <p>A short text description of the job.</p>
     #[serde(rename = "description")]
@@ -651,6 +667,7 @@ pub struct CancelJobResponse {
 
 /// <p>Information about a certificate.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Certificate {
     /// <p>The ARN of the certificate.</p>
     #[serde(rename = "certificateArn")]
@@ -672,6 +689,7 @@ pub struct Certificate {
 
 /// <p>Describes a certificate.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CertificateDescription {
     /// <p>The certificate ID of the CA certificate used to sign this certificate.</p>
     #[serde(rename = "caCertificateId")]
@@ -729,6 +747,7 @@ pub struct CertificateDescription {
 
 /// <p>When the certificate is valid.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CertificateValidity {
     /// <p>The certificate is not valid after this date.</p>
     #[serde(rename = "notAfter")]
@@ -744,6 +763,7 @@ pub struct CertificateValidity {
 pub struct ClearDefaultAuthorizerRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ClearDefaultAuthorizerResponse {}
 
 /// <p>Describes an action that updates a CloudWatch alarm.</p>
@@ -864,6 +884,7 @@ pub struct CreateAuthorizerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateAuthorizerResponse {
     /// <p>The authorizer ARN.</p>
     #[serde(rename = "authorizerArn")]
@@ -889,6 +910,7 @@ pub struct CreateCertificateFromCsrRequest {
 
 /// <p>The output from the CreateCertificateFromCsr operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateCertificateFromCsrResponse {
     /// <p>The Amazon Resource Name (ARN) of the certificate. You can use the ARN as a principal for policy operations.</p>
     #[serde(rename = "certificateArn")]
@@ -939,6 +961,7 @@ pub struct CreateJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateJobResponse {
     /// <p>The job description.</p>
     #[serde(rename = "description")]
@@ -965,6 +988,7 @@ pub struct CreateKeysAndCertificateRequest {
 
 /// <p>The output of the CreateKeysAndCertificate operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateKeysAndCertificateResponse {
     /// <p>The ARN of the certificate.</p>
     #[serde(rename = "certificateArn")]
@@ -1013,6 +1037,7 @@ pub struct CreateOTAUpdateRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateOTAUpdateResponse {
     /// <p>The AWS IoT job ARN associated with the OTA update.</p>
     #[serde(rename = "awsIotJobArn")]
@@ -1049,6 +1074,7 @@ pub struct CreatePolicyRequest {
 
 /// <p>The output from the CreatePolicy operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreatePolicyResponse {
     /// <p>The policy ARN.</p>
     #[serde(rename = "policyArn")]
@@ -1085,6 +1111,7 @@ pub struct CreatePolicyVersionRequest {
 
 /// <p>The output of the CreatePolicyVersion operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreatePolicyVersionResponse {
     /// <p>Specifies whether the policy version is the default.</p>
     #[serde(rename = "isDefaultVersion")]
@@ -1119,6 +1146,7 @@ pub struct CreateRoleAliasRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateRoleAliasResponse {
     /// <p>The role alias.</p>
     #[serde(rename = "roleAlias")]
@@ -1152,6 +1180,7 @@ pub struct CreateScheduledAuditRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateScheduledAuditResponse {
     /// <p>The ARN of the scheduled audit.</p>
     #[serde(rename = "scheduledAuditArn")]
@@ -1178,6 +1207,7 @@ pub struct CreateSecurityProfileRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateSecurityProfileResponse {
     /// <p>The ARN of the security profile.</p>
     #[serde(rename = "securityProfileArn")]
@@ -1207,6 +1237,7 @@ pub struct CreateStreamRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateStreamResponse {
     /// <p>A description of the stream.</p>
     #[serde(rename = "description")]
@@ -1242,6 +1273,7 @@ pub struct CreateThingGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateThingGroupResponse {
     /// <p>The thing group ARN.</p>
     #[serde(rename = "thingGroupArn")]
@@ -1275,6 +1307,7 @@ pub struct CreateThingRequest {
 
 /// <p>The output of the CreateThing operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateThingResponse {
     /// <p>The ARN of the new thing.</p>
     #[serde(rename = "thingArn")]
@@ -1304,6 +1337,7 @@ pub struct CreateThingTypeRequest {
 
 /// <p>The output of the CreateThingType operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateThingTypeResponse {
     /// <p>The Amazon Resource Name (ARN) of the thing type.</p>
     #[serde(rename = "thingTypeArn")]
@@ -1360,6 +1394,7 @@ pub struct DeleteAccountAuditConfigurationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteAccountAuditConfigurationResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1370,6 +1405,7 @@ pub struct DeleteAuthorizerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteAuthorizerResponse {}
 
 /// <p>Input for the DeleteCACertificate operation.</p>
@@ -1382,6 +1418,7 @@ pub struct DeleteCACertificateRequest {
 
 /// <p>The output for the DeleteCACertificate operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteCACertificateResponse {}
 
 /// <p>The input for the DeleteCertificate operation.</p>
@@ -1432,6 +1469,7 @@ pub struct DeleteOTAUpdateRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteOTAUpdateResponse {}
 
 /// <p>The input for the DeletePolicy operation.</p>
@@ -1459,6 +1497,7 @@ pub struct DeleteRegistrationCodeRequest {}
 
 /// <p>The output for the DeleteRegistrationCode operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteRegistrationCodeResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1469,6 +1508,7 @@ pub struct DeleteRoleAliasRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteRoleAliasResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1479,6 +1519,7 @@ pub struct DeleteScheduledAuditRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteScheduledAuditResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1493,6 +1534,7 @@ pub struct DeleteSecurityProfileRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteSecurityProfileResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1503,6 +1545,7 @@ pub struct DeleteStreamRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteStreamResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1517,6 +1560,7 @@ pub struct DeleteThingGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteThingGroupResponse {}
 
 /// <p>The input for the DeleteThing operation.</p>
@@ -1533,6 +1577,7 @@ pub struct DeleteThingRequest {
 
 /// <p>The output of the DeleteThing operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteThingResponse {}
 
 /// <p>The input for the DeleteThingType operation.</p>
@@ -1545,6 +1590,7 @@ pub struct DeleteThingTypeRequest {
 
 /// <p>The output for the DeleteThingType operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteThingTypeResponse {}
 
 /// <p>The input for the DeleteTopicRule operation.</p>
@@ -1567,6 +1613,7 @@ pub struct DeleteV2LoggingLevelRequest {
 
 /// <p>Contains information that denied the authorization.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Denied {
     /// <p>Information that explicitly denies the authorization. </p>
     #[serde(rename = "explicitDeny")]
@@ -1592,12 +1639,14 @@ pub struct DeprecateThingTypeRequest {
 
 /// <p>The output for the DeprecateThingType operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeprecateThingTypeResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeAccountAuditConfigurationRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAccountAuditConfigurationResponse {
     /// <p>Which audit checks are enabled and disabled for this account.</p>
     #[serde(rename = "auditCheckConfigurations")]
@@ -1623,6 +1672,7 @@ pub struct DescribeAuditTaskRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAuditTaskResponse {
     /// <p>Detailed information about each check performed during this audit.</p>
     #[serde(rename = "auditDetails")]
@@ -1658,6 +1708,7 @@ pub struct DescribeAuthorizerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAuthorizerResponse {
     /// <p>The authorizer description.</p>
     #[serde(rename = "authorizerDescription")]
@@ -1675,6 +1726,7 @@ pub struct DescribeCACertificateRequest {
 
 /// <p>The output from the DescribeCACertificate operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeCACertificateResponse {
     /// <p>The CA certificate description.</p>
     #[serde(rename = "certificateDescription")]
@@ -1696,6 +1748,7 @@ pub struct DescribeCertificateRequest {
 
 /// <p>The output of the DescribeCertificate operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeCertificateResponse {
     /// <p>The description of the certificate.</p>
     #[serde(rename = "certificateDescription")]
@@ -1707,6 +1760,7 @@ pub struct DescribeCertificateResponse {
 pub struct DescribeDefaultAuthorizerRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeDefaultAuthorizerResponse {
     /// <p>The default authorizer's description.</p>
     #[serde(rename = "authorizerDescription")]
@@ -1725,6 +1779,7 @@ pub struct DescribeEndpointRequest {
 
 /// <p>The output from the DescribeEndpoint operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEndpointResponse {
     /// <p>The endpoint. The format of the endpoint is as follows: <i>identifier</i>.iot.<i>region</i>.amazonaws.com.</p>
     #[serde(rename = "endpointAddress")]
@@ -1736,6 +1791,7 @@ pub struct DescribeEndpointResponse {
 pub struct DescribeEventConfigurationsRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEventConfigurationsResponse {
     /// <p>The creation date of the event configuration.</p>
     #[serde(rename = "creationDate")]
@@ -1759,6 +1815,7 @@ pub struct DescribeIndexRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeIndexResponse {
     /// <p>The index name.</p>
     #[serde(rename = "indexName")]
@@ -1789,6 +1846,7 @@ pub struct DescribeJobExecutionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeJobExecutionResponse {
     /// <p>Information about the job execution.</p>
     #[serde(rename = "execution")]
@@ -1804,6 +1862,7 @@ pub struct DescribeJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeJobResponse {
     /// <p>An S3 link to the job document.</p>
     #[serde(rename = "documentSource")]
@@ -1823,6 +1882,7 @@ pub struct DescribeRoleAliasRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeRoleAliasResponse {
     /// <p>The role alias description.</p>
     #[serde(rename = "roleAliasDescription")]
@@ -1838,6 +1898,7 @@ pub struct DescribeScheduledAuditRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeScheduledAuditResponse {
     /// <p>The day of the month on which the scheduled audit takes place. Will be "1" through "31" or "LAST". If days 29-31 are specified, and the month does not have that many days, the audit takes place on the "LAST" day of the month.</p>
     #[serde(rename = "dayOfMonth")]
@@ -1873,6 +1934,7 @@ pub struct DescribeSecurityProfileRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeSecurityProfileResponse {
     /// <p>Where the alerts are sent. (Alerts are always sent to the console.)</p>
     #[serde(rename = "alertTargets")]
@@ -1916,6 +1978,7 @@ pub struct DescribeStreamRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeStreamResponse {
     /// <p>Information about the stream.</p>
     #[serde(rename = "streamInfo")]
@@ -1931,6 +1994,7 @@ pub struct DescribeThingGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeThingGroupResponse {
     /// <p>The thing group ARN.</p>
     #[serde(rename = "thingGroupArn")]
@@ -1966,6 +2030,7 @@ pub struct DescribeThingRegistrationTaskRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeThingRegistrationTaskResponse {
     /// <p>The task creation date.</p>
     #[serde(rename = "creationDate")]
@@ -2027,6 +2092,7 @@ pub struct DescribeThingRequest {
 
 /// <p>The output from the DescribeThing operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeThingResponse {
     /// <p>The thing attributes.</p>
     #[serde(rename = "attributes")]
@@ -2068,6 +2134,7 @@ pub struct DescribeThingTypeRequest {
 
 /// <p>The output for the DescribeThingType operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeThingTypeResponse {
     /// <p>The thing type ARN.</p>
     #[serde(rename = "thingTypeArn")]
@@ -2123,6 +2190,7 @@ pub struct DetachSecurityProfileRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DetachSecurityProfileResponse {}
 
 /// <p>The input for the DetachThingPrincipal operation.</p>
@@ -2138,6 +2206,7 @@ pub struct DetachThingPrincipalRequest {
 
 /// <p>The output from the DetachThingPrincipal operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DetachThingPrincipalResponse {}
 
 /// <p>The input for the DisableTopicRuleRequest operation.</p>
@@ -2204,6 +2273,7 @@ pub struct DynamoDBv2Action {
 
 /// <p>The policy that has the effect on the authorization results.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EffectivePolicy {
     /// <p>The policy ARN.</p>
     #[serde(rename = "policyArn")]
@@ -2249,6 +2319,7 @@ pub struct EnableTopicRuleRequest {
 
 /// <p>Error information.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ErrorInfo {
     /// <p>The error code.</p>
     #[serde(rename = "code")]
@@ -2262,6 +2333,7 @@ pub struct ErrorInfo {
 
 /// <p>Information that explicitly denies authorization.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ExplicitDeny {
     /// <p>The policies that denied the authorization.</p>
     #[serde(rename = "policies")]
@@ -2301,6 +2373,7 @@ pub struct GetEffectivePoliciesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetEffectivePoliciesResponse {
     /// <p>The effective policies.</p>
     #[serde(rename = "effectivePolicies")]
@@ -2312,6 +2385,7 @@ pub struct GetEffectivePoliciesResponse {
 pub struct GetIndexingConfigurationRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetIndexingConfigurationResponse {
     /// <p>Thing indexing configuration.</p>
     #[serde(rename = "thingIndexingConfiguration")]
@@ -2327,6 +2401,7 @@ pub struct GetJobDocumentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetJobDocumentResponse {
     /// <p>The job document content.</p>
     #[serde(rename = "document")]
@@ -2340,6 +2415,7 @@ pub struct GetLoggingOptionsRequest {}
 
 /// <p>The output from the GetLoggingOptions operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetLoggingOptionsResponse {
     /// <p>The logging level.</p>
     #[serde(rename = "logLevel")]
@@ -2359,6 +2435,7 @@ pub struct GetOTAUpdateRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetOTAUpdateResponse {
     /// <p>The OTA update info.</p>
     #[serde(rename = "otaUpdateInfo")]
@@ -2376,6 +2453,7 @@ pub struct GetPolicyRequest {
 
 /// <p>The output from the GetPolicy operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetPolicyResponse {
     /// <p>The date the policy was created.</p>
     #[serde(rename = "creationDate")]
@@ -2420,6 +2498,7 @@ pub struct GetPolicyVersionRequest {
 
 /// <p>The output from the GetPolicyVersion operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetPolicyVersionResponse {
     /// <p>The date the policy version was created.</p>
     #[serde(rename = "creationDate")]
@@ -2461,6 +2540,7 @@ pub struct GetRegistrationCodeRequest {}
 
 /// <p>The output from the GetRegistrationCode operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetRegistrationCodeResponse {
     /// <p>The CA certificate registration code.</p>
     #[serde(rename = "registrationCode")]
@@ -2478,6 +2558,7 @@ pub struct GetTopicRuleRequest {
 
 /// <p>The output from the GetTopicRule operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetTopicRuleResponse {
     /// <p>The rule.</p>
     #[serde(rename = "rule")]
@@ -2493,6 +2574,7 @@ pub struct GetTopicRuleResponse {
 pub struct GetV2LoggingOptionsRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetV2LoggingOptionsResponse {
     /// <p>The default log level.</p>
     #[serde(rename = "defaultLogLevel")]
@@ -2510,6 +2592,7 @@ pub struct GetV2LoggingOptionsResponse {
 
 /// <p>The name and ARN of a group.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GroupNameAndArn {
     /// <p>The group ARN.</p>
     #[serde(rename = "groupArn")]
@@ -2523,6 +2606,7 @@ pub struct GroupNameAndArn {
 
 /// <p>Information that implicitly denies authorization. When policy doesn't explicitly deny or allow an action on a resource it is considered an implicit deny.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ImplicitDeny {
     /// <p>Policies that don't contain a matching allow or deny statement for the specified action on the specified resource. </p>
     #[serde(rename = "policies")]
@@ -2549,6 +2633,7 @@ pub struct IotAnalyticsAction {
 
 /// <p>The <code>Job</code> object contains details about a job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Job {
     /// <p>If the job was updated, describes the reason for the update.</p>
     #[serde(rename = "comment")]
@@ -2610,6 +2695,7 @@ pub struct Job {
 
 /// <p>The job execution object represents the execution of a job on a particular device.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct JobExecution {
     /// <p>A string (consisting of the digits "0" through "9") which identifies this particular job execution on this particular device. It can be used in commands which return or update job execution information. </p>
     #[serde(rename = "executionNumber")]
@@ -2655,6 +2741,7 @@ pub struct JobExecution {
 
 /// <p>Details of the job execution status.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct JobExecutionStatusDetails {
     /// <p>The job execution status.</p>
     #[serde(rename = "detailsMap")]
@@ -2664,6 +2751,7 @@ pub struct JobExecutionStatusDetails {
 
 /// <p>The job execution summary.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct JobExecutionSummary {
     /// <p>A string (consisting of the digits "0" through "9") which identifies this particular job execution on this particular device. It can be used later in commands which return or update job execution information.</p>
     #[serde(rename = "executionNumber")]
@@ -2689,6 +2777,7 @@ pub struct JobExecutionSummary {
 
 /// <p>Contains a summary of information about job executions for a specific job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct JobExecutionSummaryForJob {
     /// <p>Contains a subset of information about a job execution.</p>
     #[serde(rename = "jobExecutionSummary")]
@@ -2702,6 +2791,7 @@ pub struct JobExecutionSummaryForJob {
 
 /// <p>The job execution summary for a thing.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct JobExecutionSummaryForThing {
     /// <p>Contains a subset of information about a job execution.</p>
     #[serde(rename = "jobExecutionSummary")]
@@ -2724,6 +2814,7 @@ pub struct JobExecutionsRolloutConfig {
 
 /// <p>The job process details.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct JobProcessDetails {
     /// <p>The number of things that cancelled the job.</p>
     #[serde(rename = "numberOfCanceledThings")]
@@ -2761,6 +2852,7 @@ pub struct JobProcessDetails {
 
 /// <p>The job summary.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct JobSummary {
     /// <p>The time, in milliseconds since the epoch, when the job completed.</p>
     #[serde(rename = "completedAt")]
@@ -2798,6 +2890,7 @@ pub struct JobSummary {
 
 /// <p>Describes a key pair.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct KeyPair {
     /// <p>The private key.</p>
     #[serde(rename = "PrivateKey")]
@@ -2853,6 +2946,7 @@ pub struct ListActiveViolationsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListActiveViolationsResponse {
     /// <p>The list of active violations.</p>
     #[serde(rename = "activeViolations")]
@@ -2884,6 +2978,7 @@ pub struct ListAttachedPoliciesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAttachedPoliciesResponse {
     /// <p>The token to retrieve the next set of results, or ``null`` if there are no more results.</p>
     #[serde(rename = "nextMarker")]
@@ -2928,6 +3023,7 @@ pub struct ListAuditFindingsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAuditFindingsResponse {
     /// <p>The findings (results) of the audit.</p>
     #[serde(rename = "findings")]
@@ -2966,6 +3062,7 @@ pub struct ListAuditTasksRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAuditTasksResponse {
     /// <p>A token that can be used to retrieve the next set of results, or <code>null</code> if there are no additional results.</p>
     #[serde(rename = "nextToken")]
@@ -2998,6 +3095,7 @@ pub struct ListAuthorizersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAuthorizersResponse {
     /// <p>The authorizers.</p>
     #[serde(rename = "authorizers")]
@@ -3028,6 +3126,7 @@ pub struct ListCACertificatesRequest {
 
 /// <p>The output from the ListCACertificates operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListCACertificatesResponse {
     /// <p>The CA certificates registered in your AWS account.</p>
     #[serde(rename = "certificates")]
@@ -3061,6 +3160,7 @@ pub struct ListCertificatesByCARequest {
 
 /// <p>The output of the ListCertificatesByCA operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListCertificatesByCAResponse {
     /// <p>The device certificates signed by the specified CA certificate.</p>
     #[serde(rename = "certificates")]
@@ -3091,6 +3191,7 @@ pub struct ListCertificatesRequest {
 
 /// <p>The output of the ListCertificates operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListCertificatesResponse {
     /// <p>The descriptions of the certificates.</p>
     #[serde(rename = "certificates")]
@@ -3115,6 +3216,7 @@ pub struct ListIndicesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListIndicesResponse {
     /// <p>The index names.</p>
     #[serde(rename = "indexNames")]
@@ -3146,6 +3248,7 @@ pub struct ListJobExecutionsForJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListJobExecutionsForJobResponse {
     /// <p>A list of job execution summaries.</p>
     #[serde(rename = "executionSummaries")]
@@ -3177,6 +3280,7 @@ pub struct ListJobExecutionsForThingRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListJobExecutionsForThingResponse {
     /// <p>A list of job execution summaries.</p>
     #[serde(rename = "executionSummaries")]
@@ -3217,6 +3321,7 @@ pub struct ListJobsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListJobsResponse {
     /// <p>A list of jobs.</p>
     #[serde(rename = "jobs")]
@@ -3245,6 +3350,7 @@ pub struct ListOTAUpdatesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListOTAUpdatesResponse {
     /// <p>A token to use to get the next set of results.</p>
     #[serde(rename = "nextToken")]
@@ -3275,6 +3381,7 @@ pub struct ListOutgoingCertificatesRequest {
 
 /// <p>The output from the ListOutgoingCertificates operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListOutgoingCertificatesResponse {
     /// <p>The marker for the next set of results.</p>
     #[serde(rename = "nextMarker")]
@@ -3305,6 +3412,7 @@ pub struct ListPoliciesRequest {
 
 /// <p>The output from the ListPolicies operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListPoliciesResponse {
     /// <p>The marker for the next set of results, or null if there are no additional results.</p>
     #[serde(rename = "nextMarker")]
@@ -3338,6 +3446,7 @@ pub struct ListPolicyPrincipalsRequest {
 
 /// <p>The output from the ListPolicyPrincipals operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListPolicyPrincipalsResponse {
     /// <p>The marker for the next set of results, or null if there are no additional results.</p>
     #[serde(rename = "nextMarker")]
@@ -3359,6 +3468,7 @@ pub struct ListPolicyVersionsRequest {
 
 /// <p>The output from the ListPolicyVersions operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListPolicyVersionsResponse {
     /// <p>The policy versions.</p>
     #[serde(rename = "policyVersions")]
@@ -3388,6 +3498,7 @@ pub struct ListPrincipalPoliciesRequest {
 
 /// <p>The output from the ListPrincipalPolicies operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListPrincipalPoliciesResponse {
     /// <p>The marker for the next set of results, or null if there are no additional results.</p>
     #[serde(rename = "nextMarker")]
@@ -3417,6 +3528,7 @@ pub struct ListPrincipalThingsRequest {
 
 /// <p>The output from the ListPrincipalThings operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListPrincipalThingsResponse {
     /// <p>The token used to get the next set of results, or <b>null</b> if there are no additional results.</p>
     #[serde(rename = "nextToken")]
@@ -3445,6 +3557,7 @@ pub struct ListRoleAliasesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListRoleAliasesResponse {
     /// <p>A marker used to get the next set of results.</p>
     #[serde(rename = "nextMarker")]
@@ -3469,6 +3582,7 @@ pub struct ListScheduledAuditsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListScheduledAuditsResponse {
     /// <p>A token that can be used to retrieve the next set of results, or <code>null</code> if there are no additional results.</p>
     #[serde(rename = "nextToken")]
@@ -3500,6 +3614,7 @@ pub struct ListSecurityProfilesForTargetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListSecurityProfilesForTargetResponse {
     /// <p>A token that can be used to retrieve the next set of results, or <code>null</code> if there are no additional results.</p>
     #[serde(rename = "nextToken")]
@@ -3524,6 +3639,7 @@ pub struct ListSecurityProfilesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListSecurityProfilesResponse {
     /// <p>A token that can be used to retrieve the next set of results, or <code>null</code> if there are no additional results.</p>
     #[serde(rename = "nextToken")]
@@ -3552,6 +3668,7 @@ pub struct ListStreamsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListStreamsResponse {
     /// <p>A token used to get the next set of results.</p>
     #[serde(rename = "nextToken")]
@@ -3579,6 +3696,7 @@ pub struct ListTargetsForPolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTargetsForPolicyResponse {
     /// <p>A marker used to get the next set of results.</p>
     #[serde(rename = "nextMarker")]
@@ -3606,6 +3724,7 @@ pub struct ListTargetsForSecurityProfileRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTargetsForSecurityProfileResponse {
     /// <p>A token that can be used to retrieve the next set of results, or <code>null</code> if there are no additional results.</p>
     #[serde(rename = "nextToken")]
@@ -3633,6 +3752,7 @@ pub struct ListThingGroupsForThingRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListThingGroupsForThingResponse {
     /// <p>The token used to get the next set of results, or <b>null</b> if there are no additional results.</p>
     #[serde(rename = "nextToken")]
@@ -3669,6 +3789,7 @@ pub struct ListThingGroupsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListThingGroupsResponse {
     /// <p>The token used to get the next set of results, or <b>null</b> if there are no additional results.</p>
     #[serde(rename = "nextToken")]
@@ -3690,6 +3811,7 @@ pub struct ListThingPrincipalsRequest {
 
 /// <p>The output from the ListThingPrincipals operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListThingPrincipalsResponse {
     /// <p>The principals associated with the thing.</p>
     #[serde(rename = "principals")]
@@ -3716,6 +3838,7 @@ pub struct ListThingRegistrationTaskReportsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListThingRegistrationTaskReportsResponse {
     /// <p>The token used to get the next set of results, or <b>null</b> if there are no additional results.</p>
     #[serde(rename = "nextToken")]
@@ -3748,6 +3871,7 @@ pub struct ListThingRegistrationTasksRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListThingRegistrationTasksResponse {
     /// <p>The token used to get the next set of results, or <b>null</b> if there are no additional results.</p>
     #[serde(rename = "nextToken")]
@@ -3778,6 +3902,7 @@ pub struct ListThingTypesRequest {
 
 /// <p>The output for the ListThingTypes operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListThingTypesResponse {
     /// <p>The token for the next set of results, or <b>null</b> if there are no additional results.</p>
     #[serde(rename = "nextToken")]
@@ -3809,6 +3934,7 @@ pub struct ListThingsInThingGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListThingsInThingGroupResponse {
     /// <p>The token used to get the next set of results, or <b>null</b> if there are no additional results.</p>
     #[serde(rename = "nextToken")]
@@ -3847,6 +3973,7 @@ pub struct ListThingsRequest {
 
 /// <p>The output from the ListThings operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListThingsResponse {
     /// <p>The token used to get the next set of results, or <b>null</b> if there are no additional results.</p>
     #[serde(rename = "nextToken")]
@@ -3881,6 +4008,7 @@ pub struct ListTopicRulesRequest {
 
 /// <p>The output from the ListTopicRules operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTopicRulesResponse {
     /// <p>A token used to retrieve the next value.</p>
     #[serde(rename = "nextToken")]
@@ -3909,6 +4037,7 @@ pub struct ListV2LoggingLevelsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListV2LoggingLevelsResponse {
     /// <p>The logging configuration for a target.</p>
     #[serde(rename = "logTargetConfigurations")]
@@ -3947,6 +4076,7 @@ pub struct ListViolationEventsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListViolationEventsResponse {
     /// <p>A token that can be used to retrieve the next set of results, or <code>null</code> if there are no additional results.</p>
     #[serde(rename = "nextToken")]
@@ -3972,6 +4102,7 @@ pub struct LogTarget {
 
 /// <p>The target configuration.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LogTargetConfiguration {
     /// <p>The logging level.</p>
     #[serde(rename = "logLevel")]
@@ -4014,6 +4145,7 @@ pub struct MetricValue {
 
 /// <p>Information about the resource that was non-compliant with the audit check.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct NonCompliantResource {
     /// <p>Additional information about the non-compliant resource.</p>
     #[serde(rename = "additionalInfo")]
@@ -4056,6 +4188,7 @@ pub struct OTAUpdateFile {
 
 /// <p>Information about an OTA update.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct OTAUpdateInfo {
     /// <p>A collection of name/value pairs</p>
     #[serde(rename = "additionalParameters")]
@@ -4113,6 +4246,7 @@ pub struct OTAUpdateInfo {
 
 /// <p>An OTA update summary.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct OTAUpdateSummary {
     /// <p>The date when the OTA update was created.</p>
     #[serde(rename = "creationDate")]
@@ -4130,6 +4264,7 @@ pub struct OTAUpdateSummary {
 
 /// <p>A certificate that has been transferred but not yet accepted.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct OutgoingCertificate {
     /// <p>The certificate ARN.</p>
     #[serde(rename = "certificateArn")]
@@ -4159,6 +4294,7 @@ pub struct OutgoingCertificate {
 
 /// <p>Describes an AWS IoT policy.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Policy {
     /// <p>The policy ARN.</p>
     #[serde(rename = "policyArn")]
@@ -4172,6 +4308,7 @@ pub struct Policy {
 
 /// <p>Describes a policy version.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PolicyVersion {
     /// <p>The date and time the policy was created.</p>
     #[serde(rename = "createDate")]
@@ -4246,6 +4383,7 @@ pub struct RegisterCACertificateRequest {
 
 /// <p>The output from the RegisterCACertificateResponse operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegisterCACertificateResponse {
     /// <p>The CA certificate ARN.</p>
     #[serde(rename = "certificateArn")]
@@ -4275,6 +4413,7 @@ pub struct RegisterCertificateRequest {
 
 /// <p>The output from the RegisterCertificate operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegisterCertificateResponse {
     /// <p>The certificate ARN.</p>
     #[serde(rename = "certificateArn")]
@@ -4298,6 +4437,7 @@ pub struct RegisterThingRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegisterThingResponse {
     /// <p>.</p>
     #[serde(rename = "certificatePem")]
@@ -4336,6 +4476,7 @@ pub struct RejectCertificateTransferRequest {
 
 /// <p>Information about a related resource.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RelatedResource {
     /// <p>Additional information about the resource.</p>
     #[serde(rename = "additionalInfo")]
@@ -4372,6 +4513,7 @@ pub struct RemoveThingFromThingGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RemoveThingFromThingGroupResponse {}
 
 /// <p>The input for the ReplaceTopicRule operation.</p>
@@ -4427,6 +4569,7 @@ pub struct ResourceIdentifier {
 
 /// <p>Role alias description.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RoleAliasDescription {
     /// <p>The UNIX timestamp of when the role alias was created.</p>
     #[serde(rename = "creationDate")]
@@ -4504,6 +4647,7 @@ pub struct SalesforceAction {
 
 /// <p>Information about the scheduled audit.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ScheduledAuditMetadata {
     /// <p>The day of the month on which the scheduled audit is run (if the <code>frequency</code> is "MONTHLY"). If days 29-31 are specified, and the month does not have that many days, the audit takes place on the "LAST" day of the month.</p>
     #[serde(rename = "dayOfMonth")]
@@ -4551,6 +4695,7 @@ pub struct SearchIndexRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SearchIndexResponse {
     /// <p>The token used to get the next set of results, or <b>null</b> if there are no additional results.</p>
     #[serde(rename = "nextToken")]
@@ -4564,6 +4709,7 @@ pub struct SearchIndexResponse {
 
 /// <p>Identifying information for a Device Defender security profile.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SecurityProfileIdentifier {
     /// <p>The ARN of the security profile.</p>
     #[serde(rename = "arn")]
@@ -4575,6 +4721,7 @@ pub struct SecurityProfileIdentifier {
 
 /// <p>A target to which an alert is sent when a security profile behavior is violated.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SecurityProfileTarget {
     /// <p>The ARN of the security profile.</p>
     #[serde(rename = "arn")]
@@ -4583,6 +4730,7 @@ pub struct SecurityProfileTarget {
 
 /// <p>Information about a security profile and the target associated with it.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SecurityProfileTargetMapping {
     /// <p>Information that identifies the security profile.</p>
     #[serde(rename = "securityProfileIdentifier")]
@@ -4602,6 +4750,7 @@ pub struct SetDefaultAuthorizerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SetDefaultAuthorizerResponse {
     /// <p>The authorizer ARN.</p>
     #[serde(rename = "authorizerArn")]
@@ -4696,6 +4845,7 @@ pub struct StartOnDemandAuditTaskRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartOnDemandAuditTaskResponse {
     /// <p>The ID of the on-demand audit you started.</p>
     #[serde(rename = "taskId")]
@@ -4720,6 +4870,7 @@ pub struct StartThingRegistrationTaskRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartThingRegistrationTaskResponse {
     /// <p>The bulk thing provisioning task ID.</p>
     #[serde(rename = "taskId")]
@@ -4750,6 +4901,7 @@ pub struct StopThingRegistrationTaskRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopThingRegistrationTaskResponse {}
 
 /// <p>Describes a group of files that can be streamed.</p>
@@ -4780,6 +4932,7 @@ pub struct StreamFile {
 
 /// <p>Information about a stream.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StreamInfo {
     /// <p>The date when the stream was created.</p>
     #[serde(rename = "createdAt")]
@@ -4817,6 +4970,7 @@ pub struct StreamInfo {
 
 /// <p>A summary of a stream.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StreamSummary {
     /// <p>A description of the stream.</p>
     #[serde(rename = "description")]
@@ -4838,6 +4992,7 @@ pub struct StreamSummary {
 
 /// <p>Statistics for the checks performed during the audit.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TaskStatistics {
     /// <p>The number of checks that did not run because the audit was canceled.</p>
     #[serde(rename = "canceledChecks")]
@@ -4897,6 +5052,7 @@ pub struct TestAuthorizationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TestAuthorizationResponse {
     /// <p>The authentication results.</p>
     #[serde(rename = "authResults")]
@@ -4918,6 +5074,7 @@ pub struct TestInvokeAuthorizerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TestInvokeAuthorizerResponse {
     /// <p>The number of seconds after which the connection is terminated.</p>
     #[serde(rename = "disconnectAfterInSeconds")]
@@ -4943,6 +5100,7 @@ pub struct TestInvokeAuthorizerResponse {
 
 /// <p>The properties of the thing, including thing name, thing type name, and a list of thing attributes.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ThingAttribute {
     /// <p>A list of thing attributes which are name-value pairs.</p>
     #[serde(rename = "attributes")]
@@ -4968,6 +5126,7 @@ pub struct ThingAttribute {
 
 /// <p>The thing search index document.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ThingDocument {
     /// <p>The attributes.</p>
     #[serde(rename = "attributes")]
@@ -4997,6 +5156,7 @@ pub struct ThingDocument {
 
 /// <p>Thing group metadata.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ThingGroupMetadata {
     /// <p>The UNIX timestamp of when the thing group was created.</p>
     #[serde(rename = "creationDate")]
@@ -5036,6 +5196,7 @@ pub struct ThingIndexingConfiguration {
 
 /// <p>The definition of the thing type, including thing type name and description.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ThingTypeDefinition {
     /// <p>The thing type ARN.</p>
     #[serde(rename = "thingTypeArn")]
@@ -5057,6 +5218,7 @@ pub struct ThingTypeDefinition {
 
 /// <p>The ThingTypeMetadata contains additional information about the thing type including: creation date and time, a value indicating whether the thing type is deprecated, and a date and time when time was deprecated.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ThingTypeMetadata {
     /// <p>The date and time when the thing type was created.</p>
     #[serde(rename = "creationDate")]
@@ -5087,6 +5249,7 @@ pub struct ThingTypeProperties {
 
 /// <p>Describes a rule.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TopicRule {
     /// <p>The actions associated with the rule.</p>
     #[serde(rename = "actions")]
@@ -5124,6 +5287,7 @@ pub struct TopicRule {
 
 /// <p>Describes a rule.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TopicRuleListItem {
     /// <p>The date and time the rule was created.</p>
     #[serde(rename = "createdAt")]
@@ -5191,6 +5355,7 @@ pub struct TransferCertificateRequest {
 
 /// <p>The output from the TransferCertificate operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TransferCertificateResponse {
     /// <p>The ARN of the certificate.</p>
     #[serde(rename = "transferredCertificateArn")]
@@ -5200,6 +5365,7 @@ pub struct TransferCertificateResponse {
 
 /// <p>Data used to transfer a certificate to an AWS account.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TransferData {
     /// <p>The date the transfer was accepted.</p>
     #[serde(rename = "acceptDate")]
@@ -5242,6 +5408,7 @@ pub struct UpdateAccountAuditConfigurationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateAccountAuditConfigurationResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -5268,6 +5435,7 @@ pub struct UpdateAuthorizerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateAuthorizerResponse {
     /// <p>The authorizer ARN.</p>
     #[serde(rename = "authorizerArn")]
@@ -5323,6 +5491,7 @@ pub struct UpdateEventConfigurationsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateEventConfigurationsResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -5334,6 +5503,7 @@ pub struct UpdateIndexingConfigurationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateIndexingConfigurationResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -5352,6 +5522,7 @@ pub struct UpdateRoleAliasRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateRoleAliasResponse {
     /// <p>The role alias.</p>
     #[serde(rename = "roleAlias")]
@@ -5387,6 +5558,7 @@ pub struct UpdateScheduledAuditRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateScheduledAuditResponse {
     /// <p>The ARN of the scheduled audit.</p>
     #[serde(rename = "scheduledAuditArn")]
@@ -5418,6 +5590,7 @@ pub struct UpdateSecurityProfileRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateSecurityProfileResponse {
     /// <p>Where the alerts are sent. (Alerts are always sent to the console.)</p>
     #[serde(rename = "alertTargets")]
@@ -5473,6 +5646,7 @@ pub struct UpdateStreamRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateStreamResponse {
     /// <p>A description of the stream.</p>
     #[serde(rename = "description")]
@@ -5507,6 +5681,7 @@ pub struct UpdateThingGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateThingGroupResponse {
     /// <p>The version of the updated thing group.</p>
     #[serde(rename = "version")]
@@ -5531,6 +5706,7 @@ pub struct UpdateThingGroupsForThingRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateThingGroupsForThingResponse {}
 
 /// <p>The input for the UpdateThing operation.</p>
@@ -5559,6 +5735,7 @@ pub struct UpdateThingRequest {
 
 /// <p>The output from the UpdateThing operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateThingResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -5569,6 +5746,7 @@ pub struct ValidateSecurityProfileBehaviorsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ValidateSecurityProfileBehaviorsResponse {
     /// <p>True if the behaviors were valid.</p>
     #[serde(rename = "valid")]
@@ -5582,6 +5760,7 @@ pub struct ValidateSecurityProfileBehaviorsResponse {
 
 /// <p>Information about an error found in a behavior specification.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ValidationError {
     /// <p>The description of an error found in the behaviors.</p>
     #[serde(rename = "errorMessage")]
@@ -5591,6 +5770,7 @@ pub struct ValidationError {
 
 /// <p>Information about a Device Defender security profile behavior violation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ViolationEvent {
     /// <p>The behavior which was violated.</p>
     #[serde(rename = "behavior")]

--- a/rusoto/services/kinesis/src/generated.rs
+++ b/rusoto/services/kinesis/src/generated.rs
@@ -73,6 +73,7 @@ pub struct DeleteStreamInput {
 pub struct DescribeLimitsInput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeLimitsOutput {
     /// <p>The number of open shards.</p>
     #[serde(rename = "OpenShardCount")]
@@ -100,6 +101,7 @@ pub struct DescribeStreamInput {
 
 /// <p>Represents the output for <code>DescribeStream</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeStreamOutput {
     /// <p>The current status of the stream, the stream Amazon Resource Name (ARN), an array of shard objects that comprise the stream, and whether there are more shards available.</p>
     #[serde(rename = "StreamDescription")]
@@ -114,6 +116,7 @@ pub struct DescribeStreamSummaryInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeStreamSummaryOutput {
     /// <p>A <a>StreamDescriptionSummary</a> containing information about the stream.</p>
     #[serde(rename = "StreamDescriptionSummary")]
@@ -144,6 +147,7 @@ pub struct EnableEnhancedMonitoringInput {
 
 /// <p>Represents enhanced metrics types.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EnhancedMetrics {
     /// <p>List of shard-level metrics.</p> <p>The following are the valid shard-level metrics. The value "<code>ALL</code>" enhances every metric.</p> <ul> <li> <p> <code>IncomingBytes</code> </p> </li> <li> <p> <code>IncomingRecords</code> </p> </li> <li> <p> <code>OutgoingBytes</code> </p> </li> <li> <p> <code>OutgoingRecords</code> </p> </li> <li> <p> <code>WriteProvisionedThroughputExceeded</code> </p> </li> <li> <p> <code>ReadProvisionedThroughputExceeded</code> </p> </li> <li> <p> <code>IteratorAgeMilliseconds</code> </p> </li> <li> <p> <code>ALL</code> </p> </li> </ul> <p>For more information, see <a href="http://docs.aws.amazon.com/kinesis/latest/dev/monitoring-with-cloudwatch.html">Monitoring the Amazon Kinesis Data Streams Service with Amazon CloudWatch</a> in the <i>Amazon Kinesis Data Streams Developer Guide</i>.</p>
     #[serde(rename = "ShardLevelMetrics")]
@@ -153,6 +157,7 @@ pub struct EnhancedMetrics {
 
 /// <p>Represents the output for <a>EnableEnhancedMonitoring</a> and <a>DisableEnhancedMonitoring</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EnhancedMonitoringOutput {
     /// <p>Represents the current state of the metrics that are in the enhanced state before the operation.</p>
     #[serde(rename = "CurrentShardLevelMetrics")]
@@ -182,6 +187,7 @@ pub struct GetRecordsInput {
 
 /// <p>Represents the output for <a>GetRecords</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetRecordsOutput {
     /// <p>The number of milliseconds the <a>GetRecords</a> response is from the tip of the stream, indicating how far behind current time the consumer is. A value of zero indicates that record processing is caught up, and there are no new records to process at this moment.</p>
     #[serde(rename = "MillisBehindLatest")]
@@ -220,6 +226,7 @@ pub struct GetShardIteratorInput {
 
 /// <p>Represents the output for <code>GetShardIterator</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetShardIteratorOutput {
     /// <p>The position in the shard from which to start reading data records sequentially. A shard iterator specifies this position using the sequence number of a data record in a shard.</p>
     #[serde(rename = "ShardIterator")]
@@ -229,6 +236,7 @@ pub struct GetShardIteratorOutput {
 
 /// <p>The range of possible hash key values for the shard, which is a set of ordered contiguous positive integers.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct HashKeyRange {
     /// <p>The ending hash key of the hash key range.</p>
     #[serde(rename = "EndingHashKey")]
@@ -274,6 +282,7 @@ pub struct ListShardsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListShardsOutput {
     /// <p><p>When the number of shards in the data stream is greater than the default value for the <code>MaxResults</code> parameter, or if you explicitly specify a value for <code>MaxResults</code> that is less than the number of shards in the data stream, the response includes a pagination token named <code>NextToken</code>. You can specify this <code>NextToken</code> value in a subsequent call to <code>ListShards</code> to list the next set of shards. For more information about the use of this pagination token when calling the <code>ListShards</code> operation, see <a>ListShardsInput$NextToken</a>.</p> <important> <p>Tokens expire after 300 seconds. When you obtain a value for <code>NextToken</code> in the response to a call to <code>ListShards</code>, you have 300 seconds to use that value. If you specify an expired token in a call to <code>ListShards</code>, you get <code>ExpiredNextTokenException</code>.</p> </important></p>
     #[serde(rename = "NextToken")]
@@ -300,6 +309,7 @@ pub struct ListStreamsInput {
 
 /// <p>Represents the output for <code>ListStreams</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListStreamsOutput {
     /// <p>If set to <code>true</code>, there are more streams available to list.</p>
     #[serde(rename = "HasMoreStreams")]
@@ -327,6 +337,7 @@ pub struct ListTagsForStreamInput {
 
 /// <p>Represents the output for <code>ListTagsForStream</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagsForStreamOutput {
     /// <p>If set to <code>true</code>, more tags are available. To request additional tags, set <code>ExclusiveStartTagKey</code> to the key of the last tag returned.</p>
     #[serde(rename = "HasMoreTags")]
@@ -379,6 +390,7 @@ pub struct PutRecordInput {
 
 /// <p>Represents the output for <code>PutRecord</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutRecordOutput {
     /// <p><p>The encryption type to use on the record. This parameter can be one of the following values:</p> <ul> <li> <p> <code>NONE</code>: Do not encrypt the records in the stream.</p> </li> <li> <p> <code>KMS</code>: Use server-side encryption on the records in the stream using a customer-managed AWS KMS key.</p> </li> </ul></p>
     #[serde(rename = "EncryptionType")]
@@ -405,6 +417,7 @@ pub struct PutRecordsInput {
 
 /// <p> <code>PutRecords</code> results.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutRecordsOutput {
     /// <p><p>The encryption type used on the records. This parameter can be one of the following values:</p> <ul> <li> <p> <code>NONE</code>: Do not encrypt the records.</p> </li> <li> <p> <code>KMS</code>: Use server-side encryption on the records using a customer-managed AWS KMS key.</p> </li> </ul></p>
     #[serde(rename = "EncryptionType")]
@@ -441,6 +454,7 @@ pub struct PutRecordsRequestEntry {
 
 /// <p>Represents the result of an individual record from a <code>PutRecords</code> request. A record that is successfully added to a stream includes <code>SequenceNumber</code> and <code>ShardId</code> in the result. A record that fails to be added to the stream includes <code>ErrorCode</code> and <code>ErrorMessage</code> in the result.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutRecordsResultEntry {
     /// <p>The error code for an individual record result. <code>ErrorCodes</code> can be either <code>ProvisionedThroughputExceededException</code> or <code>InternalFailure</code>.</p>
     #[serde(rename = "ErrorCode")]
@@ -462,6 +476,7 @@ pub struct PutRecordsResultEntry {
 
 /// <p>The unit of data of the Kinesis data stream, which is composed of a sequence number, a partition key, and a data blob.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Record {
     /// <p>The approximate time that the record was inserted into the stream.</p>
     #[serde(rename = "ApproximateArrivalTimestamp")]
@@ -500,6 +515,7 @@ pub struct RemoveTagsFromStreamInput {
 
 /// <p>The range of possible sequence numbers for the shard.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SequenceNumberRange {
     /// <p>The ending sequence number for the range. Shards that are in the OPEN state have an ending sequence number of <code>null</code>.</p>
     #[serde(rename = "EndingSequenceNumber")]
@@ -512,6 +528,7 @@ pub struct SequenceNumberRange {
 
 /// <p>A uniquely identified group of data records in a Kinesis data stream.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Shard {
     /// <p>The shard ID of the shard adjacent to the shard's parent.</p>
     #[serde(rename = "AdjacentParentShardId")]
@@ -574,6 +591,7 @@ pub struct StopStreamEncryptionInput {
 
 /// <p>Represents the output for <a>DescribeStream</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StreamDescription {
     /// <p><p>The server-side encryption type used on the stream. This parameter can be one of the following values:</p> <ul> <li> <p> <code>NONE</code>: Do not encrypt the records in the stream.</p> </li> <li> <p> <code>KMS</code>: Use server-side encryption on the records in the stream using a customer-managed AWS KMS key.</p> </li> </ul></p>
     #[serde(rename = "EncryptionType")]
@@ -611,6 +629,7 @@ pub struct StreamDescription {
 
 /// <p>Represents the output for <a>DescribeStreamSummary</a> </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StreamDescriptionSummary {
     /// <p><p>The encryption type used. This value is one of the following:</p> <ul> <li> <p> <code>KMS</code> </p> </li> <li> <p> <code>NONE</code> </p> </li> </ul></p>
     #[serde(rename = "EncryptionType")]
@@ -645,6 +664,7 @@ pub struct StreamDescriptionSummary {
 
 /// <p>Metadata assigned to the stream, consisting of a key-value pair.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Tag {
     /// <p>A unique identifier for the tag. Maximum length: 128 characters. Valid characters: Unicode letters, digits, white space, _ . / = + - % @</p>
     #[serde(rename = "Key")]
@@ -669,6 +689,7 @@ pub struct UpdateShardCountInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateShardCountOutput {
     /// <p>The current number of shards.</p>
     #[serde(rename = "CurrentShardCount")]

--- a/rusoto/services/kinesisanalytics/src/generated.rs
+++ b/rusoto/services/kinesisanalytics/src/generated.rs
@@ -42,6 +42,7 @@ pub struct AddApplicationCloudWatchLoggingOptionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddApplicationCloudWatchLoggingOptionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -61,6 +62,7 @@ pub struct AddApplicationInputProcessingConfigurationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddApplicationInputProcessingConfigurationResponse {}
 
 /// <p><p/></p>
@@ -79,6 +81,7 @@ pub struct AddApplicationInputRequest {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddApplicationInputResponse {}
 
 /// <p><p/></p>
@@ -97,6 +100,7 @@ pub struct AddApplicationOutputRequest {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddApplicationOutputResponse {}
 
 /// <p><p/></p>
@@ -115,10 +119,12 @@ pub struct AddApplicationReferenceDataSourceRequest {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddApplicationReferenceDataSourceResponse {}
 
 /// <p>Provides a description of the application, including the application Amazon Resource Name (ARN), status, latest version, and input and output configuration.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ApplicationDetail {
     /// <p>ARN of the application.</p>
     #[serde(rename = "ApplicationARN")]
@@ -168,6 +174,7 @@ pub struct ApplicationDetail {
 
 /// <p>Provides application summary information, including the application Amazon Resource Name (ARN), name, and status.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ApplicationSummary {
     /// <p>ARN of the application.</p>
     #[serde(rename = "ApplicationARN")]
@@ -229,6 +236,7 @@ pub struct CloudWatchLoggingOption {
 
 /// <p>Description of the CloudWatch logging option.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CloudWatchLoggingOptionDescription {
     /// <p>ID of the CloudWatch logging option description.</p>
     #[serde(rename = "CloudWatchLoggingOptionId")]
@@ -288,6 +296,7 @@ pub struct CreateApplicationRequest {
 
 /// <p>TBD</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateApplicationResponse {
     /// <p>In response to your <code>CreateApplication</code> request, Amazon Kinesis Analytics returns a response with a summary of the application it created, including the application Amazon Resource Name (ARN), name, and status.</p>
     #[serde(rename = "ApplicationSummary")]
@@ -308,6 +317,7 @@ pub struct DeleteApplicationCloudWatchLoggingOptionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteApplicationCloudWatchLoggingOptionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -324,6 +334,7 @@ pub struct DeleteApplicationInputProcessingConfigurationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteApplicationInputProcessingConfigurationResponse {}
 
 /// <p><p/></p>
@@ -342,6 +353,7 @@ pub struct DeleteApplicationOutputRequest {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteApplicationOutputResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -358,6 +370,7 @@ pub struct DeleteApplicationReferenceDataSourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteApplicationReferenceDataSourceResponse {}
 
 /// <p><p/></p>
@@ -373,6 +386,7 @@ pub struct DeleteApplicationRequest {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteApplicationResponse {}
 
 /// <p><p/></p>
@@ -385,6 +399,7 @@ pub struct DescribeApplicationRequest {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeApplicationResponse {
     /// <p>Provides a description of the application, such as the application Amazon Resource Name (ARN), status, latest version, and input and output configuration details.</p>
     #[serde(rename = "ApplicationDetail")]
@@ -426,6 +441,7 @@ pub struct DiscoverInputSchemaRequest {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DiscoverInputSchemaResponse {
     /// <p>Schema inferred from the streaming source. It identifies the format of the data in the streaming source and how each data element maps to corresponding columns in the in-application stream that you can create.</p>
     #[serde(rename = "InputSchema")]
@@ -485,6 +501,7 @@ pub struct InputConfiguration {
 
 /// <p>Describes the application input configuration. For more information, see <a href="http://docs.aws.amazon.com/kinesisanalytics/latest/dev/how-it-works-input.html">Configuring Application Input</a>. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InputDescription {
     /// <p>Returns the in-application stream names that are mapped to the stream source.</p>
     #[serde(rename = "InAppStreamNames")]
@@ -537,6 +554,7 @@ pub struct InputLambdaProcessor {
 
 /// <p>An object that contains the Amazon Resource Name (ARN) of the <a href="https://aws.amazon.com/documentation/lambda/">AWS Lambda</a> function that is used to preprocess records in the stream, and the ARN of the IAM role that is used to access the AWS Lambda expression.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InputLambdaProcessorDescription {
     /// <p>The ARN of the <a href="https://aws.amazon.com/documentation/lambda/">AWS Lambda</a> function that is used to preprocess the records in the stream.</p>
     #[serde(rename = "ResourceARN")]
@@ -589,6 +607,7 @@ pub struct InputProcessingConfiguration {
 
 /// <p>Provides configuration information about an input processor. Currently, the only input processor available is <a href="https://aws.amazon.com/documentation/lambda/">AWS Lambda</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InputProcessingConfigurationDescription {
     /// <p>Provides configuration information about the associated <a>InputLambdaProcessorDescription</a>.</p>
     #[serde(rename = "InputLambdaProcessorDescription")]
@@ -683,6 +702,7 @@ pub struct KinesisFirehoseInput {
 
 /// <p> Describes the Amazon Kinesis Firehose delivery stream that is configured as the streaming source in the application input configuration. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct KinesisFirehoseInputDescription {
     /// <p>Amazon Resource Name (ARN) of the Amazon Kinesis Firehose delivery stream.</p>
     #[serde(rename = "ResourceARN")]
@@ -720,6 +740,7 @@ pub struct KinesisFirehoseOutput {
 
 /// <p> For an application output, describes the Amazon Kinesis Firehose delivery stream configured as its destination. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct KinesisFirehoseOutputDescription {
     /// <p>Amazon Resource Name (ARN) of the Amazon Kinesis Firehose delivery stream.</p>
     #[serde(rename = "ResourceARN")]
@@ -757,6 +778,7 @@ pub struct KinesisStreamsInput {
 
 /// <p> Describes the Amazon Kinesis stream that is configured as the streaming source in the application input configuration. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct KinesisStreamsInputDescription {
     /// <p>Amazon Resource Name (ARN) of the Amazon Kinesis stream.</p>
     #[serde(rename = "ResourceARN")]
@@ -794,6 +816,7 @@ pub struct KinesisStreamsOutput {
 
 /// <p> For an application output, describes the Amazon Kinesis stream configured as its destination. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct KinesisStreamsOutputDescription {
     /// <p>Amazon Resource Name (ARN) of the Amazon Kinesis stream.</p>
     #[serde(rename = "ResourceARN")]
@@ -831,6 +854,7 @@ pub struct LambdaOutput {
 
 /// <p>For an application output, describes the AWS Lambda function configured as its destination. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LambdaOutputDescription {
     /// <p>Amazon Resource Name (ARN) of the destination Lambda function.</p>
     #[serde(rename = "ResourceARN")]
@@ -870,6 +894,7 @@ pub struct ListApplicationsRequest {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListApplicationsResponse {
     /// <p>List of <code>ApplicationSummary</code> objects. </p>
     #[serde(rename = "ApplicationSummaries")]
@@ -917,6 +942,7 @@ pub struct Output {
 
 /// <p>Describes the application output configuration, which includes the in-application stream name and the destination where the stream data is written. The destination can be an Amazon Kinesis stream or an Amazon Kinesis Firehose delivery stream. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct OutputDescription {
     /// <p>Data format used for writing data to the destination.</p>
     #[serde(rename = "DestinationSchema")]
@@ -1016,6 +1042,7 @@ pub struct ReferenceDataSource {
 
 /// <p>Describes the reference data source configured for an application.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReferenceDataSourceDescription {
     /// <p>ID of the reference data source. This is the ID that Amazon Kinesis Analytics assigns when you add the reference data source to your application using the <a>AddApplicationReferenceDataSource</a> operation.</p>
     #[serde(rename = "ReferenceId")]
@@ -1082,6 +1109,7 @@ pub struct S3ReferenceDataSource {
 
 /// <p>Provides the bucket name and object key name that stores the reference data.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct S3ReferenceDataSourceDescription {
     /// <p>Amazon Resource Name (ARN) of the S3 bucket.</p>
     #[serde(rename = "BucketARN")]
@@ -1139,6 +1167,7 @@ pub struct StartApplicationRequest {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartApplicationResponse {}
 
 /// <p><p/></p>
@@ -1151,6 +1180,7 @@ pub struct StopApplicationRequest {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopApplicationResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1167,6 +1197,7 @@ pub struct UpdateApplicationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateApplicationResponse {}
 
 /// Errors returned by AddApplicationCloudWatchLoggingOption

--- a/rusoto/services/kms/src/generated.rs
+++ b/rusoto/services/kms/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Contains information about an alias.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AliasListEntry {
     /// <p>String that contains the key ARN.</p>
     #[serde(rename = "AliasArn")]
@@ -53,6 +54,7 @@ pub struct CancelKeyDeletionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CancelKeyDeletionResponse {
     /// <p>The unique identifier of the master key for which deletion is canceled.</p>
     #[serde(rename = "KeyId")]
@@ -100,6 +102,7 @@ pub struct CreateGrantRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateGrantResponse {
     /// <p>The unique identifier for the grant.</p> <p>You can use the <code>GrantId</code> in a subsequent <a>RetireGrant</a> or <a>RevokeGrant</a> operation.</p>
     #[serde(rename = "GrantId")]
@@ -140,6 +143,7 @@ pub struct CreateKeyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateKeyResponse {
     /// <p>Metadata associated with the CMK.</p>
     #[serde(rename = "KeyMetadata")]
@@ -168,6 +172,7 @@ pub struct DecryptRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DecryptResponse {
     /// <p>ARN of the key used to perform the decryption. This value is returned if no errors are encountered during the operation.</p>
     #[serde(rename = "KeyId")]
@@ -209,6 +214,7 @@ pub struct DescribeKeyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeKeyResponse {
     /// <p>Metadata associated with the key.</p>
     #[serde(rename = "KeyMetadata")]
@@ -268,6 +274,7 @@ pub struct EncryptRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EncryptResponse {
     /// <p>The encrypted plaintext. When you use the HTTP API or the AWS CLI, the value is Base64-encoded. Otherwise, it is not encoded.</p>
     #[serde(rename = "CiphertextBlob")]
@@ -307,6 +314,7 @@ pub struct GenerateDataKeyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GenerateDataKeyResponse {
     /// <p>The encrypted data encryption key. When you use the HTTP API or the AWS CLI, the value is Base64-encoded. Otherwise, it is not encoded.</p>
     #[serde(rename = "CiphertextBlob")]
@@ -354,6 +362,7 @@ pub struct GenerateDataKeyWithoutPlaintextRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GenerateDataKeyWithoutPlaintextResponse {
     /// <p>The encrypted data encryption key. When you use the HTTP API or the AWS CLI, the value is Base64-encoded. Otherwise, it is not encoded.</p>
     #[serde(rename = "CiphertextBlob")]
@@ -378,6 +387,7 @@ pub struct GenerateRandomRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GenerateRandomResponse {
     /// <p>The random byte string. When you use the HTTP API or the AWS CLI, the value is Base64-encoded. Otherwise, it is not encoded.</p>
     #[serde(rename = "Plaintext")]
@@ -400,6 +410,7 @@ pub struct GetKeyPolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetKeyPolicyResponse {
     /// <p>A key policy document in JSON format.</p>
     #[serde(rename = "Policy")]
@@ -415,6 +426,7 @@ pub struct GetKeyRotationStatusRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetKeyRotationStatusResponse {
     /// <p>A Boolean value that specifies whether key rotation is enabled.</p>
     #[serde(rename = "KeyRotationEnabled")]
@@ -436,6 +448,7 @@ pub struct GetParametersForImportRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetParametersForImportResponse {
     /// <p>The import token to send in a subsequent <a>ImportKeyMaterial</a> request.</p>
     #[serde(rename = "ImportToken")]
@@ -478,6 +491,7 @@ pub struct GrantConstraints {
 
 /// <p>Contains information about an entry in a list of grants.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GrantListEntry {
     /// <p>A list of key-value pairs that must be present in the encryption context of certain subsequent operations that the grant allows.</p>
     #[serde(rename = "Constraints")]
@@ -549,10 +563,12 @@ pub struct ImportKeyMaterialRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ImportKeyMaterialResponse {}
 
 /// <p>Contains information about each entry in the key list.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct KeyListEntry {
     /// <p>ARN of the key.</p>
     #[serde(rename = "KeyArn")]
@@ -566,6 +582,7 @@ pub struct KeyListEntry {
 
 /// <p>Contains metadata about a customer master key (CMK).</p> <p>This data type is used as a response element for the <a>CreateKey</a> and <a>DescribeKey</a> operations.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct KeyMetadata {
     /// <p>The twelve-digit account ID of the AWS account that owns the CMK.</p>
     #[serde(rename = "AWSAccountId")]
@@ -637,6 +654,7 @@ pub struct ListAliasesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAliasesResponse {
     /// <p>A list of aliases.</p>
     #[serde(rename = "Aliases")]
@@ -668,6 +686,7 @@ pub struct ListGrantsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListGrantsResponse {
     /// <p>A list of grants.</p>
     #[serde(rename = "Grants")]
@@ -699,6 +718,7 @@ pub struct ListKeyPoliciesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListKeyPoliciesResponse {
     /// <p>When <code>Truncated</code> is true, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent request.</p>
     #[serde(rename = "NextMarker")]
@@ -727,6 +747,7 @@ pub struct ListKeysRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListKeysResponse {
     /// <p>A list of customer master keys (CMKs).</p>
     #[serde(rename = "Keys")]
@@ -758,6 +779,7 @@ pub struct ListResourceTagsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListResourceTagsResponse {
     /// <p>When <code>Truncated</code> is true, this element is present and contains the value to use for the <code>Marker</code> parameter in a subsequent request.</p> <p>Do not assume or infer any information from this value.</p>
     #[serde(rename = "NextMarker")]
@@ -833,6 +855,7 @@ pub struct ReEncryptRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReEncryptResponse {
     /// <p>The reencrypted data. When you use the HTTP API or the AWS CLI, the value is Base64-encoded. Otherwise, it is not encoded.</p>
     #[serde(rename = "CiphertextBlob")]
@@ -890,6 +913,7 @@ pub struct ScheduleKeyDeletionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ScheduleKeyDeletionResponse {
     /// <p>The date and time after which AWS KMS deletes the customer master key (CMK).</p>
     #[serde(rename = "DeletionDate")]

--- a/rusoto/services/lambda/src/custom/custom_tests.rs
+++ b/rusoto/services/lambda/src/custom/custom_tests.rs
@@ -1,10 +1,26 @@
 extern crate rusoto_mock;
 
-use ::{Lambda, LambdaClient, InvocationRequest};
+use ::{GetPolicyRequest, GetPolicyResponse, Lambda, LambdaClient, InvocationRequest};
 
 use rusoto_core::Region;
 use rusoto_core::signature::{SignedRequest,SignedRequestPayload};
 use self::rusoto_mock::*;
+
+#[test]
+fn serialize_get_policy_response() {
+    let policy = GetPolicyResponse {
+        policy: Some("policy".into()),
+        ..GetPolicyResponse::default()
+    };
+    let mock = MockRequestDispatcher::with_status(200)
+        .with_json_body(policy.clone());
+    let client = LambdaClient::new_with(mock, MockCredentialsProvider, Region::UsEast1);
+    let result = client.get_policy(GetPolicyRequest {
+        function_name: "test-func".into(),
+        ..GetPolicyRequest::default()
+    }).sync().unwrap();
+    assert_eq!(result, policy);
+}
 
 /// Ensures that rest-json codegen handles the response body,
 /// headers, and status code properly

--- a/rusoto/services/lambda/src/generated.rs
+++ b/rusoto/services/lambda/src/generated.rs
@@ -31,6 +31,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Provides limits of code size and concurrency associated with the current account and region.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AccountLimit {
     /// <p>Size, in bytes, of code/dependencies that you can zip into a deployment package (uncompressed zip/jar size) for uploading. The default limit is 250 MB.</p>
     #[serde(rename = "CodeSizeUnzipped")]
@@ -56,6 +57,7 @@ pub struct AccountLimit {
 
 /// <p>Provides code size usage and function count associated with the current account and region.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AccountUsage {
     /// <p>The number of your account's existing functions per region.</p>
     #[serde(rename = "FunctionCount")]
@@ -106,6 +108,7 @@ pub struct AddPermissionRequest {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddPermissionResponse {
     /// <p>The permission statement you specified in the request. The response returns the same as a string using a backslash ("\") as an escape character in the JSON.</p>
     #[serde(rename = "Statement")]
@@ -115,6 +118,7 @@ pub struct AddPermissionResponse {
 
 /// <p>Provides configuration information about a Lambda function version alias.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AliasConfiguration {
     /// <p>Lambda function ARN that is qualified using the alias name as the suffix. For example, if you create an alias called <code>BETA</code> that points to a helloworld function version, the ARN is <code>arn:aws:lambda:aws-regions:acct-id:function:helloworld:BETA</code>.</p>
     #[serde(rename = "AliasArn")]
@@ -152,6 +156,7 @@ pub struct AliasRoutingConfiguration {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Concurrency {
     /// <p>The number of concurrent executions reserved for this function. For more information, see <a>concurrent-executions</a>.</p>
     #[serde(rename = "ReservedConcurrentExecutions")]
@@ -322,6 +327,7 @@ pub struct Environment {
 
 /// <p>The parent object that contains error information associated with your configuration settings.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EnvironmentError {
     /// <p>The error code returned by the environment error object.</p>
     #[serde(rename = "ErrorCode")]
@@ -335,6 +341,7 @@ pub struct EnvironmentError {
 
 /// <p>The parent object returned that contains your environment's configuration settings or any error information associated with your configuration settings.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EnvironmentResponse {
     #[serde(rename = "Error")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -347,6 +354,7 @@ pub struct EnvironmentResponse {
 
 /// <p>Describes mapping between an Amazon Kinesis or DynamoDB stream or an Amazon SQS queue and a Lambda function.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EventSourceMappingConfiguration {
     /// <p>The largest number of records that AWS Lambda will retrieve from your event source at the time of invoking your function. Your function receives an event with all the retrieved records.</p>
     #[serde(rename = "BatchSize")]
@@ -409,6 +417,7 @@ pub struct FunctionCode {
 
 /// <p>The object for the Lambda function location.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FunctionCodeLocation {
     /// <p>The presigned URL you can use to download the function's .zip file that you previously uploaded. The URL is valid for up to 10 minutes.</p>
     #[serde(rename = "Location")]
@@ -422,6 +431,7 @@ pub struct FunctionCodeLocation {
 
 /// <p>A complex type that describes function metadata.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FunctionConfiguration {
     /// <p>It is the SHA256 hash of your function deployment package.</p>
     #[serde(rename = "CodeSha256")]
@@ -505,6 +515,7 @@ pub struct FunctionConfiguration {
 pub struct GetAccountSettingsRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetAccountSettingsResponse {
     #[serde(rename = "AccountLimit")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -558,6 +569,7 @@ pub struct GetFunctionRequest {
 
 /// <p>This response contains the object for the Lambda function location (see <a>FunctionCodeLocation</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetFunctionResponse {
     #[serde(rename = "Code")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -589,6 +601,7 @@ pub struct GetPolicyRequest {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetPolicyResponse {
     /// <p>The resource policy associated with the specified function. The response returns the same as a string using a backslash ("\") as an escape character in the JSON.</p>
     #[serde(rename = "Policy")]
@@ -665,6 +678,7 @@ pub struct InvokeAsyncRequest {
 
 /// <p>Upon success, it returns empty response. Otherwise, throws an exception.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InvokeAsyncResponse {
     /// <p>It will be 202 upon success.</p>
     #[serde(rename = "Status")]
@@ -692,6 +706,7 @@ pub struct ListAliasesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAliasesResponse {
     /// <p>A list of aliases.</p>
     #[serde(rename = "Aliases")]
@@ -726,6 +741,7 @@ pub struct ListEventSourceMappingsRequest {
 
 /// <p>Contains a list of event sources (see <a>EventSourceMappingConfiguration</a>)</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListEventSourceMappingsResponse {
     /// <p>An array of <code>EventSourceMappingConfiguration</code> objects.</p>
     #[serde(rename = "EventSourceMappings")]
@@ -760,6 +776,7 @@ pub struct ListFunctionsRequest {
 
 /// <p>Contains a list of AWS Lambda function configurations (see <a>FunctionConfiguration</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListFunctionsResponse {
     /// <p>A list of Lambda functions.</p>
     #[serde(rename = "Functions")]
@@ -779,6 +796,7 @@ pub struct ListTagsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagsResponse {
     /// <p>The list of tags assigned to the function. For more information, see <a href="http://docs.aws.amazon.com/lambda/latest/dg/tagging.html">Tagging Lambda Functions</a> in the <b>AWS Lambda Developer Guide</b>.</p>
     #[serde(rename = "Tags")]
@@ -804,6 +822,7 @@ pub struct ListVersionsByFunctionRequest {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListVersionsByFunctionResponse {
     /// <p>A string, present if there are more function versions.</p>
     #[serde(rename = "NextMarker")]
@@ -885,6 +904,7 @@ pub struct TracingConfig {
 
 /// <p>Parent object of the tracing information associated with your Lambda function.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TracingConfigResponse {
     /// <p>The tracing mode associated with your Lambda function.</p>
     #[serde(rename = "Mode")]
@@ -1058,6 +1078,7 @@ pub struct VpcConfig {
 
 /// <p>VPC configuration associated with your Lambda function.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VpcConfigResponse {
     /// <p>A list of security group IDs associated with the Lambda function.</p>
     #[serde(rename = "SecurityGroupIds")]

--- a/rusoto/services/lex-models/src/generated.rs
+++ b/rusoto/services/lex-models/src/generated.rs
@@ -31,6 +31,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Provides information about a bot alias.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BotAliasMetadata {
     /// <p>The name of the bot to which the alias points.</p>
     #[serde(rename = "botName")]
@@ -64,6 +65,7 @@ pub struct BotAliasMetadata {
 
 /// <p>Represents an association between an Amazon Lex bot and an external messaging platform.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BotChannelAssociation {
     /// <p>An alias pointing to the specific version of the Amazon Lex bot to which this association is being made. </p>
     #[serde(rename = "botAlias")]
@@ -105,6 +107,7 @@ pub struct BotChannelAssociation {
 
 /// <p>Provides information about a bot. .</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BotMetadata {
     /// <p>The date that the bot was created.</p>
     #[serde(rename = "createdDate")]
@@ -134,6 +137,7 @@ pub struct BotMetadata {
 
 /// <p>Provides metadata for a built-in intent.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BuiltinIntentMetadata {
     /// <p>A unique identifier for the built-in intent. To find the signature for an intent, see <a href="https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/built-in-intent-ref/standard-intents">Standard Built-in Intents</a> in the <i>Alexa Skills Kit</i>.</p>
     #[serde(rename = "signature")]
@@ -147,6 +151,7 @@ pub struct BuiltinIntentMetadata {
 
 /// <p>Provides information about a slot used in a built-in intent.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BuiltinIntentSlot {
     /// <p>A list of the slots defined for the intent.</p>
     #[serde(rename = "name")]
@@ -156,6 +161,7 @@ pub struct BuiltinIntentSlot {
 
 /// <p>Provides information about a built in slot type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BuiltinSlotTypeMetadata {
     /// <p>A unique identifier for the built-in slot type. To find the signature for a slot type, see <a href="https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/built-in-intent-ref/slot-type-reference">Slot Type Reference</a> in the <i>Alexa Skills Kit</i>.</p>
     #[serde(rename = "signature")]
@@ -190,6 +196,7 @@ pub struct CreateBotVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateBotVersionResponse {
     /// <p>The message that Amazon Lex uses to abort a conversation. For more information, see <a>PutBot</a>.</p>
     #[serde(rename = "abortStatement")]
@@ -265,6 +272,7 @@ pub struct CreateIntentVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateIntentVersionResponse {
     /// <p>Checksum of the intent version created.</p>
     #[serde(rename = "checksum")]
@@ -340,6 +348,7 @@ pub struct CreateSlotTypeVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateSlotTypeVersionResponse {
     /// <p>Checksum of the <code>$LATEST</code> version of the slot type.</p>
     #[serde(rename = "checksum")]
@@ -505,6 +514,7 @@ pub struct GetBotAliasRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetBotAliasResponse {
     /// <p>The name of the bot that the alias points to.</p>
     #[serde(rename = "botName")]
@@ -556,6 +566,7 @@ pub struct GetBotAliasesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetBotAliasesResponse {
     /// <p>An array of <code>BotAliasMetadata</code> objects, each describing a bot alias.</p>
     #[serde(rename = "BotAliases")]
@@ -581,6 +592,7 @@ pub struct GetBotChannelAssociationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetBotChannelAssociationResponse {
     /// <p>An alias pointing to the specific version of the Amazon Lex bot to which this association is being made.</p>
     #[serde(rename = "botAlias")]
@@ -643,6 +655,7 @@ pub struct GetBotChannelAssociationsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetBotChannelAssociationsResponse {
     /// <p>An array of objects, one for each association, that provides information about the Amazon Lex bot and its association with the channel. </p>
     #[serde(rename = "botChannelAssociations")]
@@ -665,6 +678,7 @@ pub struct GetBotRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetBotResponse {
     /// <p>The message that Amazon Lex returns when the user elects to end the conversation without completing it. For more information, see <a>PutBot</a>.</p>
     #[serde(rename = "abortStatement")]
@@ -744,6 +758,7 @@ pub struct GetBotVersionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetBotVersionsResponse {
     /// <p>An array of <code>BotMetadata</code> objects, one for each numbered version of the bot plus one for the <code>$LATEST</code> version.</p>
     #[serde(rename = "bots")]
@@ -772,6 +787,7 @@ pub struct GetBotsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetBotsResponse {
     /// <p>An array of <code>botMetadata</code> objects, with one entry for each bot. </p>
     #[serde(rename = "bots")]
@@ -791,6 +807,7 @@ pub struct GetBuiltinIntentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetBuiltinIntentResponse {
     /// <p>The unique identifier for a built-in intent.</p>
     #[serde(rename = "signature")]
@@ -827,6 +844,7 @@ pub struct GetBuiltinIntentsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetBuiltinIntentsResponse {
     /// <p>An array of <code>builtinIntentMetadata</code> objects, one for each intent in the response.</p>
     #[serde(rename = "intents")]
@@ -859,6 +877,7 @@ pub struct GetBuiltinSlotTypesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetBuiltinSlotTypesResponse {
     /// <p>If the response is truncated, the response includes a pagination token that you can use in your next request to fetch the next page of slot types.</p>
     #[serde(rename = "nextToken")]
@@ -887,6 +906,7 @@ pub struct GetExportRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetExportResponse {
     /// <p><p>The status of the export. </p> <ul> <li> <p> <code>IN_PROGRESS</code> - The export is in progress.</p> </li> <li> <p> <code>READY</code> - The export is complete.</p> </li> <li> <p> <code>FAILED</code> - The export could not be completed.</p> </li> </ul></p>
     #[serde(rename = "exportStatus")]
@@ -926,6 +946,7 @@ pub struct GetImportRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetImportResponse {
     /// <p>A timestamp for the date and time that the import job was created.</p>
     #[serde(rename = "createdDate")]
@@ -968,6 +989,7 @@ pub struct GetIntentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetIntentResponse {
     /// <p>Checksum of the intent.</p>
     #[serde(rename = "checksum")]
@@ -1047,6 +1069,7 @@ pub struct GetIntentVersionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetIntentVersionsResponse {
     /// <p>An array of <code>IntentMetadata</code> objects, one for each numbered version of the intent plus one for the <code>$LATEST</code> version.</p>
     #[serde(rename = "intents")]
@@ -1075,6 +1098,7 @@ pub struct GetIntentsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetIntentsResponse {
     /// <p>An array of <code>Intent</code> objects. For more information, see <a>PutBot</a>.</p>
     #[serde(rename = "intents")]
@@ -1097,6 +1121,7 @@ pub struct GetSlotTypeRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetSlotTypeResponse {
     /// <p>Checksum of the <code>$LATEST</code> version of the slot type.</p>
     #[serde(rename = "checksum")]
@@ -1148,6 +1173,7 @@ pub struct GetSlotTypeVersionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetSlotTypeVersionsResponse {
     /// <p>A pagination token for fetching the next page of slot type versions. If the response to this call is truncated, Amazon Lex returns a pagination token in the response. To fetch the next page of versions, specify the pagination token in the next request. </p>
     #[serde(rename = "nextToken")]
@@ -1176,6 +1202,7 @@ pub struct GetSlotTypesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetSlotTypesResponse {
     /// <p>If the response is truncated, it includes a pagination token that you can specify in your next request to fetch the next page of slot types.</p>
     #[serde(rename = "nextToken")]
@@ -1201,6 +1228,7 @@ pub struct GetUtterancesViewRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetUtterancesViewResponse {
     /// <p>The name of the bot for which utterance information was returned.</p>
     #[serde(rename = "botName")]
@@ -1225,6 +1253,7 @@ pub struct Intent {
 
 /// <p>Provides information about an intent.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct IntentMetadata {
     /// <p>The date that the intent was created.</p>
     #[serde(rename = "createdDate")]
@@ -1300,6 +1329,7 @@ pub struct PutBotAliasRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutBotAliasResponse {
     /// <p>The name of the bot that the alias points to.</p>
     #[serde(rename = "botName")]
@@ -1380,6 +1410,7 @@ pub struct PutBotRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutBotResponse {
     /// <p>The message that Amazon Lex uses to abort a conversation. For more information, see <a>PutBot</a>.</p>
     #[serde(rename = "abortStatement")]
@@ -1501,6 +1532,7 @@ pub struct PutIntentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutIntentResponse {
     /// <p>Checksum of the <code>$LATEST</code>version of the intent created or updated.</p>
     #[serde(rename = "checksum")]
@@ -1594,6 +1626,7 @@ pub struct PutSlotTypeRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutSlotTypeResponse {
     /// <p>Checksum of the <code>$LATEST</code> version of the slot type.</p>
     #[serde(rename = "checksum")]
@@ -1682,6 +1715,7 @@ pub struct Slot {
 
 /// <p>Provides information about a slot type..</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SlotTypeMetadata {
     /// <p>The date that the slot type was created.</p>
     #[serde(rename = "createdDate")]
@@ -1724,6 +1758,7 @@ pub struct StartImportRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartImportResponse {
     /// <p>A timestamp for the date and time that the import job was requested.</p>
     #[serde(rename = "createdDate")]
@@ -1765,6 +1800,7 @@ pub struct Statement {
 
 /// <p>Provides information about a single utterance that was made to your bot. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UtteranceData {
     /// <p>The number of times that the utterance was processed.</p>
     #[serde(rename = "count")]
@@ -1790,6 +1826,7 @@ pub struct UtteranceData {
 
 /// <p>Provides a list of utterances that have been made to a specific version of your bot. The list contains a maximum of 100 utterances.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UtteranceList {
     /// <p>The version of the bot that processed the list.</p>
     #[serde(rename = "botVersion")]

--- a/rusoto/services/lex-runtime/src/generated.rs
+++ b/rusoto/services/lex-runtime/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Represents an option to be shown on the client platform (Facebook, Slack, etc.)</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Button {
     /// <p>Text that is visible to the user on the button.</p>
     #[serde(rename = "text")]
@@ -41,6 +42,7 @@ pub struct Button {
 
 /// <p>Represents an option rendered to the user when a prompt is shown. It could be an image, a button, a link, or text. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GenericAttachment {
     /// <p>The URL of an attachment to the response card.</p>
     #[serde(rename = "attachmentLinkUrl")]
@@ -149,6 +151,7 @@ pub struct PostTextRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PostTextResponse {
     /// <p><p> Identifies the current state of the user interaction. Amazon Lex returns one of the following values as <code>dialogState</code>. The client can optionally use this information to customize the user interface. </p> <ul> <li> <p> <code>ElicitIntent</code> - Amazon Lex wants to elicit user intent. </p> <p>For example, a user might utter an intent (&quot;I want to order a pizza&quot;). If Amazon Lex cannot infer the user intent from this utterance, it will return this dialogState.</p> </li> <li> <p> <code>ConfirmIntent</code> - Amazon Lex is expecting a &quot;yes&quot; or &quot;no&quot; response. </p> <p> For example, Amazon Lex wants user confirmation before fulfilling an intent. </p> <p>Instead of a simple &quot;yes&quot; or &quot;no,&quot; a user might respond with additional information. For example, &quot;yes, but make it thick crust pizza&quot; or &quot;no, I want to order a drink&quot;. Amazon Lex can process such additional information (in these examples, update the crust type slot value, or change intent from OrderPizza to OrderDrink).</p> </li> <li> <p> <code>ElicitSlot</code> - Amazon Lex is expecting a slot value for the current intent. </p> <p>For example, suppose that in the response Amazon Lex sends this message: &quot;What size pizza would you like?&quot;. A user might reply with the slot value (e.g., &quot;medium&quot;). The user might also provide additional information in the response (e.g., &quot;medium thick crust pizza&quot;). Amazon Lex can process such additional information appropriately. </p> </li> <li> <p> <code>Fulfilled</code> - Conveys that the Lambda function configured for the intent has successfully fulfilled the intent. </p> </li> <li> <p> <code>ReadyForFulfillment</code> - Conveys that the client has to fulfill the intent. </p> </li> <li> <p> <code>Failed</code> - Conveys that the conversation with the user failed. </p> <p> This can happen for various reasons including that the user did not provide an appropriate response to prompts from the service (you can configure how many times Amazon Lex can prompt a user for specific information), or the Lambda function failed to fulfill the intent. </p> </li> </ul></p>
     #[serde(rename = "dialogState")]
@@ -186,6 +189,7 @@ pub struct PostTextResponse {
 
 /// <p>If you configure a response card when creating your bots, Amazon Lex substitutes the session attributes and slot values that are available, and then returns it. The response card can also come from a Lambda function ( <code>dialogCodeHook</code> and <code>fulfillmentActivity</code> on an intent).</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResponseCard {
     /// <p>The content type of the response.</p>
     #[serde(rename = "contentType")]

--- a/rusoto/services/lightsail/src/generated.rs
+++ b/rusoto/services/lightsail/src/generated.rs
@@ -36,6 +36,7 @@ pub struct AllocateStaticIpRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AllocateStaticIpResult {
     /// <p>An array of key-value pairs containing information about the static IP address you allocated.</p>
     #[serde(rename = "operations")]
@@ -57,6 +58,7 @@ pub struct AttachDiskRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AttachDiskResult {
     /// <p>An object describing the API operations.</p>
     #[serde(rename = "operations")]
@@ -75,6 +77,7 @@ pub struct AttachInstancesToLoadBalancerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AttachInstancesToLoadBalancerResult {
     /// <p>An object representing the API operations.</p>
     #[serde(rename = "operations")]
@@ -93,6 +96,7 @@ pub struct AttachLoadBalancerTlsCertificateRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AttachLoadBalancerTlsCertificateResult {
     /// <p>An object representing the API operations.</p> <p>These SSL/TLS certificates are only usable by Lightsail load balancers. You can't get the certificate and use it for another purpose.</p>
     #[serde(rename = "operations")]
@@ -111,6 +115,7 @@ pub struct AttachStaticIpRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AttachStaticIpResult {
     /// <p>An array of key-value pairs containing information about your API operations.</p>
     #[serde(rename = "operations")]
@@ -120,6 +125,7 @@ pub struct AttachStaticIpResult {
 
 /// <p>Describes an Availability Zone.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AvailabilityZone {
     /// <p>The state of the Availability Zone.</p>
     #[serde(rename = "state")]
@@ -133,6 +139,7 @@ pub struct AvailabilityZone {
 
 /// <p>Describes a blueprint (a virtual private server image).</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Blueprint {
     /// <p>The ID for the virtual private server image (e.g., <code>app_wordpress_4_4</code> or <code>app_lamp_7_0</code>).</p>
     #[serde(rename = "blueprintId")]
@@ -186,6 +193,7 @@ pub struct Blueprint {
 
 /// <p>Describes a bundle, which is a set of specs describing your virtual private server (or <i>instance</i>).</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Bundle {
     /// <p>The bundle ID (e.g., <code>micro_1_0</code>).</p>
     #[serde(rename = "bundleId")]
@@ -244,6 +252,7 @@ pub struct CloseInstancePublicPortsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CloseInstancePublicPortsResult {
     /// <p>An array of key-value pairs that contains information about the operation.</p>
     #[serde(rename = "operation")]
@@ -268,6 +277,7 @@ pub struct CreateDiskFromSnapshotRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDiskFromSnapshotResult {
     /// <p>An object describing the API operations.</p>
     #[serde(rename = "operations")]
@@ -289,6 +299,7 @@ pub struct CreateDiskRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDiskResult {
     /// <p>An object describing the API operations.</p>
     #[serde(rename = "operations")]
@@ -307,6 +318,7 @@ pub struct CreateDiskSnapshotRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDiskSnapshotResult {
     /// <p>An object describing the API operations.</p>
     #[serde(rename = "operations")]
@@ -325,6 +337,7 @@ pub struct CreateDomainEntryRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDomainEntryResult {
     /// <p>An array of key-value pairs containing information about the operation.</p>
     #[serde(rename = "operation")]
@@ -340,6 +353,7 @@ pub struct CreateDomainRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDomainResult {
     /// <p>An array of key-value pairs containing information about the domain resource you created.</p>
     #[serde(rename = "operation")]
@@ -358,6 +372,7 @@ pub struct CreateInstanceSnapshotRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateInstanceSnapshotResult {
     /// <p>An array of key-value pairs containing information about the results of your create instances snapshot request.</p>
     #[serde(rename = "operations")]
@@ -394,6 +409,7 @@ pub struct CreateInstancesFromSnapshotRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateInstancesFromSnapshotResult {
     /// <p>An array of key-value pairs containing information about the results of your create instances from snapshot request.</p>
     #[serde(rename = "operations")]
@@ -426,6 +442,7 @@ pub struct CreateInstancesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateInstancesResult {
     /// <p>An array of key-value pairs containing information about the results of your create instances request.</p>
     #[serde(rename = "operations")]
@@ -441,6 +458,7 @@ pub struct CreateKeyPairRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateKeyPairResult {
     /// <p>An array of key-value pairs containing information about the new key pair you just created.</p>
     #[serde(rename = "keyPair")]
@@ -487,6 +505,7 @@ pub struct CreateLoadBalancerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateLoadBalancerResult {
     /// <p>An object containing information about the API operations.</p>
     #[serde(rename = "operations")]
@@ -512,6 +531,7 @@ pub struct CreateLoadBalancerTlsCertificateRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateLoadBalancerTlsCertificateResult {
     /// <p>An object containing information about the API operations.</p>
     #[serde(rename = "operations")]
@@ -527,6 +547,7 @@ pub struct DeleteDiskRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteDiskResult {
     /// <p>An object describing the API operations.</p>
     #[serde(rename = "operations")]
@@ -542,6 +563,7 @@ pub struct DeleteDiskSnapshotRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteDiskSnapshotResult {
     /// <p>An object describing the API operations.</p>
     #[serde(rename = "operations")]
@@ -560,6 +582,7 @@ pub struct DeleteDomainEntryRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteDomainEntryResult {
     /// <p>An array of key-value pairs containing information about the results of your delete domain entry request.</p>
     #[serde(rename = "operation")]
@@ -575,6 +598,7 @@ pub struct DeleteDomainRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteDomainResult {
     /// <p>An array of key-value pairs containing information about the results of your delete domain request.</p>
     #[serde(rename = "operation")]
@@ -590,6 +614,7 @@ pub struct DeleteInstanceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteInstanceResult {
     /// <p>An array of key-value pairs containing information about the results of your delete instance request.</p>
     #[serde(rename = "operations")]
@@ -605,6 +630,7 @@ pub struct DeleteInstanceSnapshotRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteInstanceSnapshotResult {
     /// <p>An array of key-value pairs containing information about the results of your delete instance snapshot request.</p>
     #[serde(rename = "operations")]
@@ -620,6 +646,7 @@ pub struct DeleteKeyPairRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteKeyPairResult {
     /// <p>An array of key-value pairs containing information about the results of your delete key pair request.</p>
     #[serde(rename = "operation")]
@@ -635,6 +662,7 @@ pub struct DeleteLoadBalancerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteLoadBalancerResult {
     /// <p>An object describing the API operations.</p>
     #[serde(rename = "operations")]
@@ -657,6 +685,7 @@ pub struct DeleteLoadBalancerTlsCertificateRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteLoadBalancerTlsCertificateResult {
     /// <p>An object describing the API operations.</p>
     #[serde(rename = "operations")]
@@ -672,6 +701,7 @@ pub struct DetachDiskRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DetachDiskResult {
     /// <p>An object describing the API operations.</p>
     #[serde(rename = "operations")]
@@ -690,6 +720,7 @@ pub struct DetachInstancesFromLoadBalancerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DetachInstancesFromLoadBalancerResult {
     /// <p>An object describing the API operations.</p>
     #[serde(rename = "operations")]
@@ -705,6 +736,7 @@ pub struct DetachStaticIpRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DetachStaticIpResult {
     /// <p>An array of key-value pairs containing information about the results of your detach static IP request.</p>
     #[serde(rename = "operations")]
@@ -714,6 +746,7 @@ pub struct DetachStaticIpResult {
 
 /// <p>Describes a system disk or an block storage disk.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Disk {
     /// <p>The Amazon Resource Name (ARN) of the disk.</p>
     #[serde(rename = "arn")]
@@ -784,6 +817,7 @@ pub struct DiskMap {
 
 /// <p>Describes a block storage disk snapshot.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DiskSnapshot {
     /// <p>The Amazon Resource Name (ARN) of the disk snapshot.</p>
     #[serde(rename = "arn")]
@@ -833,6 +867,7 @@ pub struct DiskSnapshot {
 
 /// <p>Describes a domain where you are storing recordsets in Lightsail.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Domain {
     /// <p>The Amazon Resource Name (ARN) of the domain recordset (e.g., <code>arn:aws:lightsail:global:123456789101:Domain/824cede0-abc7-4f84-8dbc-12345EXAMPLE</code>).</p>
     #[serde(rename = "arn")]
@@ -893,6 +928,7 @@ pub struct DomainEntry {
 pub struct DownloadDefaultKeyPairRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DownloadDefaultKeyPairResult {
     /// <p>A base64-encoded RSA private key.</p>
     #[serde(rename = "privateKeyBase64")]
@@ -913,6 +949,7 @@ pub struct GetActiveNamesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetActiveNamesResult {
     /// <p>The list of active names returned by the get active names request.</p>
     #[serde(rename = "activeNames")]
@@ -937,6 +974,7 @@ pub struct GetBlueprintsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetBlueprintsResult {
     /// <p>An array of key-value pairs that contains information about the available blueprints.</p>
     #[serde(rename = "blueprints")]
@@ -961,6 +999,7 @@ pub struct GetBundlesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetBundlesResult {
     /// <p>An array of key-value pairs that contains information about the available bundles.</p>
     #[serde(rename = "bundles")]
@@ -980,6 +1019,7 @@ pub struct GetDiskRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDiskResult {
     /// <p>An object containing information about the disk.</p>
     #[serde(rename = "disk")]
@@ -995,6 +1035,7 @@ pub struct GetDiskSnapshotRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDiskSnapshotResult {
     /// <p>An object containing information about the disk snapshot.</p>
     #[serde(rename = "diskSnapshot")]
@@ -1011,6 +1052,7 @@ pub struct GetDiskSnapshotsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDiskSnapshotsResult {
     /// <p>An array of objects containing information about all block storage disk snapshots.</p>
     #[serde(rename = "diskSnapshots")]
@@ -1031,6 +1073,7 @@ pub struct GetDisksRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDisksResult {
     /// <p>An array of objects containing information about all block storage disks.</p>
     #[serde(rename = "disks")]
@@ -1050,6 +1093,7 @@ pub struct GetDomainRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDomainResult {
     /// <p>An array of key-value pairs containing information about your get domain request.</p>
     #[serde(rename = "domain")]
@@ -1066,6 +1110,7 @@ pub struct GetDomainsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDomainsResult {
     /// <p>An array of key-value pairs containing information about each of the domain entries in the user's account.</p>
     #[serde(rename = "domains")]
@@ -1089,6 +1134,7 @@ pub struct GetInstanceAccessDetailsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetInstanceAccessDetailsResult {
     /// <p>An array of key-value pairs containing information about a get instance access request.</p>
     #[serde(rename = "accessDetails")]
@@ -1122,6 +1168,7 @@ pub struct GetInstanceMetricDataRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetInstanceMetricDataResult {
     /// <p>An array of key-value pairs containing information about the results of your get instance metric data request.</p>
     #[serde(rename = "metricData")]
@@ -1141,6 +1188,7 @@ pub struct GetInstancePortStatesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetInstancePortStatesResult {
     /// <p>Information about the port states resulting from your request.</p>
     #[serde(rename = "portStates")]
@@ -1156,6 +1204,7 @@ pub struct GetInstanceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetInstanceResult {
     /// <p>An array of key-value pairs containing information about the specified instance.</p>
     #[serde(rename = "instance")]
@@ -1171,6 +1220,7 @@ pub struct GetInstanceSnapshotRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetInstanceSnapshotResult {
     /// <p>An array of key-value pairs containing information about the results of your get instance snapshot request.</p>
     #[serde(rename = "instanceSnapshot")]
@@ -1187,6 +1237,7 @@ pub struct GetInstanceSnapshotsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetInstanceSnapshotsResult {
     /// <p>An array of key-value pairs containing information about the results of your get instance snapshots request.</p>
     #[serde(rename = "instanceSnapshots")]
@@ -1206,6 +1257,7 @@ pub struct GetInstanceStateRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetInstanceStateResult {
     /// <p>The state of the instance.</p>
     #[serde(rename = "state")]
@@ -1222,6 +1274,7 @@ pub struct GetInstancesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetInstancesResult {
     /// <p>An array of key-value pairs containing information about your instances.</p>
     #[serde(rename = "instances")]
@@ -1241,6 +1294,7 @@ pub struct GetKeyPairRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetKeyPairResult {
     /// <p>An array of key-value pairs containing information about the key pair.</p>
     #[serde(rename = "keyPair")]
@@ -1257,6 +1311,7 @@ pub struct GetKeyPairsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetKeyPairsResult {
     /// <p>An array of key-value pairs containing information about the key pairs.</p>
     #[serde(rename = "keyPairs")]
@@ -1294,6 +1349,7 @@ pub struct GetLoadBalancerMetricDataRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetLoadBalancerMetricDataResult {
     /// <p>An array of metric datapoint objects.</p>
     #[serde(rename = "metricData")]
@@ -1313,6 +1369,7 @@ pub struct GetLoadBalancerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetLoadBalancerResult {
     /// <p>An object containing information about your load balancer.</p>
     #[serde(rename = "loadBalancer")]
@@ -1328,6 +1385,7 @@ pub struct GetLoadBalancerTlsCertificatesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetLoadBalancerTlsCertificatesResult {
     /// <p>An array of LoadBalancerTlsCertificate objects describing your SSL/TLS certificates.</p>
     #[serde(rename = "tlsCertificates")]
@@ -1344,6 +1402,7 @@ pub struct GetLoadBalancersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetLoadBalancersResult {
     /// <p>An array of LoadBalancer objects describing your load balancers.</p>
     #[serde(rename = "loadBalancers")]
@@ -1363,6 +1422,7 @@ pub struct GetOperationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetOperationResult {
     /// <p>An array of key-value pairs containing information about the results of your get operation request.</p>
     #[serde(rename = "operation")]
@@ -1382,6 +1442,7 @@ pub struct GetOperationsForResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetOperationsForResourceResult {
     /// <p>An identifier that was returned from the previous call to this operation, which can be used to return the next set of items in the list.</p>
     #[serde(rename = "nextPageToken")]
@@ -1402,6 +1463,7 @@ pub struct GetOperationsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetOperationsResult {
     /// <p>A token used for advancing to the next page of results from your get operations request.</p>
     #[serde(rename = "nextPageToken")]
@@ -1422,6 +1484,7 @@ pub struct GetRegionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetRegionsResult {
     /// <p>An array of key-value pairs containing information about your get regions request.</p>
     #[serde(rename = "regions")]
@@ -1437,6 +1500,7 @@ pub struct GetStaticIpRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetStaticIpResult {
     /// <p>An array of key-value pairs containing information about the requested static IP.</p>
     #[serde(rename = "staticIp")]
@@ -1453,6 +1517,7 @@ pub struct GetStaticIpsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetStaticIpsResult {
     /// <p>A token used for advancing to the next page of results from your get static IPs request.</p>
     #[serde(rename = "nextPageToken")]
@@ -1475,6 +1540,7 @@ pub struct ImportKeyPairRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ImportKeyPairResult {
     /// <p>An array of key-value pairs containing information about the request operation.</p>
     #[serde(rename = "operation")]
@@ -1484,6 +1550,7 @@ pub struct ImportKeyPairResult {
 
 /// <p>Describes an instance (a virtual private server).</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Instance {
     /// <p>The Amazon Resource Name (ARN) of the instance (e.g., <code>arn:aws:lightsail:us-east-2:123456789101:Instance/244ad76f-8aad-4741-809f-12345EXAMPLE</code>).</p>
     #[serde(rename = "arn")]
@@ -1561,6 +1628,7 @@ pub struct Instance {
 
 /// <p>The parameters for gaining temporary access to one of your Amazon Lightsail instances.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceAccessDetails {
     /// <p>For SSH access, the public key to use when accessing your instance For OpenSSH clients (e.g., command line SSH), you should save this value to <code>tempkey-cert.pub</code>.</p>
     #[serde(rename = "certKey")]
@@ -1602,6 +1670,7 @@ pub struct InstanceAccessDetails {
 
 /// <p>Describes the hardware for the instance.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceHardware {
     /// <p>The number of vCPUs the instance has.</p>
     #[serde(rename = "cpuCount")]
@@ -1619,6 +1688,7 @@ pub struct InstanceHardware {
 
 /// <p>Describes information about the health of the instance.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceHealthSummary {
     /// <p>Describes the overall instance health. Valid values are below.</p>
     #[serde(rename = "instanceHealth")]
@@ -1636,6 +1706,7 @@ pub struct InstanceHealthSummary {
 
 /// <p>Describes monthly data transfer rates and port information for an instance.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceNetworking {
     /// <p>The amount of data in GB allocated for monthly data transfers.</p>
     #[serde(rename = "monthlyTransfer")]
@@ -1649,6 +1720,7 @@ pub struct InstanceNetworking {
 
 /// <p>Describes information about the instance ports.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstancePortInfo {
     /// <p>The access direction (<code>inbound</code> or <code>outbound</code>).</p>
     #[serde(rename = "accessDirection")]
@@ -1682,6 +1754,7 @@ pub struct InstancePortInfo {
 
 /// <p>Describes the port state.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstancePortState {
     /// <p>The first port in the range.</p>
     #[serde(rename = "fromPort")]
@@ -1703,6 +1776,7 @@ pub struct InstancePortState {
 
 /// <p>Describes the snapshot of the virtual private server, or <i>instance</i>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceSnapshot {
     /// <p>The Amazon Resource Name (ARN) of the snapshot (e.g., <code>arn:aws:lightsail:us-east-2:123456789101:InstanceSnapshot/d23b5706-3322-4d83-81e5-12345EXAMPLE</code>).</p>
     #[serde(rename = "arn")]
@@ -1764,6 +1838,7 @@ pub struct InstanceSnapshot {
 
 /// <p>Describes the virtual private server (or <i>instance</i>) status.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceState {
     /// <p>The status code for the instance.</p>
     #[serde(rename = "code")]
@@ -1779,6 +1854,7 @@ pub struct InstanceState {
 pub struct IsVpcPeeredRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct IsVpcPeeredResult {
     /// <p>Returns <code>true</code> if the Lightsail VPC is peered; otherwise, <code>false</code>.</p>
     #[serde(rename = "isPeered")]
@@ -1788,6 +1864,7 @@ pub struct IsVpcPeeredResult {
 
 /// <p>Describes the SSH key pair.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct KeyPair {
     /// <p>The Amazon Resource Name (ARN) of the key pair (e.g., <code>arn:aws:lightsail:us-east-2:123456789101:KeyPair/05859e3d-331d-48ba-9034-12345EXAMPLE</code>).</p>
     #[serde(rename = "arn")]
@@ -1821,6 +1898,7 @@ pub struct KeyPair {
 
 /// <p>Describes the Lightsail load balancer.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LoadBalancer {
     /// <p>The Amazon Resource Name (ARN) of the load balancer.</p>
     #[serde(rename = "arn")]
@@ -1886,6 +1964,7 @@ pub struct LoadBalancer {
 
 /// <p>Describes a load balancer SSL/TLS certificate.</p> <p>TLS is just an updated, more secure version of Secure Socket Layer (SSL).</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LoadBalancerTlsCertificate {
     /// <p>The Amazon Resource Name (ARN) of the SSL/TLS certificate.</p>
     #[serde(rename = "arn")]
@@ -1987,6 +2066,7 @@ pub struct LoadBalancerTlsCertificate {
 
 /// <p>Contains information about the domain names on an SSL/TLS certificate that you will use to validate domain ownership.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LoadBalancerTlsCertificateDomainValidationOption {
     /// <p>The fully qualified domain name in the certificate request.</p>
     #[serde(rename = "domainName")]
@@ -2000,6 +2080,7 @@ pub struct LoadBalancerTlsCertificateDomainValidationOption {
 
 /// <p>Describes the validation record of each domain name in the SSL/TLS certificate.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LoadBalancerTlsCertificateDomainValidationRecord {
     /// <p>The domain name against which your SSL/TLS certificate was validated.</p>
     #[serde(rename = "domainName")]
@@ -2025,6 +2106,7 @@ pub struct LoadBalancerTlsCertificateDomainValidationRecord {
 
 /// <p>Contains information about the status of Lightsail's managed renewal for the certificate.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LoadBalancerTlsCertificateRenewalSummary {
     /// <p>Contains information about the validation of each domain name in the certificate, as it pertains to Lightsail's managed renewal. This is different from the initial validation that occurs as a result of the RequestCertificate request.</p>
     #[serde(rename = "domainValidationOptions")]
@@ -2038,6 +2120,7 @@ pub struct LoadBalancerTlsCertificateRenewalSummary {
 
 /// <p>Provides a summary of SSL/TLS certificate metadata.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LoadBalancerTlsCertificateSummary {
     /// <p>When <code>true</code>, the SSL/TLS certificate is attached to the Lightsail load balancer.</p>
     #[serde(rename = "isAttached")]
@@ -2051,6 +2134,7 @@ pub struct LoadBalancerTlsCertificateSummary {
 
 /// <p>Describes the metric data point.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MetricDatapoint {
     /// <p>The average.</p>
     #[serde(rename = "average")]
@@ -2084,6 +2168,7 @@ pub struct MetricDatapoint {
 
 /// <p>Describes the monthly data transfer in and out of your virtual private server (or <i>instance</i>).</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MonthlyTransfer {
     /// <p>The amount allocated per month (in GB).</p>
     #[serde(rename = "gbPerMonthAllocated")]
@@ -2102,6 +2187,7 @@ pub struct OpenInstancePublicPortsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct OpenInstancePublicPortsResult {
     /// <p>An array of key-value pairs containing information about the request operation.</p>
     #[serde(rename = "operation")]
@@ -2111,6 +2197,7 @@ pub struct OpenInstancePublicPortsResult {
 
 /// <p>Describes the API operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Operation {
     /// <p>The timestamp when the operation was initialized (e.g., <code>1479816991.349</code>).</p>
     #[serde(rename = "createdAt")]
@@ -2164,6 +2251,7 @@ pub struct Operation {
 
 /// <p>The password data for the Windows Server-based instance, including the ciphertext and the key pair name.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PasswordData {
     /// <p><p>The encrypted password. Ciphertext will be an empty string if access to your new instance is not ready yet. When you create an instance, it can take up to 15 minutes for the instance to be ready.</p> <note> <p>If you use the default key pair (<code>LightsailDefaultKeyPair</code>), the decrypted password will be available in the password field.</p> <p>If you are using a custom key pair, you need to use your own means of decryption.</p> <p>If you change the Administrator password on the instance, Lightsail will continue to return the original ciphertext value. When accessing the instance using RDP, you need to manually enter the Administrator password after changing it from the default.</p> </note></p>
     #[serde(rename = "ciphertext")]
@@ -2179,6 +2267,7 @@ pub struct PasswordData {
 pub struct PeerVpcRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PeerVpcResult {
     /// <p>An array of key-value pairs containing information about the request operation.</p>
     #[serde(rename = "operation")]
@@ -2214,6 +2303,7 @@ pub struct PutInstancePublicPortsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutInstancePublicPortsResult {
     /// <p>Describes metadata about the operation you just executed.</p>
     #[serde(rename = "operation")]
@@ -2229,6 +2319,7 @@ pub struct RebootInstanceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RebootInstanceResult {
     /// <p>An array of key-value pairs containing information about the request operations.</p>
     #[serde(rename = "operations")]
@@ -2238,6 +2329,7 @@ pub struct RebootInstanceResult {
 
 /// <p>Describes the AWS Region.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Region {
     /// <p>The Availability Zones. Follows the format <code>us-east-2a</code> (case-sensitive).</p>
     #[serde(rename = "availabilityZones")]
@@ -2269,6 +2361,7 @@ pub struct ReleaseStaticIpRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReleaseStaticIpResult {
     /// <p>An array of key-value pairs containing information about the request operation.</p>
     #[serde(rename = "operations")]
@@ -2278,6 +2371,7 @@ pub struct ReleaseStaticIpResult {
 
 /// <p>Describes the resource location.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResourceLocation {
     /// <p>The Availability Zone. Follows the format <code>us-east-2a</code> (case-sensitive).</p>
     #[serde(rename = "availabilityZone")]
@@ -2297,6 +2391,7 @@ pub struct StartInstanceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartInstanceResult {
     /// <p>An array of key-value pairs containing information about the request operation.</p>
     #[serde(rename = "operations")]
@@ -2306,6 +2401,7 @@ pub struct StartInstanceResult {
 
 /// <p>Describes the static IP.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StaticIp {
     /// <p>The Amazon Resource Name (ARN) of the static IP (e.g., <code>arn:aws:lightsail:us-east-2:123456789101:StaticIp/9cbb4a9e-f8e3-4dfe-b57e-12345EXAMPLE</code>).</p>
     #[serde(rename = "arn")]
@@ -2357,6 +2453,7 @@ pub struct StopInstanceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopInstanceResult {
     /// <p>An array of key-value pairs containing information about the request operation.</p>
     #[serde(rename = "operations")]
@@ -2368,6 +2465,7 @@ pub struct StopInstanceResult {
 pub struct UnpeerVpcRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UnpeerVpcResult {
     /// <p>An array of key-value pairs containing information about the request operation.</p>
     #[serde(rename = "operation")]
@@ -2386,6 +2484,7 @@ pub struct UpdateDomainEntryRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateDomainEntryResult {
     /// <p>An array of key-value pairs containing information about the request operation.</p>
     #[serde(rename = "operations")]
@@ -2407,6 +2506,7 @@ pub struct UpdateLoadBalancerAttributeRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateLoadBalancerAttributeResult {
     /// <p>An object describing the API operations.</p>
     #[serde(rename = "operations")]

--- a/rusoto/services/logs/src/generated.rs
+++ b/rusoto/services/logs/src/generated.rs
@@ -74,6 +74,7 @@ pub struct CreateExportTaskRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateExportTaskResponse {
     /// <p>The ID of the export task.</p>
     #[serde(rename = "taskId")]
@@ -182,6 +183,7 @@ pub struct DescribeDestinationsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeDestinationsResponse {
     /// <p>The destinations.</p>
     #[serde(rename = "destinations")]
@@ -213,6 +215,7 @@ pub struct DescribeExportTasksRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeExportTasksResponse {
     /// <p>The export tasks.</p>
     #[serde(rename = "exportTasks")]
@@ -240,6 +243,7 @@ pub struct DescribeLogGroupsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeLogGroupsResponse {
     /// <p>The log groups.</p>
     #[serde(rename = "logGroups")]
@@ -278,6 +282,7 @@ pub struct DescribeLogStreamsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeLogStreamsResponse {
     /// <p>The log streams.</p>
     #[serde(rename = "logStreams")]
@@ -316,6 +321,7 @@ pub struct DescribeMetricFiltersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeMetricFiltersResponse {
     /// <p>The metric filters.</p>
     #[serde(rename = "metricFilters")]
@@ -338,6 +344,7 @@ pub struct DescribeResourcePoliciesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeResourcePoliciesResponse {
     #[serde(rename = "nextToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -368,6 +375,7 @@ pub struct DescribeSubscriptionFiltersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeSubscriptionFiltersResponse {
     #[serde(rename = "nextToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -380,6 +388,7 @@ pub struct DescribeSubscriptionFiltersResponse {
 
 /// <p>Represents a cross-account destination that receives subscription log events.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Destination {
     /// <p>An IAM policy document that governs which AWS accounts can create subscription filters against this destination.</p>
     #[serde(rename = "accessPolicy")]
@@ -416,6 +425,7 @@ pub struct DisassociateKmsKeyRequest {
 
 /// <p>Represents an export task.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ExportTask {
     /// <p>The name of Amazon S3 bucket to which the log data was exported.</p>
     #[serde(rename = "destination")]
@@ -457,6 +467,7 @@ pub struct ExportTask {
 
 /// <p>Represents the status of an export task.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ExportTaskExecutionInfo {
     /// <p>The completion time of the export task, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.</p>
     #[serde(rename = "completionTime")]
@@ -470,6 +481,7 @@ pub struct ExportTaskExecutionInfo {
 
 /// <p>Represents the status of an export task.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ExportTaskStatus {
     /// <p>The status code of the export task.</p>
     #[serde(rename = "code")]
@@ -517,6 +529,7 @@ pub struct FilterLogEventsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FilterLogEventsResponse {
     /// <p>The matched events.</p>
     #[serde(rename = "events")]
@@ -534,6 +547,7 @@ pub struct FilterLogEventsResponse {
 
 /// <p>Represents a matched event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FilteredLogEvent {
     /// <p>The ID of the event.</p>
     #[serde(rename = "eventId")]
@@ -588,6 +602,7 @@ pub struct GetLogEventsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetLogEventsResponse {
     /// <p>The events.</p>
     #[serde(rename = "events")]
@@ -622,6 +637,7 @@ pub struct ListTagsLogGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagsLogGroupResponse {
     /// <p>The tags for the log group.</p>
     #[serde(rename = "tags")]
@@ -631,6 +647,7 @@ pub struct ListTagsLogGroupResponse {
 
 /// <p>Represents a log group.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LogGroup {
     /// <p>The Amazon Resource Name (ARN) of the log group.</p>
     #[serde(rename = "arn")]
@@ -663,6 +680,7 @@ pub struct LogGroup {
 
 /// <p>Represents a log stream, which is a sequence of log events from a single emitter of logs.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LogStream {
     /// <p>The Amazon Resource Name (ARN) of the log stream.</p>
     #[serde(rename = "arn")]
@@ -700,6 +718,7 @@ pub struct LogStream {
 
 /// <p>Metric filters express how CloudWatch Logs would extract metric observations from ingested log events and transform them into metric data in a CloudWatch metric.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MetricFilter {
     /// <p>The creation time of the metric filter, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.</p>
     #[serde(rename = "creationTime")]
@@ -724,6 +743,7 @@ pub struct MetricFilter {
 
 /// <p>Represents a matched event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MetricFilterMatchRecord {
     /// <p>The raw event data.</p>
     #[serde(rename = "eventMessage")]
@@ -759,6 +779,7 @@ pub struct MetricTransformation {
 
 /// <p>Represents a log event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct OutputLogEvent {
     /// <p>The time the event was ingested, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.</p>
     #[serde(rename = "ingestionTime")]
@@ -798,6 +819,7 @@ pub struct PutDestinationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutDestinationResponse {
     /// <p>The destination.</p>
     #[serde(rename = "destination")]
@@ -823,6 +845,7 @@ pub struct PutLogEventsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutLogEventsResponse {
     /// <p>The next sequence token.</p>
     #[serde(rename = "nextSequenceToken")]
@@ -863,6 +886,7 @@ pub struct PutResourcePolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutResourcePolicyResponse {
     /// <p>The new policy.</p>
     #[serde(rename = "resourcePolicy")]
@@ -905,6 +929,7 @@ pub struct PutSubscriptionFilterRequest {
 
 /// <p>Represents the rejected events.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RejectedLogEventsInfo {
     /// <p>The expired log events.</p>
     #[serde(rename = "expiredLogEventEndIndex")]
@@ -922,6 +947,7 @@ pub struct RejectedLogEventsInfo {
 
 /// <p>A policy enabling one or more entities to put logs to a log group in this account.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResourcePolicy {
     /// <p>Time stamp showing when this policy was last updated, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.</p>
     #[serde(rename = "lastUpdatedTime")]
@@ -939,6 +965,7 @@ pub struct ResourcePolicy {
 
 /// <p>Represents the search status of a log stream.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SearchedLogStream {
     /// <p>The name of the log stream.</p>
     #[serde(rename = "logStreamName")]
@@ -952,6 +979,7 @@ pub struct SearchedLogStream {
 
 /// <p>Represents a subscription filter.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SubscriptionFilter {
     /// <p>The creation time of the subscription filter, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.</p>
     #[serde(rename = "creationTime")]
@@ -1001,6 +1029,7 @@ pub struct TestMetricFilterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TestMetricFilterResponse {
     /// <p>The matched events.</p>
     #[serde(rename = "matches")]

--- a/rusoto/services/machinelearning/src/generated.rs
+++ b/rusoto/services/machinelearning/src/generated.rs
@@ -43,6 +43,7 @@ pub struct AddTagsInput {
 
 /// <p>Amazon ML returns the following elements. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddTagsOutput {
     /// <p>The ID of the ML object that was tagged.</p>
     #[serde(rename = "ResourceId")]
@@ -56,6 +57,7 @@ pub struct AddTagsOutput {
 
 /// <p> Represents the output of a <code>GetBatchPrediction</code> operation.</p> <p> The content consists of the detailed metadata, the status, and the data file information of a <code>Batch Prediction</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchPrediction {
     /// <p>The ID of the <code>DataSource</code> that points to the group of observations to predict.</p>
     #[serde(rename = "BatchPredictionDataSourceId")]
@@ -140,6 +142,7 @@ pub struct CreateBatchPredictionInput {
 
 /// <p> Represents the output of a <code>CreateBatchPrediction</code> operation, and is an acknowledgement that Amazon ML received the request.</p> <p>The <code>CreateBatchPrediction</code> operation is asynchronous. You can poll for status updates by using the <code>&gt;GetBatchPrediction</code> operation and checking the <code>Status</code> parameter of the result. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateBatchPredictionOutput {
     /// <p>A user-supplied ID that uniquely identifies the <code>BatchPrediction</code>. This value is identical to the value of the <code>BatchPredictionId</code> in the request.</p>
     #[serde(rename = "BatchPredictionId")]
@@ -170,6 +173,7 @@ pub struct CreateDataSourceFromRDSInput {
 
 /// <p> Represents the output of a <code>CreateDataSourceFromRDS</code> operation, and is an acknowledgement that Amazon ML received the request.</p> <p>The <code>CreateDataSourceFromRDS</code>&gt; operation is asynchronous. You can poll for updates by using the <code>GetBatchPrediction</code> operation and checking the <code>Status</code> parameter. You can inspect the <code>Message</code> when <code>Status</code> shows up as <code>FAILED</code>. You can also check the progress of the copy operation by going to the <code>DataPipeline</code> console and looking up the pipeline using the <code>pipelineId </code> from the describe call.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDataSourceFromRDSOutput {
     /// <p>A user-supplied ID that uniquely identifies the datasource. This value should be identical to the value of the <code>DataSourceID</code> in the request. </p>
     #[serde(rename = "DataSourceId")]
@@ -200,6 +204,7 @@ pub struct CreateDataSourceFromRedshiftInput {
 
 /// <p> Represents the output of a <code>CreateDataSourceFromRedshift</code> operation, and is an acknowledgement that Amazon ML received the request.</p> <p>The <code>CreateDataSourceFromRedshift</code> operation is asynchronous. You can poll for updates by using the <code>GetBatchPrediction</code> operation and checking the <code>Status</code> parameter. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDataSourceFromRedshiftOutput {
     /// <p>A user-supplied ID that uniquely identifies the datasource. This value should be identical to the value of the <code>DataSourceID</code> in the request. </p>
     #[serde(rename = "DataSourceId")]
@@ -227,6 +232,7 @@ pub struct CreateDataSourceFromS3Input {
 
 /// <p> Represents the output of a <code>CreateDataSourceFromS3</code> operation, and is an acknowledgement that Amazon ML received the request.</p> <p>The <code>CreateDataSourceFromS3</code> operation is asynchronous. You can poll for updates by using the <code>GetBatchPrediction</code> operation and checking the <code>Status</code> parameter. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDataSourceFromS3Output {
     /// <p>A user-supplied ID that uniquely identifies the <code>DataSource</code>. This value should be identical to the value of the <code>DataSourceID</code> in the request. </p>
     #[serde(rename = "DataSourceId")]
@@ -253,6 +259,7 @@ pub struct CreateEvaluationInput {
 
 /// <p> Represents the output of a <code>CreateEvaluation</code> operation, and is an acknowledgement that Amazon ML received the request.</p> <p><code>CreateEvaluation</code> operation is asynchronous. You can poll for status updates by using the <code>GetEvcaluation</code> operation and checking the <code>Status</code> parameter. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateEvaluationOutput {
     /// <p>The user-supplied ID that uniquely identifies the <code>Evaluation</code>. This value should be identical to the value of the <code>EvaluationId</code> in the request.</p>
     #[serde(rename = "EvaluationId")]
@@ -291,6 +298,7 @@ pub struct CreateMLModelInput {
 
 /// <p> Represents the output of a <code>CreateMLModel</code> operation, and is an acknowledgement that Amazon ML received the request.</p> <p>The <code>CreateMLModel</code> operation is asynchronous. You can poll for status updates by using the <code>GetMLModel</code> operation and checking the <code>Status</code> parameter. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateMLModelOutput {
     /// <p>A user-supplied ID that uniquely identifies the <code>MLModel</code>. This value should be identical to the value of the <code>MLModelId</code> in the request. </p>
     #[serde(rename = "MLModelId")]
@@ -307,6 +315,7 @@ pub struct CreateRealtimeEndpointInput {
 
 /// <p><p>Represents the output of an <code>CreateRealtimeEndpoint</code> operation.</p> <p>The result contains the <code>MLModelId</code> and the endpoint information for the <code>MLModel</code>.</p> <note> <p>The endpoint information includes the URI of the <code>MLModel</code>; that is, the location to send online prediction requests for the specified <code>MLModel</code>.</p> </note></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateRealtimeEndpointOutput {
     /// <p>A user-supplied ID that uniquely identifies the <code>MLModel</code>. This value should be identical to the value of the <code>MLModelId</code> in the request.</p>
     #[serde(rename = "MLModelId")]
@@ -320,6 +329,7 @@ pub struct CreateRealtimeEndpointOutput {
 
 /// <p> Represents the output of the <code>GetDataSource</code> operation. </p> <p> The content consists of the detailed metadata and data file information and the current status of the <code>DataSource</code>. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DataSource {
     /// <p> The parameter is <code>true</code> if statistics need to be generated from the observation data. </p>
     #[serde(rename = "ComputeStatistics")]
@@ -398,6 +408,7 @@ pub struct DeleteBatchPredictionInput {
 
 /// <p> Represents the output of a <code>DeleteBatchPrediction</code> operation.</p> <p>You can use the <code>GetBatchPrediction</code> operation and check the value of the <code>Status</code> parameter to see whether a <code>BatchPrediction</code> is marked as <code>DELETED</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteBatchPredictionOutput {
     /// <p>A user-supplied ID that uniquely identifies the <code>BatchPrediction</code>. This value should be identical to the value of the <code>BatchPredictionID</code> in the request.</p>
     #[serde(rename = "BatchPredictionId")]
@@ -414,6 +425,7 @@ pub struct DeleteDataSourceInput {
 
 /// <p> Represents the output of a <code>DeleteDataSource</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteDataSourceOutput {
     /// <p>A user-supplied ID that uniquely identifies the <code>DataSource</code>. This value should be identical to the value of the <code>DataSourceID</code> in the request.</p>
     #[serde(rename = "DataSourceId")]
@@ -430,6 +442,7 @@ pub struct DeleteEvaluationInput {
 
 /// <p> Represents the output of a <code>DeleteEvaluation</code> operation. The output indicates that Amazon Machine Learning (Amazon ML) received the request.</p> <p>You can use the <code>GetEvaluation</code> operation and check the value of the <code>Status</code> parameter to see whether an <code>Evaluation</code> is marked as <code>DELETED</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteEvaluationOutput {
     /// <p>A user-supplied ID that uniquely identifies the <code>Evaluation</code>. This value should be identical to the value of the <code>EvaluationId</code> in the request.</p>
     #[serde(rename = "EvaluationId")]
@@ -446,6 +459,7 @@ pub struct DeleteMLModelInput {
 
 /// <p>Represents the output of a <code>DeleteMLModel</code> operation.</p> <p>You can use the <code>GetMLModel</code> operation and check the value of the <code>Status</code> parameter to see whether an <code>MLModel</code> is marked as <code>DELETED</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteMLModelOutput {
     /// <p>A user-supplied ID that uniquely identifies the <code>MLModel</code>. This value should be identical to the value of the <code>MLModelID</code> in the request.</p>
     #[serde(rename = "MLModelId")]
@@ -462,6 +476,7 @@ pub struct DeleteRealtimeEndpointInput {
 
 /// <p>Represents the output of an <code>DeleteRealtimeEndpoint</code> operation.</p> <p>The result contains the <code>MLModelId</code> and the endpoint information for the <code>MLModel</code>. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteRealtimeEndpointOutput {
     /// <p>A user-supplied ID that uniquely identifies the <code>MLModel</code>. This value should be identical to the value of the <code>MLModelId</code> in the request.</p>
     #[serde(rename = "MLModelId")]
@@ -488,6 +503,7 @@ pub struct DeleteTagsInput {
 
 /// <p>Amazon ML returns the following elements. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteTagsOutput {
     /// <p>The ID of the ML object from which tags were deleted.</p>
     #[serde(rename = "ResourceId")]
@@ -549,6 +565,7 @@ pub struct DescribeBatchPredictionsInput {
 
 /// <p>Represents the output of a <code>DescribeBatchPredictions</code> operation. The content is essentially a list of <code>BatchPrediction</code>s.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeBatchPredictionsOutput {
     /// <p>The ID of the next page in the paginated results that indicates at least one more page follows.</p>
     #[serde(rename = "NextToken")]
@@ -610,6 +627,7 @@ pub struct DescribeDataSourcesInput {
 
 /// <p>Represents the query results from a <a>DescribeDataSources</a> operation. The content is essentially a list of <code>DataSource</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeDataSourcesOutput {
     /// <p>An ID of the next page in the paginated results that indicates at least one more page follows.</p>
     #[serde(rename = "NextToken")]
@@ -671,6 +689,7 @@ pub struct DescribeEvaluationsInput {
 
 /// <p>Represents the query results from a <code>DescribeEvaluations</code> operation. The content is essentially a list of <code>Evaluation</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEvaluationsOutput {
     /// <p>The ID of the next page in the paginated results that indicates at least one more page follows.</p>
     #[serde(rename = "NextToken")]
@@ -732,6 +751,7 @@ pub struct DescribeMLModelsInput {
 
 /// <p>Represents the output of a <code>DescribeMLModels</code> operation. The content is essentially a list of <code>MLModel</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeMLModelsOutput {
     /// <p>The ID of the next page in the paginated results that indicates at least one more page follows.</p>
     #[serde(rename = "NextToken")]
@@ -755,6 +775,7 @@ pub struct DescribeTagsInput {
 
 /// <p>Amazon ML returns the following elements. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeTagsOutput {
     /// <p>The ID of the tagged ML object.</p>
     #[serde(rename = "ResourceId")]
@@ -772,6 +793,7 @@ pub struct DescribeTagsOutput {
 
 /// <p> Represents the output of <code>GetEvaluation</code> operation. </p> <p>The content consists of the detailed metadata and data file information and the current status of the <code>Evaluation</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Evaluation {
     #[serde(rename = "ComputeTime")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -837,6 +859,7 @@ pub struct GetBatchPredictionInput {
 
 /// <p>Represents the output of a <code>GetBatchPrediction</code> operation and describes a <code>BatchPrediction</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetBatchPredictionOutput {
     /// <p>The ID of the <code>DataSource</code> that was used to create the <code>BatchPrediction</code>. </p>
     #[serde(rename = "BatchPredictionDataSourceId")]
@@ -921,6 +944,7 @@ pub struct GetDataSourceInput {
 
 /// <p>Represents the output of a <code>GetDataSource</code> operation and describes a <code>DataSource</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDataSourceOutput {
     /// <p> The parameter is <code>true</code> if statistics need to be generated from the observation data. </p>
     #[serde(rename = "ComputeStatistics")]
@@ -1010,6 +1034,7 @@ pub struct GetEvaluationInput {
 
 /// <p>Represents the output of a <code>GetEvaluation</code> operation and describes an <code>Evaluation</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetEvaluationOutput {
     /// <p>The approximate CPU time in milliseconds that Amazon Machine Learning spent processing the <code>Evaluation</code>, normalized and scaled on computation resources. <code>ComputeTime</code> is only available if the <code>Evaluation</code> is in the <code>COMPLETED</code> state.</p>
     #[serde(rename = "ComputeTime")]
@@ -1086,6 +1111,7 @@ pub struct GetMLModelInput {
 
 /// <p>Represents the output of a <code>GetMLModel</code> operation, and provides detailed information about a <code>MLModel</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetMLModelOutput {
     /// <p>The approximate CPU time in milliseconds that Amazon Machine Learning spent processing the <code>MLModel</code>, normalized and scaled on computation resources. <code>ComputeTime</code> is only available if the <code>MLModel</code> is in the <code>COMPLETED</code> state.</p>
     #[serde(rename = "ComputeTime")]
@@ -1174,6 +1200,7 @@ pub struct GetMLModelOutput {
 
 /// <p> Represents the output of a <code>GetMLModel</code> operation. </p> <p>The content consists of the detailed metadata and the current status of the <code>MLModel</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MLModel {
     /// <p><p>The algorithm used to train the <code>MLModel</code>. The following algorithm is supported:</p> <ul> <li> <code>SGD</code> -- Stochastic gradient descent. The goal of <code>SGD</code> is to minimize the gradient of the loss function. </li> </ul></p>
     #[serde(rename = "Algorithm")]
@@ -1250,6 +1277,7 @@ pub struct MLModel {
 
 /// <p>Measurements of how well the <code>MLModel</code> performed on known observations. One of the following metrics is returned, based on the type of the <code>MLModel</code>: </p> <ul> <li> <p>BinaryAUC: The binary <code>MLModel</code> uses the Area Under the Curve (AUC) technique to measure performance. </p> </li> <li> <p>RegressionRMSE: The regression <code>MLModel</code> uses the Root Mean Square Error (RMSE) technique to measure performance. RMSE measures the difference between predicted and actual values for a single variable.</p> </li> <li> <p>MulticlassAvgFScore: The multiclass <code>MLModel</code> uses the F1 score technique to measure performance. </p> </li> </ul> <p> For more information about performance metrics, please see the <a href="http://docs.aws.amazon.com/machine-learning/latest/dg">Amazon Machine Learning Developer Guide</a>. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PerformanceMetrics {
     #[serde(rename = "Properties")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1268,6 +1296,7 @@ pub struct PredictInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PredictOutput {
     #[serde(rename = "Prediction")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1276,6 +1305,7 @@ pub struct PredictOutput {
 
 /// <p><p>The output from a <code>Predict</code> operation: </p> <ul> <li> <p> <code>Details</code> - Contains the following attributes: <code>DetailsAttributes.PREDICTIVE<em>MODEL</em>TYPE - REGRESSION | BINARY | MULTICLASS</code> <code>DetailsAttributes.ALGORITHM - SGD</code> </p> </li> <li> <p> <code>PredictedLabel</code> - Present for either a <code>BINARY</code> or <code>MULTICLASS</code> <code>MLModel</code> request. </p> </li> <li> <p> <code>PredictedScores</code> - Contains the raw classification score corresponding to each label. </p> </li> <li> <p> <code>PredictedValue</code> - Present for a <code>REGRESSION</code> <code>MLModel</code> request. </p> </li> </ul></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Prediction {
     #[serde(rename = "details")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1355,6 +1385,7 @@ pub struct RDSDatabaseCredentials {
 
 /// <p>The datasource details that are specific to Amazon RDS.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RDSMetadata {
     /// <p>The ID of the Data Pipeline instance that is used to carry to copy data from Amazon RDS to Amazon S3. You can use the ID to find details about the instance in the Data Pipeline console.</p>
     #[serde(rename = "DataPipelineId")]
@@ -1383,6 +1414,7 @@ pub struct RDSMetadata {
 
 /// <p> Describes the real-time endpoint information for an <code>MLModel</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RealtimeEndpointInfo {
     /// <p>The time that the request to create the real-time endpoint for the <code>MLModel</code> was received. The time is expressed in epoch time.</p>
     #[serde(rename = "CreatedAt")]
@@ -1451,6 +1483,7 @@ pub struct RedshiftDatabaseCredentials {
 
 /// <p>Describes the <code>DataSource</code> details specific to Amazon Redshift.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RedshiftMetadata {
     #[serde(rename = "DatabaseUserName")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1509,6 +1542,7 @@ pub struct UpdateBatchPredictionInput {
 
 /// <p>Represents the output of an <code>UpdateBatchPrediction</code> operation.</p> <p>You can see the updated content by using the <code>GetBatchPrediction</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateBatchPredictionOutput {
     /// <p>The ID assigned to the <code>BatchPrediction</code> during creation. This value should be identical to the value of the <code>BatchPredictionId</code> in the request.</p>
     #[serde(rename = "BatchPredictionId")]
@@ -1528,6 +1562,7 @@ pub struct UpdateDataSourceInput {
 
 /// <p>Represents the output of an <code>UpdateDataSource</code> operation.</p> <p>You can see the updated content by using the <code>GetBatchPrediction</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateDataSourceOutput {
     /// <p>The ID assigned to the <code>DataSource</code> during creation. This value should be identical to the value of the <code>DataSourceID</code> in the request.</p>
     #[serde(rename = "DataSourceId")]
@@ -1547,6 +1582,7 @@ pub struct UpdateEvaluationInput {
 
 /// <p>Represents the output of an <code>UpdateEvaluation</code> operation.</p> <p>You can see the updated content by using the <code>GetEvaluation</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateEvaluationOutput {
     /// <p>The ID assigned to the <code>Evaluation</code> during creation. This value should be identical to the value of the <code>Evaluation</code> in the request.</p>
     #[serde(rename = "EvaluationId")]
@@ -1571,6 +1607,7 @@ pub struct UpdateMLModelInput {
 
 /// <p>Represents the output of an <code>UpdateMLModel</code> operation.</p> <p>You can see the updated content by using the <code>GetMLModel</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateMLModelOutput {
     /// <p>The ID assigned to the <code>MLModel</code> during creation. This value should be identical to the value of the <code>MLModelID</code> in the request.</p>
     #[serde(rename = "MLModelId")]

--- a/rusoto/services/macie/src/generated.rs
+++ b/rusoto/services/macie/src/generated.rs
@@ -47,6 +47,7 @@ pub struct AssociateS3ResourcesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociateS3ResourcesResult {
     /// <p>S3 resources that couldn't be associated with Amazon Macie. An error code and an error message are provided for each failed item. </p>
     #[serde(rename = "failedS3Resources")]
@@ -97,6 +98,7 @@ pub struct DisassociateS3ResourcesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisassociateS3ResourcesResult {
     /// <p>S3 resources that couldn't be removed from being monitored and classified by Amazon Macie. An error code and an error message are provided for each failed item. </p>
     #[serde(rename = "failedS3Resources")]
@@ -106,6 +108,7 @@ pub struct DisassociateS3ResourcesResult {
 
 /// <p>Includes details about the failed S3 resources.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FailedS3Resource {
     /// <p>The status code of a failed item.</p>
     #[serde(rename = "errorCode")]
@@ -134,6 +137,7 @@ pub struct ListMemberAccountsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListMemberAccountsResult {
     /// <p>A list of the Amazon Macie member accounts returned by the action. The current master account is also included in this list. </p>
     #[serde(rename = "memberAccounts")]
@@ -162,6 +166,7 @@ pub struct ListS3ResourcesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListS3ResourcesResult {
     /// <p>When a response is generated, if there is more data to be listed, this parameter is present in the response and contains the value to use for the nextToken parameter in a subsequent pagination request. If there is no more data to be listed, this parameter is set to null. </p>
     #[serde(rename = "nextToken")]
@@ -175,6 +180,7 @@ pub struct ListS3ResourcesResult {
 
 /// <p>Contains information about the Amazon Macie member account.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MemberAccount {
     /// <p>The AWS account ID of the Amazon Macie member account.</p>
     #[serde(rename = "accountId")]
@@ -236,6 +242,7 @@ pub struct UpdateS3ResourcesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateS3ResourcesResult {
     /// <p>The S3 resources whose classification types can't be updated. An error code and an error message are provided for each failed item. </p>
     #[serde(rename = "failedS3Resources")]

--- a/rusoto/services/marketplace-entitlement/src/generated.rs
+++ b/rusoto/services/marketplace-entitlement/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>An entitlement represents capacity in a product owned by the customer. For example, a customer might own some number of users or seats in an SaaS application or some amount of data capacity in a multi-tenant database.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Entitlement {
     /// <p>The customer identifier is a handle to each unique customer in an application. Customer identifiers are obtained through the ResolveCustomer operation in AWS Marketplace Metering Service.</p>
     #[serde(rename = "CustomerIdentifier")]
@@ -55,6 +56,7 @@ pub struct Entitlement {
 
 /// <p>The EntitlementValue represents the amount of capacity that the customer is entitled to for the product.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EntitlementValue {
     /// <p>The BooleanValue field will be populated with a boolean value when the entitlement is a boolean type. Otherwise, the field will not be set.</p>
     #[serde(rename = "BooleanValue")]
@@ -96,6 +98,7 @@ pub struct GetEntitlementsRequest {
 
 /// <p>The GetEntitlementsRequest contains results from the GetEntitlements operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetEntitlementsResult {
     /// <p>The set of entitlements found through the GetEntitlements operation. If the result contains an empty set of entitlements, NextToken might still be present and should be used.</p>
     #[serde(rename = "Entitlements")]

--- a/rusoto/services/marketplacecommerceanalytics/src/generated.rs
+++ b/rusoto/services/marketplacecommerceanalytics/src/generated.rs
@@ -58,6 +58,7 @@ pub struct GenerateDataSetRequest {
 
 /// <p>Container for the result of the GenerateDataSet operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GenerateDataSetResult {
     /// <p>A unique identifier representing a specific request to the GenerateDataSet operation. This identifier can be used to correlate a request with notifications from the SNS topic.</p>
     #[serde(rename = "dataSetRequestId")]
@@ -95,6 +96,7 @@ pub struct StartSupportDataExportRequest {
 
 /// <p>Container for the result of the StartSupportDataExport operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartSupportDataExportResult {
     /// <p>A unique identifier representing a specific request to the StartSupportDataExport operation. This identifier can be used to correlate a request with notifications from the SNS topic.</p>
     #[serde(rename = "dataSetRequestId")]

--- a/rusoto/services/mediastore/src/generated.rs
+++ b/rusoto/services/mediastore/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>This section describes operations that you can perform on an AWS Elemental MediaStore container.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Container {
     /// <p>The Amazon Resource Name (ARN) of the container. The ARN has the following format:</p> <p>arn:aws:&lt;region&gt;:&lt;account that owns this container&gt;:container/&lt;name of container&gt; </p> <p>For example: arn:aws:mediastore:us-west-2:111122223333:container/movies </p>
     #[serde(rename = "ARN")]
@@ -86,6 +87,7 @@ pub struct CreateContainerInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateContainerOutput {
     /// <p>ContainerARN: The Amazon Resource Name (ARN) of the newly created container. The ARN has the following format: arn:aws:&lt;region&gt;:&lt;account that owns this container&gt;:container/&lt;name of container&gt;. For example: arn:aws:mediastore:us-west-2:111122223333:container/movies </p> <p>ContainerName: The container name as specified in the request.</p> <p>CreationTime: Unix time stamp.</p> <p>Status: The status of container creation or deletion. The status is one of the following: <code>CREATING</code>, <code>ACTIVE</code>, or <code>DELETING</code>. While the service is creating the container, the status is <code>CREATING</code>. When an endpoint is available, the status changes to <code>ACTIVE</code>.</p> <p>The return value does not include the container's endpoint. To make downstream requests, you must obtain this value by using <a>DescribeContainer</a> or <a>ListContainers</a>.</p>
     #[serde(rename = "Container")]
@@ -100,6 +102,7 @@ pub struct DeleteContainerInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteContainerOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -110,6 +113,7 @@ pub struct DeleteContainerPolicyInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteContainerPolicyOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -120,6 +124,7 @@ pub struct DeleteCorsPolicyInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteCorsPolicyOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -131,6 +136,7 @@ pub struct DescribeContainerInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeContainerOutput {
     /// <p>The name of the queried container.</p>
     #[serde(rename = "Container")]
@@ -146,6 +152,7 @@ pub struct GetContainerPolicyInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetContainerPolicyOutput {
     /// <p>The contents of the access policy.</p>
     #[serde(rename = "Policy")]
@@ -160,6 +167,7 @@ pub struct GetCorsPolicyInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetCorsPolicyOutput {
     #[serde(rename = "CorsPolicy")]
     pub cors_policy: Vec<CorsRule>,
@@ -178,6 +186,7 @@ pub struct ListContainersInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListContainersOutput {
     /// <p>The names of the containers.</p>
     #[serde(rename = "Containers")]
@@ -199,6 +208,7 @@ pub struct PutContainerPolicyInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutContainerPolicyOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -212,6 +222,7 @@ pub struct PutCorsPolicyInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutCorsPolicyOutput {}
 
 /// Errors returned by CreateContainer

--- a/rusoto/services/meteringmarketplace/src/generated.rs
+++ b/rusoto/services/meteringmarketplace/src/generated.rs
@@ -41,6 +41,7 @@ pub struct BatchMeterUsageRequest {
 
 /// <p>Contains the UsageRecords processed by BatchMeterUsage and any records that have failed due to transient error.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchMeterUsageResult {
     /// <p>Contains all UsageRecords processed by BatchMeterUsage. These records were either honored by AWS Marketplace Metering Service or were invalid.</p>
     #[serde(rename = "Results")]
@@ -72,6 +73,7 @@ pub struct MeterUsageRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MeterUsageResult {
     #[serde(rename = "MeteringRecordId")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -88,6 +90,7 @@ pub struct ResolveCustomerRequest {
 
 /// <p>The result of the ResolveCustomer operation. Contains the CustomerIdentifier and product code.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResolveCustomerResult {
     /// <p>The CustomerIdentifier is used to identify an individual customer in your application. Calls to BatchMeterUsage require CustomerIdentifiers for each UsageRecord.</p>
     #[serde(rename = "CustomerIdentifier")]
@@ -118,6 +121,7 @@ pub struct UsageRecord {
 
 /// <p>A UsageRecordResult indicates the status of a given UsageRecord processed by BatchMeterUsage.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UsageRecordResult {
     /// <p>The MeteringRecordId is a unique identifier for this metering event.</p>
     #[serde(rename = "MeteringRecordId")]

--- a/rusoto/services/mgh/src/generated.rs
+++ b/rusoto/services/mgh/src/generated.rs
@@ -46,6 +46,7 @@ pub struct AssociateCreatedArtifactRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociateCreatedArtifactResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -66,6 +67,7 @@ pub struct AssociateDiscoveredResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociateDiscoveredResourceResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -80,6 +82,7 @@ pub struct CreateProgressUpdateStreamRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateProgressUpdateStreamResult {}
 
 /// <p>An ARN of the AWS cloud resource target receiving the migration (e.g., AMI, EC2 instance, RDS instance, etc.).</p>
@@ -106,6 +109,7 @@ pub struct DeleteProgressUpdateStreamRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteProgressUpdateStreamResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -116,6 +120,7 @@ pub struct DescribeApplicationStateRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeApplicationStateResult {
     /// <p>Status of the application - Not Started, In-Progress, Complete.</p>
     #[serde(rename = "ApplicationStatus")]
@@ -138,6 +143,7 @@ pub struct DescribeMigrationTaskRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeMigrationTaskResult {
     /// <p>Object encapsulating information about the migration task.</p>
     #[serde(rename = "MigrationTask")]
@@ -163,6 +169,7 @@ pub struct DisassociateCreatedArtifactRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisassociateCreatedArtifactResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -183,6 +190,7 @@ pub struct DisassociateDiscoveredResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisassociateDiscoveredResourceResult {}
 
 /// <p>Object representing the on-premises resource being migrated.</p>
@@ -212,6 +220,7 @@ pub struct ImportMigrationTaskRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ImportMigrationTaskResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -233,6 +242,7 @@ pub struct ListCreatedArtifactsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListCreatedArtifactsResult {
     /// <p>List of created artifacts up to the maximum number of results specified in the request.</p>
     #[serde(rename = "CreatedArtifactList")]
@@ -263,6 +273,7 @@ pub struct ListDiscoveredResourcesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListDiscoveredResourcesResult {
     /// <p>Returned list of discovered resources associated with the given MigrationTask.</p>
     #[serde(rename = "DiscoveredResourceList")]
@@ -291,6 +302,7 @@ pub struct ListMigrationTasksRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListMigrationTasksResult {
     /// <p>Lists the migration task's summary which includes: <code>MigrationTaskName</code>, <code>ProgressPercent</code>, <code>ProgressUpdateStream</code>, <code>Status</code>, and the <code>UpdateDateTime</code> for each task.</p>
     #[serde(rename = "MigrationTaskSummaryList")]
@@ -315,6 +327,7 @@ pub struct ListProgressUpdateStreamsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListProgressUpdateStreamsResult {
     /// <p>If there are more streams created than the max result, return the next token to be passed to the next call as a bookmark of where to start from.</p>
     #[serde(rename = "NextToken")]
@@ -328,6 +341,7 @@ pub struct ListProgressUpdateStreamsResult {
 
 /// <p>Represents a migration task in a migration tool.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MigrationTask {
     /// <p>Unique identifier that references the migration task.</p>
     #[serde(rename = "MigrationTaskName")]
@@ -353,6 +367,7 @@ pub struct MigrationTask {
 
 /// <p>MigrationTaskSummary includes <code>MigrationTaskName</code>, <code>ProgressPercent</code>, <code>ProgressUpdateStream</code>, <code>Status</code>, and <code>UpdateDateTime</code> for each task.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MigrationTaskSummary {
     /// <p>Unique identifier that references the migration task.</p>
     #[serde(rename = "MigrationTaskName")]
@@ -395,6 +410,7 @@ pub struct NotifyApplicationStateRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct NotifyApplicationStateResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -421,10 +437,12 @@ pub struct NotifyMigrationTaskStateRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct NotifyMigrationTaskStateResult {}
 
 /// <p>Summary of the AWS resource used for access control that is implicitly linked to your AWS account.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ProgressUpdateStreamSummary {
     /// <p>The name of the ProgressUpdateStream. </p>
     #[serde(rename = "ProgressUpdateStreamName")]
@@ -450,6 +468,7 @@ pub struct PutResourceAttributesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutResourceAttributesResult {}
 
 /// <p><p>Attribute associated with a resource.</p> <p>Note the corresponding format required per type listed below:</p> <dl> <dt>IPV4</dt> <dd> <p> <code>x.x.x.x</code> </p> <p> <i>where x is an integer in the range [0,255]</i> </p> </dd> <dt>IPV6</dt> <dd> <p> <code>y : y : y : y : y : y : y : y</code> </p> <p> <i>where y is a hexadecimal between 0 and FFFF. [0, FFFF]</i> </p> </dd> <dt>MAC_ADDRESS</dt> <dd> <p> <code>^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$</code> </p> </dd> <dt>FQDN</dt> <dd> <p> <code>^[^&lt;&gt;{}\\/?,=\p{Cntrl}]{1,256}$</code> </p> </dd> </dl></p>

--- a/rusoto/services/mq/src/generated.rs
+++ b/rusoto/services/mq/src/generated.rs
@@ -31,6 +31,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Returns information about all brokers.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BrokerInstance {
     /// <p>The URL of the broker&#39;s ActiveMQ Web Console.</p>
     #[serde(rename = "ConsoleURL")]
@@ -48,6 +49,7 @@ pub struct BrokerInstance {
 
 /// <p>The Amazon Resource Name (ARN) of the broker.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BrokerSummary {
     /// <p>The Amazon Resource Name (ARN) of the broker.</p>
     #[serde(rename = "BrokerArn")]
@@ -81,6 +83,7 @@ pub struct BrokerSummary {
 
 /// <p>Returns information about all configurations.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Configuration {
     /// <p>Required. The ARN of the configuration.</p>
     #[serde(rename = "Arn")]
@@ -131,6 +134,7 @@ pub struct ConfigurationId {
 
 /// <p>Returns information about the specified configuration revision.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ConfigurationRevision {
     /// <p>Required. The date and time of the configuration revision.</p>
     #[serde(rename = "Created")]
@@ -148,6 +152,7 @@ pub struct ConfigurationRevision {
 
 /// <p>Broker configuration information</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Configurations {
     /// <p>The current configuration of the broker.</p>
     #[serde(rename = "Current")]
@@ -267,6 +272,7 @@ pub struct CreateBrokerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateBrokerResponse {
     /// <p>The Amazon Resource Name (ARN) of the broker.</p>
     #[serde(rename = "BrokerArn")]
@@ -322,6 +328,7 @@ pub struct CreateConfigurationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateConfigurationResponse {
     /// <p>Required. The Amazon Resource Name (ARN) of the configuration.</p>
     #[serde(rename = "Arn")]
@@ -380,6 +387,7 @@ pub struct CreateUserRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateUserResponse {}
 
 /// <p>Returns information about the deleted broker.</p>
@@ -397,6 +405,7 @@ pub struct DeleteBrokerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteBrokerResponse {
     /// <p>The unique ID that Amazon MQ generates for the broker.</p>
     #[serde(rename = "BrokerId")]
@@ -415,6 +424,7 @@ pub struct DeleteUserRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteUserResponse {}
 
 /// <p>The version of the broker engine. Note: Currently, Amazon MQ supports only 5.15.0.</p>
@@ -466,6 +476,7 @@ pub struct DescribeBrokerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeBrokerResponse {
     /// <p>Required. Enables automatic upgrades to new minor versions for brokers, as Apache releases the versions. The automatic upgrades occur during the maintenance window of the broker or after a manual broker reboot.</p>
     #[serde(rename = "AutoMinorVersionUpgrade")]
@@ -549,6 +560,7 @@ pub struct DescribeConfigurationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeConfigurationResponse {
     /// <p>Required. The ARN of the configuration.</p>
     #[serde(rename = "Arn")]
@@ -608,6 +620,7 @@ pub struct DescribeConfigurationRevisionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeConfigurationRevisionResponse {
     /// <p>Required. The unique ID that Amazon MQ generates for the configuration.</p>
     #[serde(rename = "ConfigurationId")]
@@ -653,6 +666,7 @@ pub struct DescribeUserRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeUserResponse {
     /// <p>Required. The unique ID that Amazon MQ generates for the broker.</p>
     #[serde(rename = "BrokerId")]
@@ -707,6 +721,7 @@ pub struct ListBrokersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListBrokersResponse {
     /// <p>A list of information about all brokers.</p>
     #[serde(rename = "BrokerSummaries")]
@@ -747,6 +762,7 @@ pub struct ListConfigurationRevisionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListConfigurationRevisionsResponse {
     /// <p>The unique ID that Amazon MQ generates for the configuration.</p>
     #[serde(rename = "ConfigurationId")]
@@ -790,6 +806,7 @@ pub struct ListConfigurationsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListConfigurationsResponse {
     /// <p>The list of all revisions for the specified configuration.</p>
     #[serde(rename = "Configurations")]
@@ -834,6 +851,7 @@ pub struct ListUsersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListUsersResponse {
     /// <p>Required. The unique ID that Amazon MQ generates for the broker.</p>
     #[serde(rename = "BrokerId")]
@@ -868,6 +886,7 @@ pub struct Logs {
 
 /// <p>The list of information about logs currently enabled and pending to be deployed for the specified broker.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LogsSummary {
     /// <p>Enables audit logging. Every user management action made using JMX or the ActiveMQ Web Console is logged.</p>
     #[serde(rename = "Audit")]
@@ -893,6 +912,7 @@ pub struct LogsSummary {
 
 /// <p>The list of information about logs to be enabled for the specified broker.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PendingLogs {
     /// <p>Enables audit logging. Every user management action made using JMX or the ActiveMQ Web Console is logged.</p>
     #[serde(rename = "Audit")]
@@ -912,10 +932,12 @@ pub struct RebootBrokerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RebootBrokerResponse {}
 
 /// <p>Returns information about the XML element or attribute that was sanitized in the configuration.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SanitizationWarning {
     /// <p>The name of the XML attribute that has been sanitized.</p>
     #[serde(rename = "AttributeName")]
@@ -968,6 +990,7 @@ pub struct UpdateBrokerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateBrokerResponse {
     /// <p>Required. The unique ID that Amazon MQ generates for the broker.</p>
     #[serde(rename = "BrokerId")]
@@ -1026,6 +1049,7 @@ pub struct UpdateConfigurationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateConfigurationResponse {
     /// <p>Required. The Amazon Resource Name (ARN) of the configuration.</p>
     #[serde(rename = "Arn")]
@@ -1088,6 +1112,7 @@ pub struct UpdateUserRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateUserResponse {}
 
 /// <p>An ActiveMQ user associated with the broker.</p>
@@ -1113,6 +1138,7 @@ pub struct User {
 
 /// <p>Returns information about the status of the changes pending for the ActiveMQ user.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UserPendingChanges {
     /// <p>Enables access to the the ActiveMQ Web Console for the ActiveMQ user.</p>
     #[serde(rename = "ConsoleAccess")]
@@ -1130,6 +1156,7 @@ pub struct UserPendingChanges {
 
 /// <p>Returns a list of all ActiveMQ users.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UserSummary {
     /// <p>The type of change pending for the ActiveMQ user.</p>
     #[serde(rename = "PendingChange")]

--- a/rusoto/services/mturk/src/generated.rs
+++ b/rusoto/services/mturk/src/generated.rs
@@ -40,6 +40,7 @@ pub struct AcceptQualificationRequestRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AcceptQualificationRequestResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -58,10 +59,12 @@ pub struct ApproveAssignmentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ApproveAssignmentResponse {}
 
 /// <p> The Assignment data structure represents a single assignment of a HIT to a Worker. The assignment tracks the Worker's efforts to complete the HIT, and contains the results for later retrieval. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Assignment {
     /// <p> The date and time the Worker accepted the assignment.</p>
     #[serde(rename = "AcceptTime")]
@@ -132,10 +135,12 @@ pub struct AssociateQualificationWithWorkerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociateQualificationWithWorkerResponse {}
 
 /// <p>An object representing a Bonus payment paid to a Worker.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BonusPayment {
     /// <p>The ID of the assignment associated with this bonus payment.</p>
     #[serde(rename = "AssignmentId")]
@@ -173,6 +178,7 @@ pub struct CreateAdditionalAssignmentsForHITRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateAdditionalAssignmentsForHITResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -239,6 +245,7 @@ pub struct CreateHITRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateHITResponse {
     /// <p> Contains the newly created HIT data. For a description of the HIT data structure as it appears in responses, see the HIT Data Structure documentation. </p>
     #[serde(rename = "HIT")]
@@ -275,6 +282,7 @@ pub struct CreateHITTypeRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateHITTypeResponse {
     /// <p> The ID of the newly registered HIT type.</p>
     #[serde(rename = "HITTypeId")]
@@ -325,6 +333,7 @@ pub struct CreateHITWithHITTypeRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateHITWithHITTypeResponse {
     /// <p> Contains the newly created HIT data. For a description of the HIT data structure as it appears in responses, see the HIT Data Structure documentation. </p>
     #[serde(rename = "HIT")]
@@ -374,6 +383,7 @@ pub struct CreateQualificationTypeRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateQualificationTypeResponse {
     /// <p>The created Qualification type, returned as a QualificationType data structure.</p>
     #[serde(rename = "QualificationType")]
@@ -392,6 +402,7 @@ pub struct CreateWorkerBlockRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateWorkerBlockResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -402,6 +413,7 @@ pub struct DeleteHITRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteHITResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -412,6 +424,7 @@ pub struct DeleteQualificationTypeRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteQualificationTypeResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -426,6 +439,7 @@ pub struct DeleteWorkerBlockRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteWorkerBlockResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -443,12 +457,14 @@ pub struct DisassociateQualificationFromWorkerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisassociateQualificationFromWorkerResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetAccountBalanceRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetAccountBalanceResponse {
     #[serde(rename = "AvailableBalance")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -466,6 +482,7 @@ pub struct GetAssignmentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetAssignmentResponse {
     /// <p> The assignment. The response includes one Assignment element. </p>
     #[serde(rename = "Assignment")]
@@ -488,6 +505,7 @@ pub struct GetFileUploadURLRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetFileUploadURLResponse {
     /// <p> A temporary URL for the file that the Worker uploaded for the answer. </p>
     #[serde(rename = "FileUploadURL")]
@@ -503,6 +521,7 @@ pub struct GetHITRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetHITResponse {
     /// <p> Contains the requested HIT data.</p>
     #[serde(rename = "HIT")]
@@ -521,6 +540,7 @@ pub struct GetQualificationScoreRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetQualificationScoreResponse {
     /// <p> The Qualification data structure of the Qualification assigned to a user, including the Qualification type and the value (score). </p>
     #[serde(rename = "Qualification")]
@@ -536,6 +556,7 @@ pub struct GetQualificationTypeRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetQualificationTypeResponse {
     /// <p> The returned Qualification Type</p>
     #[serde(rename = "QualificationType")]
@@ -545,6 +566,7 @@ pub struct GetQualificationTypeResponse {
 
 /// <p> The HIT data structure represents a single HIT, including all the information necessary for a Worker to accept and complete the HIT.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct HIT {
     /// <p> The length of time, in seconds, that a Worker has to complete the HIT after accepting it.</p>
     #[serde(rename = "AssignmentDurationInSeconds")]
@@ -661,6 +683,7 @@ pub struct ListAssignmentsForHITRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAssignmentsForHITResponse {
     /// <p> The collection of Assignment data structures returned by this call.</p>
     #[serde(rename = "Assignments")]
@@ -695,6 +718,7 @@ pub struct ListBonusPaymentsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListBonusPaymentsResponse {
     /// <p>A successful request to the ListBonusPayments operation returns a list of BonusPayment objects. </p>
     #[serde(rename = "BonusPayments")]
@@ -725,6 +749,7 @@ pub struct ListHITsForQualificationTypeRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListHITsForQualificationTypeResponse {
     /// <p> The list of HIT elements returned by the query.</p>
     #[serde(rename = "HITs")]
@@ -751,6 +776,7 @@ pub struct ListHITsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListHITsResponse {
     /// <p> The list of HIT elements returned by the query.</p>
     #[serde(rename = "HITs")]
@@ -781,6 +807,7 @@ pub struct ListQualificationRequestsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListQualificationRequestsResponse {
     #[serde(rename = "NextToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -818,6 +845,7 @@ pub struct ListQualificationTypesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListQualificationTypesResponse {
     #[serde(rename = "NextToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -860,6 +888,7 @@ pub struct ListReviewPolicyResultsForHITRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListReviewPolicyResultsForHITResponse {
     /// <p> The name of the Assignment-level Review Policy. This contains only the PolicyName element. </p>
     #[serde(rename = "AssignmentReviewPolicy")]
@@ -907,6 +936,7 @@ pub struct ListReviewableHITsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListReviewableHITsResponse {
     /// <p> The list of HIT elements returned by the query.</p>
     #[serde(rename = "HITs")]
@@ -933,6 +963,7 @@ pub struct ListWorkerBlocksRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListWorkerBlocksResponse {
     #[serde(rename = "NextToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -967,6 +998,7 @@ pub struct ListWorkersWithQualificationTypeRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListWorkersWithQualificationTypeResponse {
     #[serde(rename = "NextToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1012,6 +1044,7 @@ pub struct NotificationSpecification {
 
 /// <p> When MTurk encounters an issue with notifying the Workers you specified, it returns back this object with failure details. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct NotifyWorkersFailureStatus {
     /// <p> Encoded value for the failure type. </p>
     #[serde(rename = "NotifyWorkersFailureCode")]
@@ -1041,6 +1074,7 @@ pub struct NotifyWorkersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct NotifyWorkersResponse {
     /// <p> When MTurk sends notifications to the list of Workers, it returns back any failures it encounters in this list of NotifyWorkersFailureStatus objects. </p>
     #[serde(rename = "NotifyWorkersFailureStatuses")]
@@ -1080,6 +1114,7 @@ pub struct PolicyParameter {
 
 /// <p>The Qualification data structure represents a Qualification assigned to a user, including the Qualification type and the value (score).</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Qualification {
     /// <p> The date and time the Qualification was granted to the Worker. If the Worker's Qualification was revoked, and then re-granted based on a new Qualification request, GrantTime is the date and time of the last call to the AcceptQualificationRequest operation.</p>
     #[serde(rename = "GrantTime")]
@@ -1108,6 +1143,7 @@ pub struct Qualification {
 
 /// <p> The QualificationRequest data structure represents a request a Worker has made for a Qualification. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct QualificationRequest {
     /// <p> The Worker's answers for the Qualification type's test contained in a QuestionFormAnswers document, if the type has a test and the Worker has submitted answers. If the Worker does not provide any answers, Answer may be empty. </p>
     #[serde(rename = "Answer")]
@@ -1160,6 +1196,7 @@ pub struct QualificationRequirement {
 
 /// <p> The QualificationType data structure represents a Qualification type, a description of a property of a Worker that must match the requirements of a HIT for the Worker to be able to accept the HIT. The type also describes how a Worker can obtain a Qualification of that type, such as through a Qualification test. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct QualificationType {
     /// <p>The answers to the Qualification test specified in the Test parameter.</p>
     #[serde(rename = "AnswerKey")]
@@ -1226,6 +1263,7 @@ pub struct RejectAssignmentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RejectAssignmentResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1240,10 +1278,12 @@ pub struct RejectQualificationRequestRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RejectQualificationRequestResponse {}
 
 /// <p> Both the AssignmentReviewReport and the HITReviewReport elements contains the ReviewActionDetail data structure. This structure is returned multiple times for each action specified in the Review Policy. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReviewActionDetail {
     /// <p>The unique identifier for the action.</p>
     #[serde(rename = "ActionId")]
@@ -1293,6 +1333,7 @@ pub struct ReviewPolicy {
 
 /// <p> Contains both ReviewResult and ReviewAction elements for a particular HIT. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReviewReport {
     /// <p> A list of ReviewAction objects for each action specified in the Review Policy. </p>
     #[serde(rename = "ReviewActions")]
@@ -1306,6 +1347,7 @@ pub struct ReviewReport {
 
 /// <p> This data structure is returned multiple times for each result specified in the Review Policy. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReviewResultDetail {
     /// <p> A unique identifier of the Review action result. </p>
     #[serde(rename = "ActionId")]
@@ -1354,6 +1396,7 @@ pub struct SendBonusRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SendBonusResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1367,6 +1410,7 @@ pub struct SendTestEventNotificationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SendTestEventNotificationResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1380,6 +1424,7 @@ pub struct UpdateExpirationForHITRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateExpirationForHITResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1394,6 +1439,7 @@ pub struct UpdateHITReviewStatusRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateHITReviewStatusResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1407,6 +1453,7 @@ pub struct UpdateHITTypeOfHITRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateHITTypeOfHITResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1425,6 +1472,7 @@ pub struct UpdateNotificationSettingsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateNotificationSettingsResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1467,6 +1515,7 @@ pub struct UpdateQualificationTypeRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateQualificationTypeResponse {
     /// <p> Contains a QualificationType data structure.</p>
     #[serde(rename = "QualificationType")]
@@ -1476,6 +1525,7 @@ pub struct UpdateQualificationTypeResponse {
 
 /// <p> The WorkerBlock data structure represents a Worker who has been blocked. It has two elements: the WorkerId and the Reason for the block. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WorkerBlock {
     /// <p> A message explaining the reason the Worker was blocked. </p>
     #[serde(rename = "Reason")]

--- a/rusoto/services/opsworks/src/generated.rs
+++ b/rusoto/services/opsworks/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Describes an agent version.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AgentVersion {
     /// <p>The configuration manager.</p>
     #[serde(rename = "ConfigurationManager")]
@@ -43,6 +44,7 @@ pub struct AgentVersion {
 
 /// <p>A description of the app.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct App {
     /// <p>The app ID.</p>
     #[serde(rename = "AppId")]
@@ -302,6 +304,7 @@ pub struct CloneStackRequest {
 
 /// <p>Contains the response to a <code>CloneStack</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CloneStackResult {
     /// <p>The cloned stack ID.</p>
     #[serde(rename = "StackId")]
@@ -373,6 +376,7 @@ pub struct CloudWatchLogsLogStream {
 
 /// <p>Describes a command.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Command {
     /// <p>Date and time when the command was acknowledged.</p>
     #[serde(rename = "AcknowledgedAt")]
@@ -467,6 +471,7 @@ pub struct CreateAppRequest {
 
 /// <p>Contains the response to a <code>CreateApp</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateAppResult {
     /// <p>The app ID.</p>
     #[serde(rename = "AppId")]
@@ -506,6 +511,7 @@ pub struct CreateDeploymentRequest {
 
 /// <p>Contains the response to a <code>CreateDeployment</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDeploymentResult {
     /// <p>The deployment ID, which can be used with other requests to identify the deployment.</p>
     #[serde(rename = "DeploymentId")]
@@ -588,6 +594,7 @@ pub struct CreateInstanceRequest {
 
 /// <p>Contains the response to a <code>CreateInstance</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateInstanceResult {
     /// <p>The instance ID.</p>
     #[serde(rename = "InstanceId")]
@@ -669,6 +676,7 @@ pub struct CreateLayerRequest {
 
 /// <p>Contains the response to a <code>CreateLayer</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateLayerResult {
     /// <p>The layer ID.</p>
     #[serde(rename = "LayerId")]
@@ -753,6 +761,7 @@ pub struct CreateStackRequest {
 
 /// <p>Contains the response to a <code>CreateStack</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateStackResult {
     /// <p>The stack ID, which is an opaque string that you use to identify the stack when performing actions such as <code>DescribeStacks</code>.</p>
     #[serde(rename = "StackId")]
@@ -781,6 +790,7 @@ pub struct CreateUserProfileRequest {
 
 /// <p>Contains the response to a <code>CreateUserProfile</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateUserProfileResult {
     /// <p>The user's IAM ARN.</p>
     #[serde(rename = "IamUserArn")]
@@ -850,6 +860,7 @@ pub struct DeleteUserProfileRequest {
 
 /// <p>Describes a deployment of a stack or app.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Deployment {
     /// <p>The app ID.</p>
     #[serde(rename = "AppId")]
@@ -961,6 +972,7 @@ pub struct DescribeAgentVersionsRequest {
 
 /// <p>Contains the response to a <code>DescribeAgentVersions</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAgentVersionsResult {
     /// <p>The agent versions for the specified stack or configuration manager. Note that this value is the complete version number, not the abbreviated number used by the console.</p>
     #[serde(rename = "AgentVersions")]
@@ -982,6 +994,7 @@ pub struct DescribeAppsRequest {
 
 /// <p>Contains the response to a <code>DescribeApps</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAppsResult {
     /// <p>An array of <code>App</code> objects that describe the specified apps. </p>
     #[serde(rename = "Apps")]
@@ -1007,6 +1020,7 @@ pub struct DescribeCommandsRequest {
 
 /// <p>Contains the response to a <code>DescribeCommands</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeCommandsResult {
     /// <p>An array of <code>Command</code> objects that describe each of the specified commands.</p>
     #[serde(rename = "Commands")]
@@ -1032,6 +1046,7 @@ pub struct DescribeDeploymentsRequest {
 
 /// <p>Contains the response to a <code>DescribeDeployments</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeDeploymentsResult {
     /// <p>An array of <code>Deployment</code> objects that describe the deployments.</p>
     #[serde(rename = "Deployments")]
@@ -1061,6 +1076,7 @@ pub struct DescribeEcsClustersRequest {
 
 /// <p>Contains the response to a <code>DescribeEcsClusters</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEcsClustersResult {
     /// <p>A list of <code>EcsCluster</code> objects containing the cluster descriptions.</p>
     #[serde(rename = "EcsClusters")]
@@ -1090,6 +1106,7 @@ pub struct DescribeElasticIpsRequest {
 
 /// <p>Contains the response to a <code>DescribeElasticIps</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeElasticIpsResult {
     /// <p>An <code>ElasticIps</code> object that describes the specified Elastic IP addresses.</p>
     #[serde(rename = "ElasticIps")]
@@ -1111,6 +1128,7 @@ pub struct DescribeElasticLoadBalancersRequest {
 
 /// <p>Contains the response to a <code>DescribeElasticLoadBalancers</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeElasticLoadBalancersResult {
     /// <p>A list of <code>ElasticLoadBalancer</code> objects that describe the specified Elastic Load Balancing instances.</p>
     #[serde(rename = "ElasticLoadBalancers")]
@@ -1136,6 +1154,7 @@ pub struct DescribeInstancesRequest {
 
 /// <p>Contains the response to a <code>DescribeInstances</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeInstancesResult {
     /// <p>An array of <code>Instance</code> objects that describe the instances.</p>
     #[serde(rename = "Instances")]
@@ -1157,6 +1176,7 @@ pub struct DescribeLayersRequest {
 
 /// <p>Contains the response to a <code>DescribeLayers</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeLayersResult {
     /// <p>An array of <code>Layer</code> objects that describe the layers.</p>
     #[serde(rename = "Layers")]
@@ -1173,6 +1193,7 @@ pub struct DescribeLoadBasedAutoScalingRequest {
 
 /// <p>Contains the response to a <code>DescribeLoadBasedAutoScaling</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeLoadBasedAutoScalingResult {
     /// <p>An array of <code>LoadBasedAutoScalingConfiguration</code> objects that describe each layer's configuration.</p>
     #[serde(rename = "LoadBasedAutoScalingConfigurations")]
@@ -1182,6 +1203,7 @@ pub struct DescribeLoadBasedAutoScalingResult {
 
 /// <p>Contains the response to a <code>DescribeMyUserProfile</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeMyUserProfileResult {
     /// <p>A <code>UserProfile</code> object that describes the user's SSH information.</p>
     #[serde(rename = "UserProfile")]
@@ -1191,6 +1213,7 @@ pub struct DescribeMyUserProfileResult {
 
 /// <p>The response to a <code>DescribeOperatingSystems</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeOperatingSystemsResponse {
     /// <p>Contains information in response to a <code>DescribeOperatingSystems</code> request.</p>
     #[serde(rename = "OperatingSystems")]
@@ -1212,6 +1235,7 @@ pub struct DescribePermissionsRequest {
 
 /// <p>Contains the response to a <code>DescribePermissions</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribePermissionsResult {
     /// <p><p>An array of <code>Permission</code> objects that describe the stack permissions.</p> <ul> <li> <p>If the request object contains only a stack ID, the array contains a <code>Permission</code> object with permissions for each of the stack IAM ARNs.</p> </li> <li> <p>If the request object contains only an IAM ARN, the array contains a <code>Permission</code> object with permissions for each of the user&#39;s stack IDs.</p> </li> <li> <p>If the request contains a stack ID and an IAM ARN, the array contains a single <code>Permission</code> object with permissions for the specified stack and IAM ARN.</p> </li> </ul></p>
     #[serde(rename = "Permissions")]
@@ -1237,6 +1261,7 @@ pub struct DescribeRaidArraysRequest {
 
 /// <p>Contains the response to a <code>DescribeRaidArrays</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeRaidArraysResult {
     /// <p>A <code>RaidArrays</code> object that describes the specified RAID arrays.</p>
     #[serde(rename = "RaidArrays")]
@@ -1257,6 +1282,7 @@ pub struct DescribeRdsDbInstancesRequest {
 
 /// <p>Contains the response to a <code>DescribeRdsDbInstances</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeRdsDbInstancesResult {
     /// <p>An a array of <code>RdsDbInstance</code> objects that describe the instances.</p>
     #[serde(rename = "RdsDbInstances")]
@@ -1282,6 +1308,7 @@ pub struct DescribeServiceErrorsRequest {
 
 /// <p>Contains the response to a <code>DescribeServiceErrors</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeServiceErrorsResult {
     /// <p>An array of <code>ServiceError</code> objects that describe the specified service errors.</p>
     #[serde(rename = "ServiceErrors")]
@@ -1298,6 +1325,7 @@ pub struct DescribeStackProvisioningParametersRequest {
 
 /// <p>Contains the response to a <code>DescribeStackProvisioningParameters</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeStackProvisioningParametersResult {
     /// <p>The AWS OpsWorks Stacks agent installer's URL.</p>
     #[serde(rename = "AgentInstallerUrl")]
@@ -1318,6 +1346,7 @@ pub struct DescribeStackSummaryRequest {
 
 /// <p>Contains the response to a <code>DescribeStackSummary</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeStackSummaryResult {
     /// <p>A <code>StackSummary</code> object that contains the results.</p>
     #[serde(rename = "StackSummary")]
@@ -1335,6 +1364,7 @@ pub struct DescribeStacksRequest {
 
 /// <p>Contains the response to a <code>DescribeStacks</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeStacksResult {
     /// <p>An array of <code>Stack</code> objects that describe the stacks.</p>
     #[serde(rename = "Stacks")]
@@ -1351,6 +1381,7 @@ pub struct DescribeTimeBasedAutoScalingRequest {
 
 /// <p>Contains the response to a <code>DescribeTimeBasedAutoScaling</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeTimeBasedAutoScalingResult {
     /// <p>An array of <code>TimeBasedAutoScalingConfiguration</code> objects that describe the configuration for the specified instances.</p>
     #[serde(rename = "TimeBasedAutoScalingConfigurations")]
@@ -1368,6 +1399,7 @@ pub struct DescribeUserProfilesRequest {
 
 /// <p>Contains the response to a <code>DescribeUserProfiles</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeUserProfilesResult {
     /// <p>A <code>Users</code> object that describes the specified users.</p>
     #[serde(rename = "UserProfiles")]
@@ -1397,6 +1429,7 @@ pub struct DescribeVolumesRequest {
 
 /// <p>Contains the response to a <code>DescribeVolumes</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeVolumesResult {
     /// <p>An array of volume IDs.</p>
     #[serde(rename = "Volumes")]
@@ -1448,6 +1481,7 @@ pub struct EbsBlockDevice {
 
 /// <p>Describes a registered Amazon ECS cluster.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EcsCluster {
     /// <p>The cluster's ARN.</p>
     #[serde(rename = "EcsClusterArn")]
@@ -1469,6 +1503,7 @@ pub struct EcsCluster {
 
 /// <p>Describes an Elastic IP address.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ElasticIp {
     /// <p>The domain.</p>
     #[serde(rename = "Domain")]
@@ -1494,6 +1529,7 @@ pub struct ElasticIp {
 
 /// <p>Describes an Elastic Load Balancing instance.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ElasticLoadBalancer {
     /// <p>A list of Availability Zones.</p>
     #[serde(rename = "AvailabilityZones")]
@@ -1557,6 +1593,7 @@ pub struct GetHostnameSuggestionRequest {
 
 /// <p>Contains the response to a <code>GetHostnameSuggestion</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetHostnameSuggestionResult {
     /// <p>The generated host name.</p>
     #[serde(rename = "Hostname")]
@@ -1581,6 +1618,7 @@ pub struct GrantAccessRequest {
 
 /// <p>Contains the response to a <code>GrantAccess</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GrantAccessResult {
     /// <p>A <code>TemporaryCredential</code> object that contains the data needed to log in to the instance by RDP clients, such as the Microsoft Remote Desktop Connection.</p>
     #[serde(rename = "TemporaryCredential")]
@@ -1590,6 +1628,7 @@ pub struct GrantAccessResult {
 
 /// <p>Describes an instance.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Instance {
     /// <p>The agent version. This parameter is set to <code>INHERIT</code> if the instance inherits the default stack setting or to a a version number for a fixed agent version.</p>
     #[serde(rename = "AgentVersion")]
@@ -1772,6 +1811,7 @@ pub struct InstanceIdentity {
 
 /// <p>Describes how many instances a stack has for each status.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstancesCount {
     /// <p>The number of instances in the Assigning state.</p>
     #[serde(rename = "Assigning")]
@@ -1857,6 +1897,7 @@ pub struct InstancesCount {
 
 /// <p>Describes a layer.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Layer {
     /// <p>The Amazon Resource Number (ARN) of a layer.</p>
     #[serde(rename = "Arn")]
@@ -1977,6 +2018,7 @@ pub struct ListTagsRequest {
 
 /// <p>Contains the response to a <code>ListTags</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagsResult {
     /// <p>If a paginated request does not return all of the remaining results, this parameter is set to a token that you can assign to the request object's <code>NextToken</code> parameter to get the next set of results. If the previous paginated request returned all of the remaining results, this parameter is set to <code>null</code>. </p>
     #[serde(rename = "NextToken")]
@@ -1990,6 +2032,7 @@ pub struct ListTagsResult {
 
 /// <p>Describes a layer's load-based auto scaling configuration.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LoadBasedAutoScalingConfiguration {
     /// <p>An <code>AutoScalingThresholds</code> object that describes the downscaling configuration, which defines how and when AWS OpsWorks Stacks reduces the number of instances.</p>
     #[serde(rename = "DownScaling")]
@@ -2011,6 +2054,7 @@ pub struct LoadBasedAutoScalingConfiguration {
 
 /// <p>Describes supported operating systems in AWS OpsWorks Stacks.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct OperatingSystem {
     /// <p>Supported configuration manager name and versions for an AWS OpsWorks Stacks operating system.</p>
     #[serde(rename = "ConfigurationManagers")]
@@ -2044,6 +2088,7 @@ pub struct OperatingSystem {
 
 /// <p>A block that contains information about the configuration manager (Chef) and the versions of the configuration manager that are supported for an operating system.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct OperatingSystemConfigurationManager {
     /// <p>The name of the configuration manager, which is Chef.</p>
     #[serde(rename = "Name")]
@@ -2057,6 +2102,7 @@ pub struct OperatingSystemConfigurationManager {
 
 /// <p>Describes stack or user permissions.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Permission {
     /// <p>Whether the user can use SSH.</p>
     #[serde(rename = "AllowSsh")]
@@ -2082,6 +2128,7 @@ pub struct Permission {
 
 /// <p>Describes an instance's RAID array.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RaidArray {
     /// <p>The array's Availability Zone. For more information, see <a href="http://docs.aws.amazon.com/general/latest/gr/rande.html">Regions and Endpoints</a>.</p>
     #[serde(rename = "AvailabilityZone")]
@@ -2139,6 +2186,7 @@ pub struct RaidArray {
 
 /// <p>Describes an Amazon RDS instance.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RdsDbInstance {
     /// <p>The instance's address.</p>
     #[serde(rename = "Address")]
@@ -2222,6 +2270,7 @@ pub struct RegisterEcsClusterRequest {
 
 /// <p>Contains the response to a <code>RegisterEcsCluster</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegisterEcsClusterResult {
     /// <p>The cluster's ARN.</p>
     #[serde(rename = "EcsClusterArn")]
@@ -2241,6 +2290,7 @@ pub struct RegisterElasticIpRequest {
 
 /// <p>Contains the response to a <code>RegisterElasticIp</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegisterElasticIpResult {
     /// <p>The Elastic IP address.</p>
     #[serde(rename = "ElasticIp")]
@@ -2281,6 +2331,7 @@ pub struct RegisterInstanceRequest {
 
 /// <p>Contains the response to a <code>RegisterInstanceResult</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegisterInstanceResult {
     /// <p>The registered instance's AWS OpsWorks Stacks ID.</p>
     #[serde(rename = "InstanceId")]
@@ -2317,6 +2368,7 @@ pub struct RegisterVolumeRequest {
 
 /// <p>Contains the response to a <code>RegisterVolume</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegisterVolumeResult {
     /// <p>The volume ID.</p>
     #[serde(rename = "VolumeId")]
@@ -2326,6 +2378,7 @@ pub struct RegisterVolumeResult {
 
 /// <p>A registered instance's reported operating system.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReportedOs {
     /// <p>The operating system family.</p>
     #[serde(rename = "Family")]
@@ -2343,6 +2396,7 @@ pub struct ReportedOs {
 
 /// <p>Describes a user's SSH information.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SelfUserProfile {
     /// <p>The user's IAM ARN.</p>
     #[serde(rename = "IamUserArn")]
@@ -2364,6 +2418,7 @@ pub struct SelfUserProfile {
 
 /// <p>Describes an AWS OpsWorks Stacks service error.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ServiceError {
     /// <p>When the error occurred.</p>
     #[serde(rename = "CreatedAt")]
@@ -2502,6 +2557,7 @@ pub struct SslConfiguration {
 
 /// <p>Describes a stack.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Stack {
     /// <p>The agent version. This parameter is set to <code>LATEST</code> for auto-update. or a version number for a fixed agent version.</p>
     #[serde(rename = "AgentVersion")]
@@ -2607,6 +2663,7 @@ pub struct StackConfigurationManager {
 
 /// <p>Summarizes the number of layers, instances, and apps in a stack.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StackSummary {
     /// <p>The number of apps.</p>
     #[serde(rename = "AppsCount")]
@@ -2678,6 +2735,7 @@ pub struct TagResourceRequest {
 
 /// <p>Contains the data needed by RDP clients such as the Microsoft Remote Desktop Connection to log in to the instance.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TemporaryCredential {
     /// <p>The instance's AWS OpsWorks Stacks ID.</p>
     #[serde(rename = "InstanceId")]
@@ -2699,6 +2757,7 @@ pub struct TemporaryCredential {
 
 /// <p>Describes an instance's time-based auto scaling configuration.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TimeBasedAutoScalingConfiguration {
     /// <p>A <code>WeeklyAutoScalingSchedule</code> object with the instance schedule.</p>
     #[serde(rename = "AutoScalingSchedule")]
@@ -3047,6 +3106,7 @@ pub struct UpdateVolumeRequest {
 
 /// <p>Describes a user's SSH information.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UserProfile {
     /// <p>Whether users can specify their own SSH public key through the My Settings page. For more information, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/security-settingsshkey.html">Managing User Permissions</a>.</p>
     #[serde(rename = "AllowSelfManagement")]
@@ -3072,6 +3132,7 @@ pub struct UserProfile {
 
 /// <p>Describes an instance's Amazon EBS volume.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Volume {
     /// <p>The volume Availability Zone. For more information, see <a href="http://docs.aws.amazon.com/general/latest/gr/rande.html">Regions and Endpoints</a>.</p>
     #[serde(rename = "AvailabilityZone")]

--- a/rusoto/services/opsworkscm/src/generated.rs
+++ b/rusoto/services/opsworkscm/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Stores account attributes. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AccountAttribute {
     /// <p> The maximum allowed value. </p>
     #[serde(rename = "Maximum")]
@@ -59,6 +60,7 @@ pub struct AssociateNodeRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociateNodeResponse {
     /// <p>Contains a token which can be passed to the <code>DescribeNodeAssociationStatus</code> API call to get the status of the association request. </p>
     #[serde(rename = "NodeAssociationStatusToken")]
@@ -68,6 +70,7 @@ pub struct AssociateNodeResponse {
 
 /// <p>Describes a single backup. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Backup {
     /// <p>The ARN of the backup. </p>
     #[serde(rename = "BackupArn")]
@@ -171,6 +174,7 @@ pub struct CreateBackupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateBackupResponse {
     /// <p>Backup created by request.</p>
     #[serde(rename = "Backup")]
@@ -247,6 +251,7 @@ pub struct CreateServerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateServerResponse {
     /// <p>The server that is created by the request. </p>
     #[serde(rename = "Server")]
@@ -262,6 +267,7 @@ pub struct DeleteBackupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteBackupResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -272,12 +278,14 @@ pub struct DeleteServerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteServerResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeAccountAttributesRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAccountAttributesResponse {
     /// <p> The attributes that are currently set for the account. </p>
     #[serde(rename = "Attributes")]
@@ -306,6 +314,7 @@ pub struct DescribeBackupsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeBackupsResponse {
     /// <p>Contains the response to a <code>DescribeBackups</code> request. </p>
     #[serde(rename = "Backups")]
@@ -333,6 +342,7 @@ pub struct DescribeEventsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEventsResponse {
     /// <p>NextToken is a string that is returned in some command responses. It indicates that not all entries have been returned, and that you must run at least one more request to get remaining items. To get remaining results, call <code>DescribeEvents</code> again, and assign the token from the previous results as the value of the <code>nextToken</code> parameter. If there are no more results, the response object's <code>nextToken</code> parameter value is <code>null</code>. Setting a <code>nextToken</code> value that was not returned in your previous results causes an <code>InvalidNextTokenException</code> to occur. </p>
     #[serde(rename = "NextToken")]
@@ -355,6 +365,7 @@ pub struct DescribeNodeAssociationStatusRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeNodeAssociationStatusResponse {
     /// <p>Attributes specific to the node association. In Puppet, the attibute PUPPET_NODE_CERT contains the signed certificate (the result of the CSR). </p>
     #[serde(rename = "EngineAttributes")]
@@ -383,6 +394,7 @@ pub struct DescribeServersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeServersResponse {
     /// <p>NextToken is a string that is returned in some command responses. It indicates that not all entries have been returned, and that you must run at least one more request to get remaining items. To get remaining results, call <code>DescribeServers</code> again, and assign the token from the previous results as the value of the <code>nextToken</code> parameter. If there are no more results, the response object's <code>nextToken</code> parameter value is <code>null</code>. Setting a <code>nextToken</code> value that was not returned in your previous results causes an <code>InvalidNextTokenException</code> to occur. </p>
     #[serde(rename = "NextToken")]
@@ -409,6 +421,7 @@ pub struct DisassociateNodeRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisassociateNodeResponse {
     /// <p>Contains a token which can be passed to the <code>DescribeNodeAssociationStatus</code> API call to get the status of the disassociation request. </p>
     #[serde(rename = "NodeAssociationStatusToken")]
@@ -448,10 +461,12 @@ pub struct RestoreServerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RestoreServerResponse {}
 
 /// <p>Describes a configuration management server. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Server {
     /// <p>Associate a public IP address with a server that you are launching. </p>
     #[serde(rename = "AssociatePublicIpAddress")]
@@ -549,6 +564,7 @@ pub struct Server {
 
 /// <p>An event that is related to the server, such as the start of maintenance or backup. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ServerEvent {
     /// <p>The time when the event occurred. </p>
     #[serde(rename = "CreatedAt")]
@@ -580,6 +596,7 @@ pub struct StartMaintenanceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartMaintenanceResponse {
     /// <p>Contains the response to a <code>StartMaintenance</code> request. </p>
     #[serde(rename = "Server")]
@@ -602,6 +619,7 @@ pub struct UpdateServerEngineAttributesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateServerEngineAttributesResponse {
     /// <p>Contains the response to an <code>UpdateServerEngineAttributes</code> request. </p>
     #[serde(rename = "Server")]
@@ -631,6 +649,7 @@ pub struct UpdateServerRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateServerResponse {
     /// <p>Contains the response to a <code>UpdateServer</code> request. </p>
     #[serde(rename = "Server")]

--- a/rusoto/services/organizations/src/generated.rs
+++ b/rusoto/services/organizations/src/generated.rs
@@ -36,6 +36,7 @@ pub struct AcceptHandshakeRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AcceptHandshakeResponse {
     /// <p>A structure that contains details about the accepted handshake.</p>
     #[serde(rename = "Handshake")]
@@ -45,6 +46,7 @@ pub struct AcceptHandshakeResponse {
 
 /// <p>Contains information about an AWS account that is a member of an organization.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Account {
     /// <p>The Amazon Resource Name (ARN) of the account.</p> <p>For more information about ARNs in Organizations, see <a href="http://docs.aws.amazon.com/organizations/latest/userguide/orgs_permissions.html#orgs-permissions-arns">ARN Formats Supported by Organizations</a> in the <i>AWS Organizations User Guide</i>.</p>
     #[serde(rename = "Arn")]
@@ -94,6 +96,7 @@ pub struct CancelHandshakeRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CancelHandshakeResponse {
     /// <p>A structure that contains details about the handshake that you canceled.</p>
     #[serde(rename = "Handshake")]
@@ -103,6 +106,7 @@ pub struct CancelHandshakeResponse {
 
 /// <p>Contains a list of child entities, either OUs or accounts.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Child {
     /// <p><p>The unique identifier (ID) of this child entity.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> for a child ID string requires one of the following:</p> <ul> <li> <p>Account: a string that consists of exactly 12 digits.</p> </li> <li> <p>Organizational unit (OU): a string that begins with &quot;ou-&quot; followed by from 4 to 32 lower-case letters or digits (the ID of the root that contains the OU) followed by a second &quot;-&quot; dash and from 8 to 32 additional lower-case letters or digits.</p> </li> </ul></p>
     #[serde(rename = "Id")]
@@ -133,6 +137,7 @@ pub struct CreateAccountRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateAccountResponse {
     /// <p>A structure that contains details about the request to create an account. This response structure might not be fully populated when you first receive it because account creation is an asynchronous process. You can pass the returned CreateAccountStatus ID as a parameter to <code> <a>DescribeCreateAccountStatus</a> </code> to get status about the progress of the request at later times. </p>
     #[serde(rename = "CreateAccountStatus")]
@@ -142,6 +147,7 @@ pub struct CreateAccountResponse {
 
 /// <p>Contains the status about a <a>CreateAccount</a> request to create an AWS account in an organization.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateAccountStatus {
     /// <p>If the account was created successfully, the unique identifier (ID) of the new account.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> for an account ID string requires exactly 12 digits.</p>
     #[serde(rename = "AccountId")]
@@ -182,6 +188,7 @@ pub struct CreateOrganizationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateOrganizationResponse {
     /// <p>A structure that contains details about the newly created organization.</p>
     #[serde(rename = "Organization")]
@@ -200,6 +207,7 @@ pub struct CreateOrganizationalUnitRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateOrganizationalUnitResponse {
     /// <p>A structure that contains details about the newly created OU.</p>
     #[serde(rename = "OrganizationalUnit")]
@@ -224,6 +232,7 @@ pub struct CreatePolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreatePolicyResponse {
     /// <p>A structure that contains details about the newly created policy.</p>
     #[serde(rename = "Policy")]
@@ -239,6 +248,7 @@ pub struct DeclineHandshakeRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeclineHandshakeResponse {
     /// <p>A structure that contains details about the declined handshake. The state is updated to show the value <code>DECLINED</code>.</p>
     #[serde(rename = "Handshake")]
@@ -268,6 +278,7 @@ pub struct DescribeAccountRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAccountResponse {
     /// <p>A structure that contains information about the requested account.</p>
     #[serde(rename = "Account")]
@@ -283,6 +294,7 @@ pub struct DescribeCreateAccountStatusRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeCreateAccountStatusResponse {
     /// <p>A structure that contains the current status of an account creation request.</p>
     #[serde(rename = "CreateAccountStatus")]
@@ -298,6 +310,7 @@ pub struct DescribeHandshakeRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeHandshakeResponse {
     /// <p>A structure that contains information about the specified handshake.</p>
     #[serde(rename = "Handshake")]
@@ -306,6 +319,7 @@ pub struct DescribeHandshakeResponse {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeOrganizationResponse {
     /// <p>A structure that contains information about the organization.</p>
     #[serde(rename = "Organization")]
@@ -321,6 +335,7 @@ pub struct DescribeOrganizationalUnitRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeOrganizationalUnitResponse {
     /// <p>A structure that contains details about the specified OU.</p>
     #[serde(rename = "OrganizationalUnit")]
@@ -336,6 +351,7 @@ pub struct DescribePolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribePolicyResponse {
     /// <p>A structure that contains details about the specified policy.</p>
     #[serde(rename = "Policy")]
@@ -371,6 +387,7 @@ pub struct DisablePolicyTypeRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisablePolicyTypeResponse {
     /// <p>A structure that shows the root with the updated list of enabled policy types.</p>
     #[serde(rename = "Root")]
@@ -389,6 +406,7 @@ pub struct EnableAWSServiceAccessRequest {
 pub struct EnableAllFeaturesRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EnableAllFeaturesResponse {
     /// <p>A structure that contains details about the handshake created to support this request to enable all features in the organization.</p>
     #[serde(rename = "Handshake")]
@@ -407,6 +425,7 @@ pub struct EnablePolicyTypeRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EnablePolicyTypeResponse {
     /// <p>A structure that shows the root with the updated list of enabled policy types.</p>
     #[serde(rename = "Root")]
@@ -416,6 +435,7 @@ pub struct EnablePolicyTypeResponse {
 
 /// <p>A structure that contains details of a service principal that is enabled to integrate with AWS Organizations.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EnabledServicePrincipal {
     /// <p>The date that the service principal was enabled for integration with AWS Organizations.</p>
     #[serde(rename = "DateEnabled")]
@@ -429,6 +449,7 @@ pub struct EnabledServicePrincipal {
 
 /// <p>Contains information that must be exchanged to securely establish a relationship between two accounts (an <i>originator</i> and a <i>recipient</i>). For example, when a master account (the originator) invites another account (the recipient) to join its organization, the two accounts exchange information as a series of handshake requests and responses.</p> <p> <b>Note:</b> Handshakes that are CANCELED, ACCEPTED, or DECLINED show up in lists for only 30 days after entering that state After that they are deleted.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Handshake {
     /// <p><p>The type of handshake, indicating what action occurs when the recipient accepts the handshake. The following handshake types are supported:</p> <ul> <li> <p> <b>INVITE</b>: This type of handshake represents a request to join an organization. It is always sent from the master account to only non-member accounts.</p> </li> <li> <p> <b>ENABLE<em>ALL</em>FEATURES</b>: This type of handshake represents a request to enable all features in an organization. It is always sent from the master account to only <i>invited</i> member accounts. Created accounts do not receive this because those accounts were created by the organization&#39;s master account and approval is inferred.</p> </li> <li> <p> <b>APPROVE<em>ALL</em>FEATURES</b>: This type of handshake is sent from the Organizations service when all member accounts have approved the <code>ENABLE<em>ALL</em>FEATURES</code> invitation. It is sent only to the master account and signals the master that it can finalize the process to enable all features.</p> </li> </ul></p>
     #[serde(rename = "Action")]
@@ -490,6 +511,7 @@ pub struct HandshakeParty {
 
 /// <p>Contains additional data that is needed to process a handshake.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct HandshakeResource {
     /// <p>When needed, contains an additional array of <code>HandshakeResource</code> objects.</p>
     #[serde(rename = "Resources")]
@@ -517,6 +539,7 @@ pub struct InviteAccountToOrganizationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InviteAccountToOrganizationResponse {
     /// <p>A structure that contains details about the handshake that is created to support this invitation request.</p>
     #[serde(rename = "Handshake")]
@@ -537,6 +560,7 @@ pub struct ListAWSServiceAccessForOrganizationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAWSServiceAccessForOrganizationResponse {
     /// <p>A list of the service principals for the services that are enabled to integrate with your organization. Each principal is a structure that includes the name and the date that it was enabled for integration with AWS Organizations.</p>
     #[serde(rename = "EnabledServicePrincipals")]
@@ -564,6 +588,7 @@ pub struct ListAccountsForParentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAccountsForParentResponse {
     /// <p>A list of the accounts in the specified root or OU.</p>
     #[serde(rename = "Accounts")]
@@ -588,6 +613,7 @@ pub struct ListAccountsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAccountsResponse {
     /// <p>A list of objects in the organization.</p>
     #[serde(rename = "Accounts")]
@@ -618,6 +644,7 @@ pub struct ListChildrenRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListChildrenResponse {
     /// <p>The list of children of the specified parent container.</p>
     #[serde(rename = "Children")]
@@ -646,6 +673,7 @@ pub struct ListCreateAccountStatusRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListCreateAccountStatusResponse {
     /// <p>A list of objects with details about the requests. Certain elements, such as the accountId number, are present in the output only after the account has been successfully created.</p>
     #[serde(rename = "CreateAccountStatuses")]
@@ -674,6 +702,7 @@ pub struct ListHandshakesForAccountRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListHandshakesForAccountResponse {
     /// <p>A list of <a>Handshake</a> objects with details about each of the handshakes that is associated with the specified account.</p>
     #[serde(rename = "Handshakes")]
@@ -702,6 +731,7 @@ pub struct ListHandshakesForOrganizationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListHandshakesForOrganizationResponse {
     /// <p>A list of <a>Handshake</a> objects with details about each of the handshakes that are associated with an organization.</p>
     #[serde(rename = "Handshakes")]
@@ -729,6 +759,7 @@ pub struct ListOrganizationalUnitsForParentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListOrganizationalUnitsForParentResponse {
     /// <p>If present, this value indicates that there is more output available than is included in the current response. Use this value in the <code>NextToken</code> request parameter in a subsequent call to the operation to get the next part of the output. You should repeat this until the <code>NextToken</code> response element comes back as <code>null</code>.</p>
     #[serde(rename = "NextToken")]
@@ -756,6 +787,7 @@ pub struct ListParentsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListParentsResponse {
     /// <p>If present, this value indicates that there is more output available than is included in the current response. Use this value in the <code>NextToken</code> request parameter in a subsequent call to the operation to get the next part of the output. You should repeat this until the <code>NextToken</code> response element comes back as <code>null</code>.</p>
     #[serde(rename = "NextToken")]
@@ -786,6 +818,7 @@ pub struct ListPoliciesForTargetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListPoliciesForTargetResponse {
     /// <p>If present, this value indicates that there is more output available than is included in the current response. Use this value in the <code>NextToken</code> request parameter in a subsequent call to the operation to get the next part of the output. You should repeat this until the <code>NextToken</code> response element comes back as <code>null</code>.</p>
     #[serde(rename = "NextToken")]
@@ -813,6 +846,7 @@ pub struct ListPoliciesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListPoliciesResponse {
     /// <p>If present, this value indicates that there is more output available than is included in the current response. Use this value in the <code>NextToken</code> request parameter in a subsequent call to the operation to get the next part of the output. You should repeat this until the <code>NextToken</code> response element comes back as <code>null</code>.</p>
     #[serde(rename = "NextToken")]
@@ -837,6 +871,7 @@ pub struct ListRootsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListRootsResponse {
     /// <p>If present, this value indicates that there is more output available than is included in the current response. Use this value in the <code>NextToken</code> request parameter in a subsequent call to the operation to get the next part of the output. You should repeat this until the <code>NextToken</code> response element comes back as <code>null</code>.</p>
     #[serde(rename = "NextToken")]
@@ -864,6 +899,7 @@ pub struct ListTargetsForPolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTargetsForPolicyResponse {
     /// <p>If present, this value indicates that there is more output available than is included in the current response. Use this value in the <code>NextToken</code> request parameter in a subsequent call to the operation to get the next part of the output. You should repeat this until the <code>NextToken</code> response element comes back as <code>null</code>.</p>
     #[serde(rename = "NextToken")]
@@ -890,6 +926,7 @@ pub struct MoveAccountRequest {
 
 /// <p>Contains details about an organization. An organization is a collection of accounts that are centrally managed together using consolidated billing, organized hierarchically with organizational units (OUs), and controlled with policies .</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Organization {
     /// <p>The Amazon Resource Name (ARN) of an organization.</p> <p>For more information about ARNs in Organizations, see <a href="http://docs.aws.amazon.com/organizations/latest/userguide/orgs_permissions.html#orgs-permissions-arns">ARN Formats Supported by Organizations</a> in the <i>AWS Organizations User Guide</i>.</p>
     #[serde(rename = "Arn")]
@@ -923,6 +960,7 @@ pub struct Organization {
 
 /// <p>Contains details about an organizational unit (OU). An OU is a container of AWS accounts within a root of an organization. Policies that are attached to an OU apply to all accounts contained in that OU and in any child OUs.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct OrganizationalUnit {
     /// <p>The Amazon Resource Name (ARN) of this OU.</p> <p>For more information about ARNs in Organizations, see <a href="http://docs.aws.amazon.com/organizations/latest/userguide/orgs_permissions.html#orgs-permissions-arns">ARN Formats Supported by Organizations</a> in the <i>AWS Organizations User Guide</i>.</p>
     #[serde(rename = "Arn")]
@@ -940,6 +978,7 @@ pub struct OrganizationalUnit {
 
 /// <p>Contains information about either a root or an organizational unit (OU) that can contain OUs or accounts in an organization.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Parent {
     /// <p><p>The unique identifier (ID) of the parent entity.</p> <p>The <a href="http://wikipedia.org/wiki/regex">regex pattern</a> for a parent ID string requires one of the following:</p> <ul> <li> <p>Root: a string that begins with &quot;r-&quot; followed by from 4 to 32 lower-case letters or digits.</p> </li> <li> <p>Organizational unit (OU): a string that begins with &quot;ou-&quot; followed by from 4 to 32 lower-case letters or digits (the ID of the root that the OU is in) followed by a second &quot;-&quot; dash and from 8 to 32 additional lower-case letters or digits.</p> </li> </ul></p>
     #[serde(rename = "Id")]
@@ -953,6 +992,7 @@ pub struct Parent {
 
 /// <p>Contains rules to be applied to the affected accounts. Policies can be attached directly to accounts, or to roots and OUs to affect all accounts in those hierarchies.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Policy {
     /// <p>The text content of the policy.</p>
     #[serde(rename = "Content")]
@@ -966,6 +1006,7 @@ pub struct Policy {
 
 /// <p>Contains information about a policy, but does not include the content. To see the content of a policy, see <a>DescribePolicy</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PolicySummary {
     /// <p>The Amazon Resource Name (ARN) of the policy.</p> <p>For more information about ARNs in Organizations, see <a href="http://docs.aws.amazon.com/organizations/latest/userguide/orgs_permissions.html#orgs-permissions-arns">ARN Formats Supported by Organizations</a> in the <i>AWS Organizations User Guide</i>.</p>
     #[serde(rename = "Arn")]
@@ -995,6 +1036,7 @@ pub struct PolicySummary {
 
 /// <p>Contains information about a root, OU, or account that a policy is attached to.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PolicyTargetSummary {
     /// <p>The Amazon Resource Name (ARN) of the policy target.</p> <p>For more information about ARNs in Organizations, see <a href="http://docs.aws.amazon.com/organizations/latest/userguide/orgs_permissions.html#orgs-permissions-arns">ARN Formats Supported by Organizations</a> in the <i>AWS Organizations User Guide</i>.</p>
     #[serde(rename = "Arn")]
@@ -1016,6 +1058,7 @@ pub struct PolicyTargetSummary {
 
 /// <p>Contains information about a policy type and its status in the associated root.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PolicyTypeSummary {
     /// <p>The status of the policy type as it relates to the associated root. To attach a policy of the specified type to a root or to an OU or account in that root, it must be available in the organization and enabled for that root.</p>
     #[serde(rename = "Status")]
@@ -1036,6 +1079,7 @@ pub struct RemoveAccountFromOrganizationRequest {
 
 /// <p>Contains details about a root. A root is a top-level parent node in the hierarchy of an organization that can contain organizational units (OUs) and accounts. Every root contains every AWS account in the organization. Each root enables the accounts to be organized in a different way and to have different policy types enabled for use in that root.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Root {
     /// <p>The Amazon Resource Name (ARN) of the root.</p> <p>For more information about ARNs in Organizations, see <a href="http://docs.aws.amazon.com/organizations/latest/userguide/orgs_permissions.html#orgs-permissions-arns">ARN Formats Supported by Organizations</a> in the <i>AWS Organizations User Guide</i>.</p>
     #[serde(rename = "Arn")]
@@ -1067,6 +1111,7 @@ pub struct UpdateOrganizationalUnitRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateOrganizationalUnitResponse {
     /// <p>A structure that contains the details about the specified OU, including its new name.</p>
     #[serde(rename = "OrganizationalUnit")]
@@ -1094,6 +1139,7 @@ pub struct UpdatePolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdatePolicyResponse {
     /// <p>A structure that contains details about the updated policy, showing the requested changes.</p>
     #[serde(rename = "Policy")]

--- a/rusoto/services/pi/src/generated.rs
+++ b/rusoto/services/pi/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>A timestamp, and a single numerical value, which together represent a measurement at a particular point in time.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DataPoint {
     /// <p>The time, in epoch format, associated with a particular <code>Value</code>.</p>
     #[serde(rename = "Timestamp")]
@@ -82,6 +83,7 @@ pub struct DescribeDimensionKeysRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeDimensionKeysResponse {
     /// <p>The end time for the returned dimension keys, after alignment to a granular boundary (as specified by <code>PeriodInSeconds</code>). <code>AlignedEndTime</code> will be greater than or equal to the value of the user-specified <code>Endtime</code>.</p>
     #[serde(rename = "AlignedEndTime")]
@@ -123,6 +125,7 @@ pub struct DimensionGroup {
 
 /// <p>An array of descriptions and aggregated values for each dimension within a dimension group.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DimensionKeyDescription {
     /// <p>A map of name-value pairs for the dimensions in the group.</p>
     #[serde(rename = "Dimensions")]
@@ -170,6 +173,7 @@ pub struct GetResourceMetricsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetResourceMetricsResponse {
     /// <p>The end time for the returned metrics, after alignment to a granular boundary (as specified by <code>PeriodInSeconds</code>). <code>AlignedEndTime</code> will be greater than or equal to the value of the user-specified <code>Endtime</code>.</p>
     #[serde(rename = "AlignedEndTime")]
@@ -195,6 +199,7 @@ pub struct GetResourceMetricsResponse {
 
 /// <p>A time-ordered series of data points, correpsonding to a dimension of a Performance Insights metric.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MetricKeyDataPoints {
     /// <p>An array of timestamp-value pairs, representing measurements over a period of time.</p>
     #[serde(rename = "DataPoints")]
@@ -224,6 +229,7 @@ pub struct MetricQuery {
 
 /// <p>If <code>PartitionBy</code> was specified in a <code>DescribeDimensionKeys</code> request, the dimensions are returned in an array. Each element in the array specifies one dimension. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResponsePartitionKey {
     /// <p>A dimension map that contains the dimension(s) for this partition.</p>
     #[serde(rename = "Dimensions")]
@@ -232,6 +238,7 @@ pub struct ResponsePartitionKey {
 
 /// <p>An object describing a Performance Insights metric and one or more dimensions for that metric.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResponseResourceMetricKey {
     /// <p>The valid dimensions for the metric.</p>
     #[serde(rename = "Dimensions")]

--- a/rusoto/services/polly/src/generated.rs
+++ b/rusoto/services/polly/src/generated.rs
@@ -37,6 +37,7 @@ pub struct DeleteLexiconInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteLexiconOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -52,6 +53,7 @@ pub struct DescribeVoicesInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeVoicesOutput {
     /// <p>The pagination token to use in the next request to continue the listing of voices. <code>NextToken</code> is returned only if the response is truncated.</p>
     #[serde(rename = "NextToken")]
@@ -71,6 +73,7 @@ pub struct GetLexiconInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetLexiconOutput {
     /// <p>Lexicon object that provides name and the string content of the lexicon. </p>
     #[serde(rename = "Lexicon")]
@@ -90,6 +93,7 @@ pub struct GetSpeechSynthesisTaskInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetSpeechSynthesisTaskOutput {
     /// <p>SynthesisTask object that provides information from the requested task, including output format, creation time, task status, and so on.</p>
     #[serde(rename = "SynthesisTask")]
@@ -99,6 +103,7 @@ pub struct GetSpeechSynthesisTaskOutput {
 
 /// <p>Provides lexicon name and lexicon content in string format. For more information, see <a href="https://www.w3.org/TR/pronunciation-lexicon/">Pronunciation Lexicon Specification (PLS) Version 1.0</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Lexicon {
     /// <p>Lexicon content in string format. The content of a lexicon must be in PLS format.</p>
     #[serde(rename = "Content")]
@@ -112,6 +117,7 @@ pub struct Lexicon {
 
 /// <p>Contains metadata describing the lexicon such as the number of lexemes, language code, and so on. For more information, see <a href="http://docs.aws.amazon.com/polly/latest/dg/managing-lexicons.html">Managing Lexicons</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LexiconAttributes {
     /// <p>Phonetic alphabet used in the lexicon. Valid values are <code>ipa</code> and <code>x-sampa</code>.</p>
     #[serde(rename = "Alphabet")]
@@ -141,6 +147,7 @@ pub struct LexiconAttributes {
 
 /// <p>Describes the content of the lexicon.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LexiconDescription {
     /// <p>Provides lexicon metadata.</p>
     #[serde(rename = "Attributes")]
@@ -161,6 +168,7 @@ pub struct ListLexiconsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListLexiconsOutput {
     /// <p>A list of lexicon names and attributes.</p>
     #[serde(rename = "Lexicons")]
@@ -189,6 +197,7 @@ pub struct ListSpeechSynthesisTasksInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListSpeechSynthesisTasksOutput {
     /// <p>An opaque pagination token returned from the previous List operation in this request. If present, this indicates where to continue the listing.</p>
     #[serde(rename = "NextToken")]
@@ -211,6 +220,7 @@ pub struct PutLexiconInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutLexiconOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -254,6 +264,7 @@ pub struct StartSpeechSynthesisTaskInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartSpeechSynthesisTaskOutput {
     /// <p>SynthesisTask object that provides information and attributes about a newly submitted speech synthesis task.</p>
     #[serde(rename = "SynthesisTask")]
@@ -263,6 +274,7 @@ pub struct StartSpeechSynthesisTaskOutput {
 
 /// <p>SynthesisTask object that provides information about a speech synthesis task.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SynthesisTask {
     /// <p>Timestamp for the time the synthesis task was started.</p>
     #[serde(rename = "CreationTime")]
@@ -359,6 +371,7 @@ pub struct SynthesizeSpeechOutput {
 
 /// <p>Description of the voice.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Voice {
     /// <p>Gender of the voice.</p>
     #[serde(rename = "Gender")]

--- a/rusoto/services/pricing/src/generated.rs
+++ b/rusoto/services/pricing/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>The values of a given attribute, such as <code>Throughput Optimized HDD</code> or <code>Provisioned IOPS</code> for the <code>Amazon EC2</code> <code>volumeType</code> attribute.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AttributeValue {
     /// <p>The specific value of an <code>attributeName</code>.</p>
     #[serde(rename = "Value")]
@@ -58,6 +59,7 @@ pub struct DescribeServicesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeServicesResponse {
     /// <p>The format version of the response. For example, <code>aws_v1</code>.</p>
     #[serde(rename = "FormatVersion")]
@@ -106,6 +108,7 @@ pub struct GetAttributeValuesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetAttributeValuesResponse {
     /// <p>The list of values for an attribute. For example, <code>Throughput Optimized HDD</code> and <code>Provisioned IOPS</code> are two available values for the <code>AmazonEC2</code> <code>volumeType</code>.</p>
     #[serde(rename = "AttributeValues")]
@@ -142,6 +145,7 @@ pub struct GetProductsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetProductsResponse {
     /// <p>The format version of the response. For example, aws_v1.</p>
     #[serde(rename = "FormatVersion")]
@@ -159,6 +163,7 @@ pub struct GetProductsResponse {
 
 /// <p>The metadata for a service, such as the service code and available attribute names.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Service {
     /// <p>The attributes that are available for this service.</p>
     #[serde(rename = "AttributeNames")]

--- a/rusoto/services/rekognition/src/generated.rs
+++ b/rusoto/services/rekognition/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Structure containing the estimated age range, in years, for a face.</p> <p>Rekognition estimates an age-range for faces detected in the input image. Estimated age ranges can overlap; a face of a 5 year old may have an estimated range of 4-6 whilst the face of a 6 year old may have an estimated range of 4-8.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AgeRange {
     /// <p>The highest estimated age.</p>
     #[serde(rename = "High")]
@@ -43,6 +44,7 @@ pub struct AgeRange {
 
 /// <p>Indicates whether or not the face has a beard, and the confidence level in the determination.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Beard {
     /// <p>Level of confidence in the determination.</p>
     #[serde(rename = "Confidence")]
@@ -56,6 +58,7 @@ pub struct Beard {
 
 /// <p><p>Identifies the bounding box around the object, face or text. The <code>left</code> (x-coordinate) and <code>top</code> (y-coordinate) are coordinates representing the top and left sides of the bounding box. Note that the upper-left corner of the image is the origin (0,0). </p> <p>The <code>top</code> and <code>left</code> values returned are ratios of the overall image size. For example, if the input image is 700x200 pixels, and the top-left coordinate of the bounding box is 350x50 pixels, the API returns a <code>left</code> value of 0.5 (350/700) and a <code>top</code> value of 0.25 (50/200).</p> <p>The <code>width</code> and <code>height</code> values represent the dimensions of the bounding box as a ratio of the overall image dimension. For example, if the input image is 700x200 pixels, and the bounding box width is 70 pixels, the width returned is 0.1. </p> <note> <p> The bounding box coordinates can have negative values. For example, if Amazon Rekognition is able to detect a face that is at the image edge and is only partially visible, the service can return coordinates that are outside the image bounds and, depending on the image edge, you might get negative values or values greater than 1 for the <code>left</code> or <code>top</code> values. </p> </note></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BoundingBox {
     /// <p>Height of the bounding box as a ratio of the overall image height.</p>
     #[serde(rename = "Height")]
@@ -77,6 +80,7 @@ pub struct BoundingBox {
 
 /// <p>Provides information about a celebrity recognized by the operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Celebrity {
     /// <p>Provides information about the celebrity's face, such as its location on the image.</p>
     #[serde(rename = "Face")]
@@ -102,6 +106,7 @@ pub struct Celebrity {
 
 /// <p>Information about a recognized celebrity.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CelebrityDetail {
     /// <p>Bounding box around the body of a celebrity.</p>
     #[serde(rename = "BoundingBox")]
@@ -131,6 +136,7 @@ pub struct CelebrityDetail {
 
 /// <p>Information about a detected celebrity and the time the celebrity was detected in a stored video. For more information, see GetCelebrityRecognition in the Amazon Rekognition Developer Guide.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CelebrityRecognition {
     /// <p>Information about a recognized celebrity.</p>
     #[serde(rename = "Celebrity")]
@@ -144,6 +150,7 @@ pub struct CelebrityRecognition {
 
 /// <p>Provides information about a face in a target image that matches the source image face analysed by <code>CompareFaces</code>. The <code>Face</code> property contains the bounding box of the face in the target image. The <code>Similarity</code> property is the confidence that the source image face matches the face in the bounding box.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CompareFacesMatch {
     /// <p>Provides face metadata (bounding box and confidence that the bounding box actually contains a face).</p>
     #[serde(rename = "Face")]
@@ -170,6 +177,7 @@ pub struct CompareFacesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CompareFacesResponse {
     /// <p>An array of faces in the target image that match the source image face. Each <code>CompareFacesMatch</code> object provides the bounding box, the confidence level that the bounding box contains a face, and the similarity score for the face in the bounding box and the face in the source image.</p>
     #[serde(rename = "FaceMatches")]
@@ -195,6 +203,7 @@ pub struct CompareFacesResponse {
 
 /// <p>Provides face metadata for target image faces that are analysed by <code>CompareFaces</code> and <code>RecognizeCelebrities</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ComparedFace {
     /// <p>Bounding box of the face.</p>
     #[serde(rename = "BoundingBox")]
@@ -220,6 +229,7 @@ pub struct ComparedFace {
 
 /// <p>Type that describes the face Amazon Rekognition chose to compare with the faces in the target. This contains a bounding box for the selected face and confidence level that the bounding box contains a face. Note that Amazon Rekognition selects the largest face in the source image for this comparison. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ComparedSourceImageFace {
     /// <p>Bounding box of the face.</p>
     #[serde(rename = "BoundingBox")]
@@ -233,6 +243,7 @@ pub struct ComparedSourceImageFace {
 
 /// <p>Information about a moderation label detection in a stored video.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ContentModerationDetection {
     /// <p>The moderation label detected by in the stored video.</p>
     #[serde(rename = "ModerationLabel")]
@@ -252,6 +263,7 @@ pub struct CreateCollectionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateCollectionResponse {
     /// <p>Amazon Resource Name (ARN) of the collection. You can use this to manage permissions on your resources. </p>
     #[serde(rename = "CollectionArn")]
@@ -287,6 +299,7 @@ pub struct CreateStreamProcessorRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateStreamProcessorResponse {
     /// <p>ARN for the newly create stream processor.</p>
     #[serde(rename = "StreamProcessorArn")]
@@ -302,6 +315,7 @@ pub struct DeleteCollectionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteCollectionResponse {
     /// <p>HTTP status code that indicates the result of the operation.</p>
     #[serde(rename = "StatusCode")]
@@ -320,6 +334,7 @@ pub struct DeleteFacesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteFacesResponse {
     /// <p>An array of strings (face IDs) of the faces that were deleted.</p>
     #[serde(rename = "DeletedFaces")]
@@ -335,6 +350,7 @@ pub struct DeleteStreamProcessorRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteStreamProcessorResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -345,6 +361,7 @@ pub struct DescribeStreamProcessorRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeStreamProcessorResponse {
     /// <p>Date and time the stream processor was created</p>
     #[serde(rename = "CreationTimestamp")]
@@ -400,6 +417,7 @@ pub struct DetectFacesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DetectFacesResponse {
     /// <p>Details of each face found in the image. </p>
     #[serde(rename = "FaceDetails")]
@@ -427,6 +445,7 @@ pub struct DetectLabelsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DetectLabelsResponse {
     /// <p>An array of labels for the real-world objects detected. </p>
     #[serde(rename = "Labels")]
@@ -450,6 +469,7 @@ pub struct DetectModerationLabelsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DetectModerationLabelsResponse {
     /// <p>Array of detected Moderation labels and the time, in millseconds from the start of the video, they were detected.</p>
     #[serde(rename = "ModerationLabels")]
@@ -465,6 +485,7 @@ pub struct DetectTextRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DetectTextResponse {
     /// <p>An array of text that was detected in the input image.</p>
     #[serde(rename = "TextDetections")]
@@ -474,6 +495,7 @@ pub struct DetectTextResponse {
 
 /// <p>The emotions detected on the face, and the confidence level in the determination. For example, HAPPY, SAD, and ANGRY.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Emotion {
     /// <p>Level of confidence in the determination.</p>
     #[serde(rename = "Confidence")]
@@ -487,6 +509,7 @@ pub struct Emotion {
 
 /// <p>Indicates whether or not the eyes on the face are open, and the confidence level in the determination.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EyeOpen {
     /// <p>Level of confidence in the determination.</p>
     #[serde(rename = "Confidence")]
@@ -500,6 +523,7 @@ pub struct EyeOpen {
 
 /// <p>Indicates whether or not the face is wearing eye glasses, and the confidence level in the determination.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Eyeglasses {
     /// <p>Level of confidence in the determination.</p>
     #[serde(rename = "Confidence")]
@@ -513,6 +537,7 @@ pub struct Eyeglasses {
 
 /// <p>Describes the face properties such as the bounding box, face ID, image ID of the input image, and external image ID that you assigned. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Face {
     /// <p>Bounding box of the face.</p>
     #[serde(rename = "BoundingBox")]
@@ -538,6 +563,7 @@ pub struct Face {
 
 /// <p>Structure containing attributes of the face that the algorithm detected.</p> <p>A <code>FaceDetail</code> object contains either the default facial attributes or all facial attributes. The default attributes are <code>BoundingBox</code>, <code>Confidence</code>, <code>Landmarks</code>, <code>Pose</code>, and <code>Quality</code>.</p> <p> is the only Amazon Rekognition Video stored video operation that can return a <code>FaceDetail</code> object with all attributes. To specify which attributes to return, use the <code>FaceAttributes</code> input parameter for . The following Amazon Rekognition Video operations return only the default attributes. The corresponding Start operations don't have a <code>FaceAttributes</code> input parameter.</p> <ul> <li> <p>GetCelebrityRecognition</p> </li> <li> <p>GetPersonTracking</p> </li> <li> <p>GetFaceSearch</p> </li> </ul> <p>The Amazon Rekognition Image and operations can return all facial attributes. To specify which attributes to return, use the <code>Attributes</code> input parameter for <code>DetectFaces</code>. For <code>IndexFaces</code>, use the <code>DetectAttributes</code> input parameter.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FaceDetail {
     /// <p>The estimated age range, in years, for the face. Low represents the lowest estimated age and High represents the highest estimated age.</p>
     #[serde(rename = "AgeRange")]
@@ -603,6 +629,7 @@ pub struct FaceDetail {
 
 /// <p>Information about a face detected in a video analysis request and the time the face was detected in the video. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FaceDetection {
     /// <p>The face properties for the detected face.</p>
     #[serde(rename = "Face")]
@@ -616,6 +643,7 @@ pub struct FaceDetection {
 
 /// <p>Provides face metadata. In addition, it also provides the confidence in the match of this face with the input face.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FaceMatch {
     /// <p>Describes the face properties such as the bounding box, face ID, image ID of the source image, and external image ID that you assigned.</p>
     #[serde(rename = "Face")]
@@ -629,6 +657,7 @@ pub struct FaceMatch {
 
 /// <p>Object containing both the face metadata (stored in the back-end database) and facial attributes that are detected but aren't stored in the database.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FaceRecord {
     /// <p>Describes the face properties such as the bounding box, face ID, image ID of the input image, and external image ID that you assigned. </p>
     #[serde(rename = "Face")]
@@ -655,6 +684,7 @@ pub struct FaceSearchSettings {
 
 /// <p>Gender of the face and the confidence level in the determination.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Gender {
     /// <p>Level of confidence in the determination.</p>
     #[serde(rename = "Confidence")]
@@ -668,6 +698,7 @@ pub struct Gender {
 
 /// <p>Information about where text detected by is located on an image.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Geometry {
     /// <p>An axis-aligned coarse representation of the detected text's location on the image.</p>
     #[serde(rename = "BoundingBox")]
@@ -687,6 +718,7 @@ pub struct GetCelebrityInfoRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetCelebrityInfoResponse {
     /// <p>The name of the celebrity.</p>
     #[serde(rename = "Name")]
@@ -718,6 +750,7 @@ pub struct GetCelebrityRecognitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetCelebrityRecognitionResponse {
     /// <p>Array of celebrities recognized in the video.</p>
     #[serde(rename = "Celebrities")]
@@ -761,6 +794,7 @@ pub struct GetContentModerationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetContentModerationResponse {
     /// <p>The current status of the content moderation job.</p>
     #[serde(rename = "JobStatus")]
@@ -800,6 +834,7 @@ pub struct GetFaceDetectionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetFaceDetectionResponse {
     /// <p>An array of faces detected in the video. Each element contains a detected face's details and the time, in milliseconds from the start of the video, the face was detected. </p>
     #[serde(rename = "Faces")]
@@ -843,6 +878,7 @@ pub struct GetFaceSearchRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetFaceSearchResponse {
     /// <p>The current status of the face search job.</p>
     #[serde(rename = "JobStatus")]
@@ -886,6 +922,7 @@ pub struct GetLabelDetectionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetLabelDetectionResponse {
     /// <p>The current status of the label detection job.</p>
     #[serde(rename = "JobStatus")]
@@ -929,6 +966,7 @@ pub struct GetPersonTrackingRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetPersonTrackingResponse {
     /// <p>The current status of the person tracking job.</p>
     #[serde(rename = "JobStatus")]
@@ -971,6 +1009,7 @@ pub struct Image {
 
 /// <p>Identifies face image brightness and sharpness. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ImageQuality {
     /// <p>Value representing brightness of the face. The service returns a value between 0 and 100 (inclusive). A higher value indicates a brighter face image.</p>
     #[serde(rename = "Brightness")]
@@ -1001,6 +1040,7 @@ pub struct IndexFacesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct IndexFacesResponse {
     /// <p>Version number of the face detection model associated with the input collection (<code>CollectionId</code>).</p>
     #[serde(rename = "FaceModelVersion")]
@@ -1036,6 +1076,7 @@ pub struct KinesisVideoStream {
 
 /// <p>Structure containing details about the detected label, including name, and level of confidence.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Label {
     /// <p>Level of confidence.</p>
     #[serde(rename = "Confidence")]
@@ -1049,6 +1090,7 @@ pub struct Label {
 
 /// <p>Information about a label detected in a video analysis request and the time the label was detected in the video. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LabelDetection {
     /// <p>Details about the detected label.</p>
     #[serde(rename = "Label")]
@@ -1062,6 +1104,7 @@ pub struct LabelDetection {
 
 /// <p>Indicates the location of the landmark on the face.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Landmark {
     /// <p>Type of the landmark.</p>
     #[serde(rename = "Type")]
@@ -1090,6 +1133,7 @@ pub struct ListCollectionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListCollectionsResponse {
     /// <p>An array of collection IDs.</p>
     #[serde(rename = "CollectionIds")]
@@ -1121,6 +1165,7 @@ pub struct ListFacesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListFacesResponse {
     /// <p>Version number of the face detection model associated with the input collection (<code>CollectionId</code>).</p>
     #[serde(rename = "FaceModelVersion")]
@@ -1149,6 +1194,7 @@ pub struct ListStreamProcessorsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListStreamProcessorsResponse {
     /// <p>If the response is truncated, Amazon Rekognition Video returns this token that you can use in the subsequent request to retrieve the next set of stream processors. </p>
     #[serde(rename = "NextToken")]
@@ -1162,6 +1208,7 @@ pub struct ListStreamProcessorsResponse {
 
 /// <p>Provides information about a single type of moderated content found in an image or video. Each type of moderated content has a label within a hierarchical taxonomy. For more information, see Detecting Unsafe Content in the Amazon Rekognition Developer Guide.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ModerationLabel {
     /// <p>Specifies the confidence that Amazon Rekognition has that the label has been correctly identified.</p> <p>If you don't specify the <code>MinConfidence</code> parameter in the call to <code>DetectModerationLabels</code>, the operation returns labels with a confidence value greater than or equal to 50 percent.</p>
     #[serde(rename = "Confidence")]
@@ -1179,6 +1226,7 @@ pub struct ModerationLabel {
 
 /// <p>Indicates whether or not the mouth on the face is open, and the confidence level in the determination.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MouthOpen {
     /// <p>Level of confidence in the determination.</p>
     #[serde(rename = "Confidence")]
@@ -1192,6 +1240,7 @@ pub struct MouthOpen {
 
 /// <p>Indicates whether or not the face has a mustache, and the confidence level in the determination.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Mustache {
     /// <p>Level of confidence in the determination.</p>
     #[serde(rename = "Confidence")]
@@ -1216,6 +1265,7 @@ pub struct NotificationChannel {
 
 /// <p>Details about a person detected in a video analysis request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PersonDetail {
     /// <p>Bounding box around the detected person.</p>
     #[serde(rename = "BoundingBox")]
@@ -1233,6 +1283,7 @@ pub struct PersonDetail {
 
 /// <p>Details and tracking information for a single time a person is tracked in a video. Amazon Rekognition operations that track persons return an array of <code>PersonDetection</code> objects with elements for each time a person is tracked in a video. </p> <p>For more information, see API_GetPersonTracking in the Amazon Rekognition Developer Guide. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PersonDetection {
     /// <p>Details about a person tracked in a video.</p>
     #[serde(rename = "Person")]
@@ -1246,6 +1297,7 @@ pub struct PersonDetection {
 
 /// <p>Information about a person whose face matches a face(s) in a Amazon Rekognition collection. Includes information about the faces in the Amazon Rekognition collection (, information about the person (<a>PersonDetail</a>) and the timestamp for when the person was detected in a video. An array of <code>PersonMatch</code> objects is returned by . </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PersonMatch {
     /// <p>Information about the faces in the input collection that match the face of a person in the video.</p>
     #[serde(rename = "FaceMatches")]
@@ -1263,6 +1315,7 @@ pub struct PersonMatch {
 
 /// <p>The X and Y coordinates of a point on an image. The X and Y values returned are ratios of the overall image size. For example, if the input image is 700x200 and the operation returns X=0.5 and Y=0.25, then the point is at the (350,50) pixel coordinate on the image.</p> <p>An array of <code>Point</code> objects, <code>Polygon</code>, is returned by . <code>Polygon</code> represents a fine-grained polygon around detected text. For more information, see Geometry in the Amazon Rekognition Developer Guide. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Point {
     /// <p>The value of the X coordinate for a point on a <code>Polygon</code>.</p>
     #[serde(rename = "X")]
@@ -1276,6 +1329,7 @@ pub struct Point {
 
 /// <p>Indicates the pose of the face as determined by its pitch, roll, and yaw.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Pose {
     /// <p>Value representing the face rotation on the pitch axis.</p>
     #[serde(rename = "Pitch")]
@@ -1299,6 +1353,7 @@ pub struct RecognizeCelebritiesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RecognizeCelebritiesResponse {
     /// <p>Details about each celebrity found in the image. Amazon Rekognition can detect a maximum of 15 celebrities in an image.</p>
     #[serde(rename = "CelebrityFaces")]
@@ -1350,6 +1405,7 @@ pub struct SearchFacesByImageRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SearchFacesByImageResponse {
     /// <p>An array of faces that match the input face, along with the confidence in the match.</p>
     #[serde(rename = "FaceMatches")]
@@ -1388,6 +1444,7 @@ pub struct SearchFacesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SearchFacesResponse {
     /// <p>An array of faces that matched the input face, along with the confidence in the match.</p>
     #[serde(rename = "FaceMatches")]
@@ -1405,6 +1462,7 @@ pub struct SearchFacesResponse {
 
 /// <p>Indicates whether or not the face is smiling, and the confidence level in the determination.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Smile {
     /// <p>Level of confidence in the determination.</p>
     #[serde(rename = "Confidence")]
@@ -1436,6 +1494,7 @@ pub struct StartCelebrityRecognitionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartCelebrityRecognitionResponse {
     /// <p>The identifier for the celebrity recognition analysis job. Use <code>JobId</code> to identify the job in a subsequent call to <code>GetCelebrityRecognition</code>.</p>
     #[serde(rename = "JobId")]
@@ -1467,6 +1526,7 @@ pub struct StartContentModerationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartContentModerationResponse {
     /// <p>The identifier for the content moderation analysis job. Use <code>JobId</code> to identify the job in a subsequent call to <code>GetContentModeration</code>.</p>
     #[serde(rename = "JobId")]
@@ -1498,6 +1558,7 @@ pub struct StartFaceDetectionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartFaceDetectionResponse {
     /// <p>The identifier for the face detection job. Use <code>JobId</code> to identify the job in a subsequent call to <code>GetFaceDetection</code>.</p>
     #[serde(rename = "JobId")]
@@ -1532,6 +1593,7 @@ pub struct StartFaceSearchRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartFaceSearchResponse {
     /// <p>The identifier for the search job. Use <code>JobId</code> to identify the job in a subsequent call to <code>GetFaceSearch</code>. </p>
     #[serde(rename = "JobId")]
@@ -1563,6 +1625,7 @@ pub struct StartLabelDetectionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartLabelDetectionResponse {
     /// <p>The identifier for the label detection job. Use <code>JobId</code> to identify the job in a subsequent call to <code>GetLabelDetection</code>. </p>
     #[serde(rename = "JobId")]
@@ -1590,6 +1653,7 @@ pub struct StartPersonTrackingRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartPersonTrackingResponse {
     /// <p>The identifier for the person detection job. Use <code>JobId</code> to identify the job in a subsequent call to <code>GetPersonTracking</code>.</p>
     #[serde(rename = "JobId")]
@@ -1605,6 +1669,7 @@ pub struct StartStreamProcessorRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartStreamProcessorResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1615,10 +1680,12 @@ pub struct StopStreamProcessorRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopStreamProcessorResponse {}
 
 /// <p>An object that recognizes faces in a streaming video. An Amazon Rekognition stream processor is created by a call to . The request parameters for <code>CreateStreamProcessor</code> describe the Kinesis video stream source for the streaming video, face recognition parameters, and where to stream the analysis resullts. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StreamProcessor {
     /// <p>Name of the Amazon Rekognition stream processor. </p>
     #[serde(rename = "Name")]
@@ -1659,6 +1726,7 @@ pub struct StreamProcessorSettings {
 
 /// <p>Indicates whether or not the face is wearing sunglasses, and the confidence level in the determination.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Sunglasses {
     /// <p>Level of confidence in the determination.</p>
     #[serde(rename = "Confidence")]
@@ -1672,6 +1740,7 @@ pub struct Sunglasses {
 
 /// <p>Information about a word or line of text detected by .</p> <p>The <code>DetectedText</code> field contains the text that Amazon Rekognition detected in the image. </p> <p>Every word and line has an identifier (<code>Id</code>). Each word belongs to a line and has a parent identifier (<code>ParentId</code>) that identifies the line of text in which the word appears. The word <code>Id</code> is also an index for the word within a line of words. </p> <p>For more information, see Detecting Text in the Amazon Rekognition Developer Guide.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TextDetection {
     /// <p>The confidence that Amazon Rekognition has in the accuracy of the detected text and the accuracy of the geometry points around the detected text.</p>
     #[serde(rename = "Confidence")]
@@ -1710,6 +1779,7 @@ pub struct Video {
 
 /// <p>Information about a video that Amazon Rekognition analyzed. <code>Videometadata</code> is returned in every page of paginated responses from a Amazon Rekognition video operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VideoMetadata {
     /// <p>Type of compression used in the analyzed video. </p>
     #[serde(rename = "Codec")]

--- a/rusoto/services/resourcegroupstaggingapi/src/generated.rs
+++ b/rusoto/services/resourcegroupstaggingapi/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Details of the common errors that all actions return.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FailureInfo {
     /// <p>The code of the common error. Valid values include <code>InternalServiceException</code>, <code>InvalidParameterException</code>, and any valid error code returned by the AWS service that hosts the resource that you want to tag.</p>
     #[serde(rename = "ErrorCode")]
@@ -70,6 +71,7 @@ pub struct GetResourcesInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetResourcesOutput {
     /// <p>A string that indicates that the response contains more data than can be returned in a single response. To receive additional data, specify this string for the <code>PaginationToken</code> value in a subsequent request.</p>
     #[serde(rename = "PaginationToken")]
@@ -90,6 +92,7 @@ pub struct GetTagKeysInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetTagKeysOutput {
     /// <p>A string that indicates that the response contains more data than can be returned in a single response. To receive additional data, specify this string for the <code>PaginationToken</code> value in a subsequent request.</p>
     #[serde(rename = "PaginationToken")]
@@ -113,6 +116,7 @@ pub struct GetTagValuesInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetTagValuesOutput {
     /// <p>A string that indicates that the response contains more data than can be returned in a single response. To receive additional data, specify this string for the <code>PaginationToken</code> value in a subsequent request.</p>
     #[serde(rename = "PaginationToken")]
@@ -126,6 +130,7 @@ pub struct GetTagValuesOutput {
 
 /// <p>A list of resource ARNs and the tags (keys and values) that are associated with each.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResourceTagMapping {
     /// <p>An array of resource ARN(s).</p>
     #[serde(rename = "ResourceARN")]
@@ -139,6 +144,7 @@ pub struct ResourceTagMapping {
 
 /// <p>The metadata that you apply to AWS resources to help you categorize and organize them. Each tag consists of a key and an optional value, both of which you define. For more information, see <a href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-basics">Tag Basics</a> in the <i>Amazon EC2 User Guide for Linux Instances</i>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Tag {
     /// <p>One part of a key-value pair that make up a tag. A key is a general label that acts like a category for more specific tag values.</p>
     #[serde(rename = "Key")]
@@ -172,6 +178,7 @@ pub struct TagResourcesInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TagResourcesOutput {
     /// <p>Details of resources that could not be tagged. An error code, status code, and error message are returned for each failed item.</p>
     #[serde(rename = "FailedResourcesMap")]
@@ -190,6 +197,7 @@ pub struct UntagResourcesInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UntagResourcesOutput {
     /// <p>Details of resources that could not be untagged. An error code, status code, and error message are returned for each failed item.</p>
     #[serde(rename = "FailedResourcesMap")]

--- a/rusoto/services/route53domains/src/generated.rs
+++ b/rusoto/services/route53domains/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Information for one billing record.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BillingRecord {
     /// <p>The date that the operation was billed, in Unix format.</p>
     #[serde(rename = "BillDate")]
@@ -67,6 +68,7 @@ pub struct CheckDomainAvailabilityRequest {
 
 /// <p>The CheckDomainAvailability response includes the following elements.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CheckDomainAvailabilityResponse {
     /// <p><p>Whether the domain name is available for registering.</p> <note> <p>You can register only domains designated as <code>AVAILABLE</code>.</p> </note> <p>Valid values:</p> <dl> <dt>AVAILABLE</dt> <dd> <p>The domain name is available.</p> </dd> <dt>AVAILABLE<em>RESERVED</dt> <dd> <p>The domain name is reserved under specific conditions.</p> </dd> <dt>AVAILABLE</em>PREORDER</dt> <dd> <p>The domain name is available and can be preordered.</p> </dd> <dt>DONT<em>KNOW</dt> <dd> <p>The TLD registry didn&#39;t reply with a definitive answer about whether the domain name is available. Amazon Route 53 can return this response for a variety of reasons, for example, the registry is performing maintenance. Try again later.</p> </dd> <dt>PENDING</dt> <dd> <p>The TLD registry didn&#39;t return a response in the expected amount of time. When the response is delayed, it usually takes just a few extra seconds. You can resubmit the request immediately.</p> </dd> <dt>RESERVED</dt> <dd> <p>The domain name has been reserved for another person or organization.</p> </dd> <dt>UNAVAILABLE</dt> <dd> <p>The domain name is not available.</p> </dd> <dt>UNAVAILABLE</em>PREMIUM</dt> <dd> <p>The domain name is not available.</p> </dd> <dt>UNAVAILABLE_RESTRICTED</dt> <dd> <p>The domain name is forbidden.</p> </dd> </dl></p>
     #[serde(rename = "Availability")]
@@ -87,6 +89,7 @@ pub struct CheckDomainTransferabilityRequest {
 
 /// <p>The CheckDomainTransferability response includes the following elements.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CheckDomainTransferabilityResponse {
     /// <p>A complex type that contains information about whether the specified domain can be transferred to Amazon Route 53.</p>
     #[serde(rename = "Transferability")]
@@ -166,6 +169,7 @@ pub struct DeleteTagsForDomainRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteTagsForDomainResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -176,6 +180,7 @@ pub struct DisableDomainAutoRenewRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisableDomainAutoRenewResponse {}
 
 /// <p>The DisableDomainTransferLock request includes the following element.</p>
@@ -188,6 +193,7 @@ pub struct DisableDomainTransferLockRequest {
 
 /// <p>The DisableDomainTransferLock response includes the following element.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisableDomainTransferLockResponse {
     /// <p>Identifier for tracking the progress of the request. To use this ID to query the operation status, use <a>GetOperationDetail</a>.</p>
     #[serde(rename = "OperationId")]
@@ -196,6 +202,7 @@ pub struct DisableDomainTransferLockResponse {
 
 /// <p>Information about one suggested domain name.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DomainSuggestion {
     /// <p><p>Whether the domain name is available for registering.</p> <note> <p>You can register only the domains that are designated as <code>AVAILABLE</code>.</p> </note> <p>Valid values:</p> <dl> <dt>AVAILABLE</dt> <dd> <p>The domain name is available.</p> </dd> <dt>AVAILABLE<em>RESERVED</dt> <dd> <p>The domain name is reserved under specific conditions.</p> </dd> <dt>AVAILABLE</em>PREORDER</dt> <dd> <p>The domain name is available and can be preordered.</p> </dd> <dt>DONT<em>KNOW</dt> <dd> <p>The TLD registry didn&#39;t reply with a definitive answer about whether the domain name is available. Amazon Route 53 can return this response for a variety of reasons, for example, the registry is performing maintenance. Try again later.</p> </dd> <dt>PENDING</dt> <dd> <p>The TLD registry didn&#39;t return a response in the expected amount of time. When the response is delayed, it usually takes just a few extra seconds. You can resubmit the request immediately.</p> </dd> <dt>RESERVED</dt> <dd> <p>The domain name has been reserved for another person or organization.</p> </dd> <dt>UNAVAILABLE</dt> <dd> <p>The domain name is not available.</p> </dd> <dt>UNAVAILABLE</em>PREMIUM</dt> <dd> <p>The domain name is not available.</p> </dd> <dt>UNAVAILABLE_RESTRICTED</dt> <dd> <p>The domain name is forbidden.</p> </dd> </dl></p>
     #[serde(rename = "Availability")]
@@ -209,6 +216,7 @@ pub struct DomainSuggestion {
 
 /// <p>Summary information about one domain.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DomainSummary {
     /// <p>Indicates whether the domain is automatically renewed upon expiration.</p>
     #[serde(rename = "AutoRenew")]
@@ -229,6 +237,7 @@ pub struct DomainSummary {
 
 /// <p>A complex type that contains information about whether the specified domain can be transferred to Amazon Route 53.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DomainTransferability {
     #[serde(rename = "Transferable")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -243,6 +252,7 @@ pub struct EnableDomainAutoRenewRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EnableDomainAutoRenewResponse {}
 
 /// <p>A request to set the transfer lock for the specified domain.</p>
@@ -255,6 +265,7 @@ pub struct EnableDomainTransferLockRequest {
 
 /// <p>The EnableDomainTransferLock response includes the following elements.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EnableDomainTransferLockResponse {
     /// <p>Identifier for tracking the progress of the request. To use this ID to query the operation status, use GetOperationDetail.</p>
     #[serde(rename = "OperationId")]
@@ -281,6 +292,7 @@ pub struct GetContactReachabilityStatusRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetContactReachabilityStatusResponse {
     /// <p>The domain name for which you requested the reachability status.</p>
     #[serde(rename = "domainName")]
@@ -302,6 +314,7 @@ pub struct GetDomainDetailRequest {
 
 /// <p>The GetDomainDetail response includes the following elements.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDomainDetailResponse {
     /// <p>Email address to contact to report incorrect contact information for a domain, to report that the domain is being used to send spam, to report that someone is cybersquatting on a domain name, or report some other type of abuse.</p>
     #[serde(rename = "AbuseContactEmail")]
@@ -398,6 +411,7 @@ pub struct GetDomainSuggestionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDomainSuggestionsResponse {
     /// <p>A list of possible domain names. If you specified <code>true</code> for <code>OnlyAvailable</code> in the request, the list contains only domains that are available for registration.</p>
     #[serde(rename = "SuggestionsList")]
@@ -415,6 +429,7 @@ pub struct GetOperationDetailRequest {
 
 /// <p>The GetOperationDetail response includes the following elements.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetOperationDetailResponse {
     /// <p>The name of a domain.</p>
     #[serde(rename = "DomainName")]
@@ -457,6 +472,7 @@ pub struct ListDomainsRequest {
 
 /// <p>The ListDomains response includes the following elements.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListDomainsResponse {
     /// <p>A summary of domains.</p>
     #[serde(rename = "Domains")]
@@ -486,6 +502,7 @@ pub struct ListOperationsRequest {
 
 /// <p>The ListOperations response includes the following elements.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListOperationsResponse {
     /// <p>If there are more operations than you specified for <code>MaxItems</code> in the request, submit another request and include the value of <code>NextPageMarker</code> in the value of <code>Marker</code>.</p>
     #[serde(rename = "NextPageMarker")]
@@ -506,6 +523,7 @@ pub struct ListTagsForDomainRequest {
 
 /// <p>The ListTagsForDomain response includes the following elements.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagsForDomainResponse {
     /// <p>A list of the tags that are associated with the specified domain.</p>
     #[serde(rename = "TagList")]
@@ -526,6 +544,7 @@ pub struct Nameserver {
 
 /// <p>OperationSummary includes the following elements.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct OperationSummary {
     /// <p>Identifier returned to track the requested action.</p>
     #[serde(rename = "OperationId")]
@@ -583,6 +602,7 @@ pub struct RegisterDomainRequest {
 
 /// <p>The RegisterDomain response includes the following element.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegisterDomainResponse {
     /// <p>Identifier for tracking the progress of the request. To use this ID to query the operation status, use <a>GetOperationDetail</a>.</p>
     #[serde(rename = "OperationId")]
@@ -605,6 +625,7 @@ pub struct RenewDomainRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RenewDomainResponse {
     /// <p>The identifier for tracking the progress of the request. To use this ID to query the operation status, use <a>GetOperationDetail</a>.</p>
     #[serde(rename = "OperationId")]
@@ -620,6 +641,7 @@ pub struct ResendContactReachabilityEmailRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResendContactReachabilityEmailResponse {
     /// <p>The domain name for which you requested a confirmation email.</p>
     #[serde(rename = "domainName")]
@@ -645,6 +667,7 @@ pub struct RetrieveDomainAuthCodeRequest {
 
 /// <p>The RetrieveDomainAuthCode response includes the following element.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RetrieveDomainAuthCodeResponse {
     /// <p>The authorization code for the domain.</p>
     #[serde(rename = "AuthCode")]
@@ -714,6 +737,7 @@ pub struct TransferDomainRequest {
 
 /// <p>The TranserDomain response includes the following element.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TransferDomainResponse {
     /// <p>Identifier for tracking the progress of the request. To use this ID to query the operation status, use <a>GetOperationDetail</a>.</p>
     #[serde(rename = "OperationId")]
@@ -742,6 +766,7 @@ pub struct UpdateDomainContactPrivacyRequest {
 
 /// <p>The UpdateDomainContactPrivacy response includes the following element.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateDomainContactPrivacyResponse {
     /// <p>Identifier for tracking the progress of the request. To use this ID to query the operation status, use GetOperationDetail.</p>
     #[serde(rename = "OperationId")]
@@ -770,6 +795,7 @@ pub struct UpdateDomainContactRequest {
 
 /// <p>The UpdateDomainContact response includes the following element.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateDomainContactResponse {
     /// <p>Identifier for tracking the progress of the request. To use this ID to query the operation status, use <a>GetOperationDetail</a>.</p>
     #[serde(rename = "OperationId")]
@@ -789,6 +815,7 @@ pub struct UpdateDomainNameserversRequest {
 
 /// <p>The UpdateDomainNameservers response includes the following element.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateDomainNameserversResponse {
     /// <p>Identifier for tracking the progress of the request. To use this ID to query the operation status, use <a>GetOperationDetail</a>.</p>
     #[serde(rename = "OperationId")]
@@ -808,6 +835,7 @@ pub struct UpdateTagsForDomainRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateTagsForDomainResponse {}
 
 /// <p>The ViewBilling request includes the following elements.</p>
@@ -833,6 +861,7 @@ pub struct ViewBillingRequest {
 
 /// <p>The ViewBilling response includes the following elements.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ViewBillingResponse {
     /// <p>A summary of billing records.</p>
     #[serde(rename = "BillingRecords")]

--- a/rusoto/services/sagemaker/src/generated.rs
+++ b/rusoto/services/sagemaker/src/generated.rs
@@ -39,6 +39,7 @@ pub struct AddTagsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddTagsOutput {
     /// <p>A list of tags associated with the Amazon SageMaker resource.</p>
     #[serde(rename = "Tags")]
@@ -144,6 +145,7 @@ pub struct CreateEndpointConfigInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateEndpointConfigOutput {
     /// <p>The Amazon Resource Name (ARN) of the endpoint configuration. </p>
     #[serde(rename = "EndpointConfigArn")]
@@ -165,6 +167,7 @@ pub struct CreateEndpointInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateEndpointOutput {
     /// <p>The Amazon Resource Name (ARN) of the endpoint.</p>
     #[serde(rename = "EndpointArn")]
@@ -189,6 +192,7 @@ pub struct CreateHyperParameterTuningJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateHyperParameterTuningJobResponse {
     /// <p>The Amazon Resource Name (ARN) of the tuning job.</p>
     #[serde(rename = "HyperParameterTuningJobArn")]
@@ -217,6 +221,7 @@ pub struct CreateModelInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateModelOutput {
     /// <p>The ARN of the model created in Amazon SageMaker.</p>
     #[serde(rename = "ModelArn")]
@@ -276,6 +281,7 @@ pub struct CreateNotebookInstanceLifecycleConfigInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateNotebookInstanceLifecycleConfigOutput {
     /// <p>The Amazon Resource Name (ARN) of the lifecycle configuration.</p>
     #[serde(rename = "NotebookInstanceLifecycleConfigArn")]
@@ -284,6 +290,7 @@ pub struct CreateNotebookInstanceLifecycleConfigOutput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateNotebookInstanceOutput {
     /// <p>The Amazon Resource Name (ARN) of the notebook instance. </p>
     #[serde(rename = "NotebookInstanceArn")]
@@ -303,6 +310,7 @@ pub struct CreatePresignedNotebookInstanceUrlInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreatePresignedNotebookInstanceUrlOutput {
     /// <p>A JSON object that contains the URL string. </p>
     #[serde(rename = "AuthorizedUrl")]
@@ -348,6 +356,7 @@ pub struct CreateTrainingJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateTrainingJobResponse {
     /// <p>The Amazon Resource Name (ARN) of the training job.</p>
     #[serde(rename = "TrainingJobArn")]
@@ -394,6 +403,7 @@ pub struct CreateTransformJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateTransformJobResponse {
     /// <p>The Amazon Resource Name (ARN) of the transform job.</p>
     #[serde(rename = "TransformJobArn")]
@@ -454,10 +464,12 @@ pub struct DeleteTagsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteTagsOutput {}
 
 /// <p>Gets the Amazon EC2 Container Registry path of the docker image of the model that is hosted in this <a>ProductionVariant</a>.</p> <p>If you used the <code>registry/repository[:tag]</code> form to to specify the image path of the primary container when you created the model hosted in this <code>ProductionVariant</code>, the path resolves to a path of the form <code>registry/repository[@digest]</code>. A digest is a hash value that identifies a specific version of an image. For information about Amazon ECR paths, see <a href="http://docs.aws.amazon.com//AmazonECR/latest/userguide/docker-pull-ecr-image.html">Pulling an Image</a> in the <i>Amazon ECR User Guide</i>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeployedImage {
     /// <p>The date and time when the image path for the model resolved to the <code>ResolvedImage</code> </p>
     #[serde(rename = "ResolutionTime")]
@@ -481,6 +493,7 @@ pub struct DescribeEndpointConfigInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEndpointConfigOutput {
     /// <p>A timestamp that shows when the endpoint configuration was created.</p>
     #[serde(rename = "CreationTime")]
@@ -508,6 +521,7 @@ pub struct DescribeEndpointInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEndpointOutput {
     /// <p>A timestamp that shows when the endpoint was created.</p>
     #[serde(rename = "CreationTime")]
@@ -545,6 +559,7 @@ pub struct DescribeHyperParameterTuningJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeHyperParameterTuningJobResponse {
     /// <p>A <a>TrainingJobSummary</a> object that describes the training job that completed with the best current <a>HyperParameterTuningJobObjective</a>.</p>
     #[serde(rename = "BestTrainingJob")]
@@ -596,6 +611,7 @@ pub struct DescribeModelInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeModelOutput {
     /// <p>A timestamp that shows when the model was created.</p>
     #[serde(rename = "CreationTime")]
@@ -633,6 +649,7 @@ pub struct DescribeNotebookInstanceLifecycleConfigInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeNotebookInstanceLifecycleConfigOutput {
     /// <p>A timestamp that tells when the lifecycle configuration was created.</p>
     #[serde(rename = "CreationTime")]
@@ -661,6 +678,7 @@ pub struct DescribeNotebookInstanceLifecycleConfigOutput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeNotebookInstanceOutput {
     /// <p>A timestamp. Use this parameter to return the time when the notebook instance was created</p>
     #[serde(rename = "CreationTime")]
@@ -732,6 +750,7 @@ pub struct DescribeTrainingJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeTrainingJobResponse {
     /// <p>Information about the algorithm used for training, and algorithm metadata. </p>
     #[serde(rename = "AlgorithmSpecification")]
@@ -813,6 +832,7 @@ pub struct DescribeTransformJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeTransformJobResponse {
     /// <p>SingleRecord means only one record was used per a batch. <code>MultiRecord</code> means batches contained as many records that could possibly fit within the <code>MaxPayloadInMB</code> limit.</p>
     #[serde(rename = "BatchStrategy")]
@@ -887,6 +907,7 @@ pub struct DesiredWeightAndCapacity {
 
 /// <p>Provides summary information for an endpoint configuration.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EndpointConfigSummary {
     /// <p>A timestamp that shows when the endpoint configuration was created.</p>
     #[serde(rename = "CreationTime")]
@@ -901,6 +922,7 @@ pub struct EndpointConfigSummary {
 
 /// <p>Provides summary information for an endpoint.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EndpointSummary {
     /// <p>A timestamp that shows when the endpoint was created.</p>
     #[serde(rename = "CreationTime")]
@@ -921,6 +943,7 @@ pub struct EndpointSummary {
 
 /// <p>Shows the final value for the objective metric for a training job that was launched by a hyperparameter tuning job. You define the objective metric in the <code>HyperParameterTuningJobObjective</code> parameter of <a>HyperParameterTuningJobConfig</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FinalHyperParameterTuningJobObjectiveMetric {
     /// <p>The name of the objective metric.</p>
     #[serde(rename = "MetricName")]
@@ -982,6 +1005,7 @@ pub struct HyperParameterTrainingJobDefinition {
 
 /// <p>Specifies summary information about a training job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct HyperParameterTrainingJobSummary {
     /// <p>The date and time that the training job was created.</p>
     #[serde(rename = "CreationTime")]
@@ -1051,6 +1075,7 @@ pub struct HyperParameterTuningJobObjective {
 
 /// <p>Provides summary information about a hyperparameter tuning job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct HyperParameterTuningJobSummary {
     /// <p>The date and time that the tuning job was created.</p>
     #[serde(rename = "CreationTime")]
@@ -1134,6 +1159,7 @@ pub struct ListEndpointConfigsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListEndpointConfigsOutput {
     /// <p>An array of endpoint configurations.</p>
     #[serde(rename = "EndpointConfigs")]
@@ -1189,6 +1215,7 @@ pub struct ListEndpointsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListEndpointsOutput {
     /// <p> An array or endpoint objects. </p>
     #[serde(rename = "Endpoints")]
@@ -1244,6 +1271,7 @@ pub struct ListHyperParameterTuningJobsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListHyperParameterTuningJobsResponse {
     /// <p>A list of <a>HyperParameterTuningJobSummary</a> objects that describe the tuning jobs that the <code>ListHyperParameterTuningJobs</code> request returned.</p>
     #[serde(rename = "HyperParameterTuningJobSummaries")]
@@ -1287,6 +1315,7 @@ pub struct ListModelsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListModelsOutput {
     /// <p>An array of <code>ModelSummary</code> objects, each of which lists a model.</p>
     #[serde(rename = "Models")]
@@ -1338,6 +1367,7 @@ pub struct ListNotebookInstanceLifecycleConfigsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListNotebookInstanceLifecycleConfigsOutput {
     /// <p>If the response is truncated, Amazon SageMaker returns this token. To get the next set of lifecycle configurations, use it in the next request. </p>
     #[serde(rename = "NextToken")]
@@ -1398,6 +1428,7 @@ pub struct ListNotebookInstancesInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListNotebookInstancesOutput {
     /// <p>If the response to the previous <code>ListNotebookInstances</code> request was truncated, Amazon SageMaker returns this token. To retrieve the next set of notebook instances, use the token in the next request.</p>
     #[serde(rename = "NextToken")]
@@ -1425,6 +1456,7 @@ pub struct ListTagsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagsOutput {
     /// <p> If response is truncated, Amazon SageMaker includes a token in the response. You can use this token in your subsequent request to fetch next set of tokens. </p>
     #[serde(rename = "NextToken")]
@@ -1464,6 +1496,7 @@ pub struct ListTrainingJobsForHyperParameterTuningJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTrainingJobsForHyperParameterTuningJobResponse {
     /// <p>If the result of this <code>ListTrainingJobsForHyperParameterTuningJob</code> request was truncated, the response includes a <code>NextToken</code>. To retrieve the next set of training jobs, use the token in the next request.</p>
     #[serde(rename = "NextToken")]
@@ -1519,6 +1552,7 @@ pub struct ListTrainingJobsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTrainingJobsResponse {
     /// <p>If the response is truncated, Amazon SageMaker returns this token. To retrieve the next set of training jobs, use it in the subsequent request.</p>
     #[serde(rename = "NextToken")]
@@ -1574,6 +1608,7 @@ pub struct ListTransformJobsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTransformJobsResponse {
     /// <p>If the response is truncated, Amazon SageMaker returns this token. To retrieve the next set of transform jobs, use it in the next request.</p>
     #[serde(rename = "NextToken")]
@@ -1597,6 +1632,7 @@ pub struct MetricDefinition {
 
 /// <p>Provides information about the location that is configured for storing model artifacts. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ModelArtifacts {
     /// <p>The path of the S3 object that contains the model artifacts. For example, <code>s3://bucket-name/keynameprefix/model.tar.gz</code>.</p>
     #[serde(rename = "S3ModelArtifacts")]
@@ -1605,6 +1641,7 @@ pub struct ModelArtifacts {
 
 /// <p>Provides summary information about a model.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ModelSummary {
     /// <p>A timestamp that indicates when the model was created.</p>
     #[serde(rename = "CreationTime")]
@@ -1619,6 +1656,7 @@ pub struct ModelSummary {
 
 /// <p>Provides a summary of a notebook instance lifecycle configuration.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct NotebookInstanceLifecycleConfigSummary {
     /// <p>A timestamp that tells when the lifecycle configuration was created.</p>
     #[serde(rename = "CreationTime")]
@@ -1647,6 +1685,7 @@ pub struct NotebookInstanceLifecycleHook {
 
 /// <p>Provides summary information for an Amazon SageMaker notebook instance.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct NotebookInstanceSummary {
     /// <p>A timestamp that shows when the notebook instance was created.</p>
     #[serde(rename = "CreationTime")]
@@ -1682,6 +1721,7 @@ pub struct NotebookInstanceSummary {
 
 /// <p>Specifies the number of training jobs that this hyperparameter tuning job launched, categorized by the status of their objective metric. The objective metric status shows whether the final objective metric for the training job has been evaluated by the tuning job and used in the hyperparameter tuning process.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ObjectiveStatusCounters {
     /// <p>The number of training jobs whose final objective metric was not evaluated and used in the hyperparameter tuning process. This typically occurs when the training job failed or did not emit an objective metric.</p>
     #[serde(rename = "Failed")]
@@ -1749,6 +1789,7 @@ pub struct ProductionVariant {
 
 /// <p>Describes weight and capacities for a production variant associated with an endpoint. If you sent a request to the <code>UpdateEndpointWeightsAndCapacities</code> API and the endpoint status is <code>Updating</code>, you get different desired and current values. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ProductionVariantSummary {
     /// <p>The number of instances associated with the variant.</p>
     #[serde(rename = "CurrentInstanceCount")]
@@ -1821,6 +1862,7 @@ pub struct S3DataSource {
 
 /// <p>Specifies a secondary status the job has transitioned into. It includes a start timestamp and later an end timestamp. The end timestamp is added either after the job transitions to a different secondary status or after the job has ended.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SecondaryStatusTransition {
     /// <p>A timestamp that shows when the secondary status has ended and the job has transitioned into another secondary status. The <code>EndTime</code> timestamp is also set after the training job has ended.</p>
     #[serde(rename = "EndTime")]
@@ -1895,6 +1937,7 @@ pub struct Tag {
 
 /// <p>The numbers of training jobs launched by a hyperparameter tuning job, categorized by status.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TrainingJobStatusCounters {
     /// <p>The number of completed training jobs launched by a hyperparameter tuning job.</p>
     #[serde(rename = "Completed")]
@@ -1920,6 +1963,7 @@ pub struct TrainingJobStatusCounters {
 
 /// <p>Provides summary information about a training job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TrainingJobSummary {
     /// <p>A timestamp that shows when the training job was created.</p>
     #[serde(rename = "CreationTime")]
@@ -1973,6 +2017,7 @@ pub struct TransformInput {
 
 /// <p>Provides a summary information for a transform job. Multiple TransformJobSummary objects are returned as a list after calling <a>ListTransformJobs</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TransformJobSummary {
     /// <p>A timestamp that shows when the transform Job was created.</p>
     #[serde(rename = "CreationTime")]
@@ -2053,6 +2098,7 @@ pub struct UpdateEndpointInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateEndpointOutput {
     /// <p>The Amazon Resource Name (ARN) of the endpoint.</p>
     #[serde(rename = "EndpointArn")]
@@ -2070,6 +2116,7 @@ pub struct UpdateEndpointWeightsAndCapacitiesInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateEndpointWeightsAndCapacitiesOutput {
     /// <p>The Amazon Resource Name (ARN) of the updated endpoint.</p>
     #[serde(rename = "EndpointArn")]
@@ -2107,9 +2154,11 @@ pub struct UpdateNotebookInstanceLifecycleConfigInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateNotebookInstanceLifecycleConfigOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateNotebookInstanceOutput {}
 
 /// <p>Specifies a VPC that your training jobs and hosted models have access to. Control access to and from your training and model containers by configuring the VPC. For more information, see <a>host-vpc</a> and <a>train-vpc</a>.</p>

--- a/rusoto/services/secretsmanager/src/generated.rs
+++ b/rusoto/services/secretsmanager/src/generated.rs
@@ -36,6 +36,7 @@ pub struct CancelRotateSecretRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CancelRotateSecretResponse {
     /// <p>The ARN of the secret for which rotation was canceled.</p>
     #[serde(rename = "ARN")]
@@ -87,6 +88,7 @@ pub struct CreateSecretRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateSecretResponse {
     /// <p><p>The Amazon Resource Name (ARN) of the secret that you just created.</p> <note> <p>Secrets Manager automatically adds several random characters to the name at the end of the ARN when you initially create a secret. This affects only the ARN and not the actual friendly name. This ensures that if you create a new secret with the same name as an old secret that you previously deleted, then users with access to the old secret <i>don&#39;t</i> automatically get access to the new secret because the ARNs are different.</p> </note></p>
     #[serde(rename = "ARN")]
@@ -110,6 +112,7 @@ pub struct DeleteResourcePolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteResourcePolicyResponse {
     /// <p>The ARN of the secret that the resource-based policy was deleted for.</p>
     #[serde(rename = "ARN")]
@@ -133,6 +136,7 @@ pub struct DeleteSecretRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteSecretResponse {
     /// <p>The ARN of the secret that is now scheduled for deletion.</p>
     #[serde(rename = "ARN")]
@@ -156,6 +160,7 @@ pub struct DescribeSecretRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeSecretResponse {
     /// <p>The ARN of the secret.</p>
     #[serde(rename = "ARN")]
@@ -248,6 +253,7 @@ pub struct GetRandomPasswordRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetRandomPasswordResponse {
     /// <p>A string with the generated password.</p>
     #[serde(rename = "RandomPassword")]
@@ -263,6 +269,7 @@ pub struct GetResourcePolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetResourcePolicyResponse {
     /// <p>The ARN of the secret that the resource-based policy was retrieved for.</p>
     #[serde(rename = "ARN")]
@@ -294,6 +301,7 @@ pub struct GetSecretValueRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetSecretValueResponse {
     /// <p>The ARN of the secret.</p>
     #[serde(rename = "ARN")]
@@ -349,6 +357,7 @@ pub struct ListSecretVersionIdsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListSecretVersionIdsResponse {
     /// <p><p>The Amazon Resource Name (ARN) for the secret.</p> <note> <p>Secrets Manager automatically adds several random characters to the name at the end of the ARN when you initially create a secret. This affects only the ARN and not the actual friendly name. This ensures that if you create a new secret with the same name as an old secret that you previously deleted, then users with access to the old secret <i>don&#39;t</i> automatically get access to the new secret because the ARNs are different.</p> </note></p>
     #[serde(rename = "ARN")]
@@ -381,6 +390,7 @@ pub struct ListSecretsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListSecretsResponse {
     /// <p>If present in the response, this value indicates that there's more output available than what's included in the current response. This can occur even when the response includes no values at all, such as when you ask for a filtered view of a very long list. Use this value in the <code>NextToken</code> request parameter in a subsequent call to the operation to continue processing and get the next part of the output. You should repeat this until the <code>NextToken</code> response element comes back empty (as <code>null</code>).</p>
     #[serde(rename = "NextToken")]
@@ -403,6 +413,7 @@ pub struct PutResourcePolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutResourcePolicyResponse {
     /// <p>The ARN of the secret that the resource-based policy was retrieved for.</p>
     #[serde(rename = "ARN")]
@@ -442,6 +453,7 @@ pub struct PutSecretValueRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutSecretValueResponse {
     /// <p>The Amazon Resource Name (ARN) for the secret for which you just created a version.</p>
     #[serde(rename = "ARN")]
@@ -469,6 +481,7 @@ pub struct RestoreSecretRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RestoreSecretResponse {
     /// <p>The ARN of the secret that was restored.</p>
     #[serde(rename = "ARN")]
@@ -500,6 +513,7 @@ pub struct RotateSecretRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RotateSecretResponse {
     /// <p>The ARN of the secret.</p>
     #[serde(rename = "ARN")]
@@ -526,6 +540,7 @@ pub struct RotationRulesType {
 
 /// <p>A structure that contains the details about a secret. It does not include the encrypted <code>SecretString</code> and <code>SecretBinary</code> values. To get those values, use the <a>GetSecretValue</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SecretListEntry {
     /// <p>The Amazon Resource Name (ARN) of the secret.</p> <p>For more information about ARNs in Secrets Manager, see <a href="http://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_iam-permissions.html#iam-resources">Policy Resources</a> in the <i>AWS Secrets Manager User Guide</i>.</p>
     #[serde(rename = "ARN")]
@@ -583,6 +598,7 @@ pub struct SecretListEntry {
 
 /// <p>A structure that contains information about one version of a secret.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SecretVersionsListEntry {
     /// <p>The date and time this version of the secret was created.</p>
     #[serde(rename = "CreatedDate")]
@@ -667,6 +683,7 @@ pub struct UpdateSecretRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateSecretResponse {
     /// <p><p>The ARN of this secret.</p> <note> <p>Secrets Manager automatically adds several random characters to the name at the end of the ARN when you initially create a secret. This affects only the ARN and not the actual friendly name. This ensures that if you create a new secret with the same name as an old secret that you previously deleted, then users with access to the old secret <i>don&#39;t</i> automatically get access to the new secret because the ARNs are different.</p> </note></p>
     #[serde(rename = "ARN")]
@@ -701,6 +718,7 @@ pub struct UpdateSecretVersionStageRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateSecretVersionStageResponse {
     /// <p>The ARN of the secret with the staging labels that were modified.</p>
     #[serde(rename = "ARN")]

--- a/rusoto/services/serverlessrepo/src/generated.rs
+++ b/rusoto/services/serverlessrepo/src/generated.rs
@@ -90,6 +90,7 @@ pub struct ApplicationPolicyStatement {
 
 /// <p>Summary of details about the application.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ApplicationSummary {
     /// <p>The application Amazon Resource Name (ARN).</p>
     #[serde(rename = "ApplicationId")]
@@ -249,6 +250,7 @@ pub struct CreateApplicationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateApplicationResponse {
     /// <p>The application Amazon Resource Name (ARN).</p>
     #[serde(rename = "ApplicationId")]
@@ -331,6 +333,7 @@ pub struct CreateApplicationVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateApplicationVersionResponse {
     /// <p>The application Amazon Resource Name (ARN).</p>
     #[serde(rename = "ApplicationId")]
@@ -398,6 +401,7 @@ pub struct CreateCloudFormationChangeSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateCloudFormationChangeSetResponse {
     /// <p>The application Amazon Resource Name (ARN).</p>
     #[serde(rename = "ApplicationId")]
@@ -434,6 +438,7 @@ pub struct GetApplicationPolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetApplicationPolicyResponse {
     /// <p>An array of policy statements applied to the application.</p>
     #[serde(rename = "Statements")]
@@ -453,6 +458,7 @@ pub struct GetApplicationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetApplicationResponse {
     /// <p>The application Amazon Resource Name (ARN).</p>
     #[serde(rename = "ApplicationId")]
@@ -517,6 +523,7 @@ pub struct ListApplicationVersionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListApplicationVersionsResponse {
     /// <p>The token to request the next page of results.</p>
     #[serde(rename = "NextToken")]
@@ -541,6 +548,7 @@ pub struct ListApplicationsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListApplicationsResponse {
     /// <p>An array of application summaries.</p>
     #[serde(rename = "Applications")]
@@ -554,6 +562,7 @@ pub struct ListApplicationsResponse {
 
 /// <p>Parameters supported by the application.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ParameterDefinition {
     /// <p>A regular expression that represents the patterns to allow for String types.</p>
     #[serde(rename = "AllowedPattern")]
@@ -647,6 +656,7 @@ pub struct PutApplicationPolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutApplicationPolicyResponse {
     /// <p>An array of policy statements applied to the application.</p>
     #[serde(rename = "Statements")]
@@ -705,6 +715,7 @@ pub struct UpdateApplicationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateApplicationResponse {
     /// <p>The application Amazon Resource Name (ARN).</p>
     #[serde(rename = "ApplicationId")]
@@ -755,6 +766,7 @@ pub struct UpdateApplicationResponse {
 
 /// <p>Application version details.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Version {
     /// <p>The application Amazon Resource Name (ARN).</p>
     #[serde(rename = "ApplicationId")]
@@ -781,6 +793,7 @@ pub struct Version {
 
 /// <p>An application version summary.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VersionSummary {
     /// <p>The application Amazon Resource Name (ARN).</p>
     #[serde(rename = "ApplicationId")]

--- a/rusoto/services/servicecatalog/src/generated.rs
+++ b/rusoto/services/servicecatalog/src/generated.rs
@@ -40,6 +40,7 @@ pub struct AcceptPortfolioShareInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AcceptPortfolioShareOutput {}
 
 /// <p>The access level to use to filter results.</p>
@@ -73,6 +74,7 @@ pub struct AssociatePrincipalWithPortfolioInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociatePrincipalWithPortfolioOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -94,6 +96,7 @@ pub struct AssociateProductWithPortfolioInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociateProductWithPortfolioOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -107,10 +110,12 @@ pub struct AssociateTagOptionWithResourceInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociateTagOptionWithResourceOutput {}
 
 /// <p>Information about a CloudWatch dashboard.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CloudWatchDashboard {
     /// <p>The name of the CloudWatch dashboard.</p>
     #[serde(rename = "Name")]
@@ -120,6 +125,7 @@ pub struct CloudWatchDashboard {
 
 /// <p>Information about a constraint.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ConstraintDetail {
     /// <p>The identifier of the constraint.</p>
     #[serde(rename = "ConstraintId")]
@@ -141,6 +147,7 @@ pub struct ConstraintDetail {
 
 /// <p>Summary information about a constraint.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ConstraintSummary {
     /// <p>The description of the constraint.</p>
     #[serde(rename = "Description")]
@@ -184,6 +191,7 @@ pub struct CopyProductInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CopyProductOutput {
     /// <p>The token to use to track the progress of the operation.</p>
     #[serde(rename = "CopyProductToken")]
@@ -219,6 +227,7 @@ pub struct CreateConstraintInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateConstraintOutput {
     /// <p>Information about the constraint.</p>
     #[serde(rename = "ConstraintDetail")]
@@ -260,6 +269,7 @@ pub struct CreatePortfolioInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreatePortfolioOutput {
     /// <p>Information about the portfolio.</p>
     #[serde(rename = "PortfolioDetail")]
@@ -286,6 +296,7 @@ pub struct CreatePortfolioShareInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreatePortfolioShareOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -336,6 +347,7 @@ pub struct CreateProductInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateProductOutput {
     /// <p>Information about the product view.</p>
     #[serde(rename = "ProductViewDetail")]
@@ -394,6 +406,7 @@ pub struct CreateProvisionedProductPlanInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateProvisionedProductPlanOutput {
     /// <p>The plan identifier.</p>
     #[serde(rename = "PlanId")]
@@ -435,6 +448,7 @@ pub struct CreateProvisioningArtifactInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateProvisioningArtifactOutput {
     /// <p>The URL of the CloudFormation template in Amazon S3, in JSON format.</p>
     #[serde(rename = "Info")]
@@ -461,6 +475,7 @@ pub struct CreateTagOptionInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateTagOptionOutput {
     /// <p>Information about the TagOption.</p>
     #[serde(rename = "TagOptionDetail")]
@@ -480,6 +495,7 @@ pub struct DeleteConstraintInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteConstraintOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -494,6 +510,7 @@ pub struct DeletePortfolioInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeletePortfolioOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -511,6 +528,7 @@ pub struct DeletePortfolioShareInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeletePortfolioShareOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -525,6 +543,7 @@ pub struct DeleteProductInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteProductOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -543,6 +562,7 @@ pub struct DeleteProvisionedProductPlanInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteProvisionedProductPlanOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -560,6 +580,7 @@ pub struct DeleteProvisioningArtifactInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteProvisioningArtifactOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -570,6 +591,7 @@ pub struct DeleteTagOptionInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteTagOptionOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -584,6 +606,7 @@ pub struct DescribeConstraintInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeConstraintOutput {
     /// <p>Information about the constraint.</p>
     #[serde(rename = "ConstraintDetail")]
@@ -611,6 +634,7 @@ pub struct DescribeCopyProductStatusInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeCopyProductStatusOutput {
     /// <p>The status of the copy product operation.</p>
     #[serde(rename = "CopyProductStatus")]
@@ -638,6 +662,7 @@ pub struct DescribePortfolioInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribePortfolioOutput {
     /// <p>Information about the portfolio.</p>
     #[serde(rename = "PortfolioDetail")]
@@ -665,6 +690,7 @@ pub struct DescribeProductAsAdminInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeProductAsAdminOutput {
     /// <p>Information about the product view.</p>
     #[serde(rename = "ProductViewDetail")]
@@ -696,6 +722,7 @@ pub struct DescribeProductInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeProductOutput {
     /// <p>Summary information about the product view.</p>
     #[serde(rename = "ProductViewSummary")]
@@ -719,6 +746,7 @@ pub struct DescribeProductViewInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeProductViewOutput {
     /// <p>Summary information about the product.</p>
     #[serde(rename = "ProductViewSummary")]
@@ -742,6 +770,7 @@ pub struct DescribeProvisionedProductInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeProvisionedProductOutput {
     /// <p>Any CloudWatch dashboards that were created when provisioning the product.</p>
     #[serde(rename = "CloudWatchDashboards")]
@@ -773,6 +802,7 @@ pub struct DescribeProvisionedProductPlanInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeProvisionedProductPlanOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -807,6 +837,7 @@ pub struct DescribeProvisioningArtifactInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeProvisioningArtifactOutput {
     /// <p>The URL of the CloudFormation template in Amazon S3.</p>
     #[serde(rename = "Info")]
@@ -841,6 +872,7 @@ pub struct DescribeProvisioningParametersInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeProvisioningParametersOutput {
     /// <p>Information about the constraints used to provision the product.</p>
     #[serde(rename = "ConstraintSummaries")]
@@ -880,6 +912,7 @@ pub struct DescribeRecordInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeRecordOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -903,6 +936,7 @@ pub struct DescribeTagOptionInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeTagOptionOutput {
     /// <p>Information about the TagOption.</p>
     #[serde(rename = "TagOptionDetail")]
@@ -925,6 +959,7 @@ pub struct DisassociatePrincipalFromPortfolioInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisassociatePrincipalFromPortfolioOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -942,6 +977,7 @@ pub struct DisassociateProductFromPortfolioInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisassociateProductFromPortfolioOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -955,6 +991,7 @@ pub struct DisassociateTagOptionFromResourceInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisassociateTagOptionFromResourceOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -972,6 +1009,7 @@ pub struct ExecuteProvisionedProductPlanInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ExecuteProvisionedProductPlanOutput {
     /// <p>Information about the result of provisioning the product.</p>
     #[serde(rename = "RecordDetail")]
@@ -981,6 +1019,7 @@ pub struct ExecuteProvisionedProductPlanOutput {
 
 /// <p>Summary information about a product path for a user.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LaunchPathSummary {
     /// <p>The constraints on the portfolio-product relationship.</p>
     #[serde(rename = "ConstraintSummaries")]
@@ -1021,6 +1060,7 @@ pub struct ListAcceptedPortfolioSharesInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAcceptedPortfolioSharesOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -1056,6 +1096,7 @@ pub struct ListConstraintsForPortfolioInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListConstraintsForPortfolioOutput {
     /// <p>Information about the constraints.</p>
     #[serde(rename = "ConstraintDetails")]
@@ -1087,6 +1128,7 @@ pub struct ListLaunchPathsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListLaunchPathsOutput {
     /// <p>Information about the launch path.</p>
     #[serde(rename = "LaunchPathSummaries")]
@@ -1110,6 +1152,7 @@ pub struct ListPortfolioAccessInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListPortfolioAccessOutput {
     /// <p>Information about the AWS accounts with access to the portfolio.</p>
     #[serde(rename = "AccountIds")]
@@ -1141,6 +1184,7 @@ pub struct ListPortfoliosForProductInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListPortfoliosForProductOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -1169,6 +1213,7 @@ pub struct ListPortfoliosInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListPortfoliosOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -1200,6 +1245,7 @@ pub struct ListPrincipalsForPortfolioInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListPrincipalsForPortfolioOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -1236,6 +1282,7 @@ pub struct ListProvisionedProductPlansInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListProvisionedProductPlansOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -1259,6 +1306,7 @@ pub struct ListProvisioningArtifactsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListProvisioningArtifactsOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -1295,6 +1343,7 @@ pub struct ListRecordHistoryInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListRecordHistoryOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -1339,6 +1388,7 @@ pub struct ListResourcesForTagOptionInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListResourcesForTagOptionOutput {
     /// <p>The page token for the next set of results. To retrieve the first set of results, use null.</p>
     #[serde(rename = "PageToken")]
@@ -1384,6 +1434,7 @@ pub struct ListTagOptionsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagOptionsOutput {
     /// <p>The page token for the next set of results. To retrieve the first set of results, use null.</p>
     #[serde(rename = "PageToken")]
@@ -1397,6 +1448,7 @@ pub struct ListTagOptionsOutput {
 
 /// <p>The constraints that the administrator has put on the parameter.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ParameterConstraints {
     /// <p>The values that the administrator has allowed for the parameter.</p>
     #[serde(rename = "AllowedValues")]
@@ -1406,6 +1458,7 @@ pub struct ParameterConstraints {
 
 /// <p>Information about a portfolio.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PortfolioDetail {
     /// <p>The ARN assigned to the portfolio.</p>
     #[serde(rename = "ARN")]
@@ -1435,6 +1488,7 @@ pub struct PortfolioDetail {
 
 /// <p>Information about a principal.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Principal {
     /// <p>The ARN of the principal (IAM user, role, or group).</p>
     #[serde(rename = "PrincipalARN")]
@@ -1448,6 +1502,7 @@ pub struct Principal {
 
 /// <p>A single product view aggregation value/count pair, containing metadata about each product to which the calling user has access.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ProductViewAggregationValue {
     /// <p>An approximate count of the products that match the value.</p>
     #[serde(rename = "ApproximateCount")]
@@ -1461,6 +1516,7 @@ pub struct ProductViewAggregationValue {
 
 /// <p>Information about a product view.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ProductViewDetail {
     /// <p>The UTC time stamp of the creation time.</p>
     #[serde(rename = "CreatedTime")]
@@ -1482,6 +1538,7 @@ pub struct ProductViewDetail {
 
 /// <p>Summary information about a product view.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ProductViewSummary {
     /// <p>The distributor of the product. Contact the product administrator for the significance of this value.</p>
     #[serde(rename = "Distributor")]
@@ -1566,6 +1623,7 @@ pub struct ProvisionProductInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ProvisionProductOutput {
     /// <p>Information about the result of provisioning the product.</p>
     #[serde(rename = "RecordDetail")]
@@ -1575,6 +1633,7 @@ pub struct ProvisionProductOutput {
 
 /// <p>Information about a provisioned product.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ProvisionedProductAttribute {
     /// <p>The ARN of the provisioned product.</p>
     #[serde(rename = "Arn")]
@@ -1640,6 +1699,7 @@ pub struct ProvisionedProductAttribute {
 
 /// <p>Information about a provisioned product.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ProvisionedProductDetail {
     /// <p>The ARN of the provisioned product.</p>
     #[serde(rename = "Arn")]
@@ -1681,6 +1741,7 @@ pub struct ProvisionedProductDetail {
 
 /// <p>Information about a plan.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ProvisionedProductPlanDetails {
     /// <p>The UTC time stamp of the creation time.</p>
     #[serde(rename = "CreatedTime")]
@@ -1746,6 +1807,7 @@ pub struct ProvisionedProductPlanDetails {
 
 /// <p>Summary information about a plan.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ProvisionedProductPlanSummary {
     /// <p>The plan identifier.</p>
     #[serde(rename = "PlanId")]
@@ -1775,6 +1837,7 @@ pub struct ProvisionedProductPlanSummary {
 
 /// <p>Information about a provisioning artifact. A provisioning artifact is also known as a product version.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ProvisioningArtifact {
     /// <p>The UTC time stamp of the creation time.</p>
     #[serde(rename = "CreatedTime")]
@@ -1796,6 +1859,7 @@ pub struct ProvisioningArtifact {
 
 /// <p>Information about a provisioning artifact (also known as a version) for a product.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ProvisioningArtifactDetail {
     /// <p>Indicates whether the product version is active.</p>
     #[serde(rename = "Active")]
@@ -1825,6 +1889,7 @@ pub struct ProvisioningArtifactDetail {
 
 /// <p>Information about a parameter used to provision a product.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ProvisioningArtifactParameter {
     /// <p>The default value.</p>
     #[serde(rename = "DefaultValue")]
@@ -1874,6 +1939,7 @@ pub struct ProvisioningArtifactProperties {
 
 /// <p>Summary information about a provisioning artifact (also known as a version) for a product.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ProvisioningArtifactSummary {
     /// <p>The UTC time stamp of the creation time.</p>
     #[serde(rename = "CreatedTime")]
@@ -1912,6 +1978,7 @@ pub struct ProvisioningParameter {
 
 /// <p>Information about a request operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RecordDetail {
     /// <p>The UTC time stamp of the creation time.</p>
     #[serde(rename = "CreatedTime")]
@@ -1969,6 +2036,7 @@ pub struct RecordDetail {
 
 /// <p>The error code and description resulting from an operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RecordError {
     /// <p>The numeric value of the error.</p>
     #[serde(rename = "Code")]
@@ -1982,6 +2050,7 @@ pub struct RecordError {
 
 /// <p>The output for the product created as the result of a request. For example, the output for a CloudFormation-backed product that creates an S3 bucket would include the S3 bucket URL.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RecordOutput {
     /// <p>The description of the output.</p>
     #[serde(rename = "Description")]
@@ -1999,6 +2068,7 @@ pub struct RecordOutput {
 
 /// <p>Information about a tag, which is a key-value pair.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RecordTag {
     /// <p>The key for this tag.</p>
     #[serde(rename = "Key")]
@@ -2022,10 +2092,12 @@ pub struct RejectPortfolioShareInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RejectPortfolioShareOutput {}
 
 /// <p>Information about a resource change that will occur when a plan is executed.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResourceChange {
     /// <p>The change action.</p>
     #[serde(rename = "Action")]
@@ -2059,6 +2131,7 @@ pub struct ResourceChange {
 
 /// <p>Information about a change to a resource attribute.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResourceChangeDetail {
     /// <p>The ID of the entity that caused the change.</p>
     #[serde(rename = "CausingEntity")]
@@ -2076,6 +2149,7 @@ pub struct ResourceChangeDetail {
 
 /// <p>Information about a resource.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResourceDetail {
     /// <p>The ARN of the resource.</p>
     #[serde(rename = "ARN")]
@@ -2101,6 +2175,7 @@ pub struct ResourceDetail {
 
 /// <p>Information about a change to a resource attribute.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResourceTargetDefinition {
     /// <p>The attribute to be changed.</p>
     #[serde(rename = "Attribute")]
@@ -2137,6 +2212,7 @@ pub struct ScanProvisionedProductsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ScanProvisionedProductsOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -2185,6 +2261,7 @@ pub struct SearchProductsAsAdminInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SearchProductsAsAdminOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -2225,6 +2302,7 @@ pub struct SearchProductsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SearchProductsOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -2274,6 +2352,7 @@ pub struct SearchProvisionedProductsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SearchProvisionedProductsOutput {
     /// <p>The page token to use to retrieve the next set of results. If there are no additional results, this value is null.</p>
     #[serde(rename = "NextPageToken")]
@@ -2302,6 +2381,7 @@ pub struct Tag {
 
 /// <p>Information about a TagOption.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TagOptionDetail {
     /// <p>The TagOption active state.</p>
     #[serde(rename = "Active")]
@@ -2323,6 +2403,7 @@ pub struct TagOptionDetail {
 
 /// <p>Summary information about a TagOption.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TagOptionSummary {
     /// <p>The TagOption key.</p>
     #[serde(rename = "Key")]
@@ -2358,6 +2439,7 @@ pub struct TerminateProvisionedProductInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TerminateProvisionedProductOutput {
     /// <p>Information about the result of this request.</p>
     #[serde(rename = "RecordDetail")]
@@ -2381,6 +2463,7 @@ pub struct UpdateConstraintInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateConstraintOutput {
     /// <p>Information about the constraint.</p>
     #[serde(rename = "ConstraintDetail")]
@@ -2428,6 +2511,7 @@ pub struct UpdatePortfolioInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdatePortfolioOutput {
     /// <p>Information about the portfolio.</p>
     #[serde(rename = "PortfolioDetail")]
@@ -2487,6 +2571,7 @@ pub struct UpdateProductInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateProductOutput {
     /// <p>Information about the product view.</p>
     #[serde(rename = "ProductViewDetail")]
@@ -2534,6 +2619,7 @@ pub struct UpdateProvisionedProductInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateProvisionedProductOutput {
     /// <p>Information about the result of the request.</p>
     #[serde(rename = "RecordDetail")]
@@ -2568,6 +2654,7 @@ pub struct UpdateProvisioningArtifactInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateProvisioningArtifactOutput {
     /// <p>The URL of the CloudFormation template in Amazon S3.</p>
     #[serde(rename = "Info")]
@@ -2616,6 +2703,7 @@ pub struct UpdateTagOptionInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateTagOptionOutput {
     /// <p>Information about the TagOption.</p>
     #[serde(rename = "TagOptionDetail")]
@@ -2625,6 +2713,7 @@ pub struct UpdateTagOptionOutput {
 
 /// <p>Additional information provided by the administrator.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UsageInstruction {
     /// <p>The usage instruction type for the value.</p>
     #[serde(rename = "Type")]

--- a/rusoto/services/servicediscovery/src/generated.rs
+++ b/rusoto/services/servicediscovery/src/generated.rs
@@ -47,6 +47,7 @@ pub struct CreatePrivateDnsNamespaceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreatePrivateDnsNamespaceResponse {
     /// <p>A value that you can use to determine whether the request completed successfully. To get the status of the operation, see <a>GetOperation</a>.</p>
     #[serde(rename = "OperationId")]
@@ -70,6 +71,7 @@ pub struct CreatePublicDnsNamespaceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreatePublicDnsNamespaceResponse {
     /// <p>A value that you can use to determine whether the request completed successfully. To get the status of the operation, see <a>GetOperation</a>.</p>
     #[serde(rename = "OperationId")]
@@ -103,6 +105,7 @@ pub struct CreateServiceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateServiceResponse {
     /// <p>A complex type that contains information about the new service.</p>
     #[serde(rename = "Service")]
@@ -118,6 +121,7 @@ pub struct DeleteNamespaceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteNamespaceResponse {
     /// <p>A value that you can use to determine whether the request completed successfully. To get the status of the operation, see <a>GetOperation</a>.</p>
     #[serde(rename = "OperationId")]
@@ -133,6 +137,7 @@ pub struct DeleteServiceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteServiceResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -146,6 +151,7 @@ pub struct DeregisterInstanceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeregisterInstanceResponse {
     /// <p>A value that you can use to determine whether the request completed successfully. For more information, see <a>GetOperation</a>.</p>
     #[serde(rename = "OperationId")]
@@ -178,6 +184,7 @@ pub struct DnsConfigChange {
 
 /// <p>A complex type that contains the ID for the hosted zone that Route 53 creates when you create a namespace.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DnsProperties {
     /// <p>The ID for the hosted zone that Route 53 creates when you create a namespace.</p>
     #[serde(rename = "HostedZoneId")]
@@ -207,6 +214,7 @@ pub struct GetInstanceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetInstanceResponse {
     /// <p>A complex type that contains information about a specified instance.</p>
     #[serde(rename = "Instance")]
@@ -234,6 +242,7 @@ pub struct GetInstancesHealthStatusRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetInstancesHealthStatusResponse {
     /// <p>If more than <code>MaxResults</code> instances match the specified criteria, you can submit another <code>GetInstancesHealthStatus</code> request to get the next group of results. Specify the value of <code>NextToken</code> from the previous response in the next request.</p>
     #[serde(rename = "NextToken")]
@@ -253,6 +262,7 @@ pub struct GetNamespaceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetNamespaceResponse {
     /// <p>A complex type that contains information about the specified namespace.</p>
     #[serde(rename = "Namespace")]
@@ -268,6 +278,7 @@ pub struct GetOperationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetOperationResponse {
     /// <p>A complex type that contains information about the operation.</p>
     #[serde(rename = "Operation")]
@@ -283,6 +294,7 @@ pub struct GetServiceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetServiceResponse {
     /// <p>A complex type that contains information about the service.</p>
     #[serde(rename = "Service")]
@@ -316,6 +328,7 @@ pub struct HealthCheckCustomConfig {
 
 /// <p>A complex type that contains information about an instance that Amazon Route 53 creates when you submit a <code>RegisterInstance</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Instance {
     /// <p>A string map that contains the following information for the service that you specify in <code>ServiceId</code>:</p> <ul> <li> <p>The attributes that apply to the records that are defined in the service. </p> </li> <li> <p>For each attribute, the applicable value.</p> </li> </ul> <p>Supported attribute keys include the following:</p> <p> <b>AWS_ALIAS_DNS_NAME</b> </p> <p> <b/> </p> <p>If you want Route 53 to create an alias record that routes traffic to an Elastic Load Balancing load balancer, specify the DNS name that is associated with the load balancer. For information about how to get the DNS name, see "DNSName" in the topic <a href="http://docs.aws.amazon.com/http:/docs.aws.amazon.com/Route53/latest/APIReference/API_AliasTarget.html">AliasTarget</a>.</p> <p>Note the following:</p> <ul> <li> <p>The configuration for the service that is specified by <code>ServiceId</code> must include settings for an A record, an AAAA record, or both.</p> </li> <li> <p>In the service that is specified by <code>ServiceId</code>, the value of <code>RoutingPolicy</code> must be <code>WEIGHTED</code>.</p> </li> <li> <p>If the service that is specified by <code>ServiceId</code> includes <code>HealthCheckConfig</code> settings, Route 53 will create the health check, but it won't associate the health check with the alias record.</p> </li> <li> <p>Auto naming currently doesn't support creating alias records that route traffic to AWS resources other than ELB load balancers.</p> </li> <li> <p>If you specify a value for <code>AWS_ALIAS_DNS_NAME</code>, don't specify values for any of the <code>AWS_INSTANCE</code> attributes.</p> </li> </ul> <p> <b>AWS_INSTANCE_CNAME</b> </p> <p>If the service configuration includes a CNAME record, the domain name that you want Route 53 to return in response to DNS queries, for example, <code>example.com</code>.</p> <p>This value is required if the service specified by <code>ServiceId</code> includes settings for an CNAME record.</p> <p> <b>AWS_INSTANCE_IPV4</b> </p> <p>If the service configuration includes an A record, the IPv4 address that you want Route 53 to return in response to DNS queries, for example, <code>192.0.2.44</code>.</p> <p>This value is required if the service specified by <code>ServiceId</code> includes settings for an A record. If the service includes settings for an SRV record, you must specify a value for <code>AWS_INSTANCE_IPV4</code>, <code>AWS_INSTANCE_IPV6</code>, or both.</p> <p> <b>AWS_INSTANCE_IPV6</b> </p> <p>If the service configuration includes an AAAA record, the IPv6 address that you want Route 53 to return in response to DNS queries, for example, <code>2001:0db8:85a3:0000:0000:abcd:0001:2345</code>.</p> <p>This value is required if the service specified by <code>ServiceId</code> includes settings for an AAAA record. If the service includes settings for an SRV record, you must specify a value for <code>AWS_INSTANCE_IPV4</code>, <code>AWS_INSTANCE_IPV6</code>, or both.</p> <p> <b>AWS_INSTANCE_PORT</b> </p> <p>If the service includes an SRV record, the value that you want Route 53 to return for the port.</p> <p>If the service includes <code>HealthCheckConfig</code>, the port on the endpoint that you want Route 53 to send requests to. </p> <p>This value is required if you specified settings for an SRV record when you created the service.</p>
     #[serde(rename = "Attributes")]
@@ -332,6 +345,7 @@ pub struct Instance {
 
 /// <p>A complex type that contains information about the instances that you registered by using a specified service.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceSummary {
     /// <p><p>A string map that contains the following information:</p> <ul> <li> <p>The attributes that are associate with the instance. </p> </li> <li> <p>For each attribute, the applicable value.</p> </li> </ul> <p>Supported attribute keys include the following:</p> <ul> <li> <p> <code>AWS<em>ALIAS</em>DNS<em>NAME</code>: For an alias record that routes traffic to an Elastic Load Balancing load balancer, the DNS name that is associated with the load balancer. </p> </li> <li> <p> <code>AWS</em>INSTANCE<em>CNAME</code>: For a CNAME record, the domain name that Route 53 returns in response to DNS queries, for example, <code>example.com</code>.</p> </li> <li> <p> <code>AWS</em>INSTANCE<em>IPV4</code>: For an A record, the IPv4 address that Route 53 returns in response to DNS queries, for example, <code>192.0.2.44</code>.</p> </li> <li> <p> <code>AWS</em>INSTANCE<em>IPV6</code>: For an AAAA record, the IPv6 address that Route 53 returns in response to DNS queries, for example, <code>2001:0db8:85a3:0000:0000:abcd:0001:2345</code>.</p> </li> <li> <p> <code>AWS</em>INSTANCE_PORT</code>: For an SRV record, the value that Route 53 returns for the port. In addition, if the service includes <code>HealthCheckConfig</code>, the port on the endpoint that Route 53 sends requests to.</p> </li> </ul></p>
     #[serde(rename = "Attributes")]
@@ -359,6 +373,7 @@ pub struct ListInstancesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListInstancesResponse {
     /// <p>Summary information about the instances that are associated with the specified service.</p>
     #[serde(rename = "Instances")]
@@ -387,6 +402,7 @@ pub struct ListNamespacesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListNamespacesResponse {
     /// <p>An array that contains one <code>NamespaceSummary</code> object for each namespace that matches the specified filter criteria.</p>
     #[serde(rename = "Namespaces")]
@@ -415,6 +431,7 @@ pub struct ListOperationsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListOperationsResponse {
     /// <p><p>If the response contains <code>NextToken</code>, submit another <code>ListOperations</code> request to get the next group of results. Specify the value of <code>NextToken</code> from the previous response in the next request.</p> <note> <p>Route 53 gets <code>MaxResults</code> operations and then filters them based on the specified criteria. It&#39;s possible that no operations in the first <code>MaxResults</code> operations matched the specified criteria but that subsequent groups of <code>MaxResults</code> operations do contain operations that match the criteria.</p> </note></p>
     #[serde(rename = "NextToken")]
@@ -443,6 +460,7 @@ pub struct ListServicesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListServicesResponse {
     /// <p><p>If the response contains <code>NextToken</code>, submit another <code>ListServices</code> request to get the next group of results. Specify the value of <code>NextToken</code> from the previous response in the next request.</p> <note> <p>Route 53 gets <code>MaxResults</code> services and then filters them based on the specified criteria. It&#39;s possible that no services in the first <code>MaxResults</code> services matched the specified criteria but that subsequent groups of <code>MaxResults</code> services do contain services that match the criteria.</p> </note></p>
     #[serde(rename = "NextToken")]
@@ -456,6 +474,7 @@ pub struct ListServicesResponse {
 
 /// <p>A complex type that contains information about a specified namespace.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Namespace {
     /// <p>The Amazon Resource Name (ARN) that Route 53 assigns to the namespace when you create it.</p>
     #[serde(rename = "Arn")]
@@ -512,6 +531,7 @@ pub struct NamespaceFilter {
 
 /// <p>A complex type that contains information that is specific to the namespace type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct NamespaceProperties {
     /// <p>A complex type that contains the ID for the hosted zone that Route 53 creates when you create a namespace.</p>
     #[serde(rename = "DnsProperties")]
@@ -521,6 +541,7 @@ pub struct NamespaceProperties {
 
 /// <p>A complex type that contains information about a namespace.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct NamespaceSummary {
     /// <p>The Amazon Resource Name (ARN) that Route 53 assigns to the namespace when you create it.</p>
     #[serde(rename = "Arn")]
@@ -542,6 +563,7 @@ pub struct NamespaceSummary {
 
 /// <p>A complex type that contains information about a specified operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Operation {
     /// <p>The date and time that the request was submitted, in Unix date/time format and Coordinated Universal Time (UTC). The value of <code>CreateDate</code> is accurate to milliseconds. For example, the value <code>1516925490.087</code> represents Friday, January 26, 2018 12:11:30.087 AM.</p>
     #[serde(rename = "CreateDate")]
@@ -594,6 +616,7 @@ pub struct OperationFilter {
 
 /// <p>A complex type that contains information about an operation that matches the criteria that you specified in a <a>ListOperations</a> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct OperationSummary {
     /// <p>The ID for an operation.</p>
     #[serde(rename = "Id")]
@@ -623,6 +646,7 @@ pub struct RegisterInstanceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegisterInstanceResponse {
     /// <p>A value that you can use to determine whether the request completed successfully. To get the status of the operation, see <a>GetOperation</a>.</p>
     #[serde(rename = "OperationId")]
@@ -632,6 +656,7 @@ pub struct RegisterInstanceResponse {
 
 /// <p>A complex type that contains information about the specified service.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Service {
     /// <p>The Amazon Resource Name (ARN) that Route 53 assigns to the service when you create it.</p>
     #[serde(rename = "Arn")]
@@ -706,6 +731,7 @@ pub struct ServiceFilter {
 
 /// <p>A complex type that contains information about a specified service.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ServiceSummary {
     /// <p>The Amazon Resource Name (ARN) that Route 53 assigns to the service when you create it.</p>
     #[serde(rename = "Arn")]
@@ -750,6 +776,7 @@ pub struct UpdateServiceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateServiceResponse {
     /// <p>A value that you can use to determine whether the request completed successfully. To get the status of the operation, see <a>GetOperation</a>.</p>
     #[serde(rename = "OperationId")]

--- a/rusoto/services/shield/src/generated.rs
+++ b/rusoto/services/shield/src/generated.rs
@@ -36,6 +36,7 @@ pub struct AssociateDRTLogBucketRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociateDRTLogBucketResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -46,10 +47,12 @@ pub struct AssociateDRTRoleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociateDRTRoleResponse {}
 
 /// <p>The details of a DDoS attack.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AttackDetail {
     /// <p>List of counters that describe the attack for the specified time period.</p>
     #[serde(rename = "AttackCounters")]
@@ -87,6 +90,7 @@ pub struct AttackDetail {
 
 /// <p>Details of the described attack.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AttackProperty {
     /// <p>The type of DDoS event that was observed. <code>NETWORK</code> indicates layer 3 and layer 4 events and <code>APPLICATION</code> indicates layer 7 events.</p>
     #[serde(rename = "AttackLayer")]
@@ -112,6 +116,7 @@ pub struct AttackProperty {
 
 /// <p>Summarizes all DDoS attacks for a specified time period.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AttackSummary {
     /// <p>The unique identifier (ID) of the attack.</p>
     #[serde(rename = "AttackId")]
@@ -137,6 +142,7 @@ pub struct AttackSummary {
 
 /// <p>Describes the attack.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AttackVectorDescription {
     /// <p><p>The attack type. Valid values:</p> <ul> <li> <p>UDP<em>TRAFFIC</p> </li> <li> <p>UDP</em>FRAGMENT</p> </li> <li> <p>GENERIC<em>UDP</em>REFLECTION</p> </li> <li> <p>DNS<em>REFLECTION</p> </li> <li> <p>NTP</em>REFLECTION</p> </li> <li> <p>CHARGEN<em>REFLECTION</p> </li> <li> <p>SSDP</em>REFLECTION</p> </li> <li> <p>PORT<em>MAPPER</p> </li> <li> <p>RIP</em>REFLECTION</p> </li> <li> <p>SNMP<em>REFLECTION</p> </li> <li> <p>MSSQL</em>REFLECTION</p> </li> <li> <p>NET<em>BIOS</em>REFLECTION</p> </li> <li> <p>SYN<em>FLOOD</p> </li> <li> <p>ACK</em>FLOOD</p> </li> <li> <p>REQUEST_FLOOD</p> </li> </ul></p>
     #[serde(rename = "VectorType")]
@@ -145,6 +151,7 @@ pub struct AttackVectorDescription {
 
 /// <p>A contributor to the attack and their contribution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Contributor {
     /// <p>The name of the contributor. This is dependent on the <code>AttackPropertyIdentifier</code>. For example, if the <code>AttackPropertyIdentifier</code> is <code>SOURCE_COUNTRY</code>, the <code>Name</code> could be <code>United States</code>.</p>
     #[serde(rename = "Name")]
@@ -167,6 +174,7 @@ pub struct CreateProtectionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateProtectionResponse {
     /// <p>The unique identifier (ID) for the <a>Protection</a> object that is created.</p>
     #[serde(rename = "ProtectionId")]
@@ -178,6 +186,7 @@ pub struct CreateProtectionResponse {
 pub struct CreateSubscriptionRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateSubscriptionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -188,12 +197,14 @@ pub struct DeleteProtectionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteProtectionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteSubscriptionRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteSubscriptionResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -204,6 +215,7 @@ pub struct DescribeAttackRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAttackResponse {
     /// <p>The attack that is described.</p>
     #[serde(rename = "Attack")]
@@ -215,6 +227,7 @@ pub struct DescribeAttackResponse {
 pub struct DescribeDRTAccessRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeDRTAccessResponse {
     /// <p>The list of Amazon S3 buckets accessed by the DRT.</p>
     #[serde(rename = "LogBucketList")]
@@ -230,6 +243,7 @@ pub struct DescribeDRTAccessResponse {
 pub struct DescribeEmergencyContactSettingsRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEmergencyContactSettingsResponse {
     /// <p>A list of email addresses that the DRT can use to contact you during a suspected attack.</p>
     #[serde(rename = "EmergencyContactList")]
@@ -245,6 +259,7 @@ pub struct DescribeProtectionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeProtectionResponse {
     /// <p>The <a>Protection</a> object that is described.</p>
     #[serde(rename = "Protection")]
@@ -256,6 +271,7 @@ pub struct DescribeProtectionResponse {
 pub struct DescribeSubscriptionRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeSubscriptionResponse {
     /// <p>The AWS Shield Advanced subscription details for an account.</p>
     #[serde(rename = "Subscription")]
@@ -271,12 +287,14 @@ pub struct DisassociateDRTLogBucketRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisassociateDRTLogBucketResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DisassociateDRTRoleRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisassociateDRTRoleResponse {}
 
 /// <p>Contact information that the DRT can use to contact you during a suspected attack.</p>
@@ -291,6 +309,7 @@ pub struct EmergencyContact {
 pub struct GetSubscriptionStateRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetSubscriptionStateResponse {
     /// <p>The status of the subscription.</p>
     #[serde(rename = "SubscriptionState")]
@@ -299,6 +318,7 @@ pub struct GetSubscriptionStateResponse {
 
 /// <p>Specifies how many protections of a given type you can create.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Limit {
     /// <p>The maximum number of protections that can be created for the specified <code>Type</code>.</p>
     #[serde(rename = "Max")]
@@ -335,6 +355,7 @@ pub struct ListAttacksRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAttacksResponse {
     /// <p>The attack information for the specified time range.</p>
     #[serde(rename = "AttackSummaries")]
@@ -359,6 +380,7 @@ pub struct ListProtectionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListProtectionsResponse {
     /// <p>If you specify a value for <code>MaxResults</code> and you have more Protections than the value of MaxResults, AWS Shield Advanced returns a NextToken value in the response that allows you to list another group of Protections. For the second and subsequent ListProtections requests, specify the value of NextToken from the previous response to get information about another batch of Protections.</p>
     #[serde(rename = "NextToken")]
@@ -372,6 +394,7 @@ pub struct ListProtectionsResponse {
 
 /// <p>The mitigation applied to a DDoS attack.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Mitigation {
     /// <p>The name of the mitigation taken for this attack.</p>
     #[serde(rename = "MitigationName")]
@@ -381,6 +404,7 @@ pub struct Mitigation {
 
 /// <p>An object that represents a resource that is under DDoS protection.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Protection {
     /// <p>The unique identifier (ID) of the protection.</p>
     #[serde(rename = "Id")]
@@ -398,6 +422,7 @@ pub struct Protection {
 
 /// <p>The attack information for the specified SubResource.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SubResourceSummary {
     /// <p>The list of attack types and associated counters.</p>
     #[serde(rename = "AttackVectors")]
@@ -419,6 +444,7 @@ pub struct SubResourceSummary {
 
 /// <p>Information about the AWS Shield Advanced subscription for an account.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Subscription {
     /// <p>If <code>ENABLED</code>, the subscription will be automatically renewed at the end of the existing subscription period.</p> <p>When you initally create a subscription, <code>AutoRenew</code> is set to <code>ENABLED</code>. You can change this by submitting an <code>UpdateSubscription</code> request. If the <code>UpdateSubscription</code> request does not included a value for <code>AutoRenew</code>, the existing value for <code>AutoRenew</code> remains unchanged.</p>
     #[serde(rename = "AutoRenew")]
@@ -444,6 +470,7 @@ pub struct Subscription {
 
 /// <p>A summary of information about the attack.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SummarizedAttackVector {
     /// <p>The list of counters that describe the details of the attack.</p>
     #[serde(rename = "VectorCounters")]
@@ -456,6 +483,7 @@ pub struct SummarizedAttackVector {
 
 /// <p>The counter that describes a DDoS attack.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SummarizedCounter {
     /// <p>The average value of the counter for a specified time period.</p>
     #[serde(rename = "Average")]
@@ -505,6 +533,7 @@ pub struct UpdateEmergencyContactSettingsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateEmergencyContactSettingsResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -516,6 +545,7 @@ pub struct UpdateSubscriptionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateSubscriptionResponse {}
 
 /// Errors returned by AssociateDRTLogBucket

--- a/rusoto/services/sms/src/generated.rs
+++ b/rusoto/services/sms/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Object representing a Connector</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Connector {
     #[serde(rename = "associatedOn")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -83,6 +84,7 @@ pub struct CreateReplicationJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateReplicationJobResponse {
     #[serde(rename = "replicationJobId")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -96,12 +98,14 @@ pub struct DeleteReplicationJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteReplicationJobResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteServerCatalogRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteServerCatalogResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -111,6 +115,7 @@ pub struct DisassociateConnectorRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisassociateConnectorResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -124,6 +129,7 @@ pub struct GetConnectorsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetConnectorsResponse {
     #[serde(rename = "connectorList")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -147,6 +153,7 @@ pub struct GetReplicationJobsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetReplicationJobsResponse {
     #[serde(rename = "nextToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -169,6 +176,7 @@ pub struct GetReplicationRunsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetReplicationRunsResponse {
     #[serde(rename = "nextToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -192,6 +200,7 @@ pub struct GetServersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetServersResponse {
     #[serde(rename = "lastModifiedOn")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -211,10 +220,12 @@ pub struct GetServersResponse {
 pub struct ImportServerCatalogRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ImportServerCatalogResponse {}
 
 /// <p>Object representing a Replication Job</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReplicationJob {
     #[serde(rename = "description")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -262,6 +273,7 @@ pub struct ReplicationJob {
 
 /// <p>Object representing a Replication Run</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ReplicationRun {
     #[serde(rename = "amiId")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -291,6 +303,7 @@ pub struct ReplicationRun {
 
 /// <p>Object representing a server</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Server {
     #[serde(rename = "replicationJobId")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -319,6 +332,7 @@ pub struct StartOnDemandReplicationRunRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartOnDemandReplicationRunResponse {
     #[serde(rename = "replicationRunId")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -347,10 +361,12 @@ pub struct UpdateReplicationJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateReplicationJobResponse {}
 
 /// <p>Object representing a VM server</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VmServer {
     #[serde(rename = "vmManagerName")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -371,6 +387,7 @@ pub struct VmServer {
 
 /// <p>Object representing a server&#39;s location</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VmServerAddress {
     #[serde(rename = "vmId")]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/rusoto/services/snowball/src/generated.rs
+++ b/rusoto/services/snowball/src/generated.rs
@@ -97,6 +97,7 @@ pub struct CancelClusterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CancelClusterResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -107,10 +108,12 @@ pub struct CancelJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CancelJobResult {}
 
 /// <p>Contains a cluster's state, a cluster's ID, and other important information.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ClusterListEntry {
     /// <p>The 39-character ID for the cluster that you want to list, for example <code>CID123e4567-e89b-12d3-a456-426655440000</code>.</p>
     #[serde(rename = "ClusterId")]
@@ -132,6 +135,7 @@ pub struct ClusterListEntry {
 
 /// <p>Contains metadata about a specific cluster.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ClusterMetadata {
     /// <p>The automatically generated ID for a specific address.</p>
     #[serde(rename = "AddressId")]
@@ -189,6 +193,7 @@ pub struct ClusterMetadata {
 
 /// <p>A JSON-formatted object that describes a compatible Amazon Machine Image (AMI), including the ID and name for a Snowball Edge AMI. This AMI is compatible with the device's physical hardware requirements, and it should be able to be run in an SBE1 instance on the device.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CompatibleImage {
     /// <p>The unique identifier for an individual Snowball Edge AMI.</p>
     #[serde(rename = "AmiId")]
@@ -208,6 +213,7 @@ pub struct CreateAddressRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateAddressResult {
     /// <p>The automatically generated ID for a specific address. You'll use this ID when you create a job to specify which address you want the Snowball for that job shipped to.</p>
     #[serde(rename = "AddressId")]
@@ -255,6 +261,7 @@ pub struct CreateClusterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateClusterResult {
     /// <p>The automatically generated ID for a cluster.</p>
     #[serde(rename = "ClusterId")]
@@ -315,6 +322,7 @@ pub struct CreateJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateJobResult {
     /// <p>The automatically generated ID for a job, for example <code>JID123e4567-e89b-12d3-a456-426655440000</code>.</p>
     #[serde(rename = "JobId")]
@@ -324,6 +332,7 @@ pub struct CreateJobResult {
 
 /// <p>Defines the real-time status of a Snowball's data transfer while the device is at AWS. This data is only available while a job has a <code>JobState</code> value of <code>InProgress</code>, for both import and export jobs.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DataTransfer {
     /// <p>The number of bytes transferred between a Snowball and Amazon S3.</p>
     #[serde(rename = "BytesTransferred")]
@@ -351,6 +360,7 @@ pub struct DescribeAddressRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAddressResult {
     /// <p>The address that you want the Snowball or Snowballs associated with a specific job to be shipped to.</p>
     #[serde(rename = "Address")]
@@ -371,6 +381,7 @@ pub struct DescribeAddressesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAddressesResult {
     /// <p>The Snowball shipping addresses that were created for this account.</p>
     #[serde(rename = "Addresses")]
@@ -390,6 +401,7 @@ pub struct DescribeClusterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeClusterResult {
     /// <p>Information about a specific cluster, including shipping information, cluster status, and other important metadata.</p>
     #[serde(rename = "ClusterMetadata")]
@@ -405,6 +417,7 @@ pub struct DescribeJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeJobResult {
     /// <p>Information about a specific job, including shipping information, job status, and other important metadata.</p>
     #[serde(rename = "JobMetadata")]
@@ -445,6 +458,7 @@ pub struct GetJobManifestRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetJobManifestResult {
     /// <p>The Amazon S3 presigned URL for the manifest file associated with the specified <code>JobId</code> value.</p>
     #[serde(rename = "ManifestURI")]
@@ -460,6 +474,7 @@ pub struct GetJobUnlockCodeRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetJobUnlockCodeResult {
     /// <p>The <code>UnlockCode</code> value for the specified job. The <code>UnlockCode</code> value can be accessed for up to 90 days after the job has been created.</p>
     #[serde(rename = "UnlockCode")]
@@ -471,6 +486,7 @@ pub struct GetJobUnlockCodeResult {
 pub struct GetSnowballUsageRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetSnowballUsageResult {
     /// <p>The service limit for number of Snowballs this account can have at once. The default service limit is 1 (one).</p>
     #[serde(rename = "SnowballLimit")]
@@ -484,6 +500,7 @@ pub struct GetSnowballUsageResult {
 
 /// <p>Each <code>JobListEntry</code> object contains a job's state, a job's ID, and a value that indicates whether the job is a job part, in the case of an export job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct JobListEntry {
     /// <p>The creation date for this job.</p>
     #[serde(rename = "CreationDate")]
@@ -517,6 +534,7 @@ pub struct JobListEntry {
 
 /// <p>Contains job logs. Whenever Snowball is used to import data into or export data out of Amazon S3, you'll have the option of downloading a PDF job report. Job logs are returned as a part of the response syntax of the <code>DescribeJob</code> action in the <code>JobMetadata</code> data type. The job logs can be accessed for up to 60 minutes after this request has been made. To access any of the job logs after 60 minutes have passed, you'll have to make another call to the <code>DescribeJob</code> action.</p> <p>For import jobs, the PDF job report becomes available at the end of the import process. For export jobs, your job report typically becomes available while the Snowball for your job part is being delivered to you.</p> <p>The job report provides you insight into the state of your Amazon S3 data transfer. The report includes details about your job or job part for your records.</p> <p>For deeper visibility into the status of your transferred objects, you can look at the two associated logs: a success log and a failure log. The logs are saved in comma-separated value (CSV) format, and the name of each log includes the ID of the job or job part that the log describes.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct JobLogs {
     /// <p>A link to an Amazon S3 presigned URL where the job completion report is located.</p>
     #[serde(rename = "JobCompletionReportURI")]
@@ -534,6 +552,7 @@ pub struct JobLogs {
 
 /// <p>Contains information about a specific job including shipping information, job status, and other important metadata. This information is returned as a part of the response syntax of the <code>DescribeJob</code> action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct JobMetadata {
     /// <p>The ID for the address that you want the Snowball shipped to.</p>
     #[serde(rename = "AddressId")]
@@ -664,6 +683,7 @@ pub struct ListClusterJobsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListClusterJobsResult {
     /// <p>Each <code>JobListEntry</code> object contains a job's state, a job's ID, and a value that indicates whether the job is a job part, in the case of export jobs. </p>
     #[serde(rename = "JobListEntries")]
@@ -688,6 +708,7 @@ pub struct ListClustersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListClustersResult {
     /// <p>Each <code>ClusterListEntry</code> object contains a cluster's state, a cluster's ID, and other important status information.</p>
     #[serde(rename = "ClusterListEntries")]
@@ -712,6 +733,7 @@ pub struct ListCompatibleImagesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListCompatibleImagesResult {
     /// <p>A JSON-formatted object that describes a compatible AMI, including the ID and name for a Snowball Edge AMI.</p>
     #[serde(rename = "CompatibleImages")]
@@ -736,6 +758,7 @@ pub struct ListJobsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListJobsResult {
     /// <p>Each <code>JobListEntry</code> object contains a job's state, a job's ID, and a value that indicates whether the job is a job part, in the case of export jobs. </p>
     #[serde(rename = "JobListEntries")]
@@ -779,6 +802,7 @@ pub struct S3Resource {
 
 /// <p>The <code>Status</code> and <code>TrackingNumber</code> information for an inbound or outbound shipment.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Shipment {
     /// <p>Status information for a shipment.</p>
     #[serde(rename = "Status")]
@@ -792,6 +816,7 @@ pub struct Shipment {
 
 /// <p>A job's shipping information, including inbound and outbound tracking numbers and shipping speed options.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ShippingDetails {
     /// <p>The <code>Status</code> and <code>TrackingNumber</code> values for a Snowball being returned to AWS for a particular job.</p>
     #[serde(rename = "InboundShipment")]
@@ -843,6 +868,7 @@ pub struct UpdateClusterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateClusterResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -885,6 +911,7 @@ pub struct UpdateJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateJobResult {}
 
 /// Errors returned by CancelCluster

--- a/rusoto/services/ssm/src/generated.rs
+++ b/rusoto/services/ssm/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>An activation registers one or more on-premises servers or virtual machines (VMs) with AWS so that you can configure those servers or VMs using Run Command. A server or VM that has been registered with AWS is called a managed instance.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Activation {
     /// <p>The ID created by Systems Manager when you submitted the activation.</p>
     #[serde(rename = "ActivationId")]
@@ -83,10 +84,12 @@ pub struct AddTagsToResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddTagsToResourceResult {}
 
 /// <p>Describes an association of a Systems Manager document and an instance.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Association {
     /// <p>The ID created by the system when you create an association. An association is a binding between a document and a set of targets with a schedule.</p>
     #[serde(rename = "AssociationId")]
@@ -132,6 +135,7 @@ pub struct Association {
 
 /// <p>Describes the parameters for a document.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociationDescription {
     /// <p>The association ID.</p>
     #[serde(rename = "AssociationId")]
@@ -201,6 +205,7 @@ pub struct AssociationDescription {
 
 /// <p>Includes information about the specified association.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociationExecution {
     /// <p>The association ID.</p>
     #[serde(rename = "AssociationId")]
@@ -252,6 +257,7 @@ pub struct AssociationExecutionFilter {
 
 /// <p>Includes information about the specified association execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociationExecutionTarget {
     /// <p>The association ID.</p>
     #[serde(rename = "AssociationId")]
@@ -315,6 +321,7 @@ pub struct AssociationFilter {
 
 /// <p>Information about the association.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociationOverview {
     /// <p>Returns the number of targets for the association status. For example, if you created an association with two instances, and one of them was successful, this would return the count of instances by status.</p>
     #[serde(rename = "AssociationStatusAggregatedCount")]
@@ -350,6 +357,7 @@ pub struct AssociationStatus {
 
 /// <p>Information about the association version.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociationVersionInfo {
     /// <p>The ID created by the system when the association was created.</p>
     #[serde(rename = "AssociationId")]
@@ -395,6 +403,7 @@ pub struct AssociationVersionInfo {
 
 /// <p>Detailed information about the current state of an individual Automation execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AutomationExecution {
     /// <p>The execution ID.</p>
     #[serde(rename = "AutomationExecutionId")]
@@ -499,6 +508,7 @@ pub struct AutomationExecutionFilter {
 
 /// <p>Details about a specific Automation execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AutomationExecutionMetadata {
     /// <p>The execution ID.</p>
     #[serde(rename = "AutomationExecutionId")]
@@ -596,6 +606,7 @@ pub struct CancelCommandRequest {
 
 /// <p>Whether or not the command was successfully canceled. There is no guarantee that a request can be canceled.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CancelCommandResult {}
 
 /// <p>Configuration options for sending command output to CloudWatch Logs.</p>
@@ -613,6 +624,7 @@ pub struct CloudWatchOutputConfig {
 
 /// <p>Describes a command request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Command {
     /// <p>CloudWatch Logs information where you want Systems Manager to send the command output.</p>
     #[serde(rename = "CloudWatchOutputConfig")]
@@ -721,6 +733,7 @@ pub struct CommandFilter {
 
 /// <p>An invocation is copy of a command sent to a specific instance. A command can apply to one or more instances. A command invocation applies to one instance. For example, if a user executes SendCommand against three instances, then a command invocation is created for each requested instance ID. A command invocation returns status and detail information about a command you executed. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CommandInvocation {
     /// <p>CloudWatch Logs information where you want Systems Manager to send the command output.</p>
     #[serde(rename = "CloudWatchOutputConfig")]
@@ -789,6 +802,7 @@ pub struct CommandInvocation {
 
 /// <p>Describes plugin details.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CommandPlugin {
     /// <p>The name of the plugin. Must be one of the following: aws:updateAgent, aws:domainjoin, aws:applications, aws:runPowerShellScript, aws:psmodule, aws:cloudWatch, aws:runShellScript, or aws:updateSSMAgent. </p>
     #[serde(rename = "Name")]
@@ -858,6 +872,7 @@ pub struct ComplianceExecutionSummary {
 
 /// <p>Information about the compliance as defined by the resource type. For example, for a patch resource type, <code>Items</code> includes information about the PatchSeverity, Classification, etc.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ComplianceItem {
     /// <p>The compliance type. For example, Association (for a State Manager association), Patch, or Custom:<code>string</code> are all valid compliance types.</p>
     #[serde(rename = "ComplianceType")]
@@ -939,6 +954,7 @@ pub struct ComplianceStringFilter {
 
 /// <p>A summary of compliance information by compliance type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ComplianceSummaryItem {
     /// <p>The type of compliance item. For example, the compliance type can be Association, Patch, or Custom:string.</p>
     #[serde(rename = "ComplianceType")]
@@ -956,6 +972,7 @@ pub struct ComplianceSummaryItem {
 
 /// <p>A summary of resources that are compliant. The summary is organized according to the resource count for each compliance type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CompliantSummary {
     /// <p>The total number of resources that are compliant.</p>
     #[serde(rename = "CompliantCount")]
@@ -991,6 +1008,7 @@ pub struct CreateActivationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateActivationResult {
     /// <p>The code the system generates when it processes the activation. The activation code functions like a password to validate the activation ID. </p>
     #[serde(rename = "ActivationCode")]
@@ -1046,6 +1064,7 @@ pub struct CreateAssociationBatchRequestEntry {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateAssociationBatchResult {
     /// <p>Information about the associations that failed.</p>
     #[serde(rename = "Failed")]
@@ -1093,6 +1112,7 @@ pub struct CreateAssociationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateAssociationResult {
     /// <p>Information about the association.</p>
     #[serde(rename = "AssociationDescription")]
@@ -1123,6 +1143,7 @@ pub struct CreateDocumentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateDocumentResult {
     /// <p>Information about the Systems Manager document.</p>
     #[serde(rename = "DocumentDescription")]
@@ -1158,6 +1179,7 @@ pub struct CreateMaintenanceWindowRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateMaintenanceWindowResult {
     /// <p>The ID of the created Maintenance Window.</p>
     #[serde(rename = "WindowId")]
@@ -1213,6 +1235,7 @@ pub struct CreatePatchBaselineRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreatePatchBaselineResult {
     /// <p>The ID of the created patch baseline.</p>
     #[serde(rename = "BaselineId")]
@@ -1231,6 +1254,7 @@ pub struct CreateResourceDataSyncRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateResourceDataSyncResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1241,6 +1265,7 @@ pub struct DeleteActivationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteActivationResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1260,6 +1285,7 @@ pub struct DeleteAssociationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteAssociationResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1270,6 +1296,7 @@ pub struct DeleteDocumentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteDocumentResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1292,6 +1319,7 @@ pub struct DeleteInventoryRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteInventoryResult {
     /// <p>Every <code>DeleteInventory</code> action is assigned a unique ID. This option returns a unique ID. You can use this ID to query the status of a delete operation. This option is useful for ensuring that a delete operation has completed before you begin other actions. </p>
     #[serde(rename = "DeletionId")]
@@ -1315,6 +1343,7 @@ pub struct DeleteMaintenanceWindowRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteMaintenanceWindowResult {
     /// <p>The ID of the deleted Maintenance Window.</p>
     #[serde(rename = "WindowId")]
@@ -1330,6 +1359,7 @@ pub struct DeleteParameterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteParameterResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1340,6 +1370,7 @@ pub struct DeleteParametersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteParametersResult {
     /// <p>The names of the deleted parameters.</p>
     #[serde(rename = "DeletedParameters")]
@@ -1359,6 +1390,7 @@ pub struct DeletePatchBaselineRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeletePatchBaselineResult {
     /// <p>The ID of the deleted patch baseline.</p>
     #[serde(rename = "BaselineId")]
@@ -1374,6 +1406,7 @@ pub struct DeleteResourceDataSyncRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteResourceDataSyncResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1384,6 +1417,7 @@ pub struct DeregisterManagedInstanceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeregisterManagedInstanceResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1397,6 +1431,7 @@ pub struct DeregisterPatchBaselineForPatchGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeregisterPatchBaselineForPatchGroupResult {
     /// <p>The ID of the patch baseline the patch group was deregistered from.</p>
     #[serde(rename = "BaselineId")]
@@ -1423,6 +1458,7 @@ pub struct DeregisterTargetFromMaintenanceWindowRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeregisterTargetFromMaintenanceWindowResult {
     /// <p>The ID of the Maintenance Window the target was removed from.</p>
     #[serde(rename = "WindowId")]
@@ -1445,6 +1481,7 @@ pub struct DeregisterTaskFromMaintenanceWindowRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeregisterTaskFromMaintenanceWindowResult {
     /// <p>The ID of the Maintenance Window the task was removed from.</p>
     #[serde(rename = "WindowId")]
@@ -1486,6 +1523,7 @@ pub struct DescribeActivationsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeActivationsResult {
     /// <p>A list of activations for your AWS account.</p>
     #[serde(rename = "ActivationList")]
@@ -1520,6 +1558,7 @@ pub struct DescribeAssociationExecutionTargetsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAssociationExecutionTargetsResult {
     /// <p>Information about the execution.</p>
     #[serde(rename = "AssociationExecutionTargets")]
@@ -1551,6 +1590,7 @@ pub struct DescribeAssociationExecutionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAssociationExecutionsResult {
     /// <p>A list of the executions for the specified association ID.</p>
     #[serde(rename = "AssociationExecutions")]
@@ -1583,6 +1623,7 @@ pub struct DescribeAssociationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAssociationResult {
     /// <p>Information about the association.</p>
     #[serde(rename = "AssociationDescription")]
@@ -1607,6 +1648,7 @@ pub struct DescribeAutomationExecutionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAutomationExecutionsResult {
     /// <p>The list of details about each automation execution which has occurred which matches the filter specification, if any.</p>
     #[serde(rename = "AutomationExecutionMetadataList")]
@@ -1642,6 +1684,7 @@ pub struct DescribeAutomationStepExecutionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAutomationStepExecutionsResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     #[serde(rename = "NextToken")]
@@ -1670,6 +1713,7 @@ pub struct DescribeAvailablePatchesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAvailablePatchesResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     #[serde(rename = "NextToken")]
@@ -1692,6 +1736,7 @@ pub struct DescribeDocumentPermissionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeDocumentPermissionResponse {
     /// <p>The account IDs that have permission to use this document. The ID can be either an AWS account or <i>All</i>.</p>
     #[serde(rename = "AccountIds")]
@@ -1711,6 +1756,7 @@ pub struct DescribeDocumentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeDocumentResult {
     /// <p>Information about the Systems Manager document.</p>
     #[serde(rename = "Document")]
@@ -1734,6 +1780,7 @@ pub struct DescribeEffectiveInstanceAssociationsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEffectiveInstanceAssociationsResult {
     /// <p>The associations for the requested instance.</p>
     #[serde(rename = "Associations")]
@@ -1761,6 +1808,7 @@ pub struct DescribeEffectivePatchesForPatchBaselineRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeEffectivePatchesForPatchBaselineResult {
     /// <p>An array of patches and patch status.</p>
     #[serde(rename = "EffectivePatches")]
@@ -1788,6 +1836,7 @@ pub struct DescribeInstanceAssociationsStatusRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeInstanceAssociationsStatusResult {
     /// <p>Status information about the association.</p>
     #[serde(rename = "InstanceAssociationStatusInfos")]
@@ -1820,6 +1869,7 @@ pub struct DescribeInstanceInformationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeInstanceInformationResult {
     /// <p>The instance information list.</p>
     #[serde(rename = "InstanceInformationList")]
@@ -1851,6 +1901,7 @@ pub struct DescribeInstancePatchStatesForPatchGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeInstancePatchStatesForPatchGroupResult {
     /// <p>The high-level patch state for the requested instances. </p>
     #[serde(rename = "InstancePatchStates")]
@@ -1878,6 +1929,7 @@ pub struct DescribeInstancePatchStatesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeInstancePatchStatesResult {
     /// <p>The high-level patch state for the requested instances.</p>
     #[serde(rename = "InstancePatchStates")]
@@ -1909,6 +1961,7 @@ pub struct DescribeInstancePatchesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeInstancePatchesResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     #[serde(rename = "NextToken")]
@@ -1937,6 +1990,7 @@ pub struct DescribeInventoryDeletionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeInventoryDeletionsResult {
     /// <p>A list of status items for deleted inventory.</p>
     #[serde(rename = "InventoryDeletions")]
@@ -1971,6 +2025,7 @@ pub struct DescribeMaintenanceWindowExecutionTaskInvocationsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeMaintenanceWindowExecutionTaskInvocationsResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     #[serde(rename = "NextToken")]
@@ -2003,6 +2058,7 @@ pub struct DescribeMaintenanceWindowExecutionTasksRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeMaintenanceWindowExecutionTasksResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     #[serde(rename = "NextToken")]
@@ -2034,6 +2090,7 @@ pub struct DescribeMaintenanceWindowExecutionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeMaintenanceWindowExecutionsResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     #[serde(rename = "NextToken")]
@@ -2065,6 +2122,7 @@ pub struct DescribeMaintenanceWindowTargetsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeMaintenanceWindowTargetsResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     #[serde(rename = "NextToken")]
@@ -2096,6 +2154,7 @@ pub struct DescribeMaintenanceWindowTasksRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeMaintenanceWindowTasksResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     #[serde(rename = "NextToken")]
@@ -2124,6 +2183,7 @@ pub struct DescribeMaintenanceWindowsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeMaintenanceWindowsResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     #[serde(rename = "NextToken")]
@@ -2156,6 +2216,7 @@ pub struct DescribeParametersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeParametersResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     #[serde(rename = "NextToken")]
@@ -2184,6 +2245,7 @@ pub struct DescribePatchBaselinesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribePatchBaselinesResult {
     /// <p>An array of PatchBaselineIdentity elements.</p>
     #[serde(rename = "BaselineIdentities")]
@@ -2203,6 +2265,7 @@ pub struct DescribePatchGroupStateRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribePatchGroupStateResult {
     /// <p>The number of instances in the patch group.</p>
     #[serde(rename = "Instances")]
@@ -2247,6 +2310,7 @@ pub struct DescribePatchGroupsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribePatchGroupsResult {
     /// <p>Each entry in the array contains:</p> <p>PatchGroup: string (between 1 and 256 characters, Regex: ^([\p{L}\p{Z}\p{N}_.:/=+\-@]*)$)</p> <p>PatchBaselineIdentity: A PatchBaselineIdentity element. </p>
     #[serde(rename = "Mappings")]
@@ -2260,6 +2324,7 @@ pub struct DescribePatchGroupsResult {
 
 /// <p>A default version of a document.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DocumentDefaultVersionDescription {
     /// <p>The default version of the document.</p>
     #[serde(rename = "DefaultVersion")]
@@ -2273,6 +2338,7 @@ pub struct DocumentDefaultVersionDescription {
 
 /// <p>Describes a Systems Manager document. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DocumentDescription {
     /// <p>The date when the document was created.</p>
     #[serde(rename = "CreatedDate")]
@@ -2361,6 +2427,7 @@ pub struct DocumentFilter {
 
 /// <p>Describes the name of a Systems Manager document.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DocumentIdentifier {
     /// <p>The document format, either JSON or YAML.</p>
     #[serde(rename = "DocumentFormat")]
@@ -2415,6 +2482,7 @@ pub struct DocumentKeyValuesFilter {
 
 /// <p>Parameters specified in a System Manager document that execute on the server when the command is run. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DocumentParameter {
     /// <p>If specified, the default values for the parameters. Parameters without a default value are required. Parameters with a default value are optional.</p>
     #[serde(rename = "DefaultValue")]
@@ -2436,6 +2504,7 @@ pub struct DocumentParameter {
 
 /// <p>Version information about the document.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DocumentVersionInfo {
     /// <p>The date the document was created.</p>
     #[serde(rename = "CreatedDate")]
@@ -2461,6 +2530,7 @@ pub struct DocumentVersionInfo {
 
 /// <p>The EffectivePatch structure defines metadata about a patch along with the approval state of the patch in a particular patch baseline. The approval state includes information about whether the patch is currently approved, due to be approved by a rule, explicitly approved, or explicitly rejected and the date the patch was or will be approved.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EffectivePatch {
     /// <p>Provides metadata for a patch, including information such as the KB ID, severity, classification and a URL for where more information can be obtained about the patch.</p>
     #[serde(rename = "Patch")]
@@ -2474,6 +2544,7 @@ pub struct EffectivePatch {
 
 /// <p>Describes a failed association.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FailedCreateAssociation {
     /// <p>The association.</p>
     #[serde(rename = "Entry")]
@@ -2491,6 +2562,7 @@ pub struct FailedCreateAssociation {
 
 /// <p>Information about an Automation failure.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FailureDetails {
     /// <p>Detailed information about the Automation step failure.</p>
     #[serde(rename = "Details")]
@@ -2514,6 +2586,7 @@ pub struct GetAutomationExecutionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetAutomationExecutionResult {
     /// <p>Detailed information about the current state of an automation execution.</p>
     #[serde(rename = "AutomationExecution")]
@@ -2536,6 +2609,7 @@ pub struct GetCommandInvocationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetCommandInvocationResult {
     /// <p>CloudWatch Logs information where Systems Manager sent the command output.</p>
     #[serde(rename = "CloudWatchOutputConfig")]
@@ -2616,6 +2690,7 @@ pub struct GetDefaultPatchBaselineRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDefaultPatchBaselineResult {
     /// <p>The ID of the default patch baseline.</p>
     #[serde(rename = "BaselineId")]
@@ -2638,6 +2713,7 @@ pub struct GetDeployablePatchSnapshotForInstanceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDeployablePatchSnapshotForInstanceResult {
     /// <p>The ID of the instance.</p>
     #[serde(rename = "InstanceId")]
@@ -2673,6 +2749,7 @@ pub struct GetDocumentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDocumentResult {
     /// <p>The contents of the Systems Manager document.</p>
     #[serde(rename = "Content")]
@@ -2721,6 +2798,7 @@ pub struct GetInventoryRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetInventoryResult {
     /// <p>Collection of inventory entities such as a collection of instance inventory. </p>
     #[serde(rename = "Entities")]
@@ -2757,6 +2835,7 @@ pub struct GetInventorySchemaRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetInventorySchemaResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     #[serde(rename = "NextToken")]
@@ -2776,6 +2855,7 @@ pub struct GetMaintenanceWindowExecutionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetMaintenanceWindowExecutionResult {
     /// <p>The time the Maintenance Window finished executing.</p>
     #[serde(rename = "EndTime")]
@@ -2817,6 +2897,7 @@ pub struct GetMaintenanceWindowExecutionTaskInvocationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetMaintenanceWindowExecutionTaskInvocationResult {
     /// <p>The time that the task finished executing on the target.</p>
     #[serde(rename = "EndTime")]
@@ -2879,6 +2960,7 @@ pub struct GetMaintenanceWindowExecutionTaskRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetMaintenanceWindowExecutionTaskResult {
     /// <p>The time the task execution completed.</p>
     #[serde(rename = "EndTime")]
@@ -2944,6 +3026,7 @@ pub struct GetMaintenanceWindowRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetMaintenanceWindowResult {
     /// <p>Whether targets must be registered with the Maintenance Window before tasks can be defined for those targets.</p>
     #[serde(rename = "AllowUnassociatedTargets")]
@@ -2998,6 +3081,7 @@ pub struct GetMaintenanceWindowTaskRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetMaintenanceWindowTaskResult {
     /// <p>The retrieved task description.</p>
     #[serde(rename = "Description")]
@@ -3078,6 +3162,7 @@ pub struct GetParameterHistoryRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetParameterHistoryResult {
     /// <p>The token to use when requesting the next set of items. If there are no additional items to return, the string is empty.</p>
     #[serde(rename = "NextToken")]
@@ -3101,6 +3186,7 @@ pub struct GetParameterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetParameterResult {
     /// <p>Information about a parameter.</p>
     #[serde(rename = "Parameter")]
@@ -3136,6 +3222,7 @@ pub struct GetParametersByPathRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetParametersByPathResult {
     /// <p>The token for the next set of items to return. Use this token to get the next set of results.</p>
     #[serde(rename = "NextToken")]
@@ -3159,6 +3246,7 @@ pub struct GetParametersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetParametersResult {
     /// <p>A list of parameters that are not formatted correctly or do not run when executed.</p>
     #[serde(rename = "InvalidParameters")]
@@ -3182,6 +3270,7 @@ pub struct GetPatchBaselineForPatchGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetPatchBaselineForPatchGroupResult {
     /// <p>The ID of the patch baseline that should be used for the patch group.</p>
     #[serde(rename = "BaselineId")]
@@ -3205,6 +3294,7 @@ pub struct GetPatchBaselineRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetPatchBaselineResult {
     /// <p>A set of rules used to include patches in the baseline.</p>
     #[serde(rename = "ApprovalRules")]
@@ -3266,6 +3356,7 @@ pub struct GetPatchBaselineResult {
 
 /// <p>Status information about the aggregated associations.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceAggregatedAssociationOverview {
     /// <p>Detailed status information about the aggregated associations.</p>
     #[serde(rename = "DetailedStatus")]
@@ -3280,6 +3371,7 @@ pub struct InstanceAggregatedAssociationOverview {
 
 /// <p>One or more association documents on the instance. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceAssociation {
     /// <p>The association ID.</p>
     #[serde(rename = "AssociationId")]
@@ -3310,6 +3402,7 @@ pub struct InstanceAssociationOutputLocation {
 
 /// <p>The URL of Amazon S3 bucket where you want to store the results of this request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceAssociationOutputUrl {
     /// <p>The URL of Amazon S3 bucket where you want to store the results of this request.</p>
     #[serde(rename = "S3OutputUrl")]
@@ -3319,6 +3412,7 @@ pub struct InstanceAssociationOutputUrl {
 
 /// <p>Status information about the instance association.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceAssociationStatusInfo {
     /// <p>The association ID.</p>
     #[serde(rename = "AssociationId")]
@@ -3372,6 +3466,7 @@ pub struct InstanceAssociationStatusInfo {
 
 /// <p>Describes a filter for a specific list of instances. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstanceInformation {
     /// <p>The activation ID created by Systems Manager when the server or VM was registered.</p>
     #[serde(rename = "ActivationId")]
@@ -3475,6 +3570,7 @@ pub struct InstanceInformationStringFilter {
 
 /// <p>Defines the high-level patch compliance state for a managed instance, providing information about the number of installed, missing, not applicable, and failed patches along with metadata about the operation when this information was gathered for the instance.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InstancePatchState {
     /// <p>The ID of the patch baseline used to patch the instance.</p>
     #[serde(rename = "BaselineId")]
@@ -3553,6 +3649,7 @@ pub struct InventoryAggregator {
 
 /// <p>Status information returned by the <code>DeleteInventory</code> action.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InventoryDeletionStatusItem {
     /// <p>The deletion ID returned by the <code>DeleteInventory</code> action.</p>
     #[serde(rename = "DeletionId")]
@@ -3586,6 +3683,7 @@ pub struct InventoryDeletionStatusItem {
 
 /// <p>Information about the delete operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InventoryDeletionSummary {
     /// <p>Remaining number of items to delete.</p>
     #[serde(rename = "RemainingCount")]
@@ -3603,6 +3701,7 @@ pub struct InventoryDeletionSummary {
 
 /// <p>Either a count, remaining count, or a version number in a delete inventory summary.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InventoryDeletionSummaryItem {
     /// <p>A count of the number of deleted items.</p>
     #[serde(rename = "Count")]
@@ -3661,6 +3760,7 @@ pub struct InventoryItem {
 
 /// <p>Attributes are the entries within the inventory item content. It contains name and value.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InventoryItemAttribute {
     /// <p>The data type of the inventory item attribute. </p>
     #[serde(rename = "DataType")]
@@ -3672,6 +3772,7 @@ pub struct InventoryItemAttribute {
 
 /// <p>The inventory item schema definition. Users can use this to compose inventory query filters.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InventoryItemSchema {
     /// <p>The schema attributes for inventory. This contains data type and attribute name.</p>
     #[serde(rename = "Attributes")]
@@ -3691,6 +3792,7 @@ pub struct InventoryItemSchema {
 
 /// <p>Inventory query results.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InventoryResultEntity {
     /// <p>The data section in the inventory result entity JSON.</p>
     #[serde(rename = "Data")]
@@ -3704,6 +3806,7 @@ pub struct InventoryResultEntity {
 
 /// <p>The inventory result item.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InventoryResultItem {
     /// <p>The time inventory item data was captured.</p>
     #[serde(rename = "CaptureTime")]
@@ -3736,6 +3839,7 @@ pub struct LabelParameterVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LabelParameterVersionResult {
     #[serde(rename = "InvalidLabels")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3758,6 +3862,7 @@ pub struct ListAssociationVersionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAssociationVersionsResult {
     /// <p>Information about all versions of the association for the specified association ID.</p>
     #[serde(rename = "AssociationVersions")]
@@ -3786,6 +3891,7 @@ pub struct ListAssociationsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListAssociationsResult {
     /// <p>The associations.</p>
     #[serde(rename = "Associations")]
@@ -3826,6 +3932,7 @@ pub struct ListCommandInvocationsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListCommandInvocationsResult {
     /// <p>(Optional) A list of all invocations. </p>
     #[serde(rename = "CommandInvocations")]
@@ -3862,6 +3969,7 @@ pub struct ListCommandsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListCommandsResult {
     /// <p>(Optional) The list of commands requested by the user. </p>
     #[serde(rename = "Commands")]
@@ -3898,6 +4006,7 @@ pub struct ListComplianceItemsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListComplianceItemsResult {
     /// <p>A list of compliance information for the specified resource ID. </p>
     #[serde(rename = "ComplianceItems")]
@@ -3926,6 +4035,7 @@ pub struct ListComplianceSummariesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListComplianceSummariesResult {
     /// <p>A list of compliant and non-compliant summary counts based on compliance types. For example, this call returns State Manager associations, patches, or custom compliance types according to the filter criteria that you specified.</p>
     #[serde(rename = "ComplianceSummaryItems")]
@@ -3953,6 +4063,7 @@ pub struct ListDocumentVersionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListDocumentVersionsResult {
     /// <p>The document versions.</p>
     #[serde(rename = "DocumentVersions")]
@@ -3985,6 +4096,7 @@ pub struct ListDocumentsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListDocumentsResult {
     /// <p>The names of the Systems Manager documents.</p>
     #[serde(rename = "DocumentIdentifiers")]
@@ -4019,6 +4131,7 @@ pub struct ListInventoryEntriesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListInventoryEntriesResult {
     /// <p>The time that inventory information was collected for the instance(s).</p>
     #[serde(rename = "CaptureTime")]
@@ -4063,6 +4176,7 @@ pub struct ListResourceComplianceSummariesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListResourceComplianceSummariesResult {
     /// <p>The token for the next set of items to return. Use this token to get the next set of results.</p>
     #[serde(rename = "NextToken")]
@@ -4087,6 +4201,7 @@ pub struct ListResourceDataSyncRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListResourceDataSyncResult {
     /// <p>The token for the next set of items to return. Use this token to get the next set of results.</p>
     #[serde(rename = "NextToken")]
@@ -4109,6 +4224,7 @@ pub struct ListTagsForResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagsForResourceResult {
     /// <p>A list of tags.</p>
     #[serde(rename = "TagList")]
@@ -4146,6 +4262,7 @@ pub struct MaintenanceWindowAutomationParameters {
 
 /// <p>Describes the information about an execution of a Maintenance Window. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MaintenanceWindowExecution {
     /// <p>The time the execution finished.</p>
     #[serde(rename = "EndTime")]
@@ -4175,6 +4292,7 @@ pub struct MaintenanceWindowExecution {
 
 /// <p>Information about a task execution performed as part of a Maintenance Window execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MaintenanceWindowExecutionTaskIdentity {
     /// <p>The time the task execution finished.</p>
     #[serde(rename = "EndTime")]
@@ -4212,6 +4330,7 @@ pub struct MaintenanceWindowExecutionTaskIdentity {
 
 /// <p>Describes the information about a task invocation for a particular target as part of a task execution performed as part of a Maintenance Window execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MaintenanceWindowExecutionTaskInvocationIdentity {
     /// <p>The time the invocation finished.</p>
     #[serde(rename = "EndTime")]
@@ -4278,6 +4397,7 @@ pub struct MaintenanceWindowFilter {
 
 /// <p>Information about the Maintenance Window.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MaintenanceWindowIdentity {
     /// <p>The number of hours before the end of the Maintenance Window that Systems Manager stops scheduling new tasks for execution.</p>
     #[serde(rename = "Cutoff")]
@@ -4382,6 +4502,7 @@ pub struct MaintenanceWindowStepFunctionsParameters {
 
 /// <p>The target registered with the Maintenance Window.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MaintenanceWindowTarget {
     /// <p>A description of the target.</p>
     #[serde(rename = "Description")]
@@ -4415,6 +4536,7 @@ pub struct MaintenanceWindowTarget {
 
 /// <p>Information about a task defined for a Maintenance Window.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MaintenanceWindowTask {
     /// <p>A description of the task.</p>
     #[serde(rename = "Description")]
@@ -4520,10 +4642,12 @@ pub struct ModifyDocumentPermissionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ModifyDocumentPermissionResponse {}
 
 /// <p>A summary of resources that are not compliant. The summary is organized according to resource type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct NonCompliantSummary {
     /// <p>The total number of compliance items that are not compliant.</p>
     #[serde(rename = "NonCompliantCount")]
@@ -4554,6 +4678,7 @@ pub struct NotificationConfig {
 
 /// <p>Information about the source where the association execution details are stored.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct OutputSource {
     /// <p>The ID of the output source, for example the URL of an Amazon S3 bucket.</p>
     #[serde(rename = "OutputSourceId")]
@@ -4567,6 +4692,7 @@ pub struct OutputSource {
 
 /// <p>An Amazon EC2 Systems Manager parameter in Parameter Store.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Parameter {
     /// <p>The Amazon Resource Name (ARN) of the parameter.</p>
     #[serde(rename = "ARN")]
@@ -4604,6 +4730,7 @@ pub struct Parameter {
 
 /// <p>Information about parameter usage.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ParameterHistory {
     /// <p>Parameter names can include the following letters and symbols.</p> <p>a-zA-Z0-9_.-</p>
     #[serde(rename = "AllowedPattern")]
@@ -4649,6 +4776,7 @@ pub struct ParameterHistory {
 
 /// <p>Metada includes information like the ARN of the last user and the date/time the parameter was last used.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ParameterMetadata {
     /// <p>A parameter name can include only the following letters and symbols.</p> <p>a-zA-Z0-9_.-</p>
     #[serde(rename = "AllowedPattern")]
@@ -4713,6 +4841,7 @@ pub struct ParametersFilter {
 
 /// <p>Represents metadata about a patch.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Patch {
     /// <p>The classification of the patch (for example, SecurityUpdates, Updates, CriticalUpdates).</p>
     #[serde(rename = "Classification")]
@@ -4770,6 +4899,7 @@ pub struct Patch {
 
 /// <p>Defines the basic information about a patch baseline.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PatchBaselineIdentity {
     /// <p>The description of the patch baseline.</p>
     #[serde(rename = "BaselineDescription")]
@@ -4795,6 +4925,7 @@ pub struct PatchBaselineIdentity {
 
 /// <p>Information about the state of a patch on a particular instance as it relates to the patch baseline used to patch the instance.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PatchComplianceData {
     /// <p>The classification of the patch (for example, SecurityUpdates, Updates, CriticalUpdates).</p>
     #[serde(rename = "Classification")]
@@ -4837,6 +4968,7 @@ pub struct PatchFilterGroup {
 
 /// <p>The mapping between a patch group and the patch baseline the patch group is registered with.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PatchGroupPatchBaselineMapping {
     /// <p>The patch baseline the patch group is registered with.</p>
     #[serde(rename = "BaselineIdentity")]
@@ -4904,6 +5036,7 @@ pub struct PatchSource {
 
 /// <p>Information about the approval status of a patch.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PatchStatus {
     /// <p>The date the patch was approved (or will be approved if the status is PENDING_APPROVAL).</p>
     #[serde(rename = "ApprovalDate")]
@@ -4943,6 +5076,7 @@ pub struct PutComplianceItemsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutComplianceItemsResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -4956,6 +5090,7 @@ pub struct PutInventoryRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutInventoryResult {
     /// <p>Information about the request.</p>
     #[serde(rename = "Message")]
@@ -4993,6 +5128,7 @@ pub struct PutParameterRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutParameterResult {
     /// <p>The new version number of a parameter. If you edit a parameter value, Parameter Store automatically creates a new version and assigns this new version a unique ID. You can reference a parameter version ID in API actions or in Systems Manager documents (SSM documents). By default, if you don't specify a specific version, the system returns the latest parameter value when a parameter is called.</p>
     #[serde(rename = "Version")]
@@ -5008,6 +5144,7 @@ pub struct RegisterDefaultPatchBaselineRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegisterDefaultPatchBaselineResult {
     /// <p>The ID of the default patch baseline.</p>
     #[serde(rename = "BaselineId")]
@@ -5026,6 +5163,7 @@ pub struct RegisterPatchBaselineForPatchGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegisterPatchBaselineForPatchGroupResult {
     /// <p>The ID of the patch baseline the patch group was registered with.</p>
     #[serde(rename = "BaselineId")]
@@ -5067,6 +5205,7 @@ pub struct RegisterTargetWithMaintenanceWindowRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegisterTargetWithMaintenanceWindowResult {
     /// <p>The ID of the target definition in this Maintenance Window.</p>
     #[serde(rename = "WindowTargetId")]
@@ -5129,6 +5268,7 @@ pub struct RegisterTaskWithMaintenanceWindowRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegisterTaskWithMaintenanceWindowResult {
     /// <p>The id of the task in the Maintenance Window.</p>
     #[serde(rename = "WindowTaskId")]
@@ -5150,10 +5290,12 @@ pub struct RemoveTagsFromResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RemoveTagsFromResourceResult {}
 
 /// <p>Information about targets that resolved during the Automation execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResolvedTargets {
     /// <p>A list of parameter values sent to targets that resolved during the Automation execution.</p>
     #[serde(rename = "ParameterValues")]
@@ -5167,6 +5309,7 @@ pub struct ResolvedTargets {
 
 /// <p>Compliance summary information for a specific resource. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResourceComplianceSummaryItem {
     /// <p>The compliance type.</p>
     #[serde(rename = "ComplianceType")]
@@ -5204,6 +5347,7 @@ pub struct ResourceComplianceSummaryItem {
 
 /// <p>Information about a Resource Data Sync configuration, including its current status and last successful sync.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResourceDataSyncItem {
     /// <p>The status reported by the last sync.</p>
     #[serde(rename = "LastStatus")]
@@ -5284,6 +5428,7 @@ pub struct S3OutputLocation {
 
 /// <p>A URL for the Amazon S3 bucket where you want to store the results of this request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct S3OutputUrl {
     /// <p>A URL for an Amazon S3 bucket where you want to store the results of this request.</p>
     #[serde(rename = "OutputUrl")]
@@ -5306,6 +5451,7 @@ pub struct SendAutomationSignalRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SendAutomationSignalResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -5380,6 +5526,7 @@ pub struct SendCommandRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SendCommandResult {
     /// <p>The request as it was received by Systems Manager. Also provides the command ID which can be used future references to this request.</p>
     #[serde(rename = "Command")]
@@ -5389,6 +5536,7 @@ pub struct SendCommandResult {
 
 /// <p>The number of managed instances found for each patch severity level defined in the request filter.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SeveritySummary {
     /// <p>The total number of resources or compliance items that have a severity level of critical. Critical severity is determined by the organization that published the compliance items.</p>
     #[serde(rename = "CriticalCount")]
@@ -5424,6 +5572,7 @@ pub struct StartAssociationsOnceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartAssociationsOnceResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -5466,6 +5615,7 @@ pub struct StartAutomationExecutionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartAutomationExecutionResult {
     /// <p>The unique ID of a newly scheduled automation execution.</p>
     #[serde(rename = "AutomationExecutionId")]
@@ -5475,6 +5625,7 @@ pub struct StartAutomationExecutionResult {
 
 /// <p>Detailed information about an the execution state of an Automation step.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StepExecution {
     /// <p>The action this step performs. The action determines the behavior of the step.</p>
     #[serde(rename = "Action")]
@@ -5581,6 +5732,7 @@ pub struct StopAutomationExecutionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopAutomationExecutionResult {}
 
 /// <p>Metadata that you assign to your AWS resources. Tags enable you to categorize your resources in different ways, for example, by purpose, owner, or environment. In Systems Manager, you can apply tags to documents, managed instances, Maintenance Windows, Parameter Store parameters, and patch baselines.</p>
@@ -5647,6 +5799,7 @@ pub struct UpdateAssociationRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateAssociationResult {
     /// <p>The description of the association that was updated.</p>
     #[serde(rename = "AssociationDescription")]
@@ -5668,6 +5821,7 @@ pub struct UpdateAssociationStatusRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateAssociationStatusResult {
     /// <p>Information about the association.</p>
     #[serde(rename = "AssociationDescription")]
@@ -5686,6 +5840,7 @@ pub struct UpdateDocumentDefaultVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateDocumentDefaultVersionResult {
     /// <p>The description of a custom document that you want to set as the default version.</p>
     #[serde(rename = "Description")]
@@ -5716,6 +5871,7 @@ pub struct UpdateDocumentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateDocumentResult {
     /// <p>A description of the document that was updated.</p>
     #[serde(rename = "DocumentDescription")]
@@ -5763,6 +5919,7 @@ pub struct UpdateMaintenanceWindowRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateMaintenanceWindowResult {
     /// <p>Whether targets must be registered with the Maintenance Window before tasks can be defined for those targets.</p>
     #[serde(rename = "AllowUnassociatedTargets")]
@@ -5829,6 +5986,7 @@ pub struct UpdateMaintenanceWindowTargetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateMaintenanceWindowTargetResult {
     /// <p>The updated description.</p>
     #[serde(rename = "Description")]
@@ -5916,6 +6074,7 @@ pub struct UpdateMaintenanceWindowTaskRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateMaintenanceWindowTaskResult {
     /// <p>The updated task description.</p>
     #[serde(rename = "Description")]
@@ -5983,6 +6142,7 @@ pub struct UpdateManagedInstanceRoleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateManagedInstanceRoleResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -6033,6 +6193,7 @@ pub struct UpdatePatchBaselineRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdatePatchBaselineResult {
     /// <p>A set of rules used to include patches in the baseline.</p>
     #[serde(rename = "ApprovalRules")]

--- a/rusoto/services/stepfunctions/src/generated.rs
+++ b/rusoto/services/stepfunctions/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Contains details about an activity which failed during an execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActivityFailedEventDetails {
     /// <p>A more detailed explanation of the cause of the failure.</p>
     #[serde(rename = "cause")]
@@ -43,6 +44,7 @@ pub struct ActivityFailedEventDetails {
 
 /// <p>Contains details about an activity.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActivityListItem {
     /// <p>The Amazon Resource Name (ARN) that identifies the activity.</p>
     #[serde(rename = "activityArn")]
@@ -57,6 +59,7 @@ pub struct ActivityListItem {
 
 /// <p>Contains details about an activity schedule failure which occurred during an execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActivityScheduleFailedEventDetails {
     /// <p>A more detailed explanation of the cause of the failure.</p>
     #[serde(rename = "cause")]
@@ -70,6 +73,7 @@ pub struct ActivityScheduleFailedEventDetails {
 
 /// <p>Contains details about an activity scheduled during an execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActivityScheduledEventDetails {
     /// <p>The maximum allowed duration between two heartbeats for the activity task.</p>
     #[serde(rename = "heartbeatInSeconds")]
@@ -90,6 +94,7 @@ pub struct ActivityScheduledEventDetails {
 
 /// <p>Contains details about the start of an activity during an execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActivityStartedEventDetails {
     /// <p>The name of the worker that the task is assigned to. These names are provided by the workers when calling <a>GetActivityTask</a>.</p>
     #[serde(rename = "workerName")]
@@ -99,6 +104,7 @@ pub struct ActivityStartedEventDetails {
 
 /// <p>Contains details about an activity which successfully terminated during an execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActivitySucceededEventDetails {
     /// <p>The JSON data output by the activity task.</p>
     #[serde(rename = "output")]
@@ -108,6 +114,7 @@ pub struct ActivitySucceededEventDetails {
 
 /// <p>Contains details about an activity timeout which occurred during an execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActivityTimedOutEventDetails {
     /// <p>A more detailed explanation of the cause of the timeout.</p>
     #[serde(rename = "cause")]
@@ -127,6 +134,7 @@ pub struct CreateActivityInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateActivityOutput {
     /// <p>The Amazon Resource Name (ARN) that identifies the created activity.</p>
     #[serde(rename = "activityArn")]
@@ -150,6 +158,7 @@ pub struct CreateStateMachineInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateStateMachineOutput {
     /// <p>The date the state machine is created.</p>
     #[serde(rename = "creationDate")]
@@ -167,6 +176,7 @@ pub struct DeleteActivityInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteActivityOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -177,6 +187,7 @@ pub struct DeleteStateMachineInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteStateMachineOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -187,6 +198,7 @@ pub struct DescribeActivityInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeActivityOutput {
     /// <p>The Amazon Resource Name (ARN) that identifies the activity.</p>
     #[serde(rename = "activityArn")]
@@ -207,6 +219,7 @@ pub struct DescribeExecutionInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeExecutionOutput {
     /// <p>The Amazon Resource Name (ARN) that identifies the execution.</p>
     #[serde(rename = "executionArn")]
@@ -245,6 +258,7 @@ pub struct DescribeStateMachineForExecutionInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeStateMachineForExecutionOutput {
     /// <p>The Amazon States Language definition of the state machine.</p>
     #[serde(rename = "definition")]
@@ -271,6 +285,7 @@ pub struct DescribeStateMachineInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeStateMachineOutput {
     /// <p>The date the state machine is created.</p>
     #[serde(rename = "creationDate")]
@@ -295,6 +310,7 @@ pub struct DescribeStateMachineOutput {
 
 /// <p>Contains details about an abort of an execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ExecutionAbortedEventDetails {
     /// <p>A more detailed explanation of the cause of the failure.</p>
     #[serde(rename = "cause")]
@@ -308,6 +324,7 @@ pub struct ExecutionAbortedEventDetails {
 
 /// <p>Contains details about an execution failure event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ExecutionFailedEventDetails {
     /// <p>A more detailed explanation of the cause of the failure.</p>
     #[serde(rename = "cause")]
@@ -321,6 +338,7 @@ pub struct ExecutionFailedEventDetails {
 
 /// <p>Contains details about an execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ExecutionListItem {
     /// <p>The Amazon Resource Name (ARN) that identifies the execution.</p>
     #[serde(rename = "executionArn")]
@@ -345,6 +363,7 @@ pub struct ExecutionListItem {
 
 /// <p>Contains details about the start of the execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ExecutionStartedEventDetails {
     /// <p>The JSON data input to the execution.</p>
     #[serde(rename = "input")]
@@ -358,6 +377,7 @@ pub struct ExecutionStartedEventDetails {
 
 /// <p>Contains details about the successful termination of the execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ExecutionSucceededEventDetails {
     /// <p>The JSON data output by the execution.</p>
     #[serde(rename = "output")]
@@ -367,6 +387,7 @@ pub struct ExecutionSucceededEventDetails {
 
 /// <p>Contains details about the execution timeout which occurred during the execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ExecutionTimedOutEventDetails {
     /// <p>A more detailed explanation of the cause of the timeout.</p>
     #[serde(rename = "cause")]
@@ -390,6 +411,7 @@ pub struct GetActivityTaskInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetActivityTaskOutput {
     /// <p>The string that contains the JSON input data for the task.</p>
     #[serde(rename = "input")]
@@ -421,6 +443,7 @@ pub struct GetExecutionHistoryInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetExecutionHistoryOutput {
     /// <p>The list of events that occurred in the execution.</p>
     #[serde(rename = "events")]
@@ -433,6 +456,7 @@ pub struct GetExecutionHistoryOutput {
 
 /// <p>Contains details about the events of an execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct HistoryEvent {
     #[serde(rename = "activityFailedEventDetails")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -512,6 +536,7 @@ pub struct HistoryEvent {
 
 /// <p>Contains details about a lambda function which failed during an execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LambdaFunctionFailedEventDetails {
     /// <p>A more detailed explanation of the cause of the failure.</p>
     #[serde(rename = "cause")]
@@ -525,6 +550,7 @@ pub struct LambdaFunctionFailedEventDetails {
 
 /// <p>Contains details about a failed lambda function schedule event which occurred during an execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LambdaFunctionScheduleFailedEventDetails {
     /// <p>A more detailed explanation of the cause of the failure.</p>
     #[serde(rename = "cause")]
@@ -538,6 +564,7 @@ pub struct LambdaFunctionScheduleFailedEventDetails {
 
 /// <p>Contains details about a lambda function scheduled during an execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LambdaFunctionScheduledEventDetails {
     /// <p>The JSON data input to the lambda function.</p>
     #[serde(rename = "input")]
@@ -554,6 +581,7 @@ pub struct LambdaFunctionScheduledEventDetails {
 
 /// <p>Contains details about a lambda function which failed to start during an execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LambdaFunctionStartFailedEventDetails {
     /// <p>A more detailed explanation of the cause of the failure.</p>
     #[serde(rename = "cause")]
@@ -567,6 +595,7 @@ pub struct LambdaFunctionStartFailedEventDetails {
 
 /// <p>Contains details about a lambda function which successfully terminated during an execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LambdaFunctionSucceededEventDetails {
     /// <p>The JSON data output by the lambda function.</p>
     #[serde(rename = "output")]
@@ -576,6 +605,7 @@ pub struct LambdaFunctionSucceededEventDetails {
 
 /// <p>Contains details about a lambda function timeout which occurred during an execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LambdaFunctionTimedOutEventDetails {
     /// <p>A more detailed explanation of the cause of the timeout.</p>
     #[serde(rename = "cause")]
@@ -600,6 +630,7 @@ pub struct ListActivitiesInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListActivitiesOutput {
     /// <p>The list of activities.</p>
     #[serde(rename = "activities")]
@@ -630,6 +661,7 @@ pub struct ListExecutionsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListExecutionsOutput {
     /// <p>The list of matching executions.</p>
     #[serde(rename = "executions")]
@@ -653,6 +685,7 @@ pub struct ListStateMachinesInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListStateMachinesOutput {
     /// <p>If a <code>nextToken</code> is returned by a previous call, there are more results available. To retrieve the next page of results, make the call again using the returned token in <code>nextToken</code>. Keep all other arguments unchanged.</p> <p>The configured <code>maxResults</code> determines how many results can be returned in a single call.</p>
     #[serde(rename = "nextToken")]
@@ -678,6 +711,7 @@ pub struct SendTaskFailureInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SendTaskFailureOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -688,6 +722,7 @@ pub struct SendTaskHeartbeatInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SendTaskHeartbeatOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -701,6 +736,7 @@ pub struct SendTaskSuccessInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SendTaskSuccessOutput {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -719,6 +755,7 @@ pub struct StartExecutionInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartExecutionOutput {
     /// <p>The Amazon Resource Name (ARN) that identifies the execution.</p>
     #[serde(rename = "executionArn")]
@@ -730,6 +767,7 @@ pub struct StartExecutionOutput {
 
 /// <p>Contains details about a state entered during an execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StateEnteredEventDetails {
     /// <p>The string that contains the JSON input data for the state.</p>
     #[serde(rename = "input")]
@@ -742,6 +780,7 @@ pub struct StateEnteredEventDetails {
 
 /// <p>Contains details about an exit from a state during an execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StateExitedEventDetails {
     /// <p><p>The name of the state.</p> <p>A name must <i>not</i> contain:</p> <ul> <li> <p>whitespace</p> </li> <li> <p>brackets <code>&lt; &gt; { } [ ]</code> </p> </li> <li> <p>wildcard characters <code>? *</code> </p> </li> <li> <p>special characters <code>&quot; # % \ ^ | ~ ` $ &amp; , ; : /</code> </p> </li> <li> <p>control characters (<code>U+0000-001F</code>, <code>U+007F-009F</code>)</p> </li> </ul></p>
     #[serde(rename = "name")]
@@ -754,6 +793,7 @@ pub struct StateExitedEventDetails {
 
 /// <p>Contains details about the state machine.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StateMachineListItem {
     /// <p>The date the state machine is created.</p>
     #[serde(rename = "creationDate")]
@@ -782,6 +822,7 @@ pub struct StopExecutionInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopExecutionOutput {
     /// <p>The date the execution is stopped.</p>
     #[serde(rename = "stopDate")]
@@ -804,6 +845,7 @@ pub struct UpdateStateMachineInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateStateMachineOutput {
     /// <p>The date and time the state machine was updated.</p>
     #[serde(rename = "updateDate")]

--- a/rusoto/services/storagegateway/src/generated.rs
+++ b/rusoto/services/storagegateway/src/generated.rs
@@ -59,6 +59,7 @@ pub struct ActivateGatewayInput {
 
 /// <p><p>AWS Storage Gateway returns the Amazon Resource Name (ARN) of the activated gateway. It is a string made of information such as your account, gateway name, and region. This ARN is used to reference the gateway in other API operations as well as resource-based authorization.</p> <note> <p>For gateways activated prior to September 02, 2015, the gateway ARN contains the gateway name rather than the gateway ID. Changing the name of the gateway has no effect on the gateway ARN.</p> </note></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActivateGatewayOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -74,6 +75,7 @@ pub struct AddCacheInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddCacheOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -93,6 +95,7 @@ pub struct AddTagsToResourceInput {
 
 /// <p>AddTagsToResourceOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddTagsToResourceOutput {
     /// <p>The Amazon Resource Name (ARN) of the resource you want to add tags to.</p>
     #[serde(rename = "ResourceARN")]
@@ -109,6 +112,7 @@ pub struct AddUploadBufferInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddUploadBufferOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -127,6 +131,7 @@ pub struct AddWorkingStorageInput {
 
 /// <p>A JSON object containing the of the gateway for which working storage was configured.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddWorkingStorageOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -135,6 +140,7 @@ pub struct AddWorkingStorageOutput {
 
 /// <p>Describes an iSCSI cached volume.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CachediSCSIVolume {
     /// <p>The date the volume was created. Volumes created prior to March 28, 2017 don’t have this time stamp.</p>
     #[serde(rename = "CreatedDate")]
@@ -193,6 +199,7 @@ pub struct CancelArchivalInput {
 
 /// <p>CancelArchivalOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CancelArchivalOutput {
     /// <p>The Amazon Resource Name (ARN) of the virtual tape for which archiving was canceled.</p>
     #[serde(rename = "TapeARN")]
@@ -212,6 +219,7 @@ pub struct CancelRetrievalInput {
 
 /// <p>CancelRetrievalOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CancelRetrievalOutput {
     /// <p>The Amazon Resource Name (ARN) of the virtual tape for which retrieval was canceled.</p>
     #[serde(rename = "TapeARN")]
@@ -221,6 +229,7 @@ pub struct CancelRetrievalOutput {
 
 /// <p>Describes Challenge-Handshake Authentication Protocol (CHAP) information that supports authentication between your gateway and iSCSI initiators.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ChapInfo {
     /// <p>The iSCSI initiator that connects to the target.</p>
     #[serde(rename = "InitiatorName")]
@@ -275,6 +284,7 @@ pub struct CreateCachediSCSIVolumeInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateCachediSCSIVolumeOutput {
     /// <p>he Amazon Resource Name (ARN) of the volume target that includes the iSCSI name that initiators can use to connect to the target.</p>
     #[serde(rename = "TargetARN")]
@@ -345,6 +355,7 @@ pub struct CreateNFSFileShareInput {
 
 /// <p>CreateNFSFileShareOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateNFSFileShareOutput {
     /// <p>The Amazon Resource Name (ARN) of the newly created file share. </p>
     #[serde(rename = "FileShareARN")]
@@ -411,6 +422,7 @@ pub struct CreateSMBFileShareInput {
 
 /// <p>CreateSMBFileShareOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateSMBFileShareOutput {
     /// <p>The Amazon Resource Name (ARN) of the newly created file share. </p>
     #[serde(rename = "FileShareARN")]
@@ -427,6 +439,7 @@ pub struct CreateSnapshotFromVolumeRecoveryPointInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateSnapshotFromVolumeRecoveryPointOutput {
     #[serde(rename = "SnapshotId")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -452,6 +465,7 @@ pub struct CreateSnapshotInput {
 
 /// <p>A JSON object containing the following fields:</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateSnapshotOutput {
     /// <p>The snapshot ID that is used to refer to the snapshot in future operations such as describing snapshots (Amazon Elastic Compute Cloud API <code>DescribeSnapshots</code>) or creating a volume from a snapshot (<a>CreateStorediSCSIVolume</a>).</p>
     #[serde(rename = "SnapshotId")]
@@ -496,6 +510,7 @@ pub struct CreateStorediSCSIVolumeInput {
 
 /// <p>A JSON object containing the following fields:</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateStorediSCSIVolumeOutput {
     /// <p>he Amazon Resource Name (ARN) of the volume target that includes the iSCSI name that initiators can use to connect to the target.</p>
     #[serde(rename = "TargetARN")]
@@ -535,6 +550,7 @@ pub struct CreateTapeWithBarcodeInput {
 
 /// <p>CreateTapeOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateTapeWithBarcodeOutput {
     /// <p>A unique Amazon Resource Name (ARN) that represents the virtual tape that was created.</p>
     #[serde(rename = "TapeARN")]
@@ -572,6 +588,7 @@ pub struct CreateTapesInput {
 
 /// <p>CreateTapeOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateTapesOutput {
     /// <p>A list of unique Amazon Resource Names (ARNs) that represents the virtual tapes that were created.</p>
     #[serde(rename = "TapeARNs")]
@@ -591,6 +608,7 @@ pub struct DeleteBandwidthRateLimitInput {
 
 /// <p>A JSON object containing the of the gateway whose bandwidth rate information was deleted.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteBandwidthRateLimitOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -610,6 +628,7 @@ pub struct DeleteChapCredentialsInput {
 
 /// <p>A JSON object containing the following fields:</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteChapCredentialsOutput {
     /// <p>The iSCSI initiator that connects to the target.</p>
     #[serde(rename = "InitiatorName")]
@@ -635,6 +654,7 @@ pub struct DeleteFileShareInput {
 
 /// <p>DeleteFileShareOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteFileShareOutput {
     /// <p>The Amazon Resource Name (ARN) of the deleted file share. </p>
     #[serde(rename = "FileShareARN")]
@@ -651,6 +671,7 @@ pub struct DeleteGatewayInput {
 
 /// <p>A JSON object containing the ID of the deleted gateway.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteGatewayOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -664,6 +685,7 @@ pub struct DeleteSnapshotScheduleInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteSnapshotScheduleOutput {
     #[serde(rename = "VolumeARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -680,6 +702,7 @@ pub struct DeleteTapeArchiveInput {
 
 /// <p>DeleteTapeArchiveOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteTapeArchiveOutput {
     /// <p>The Amazon Resource Name (ARN) of the virtual tape that was deleted from the virtual tape shelf (VTS).</p>
     #[serde(rename = "TapeARN")]
@@ -700,6 +723,7 @@ pub struct DeleteTapeInput {
 
 /// <p>DeleteTapeOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteTapeOutput {
     /// <p>The Amazon Resource Name (ARN) of the deleted virtual tape.</p>
     #[serde(rename = "TapeARN")]
@@ -717,6 +741,7 @@ pub struct DeleteVolumeInput {
 
 /// <p>A JSON object containing the of the storage volume that was deleted</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteVolumeOutput {
     /// <p>The Amazon Resource Name (ARN) of the storage volume that was deleted. It is the same ARN you provided in the request.</p>
     #[serde(rename = "VolumeARN")]
@@ -733,6 +758,7 @@ pub struct DescribeBandwidthRateLimitInput {
 
 /// <p>A JSON object containing the following fields:</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeBandwidthRateLimitOutput {
     /// <p>The average download bandwidth rate limit in bits per second. This field does not appear in the response if the download rate limit is not set.</p>
     #[serde(rename = "AverageDownloadRateLimitInBitsPerSec")]
@@ -754,6 +780,7 @@ pub struct DescribeCacheInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeCacheOutput {
     #[serde(rename = "CacheAllocatedInBytes")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -786,6 +813,7 @@ pub struct DescribeCachediSCSIVolumesInput {
 
 /// <p>A JSON object containing the following fields:</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeCachediSCSIVolumesOutput {
     /// <p>An array of objects where each object contains metadata about one cached volume.</p>
     #[serde(rename = "CachediSCSIVolumes")]
@@ -803,6 +831,7 @@ pub struct DescribeChapCredentialsInput {
 
 /// <p>A JSON object containing a .</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeChapCredentialsOutput {
     /// <p><p>An array of <a>ChapInfo</a> objects that represent CHAP credentials. Each object in the array contains CHAP credential information for one target-initiator pair. If no CHAP credentials are set, an empty array is returned. CHAP credential information is provided in a JSON object with the following fields:</p> <ul> <li> <p> <b>InitiatorName</b>: The iSCSI initiator that connects to the target.</p> </li> <li> <p> <b>SecretToAuthenticateInitiator</b>: The secret key that the initiator (for example, the Windows client) must provide to participate in mutual CHAP with the target.</p> </li> <li> <p> <b>SecretToAuthenticateTarget</b>: The secret key that the target must provide to participate in mutual CHAP with the initiator (e.g. Windows client).</p> </li> <li> <p> <b>TargetARN</b>: The Amazon Resource Name (ARN) of the storage volume.</p> </li> </ul></p>
     #[serde(rename = "ChapCredentials")]
@@ -819,6 +848,7 @@ pub struct DescribeGatewayInformationInput {
 
 /// <p>A JSON object containing the following fields:</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeGatewayInformationOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -866,6 +896,7 @@ pub struct DescribeMaintenanceStartTimeInput {
 
 /// <p><p>A JSON object containing the following fields:</p> <ul> <li> <p> <a>DescribeMaintenanceStartTimeOutput$DayOfWeek</a> </p> </li> <li> <p> <a>DescribeMaintenanceStartTimeOutput$HourOfDay</a> </p> </li> <li> <p> <a>DescribeMaintenanceStartTimeOutput$MinuteOfHour</a> </p> </li> <li> <p> <a>DescribeMaintenanceStartTimeOutput$Timezone</a> </p> </li> </ul></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeMaintenanceStartTimeOutput {
     /// <p>An ordinal number between 0 and 6 that represents the day of the week, where 0 represents Sunday and 6 represents Saturday. The day of week is in the time zone of the gateway.</p>
     #[serde(rename = "DayOfWeek")]
@@ -897,6 +928,7 @@ pub struct DescribeNFSFileSharesInput {
 
 /// <p>DescribeNFSFileSharesOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeNFSFileSharesOutput {
     /// <p>An array containing a description for each requested file share. </p>
     #[serde(rename = "NFSFileShareInfoList")]
@@ -914,6 +946,7 @@ pub struct DescribeSMBFileSharesInput {
 
 /// <p>DescribeSMBFileSharesOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeSMBFileSharesOutput {
     /// <p>An array containing a description for each requested file share. </p>
     #[serde(rename = "SMBFileShareInfoList")]
@@ -928,6 +961,7 @@ pub struct DescribeSMBSettingsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeSMBSettingsOutput {
     /// <p>The name of the domain that the gateway is joined to.</p>
     #[serde(rename = "DomainName")]
@@ -951,6 +985,7 @@ pub struct DescribeSnapshotScheduleInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeSnapshotScheduleOutput {
     #[serde(rename = "Description")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -978,6 +1013,7 @@ pub struct DescribeStorediSCSIVolumesInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeStorediSCSIVolumesOutput {
     #[serde(rename = "StorediSCSIVolumes")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1003,6 +1039,7 @@ pub struct DescribeTapeArchivesInput {
 
 /// <p>DescribeTapeArchivesOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeTapeArchivesOutput {
     /// <p>An opaque string that indicates the position at which the virtual tapes that were fetched for description ended. Use this marker in your next request to fetch the next set of virtual tapes in the virtual tape shelf (VTS). If there are no more virtual tapes to describe, this field does not appear in the response.</p>
     #[serde(rename = "Marker")]
@@ -1031,6 +1068,7 @@ pub struct DescribeTapeRecoveryPointsInput {
 
 /// <p>DescribeTapeRecoveryPointsOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeTapeRecoveryPointsOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1066,6 +1104,7 @@ pub struct DescribeTapesInput {
 
 /// <p>DescribeTapesOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeTapesOutput {
     /// <p>An opaque string which can be used as part of a subsequent DescribeTapes call to retrieve the next page of results.</p> <p>If a response does not contain a marker, then there are no more results to be retrieved.</p>
     #[serde(rename = "Marker")]
@@ -1084,6 +1123,7 @@ pub struct DescribeUploadBufferInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeUploadBufferOutput {
     #[serde(rename = "DiskIds")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1120,6 +1160,7 @@ pub struct DescribeVTLDevicesInput {
 
 /// <p>DescribeVTLDevicesOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeVTLDevicesOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1143,6 +1184,7 @@ pub struct DescribeWorkingStorageInput {
 
 /// <p>A JSON object containing the following fields:</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeWorkingStorageOutput {
     /// <p>An array of the gateway's local disk IDs that are configured as working storage. Each local disk ID is specified as a string (minimum length of 1 and maximum length of 300). If no local disks are configured as working storage, then the DiskIds array is empty.</p>
     #[serde(rename = "DiskIds")]
@@ -1163,6 +1205,7 @@ pub struct DescribeWorkingStorageOutput {
 
 /// <p>Lists iSCSI information about a VTL device.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeviceiSCSIAttributes {
     /// <p>Indicates whether mutual CHAP is enabled for the iSCSI target.</p>
     #[serde(rename = "ChapEnabled")]
@@ -1191,6 +1234,7 @@ pub struct DisableGatewayInput {
 
 /// <p>DisableGatewayOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisableGatewayOutput {
     /// <p>The unique Amazon Resource Name (ARN) of the disabled gateway.</p>
     #[serde(rename = "GatewayARN")]
@@ -1199,6 +1243,7 @@ pub struct DisableGatewayOutput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Disk {
     #[serde(rename = "DiskAllocationResource")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1225,6 +1270,7 @@ pub struct Disk {
 
 /// <p>Describes a file share.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FileShareInfo {
     #[serde(rename = "FileShareARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1245,6 +1291,7 @@ pub struct FileShareInfo {
 
 /// <p>Describes a gateway object.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GatewayInfo {
     /// <p>The Amazon Resource Name (ARN) of the gateway. Use the <a>ListGateways</a> operation to return a list of gateways for your account and region.</p>
     #[serde(rename = "GatewayARN")]
@@ -1287,6 +1334,7 @@ pub struct JoinDomainInput {
 
 /// <p>JoinDomainOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct JoinDomainOutput {
     /// <p>The unique Amazon Resource Name (ARN) of the gateway that joined the domain.</p>
     #[serde(rename = "GatewayARN")]
@@ -1313,6 +1361,7 @@ pub struct ListFileSharesInput {
 
 /// <p>ListFileShareOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListFileSharesOutput {
     /// <p>An array of information about the file gateway's file shares. </p>
     #[serde(rename = "FileShareInfoList")]
@@ -1342,6 +1391,7 @@ pub struct ListGatewaysInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListGatewaysOutput {
     #[serde(rename = "Gateways")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1359,6 +1409,7 @@ pub struct ListLocalDisksInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListLocalDisksOutput {
     #[serde(rename = "Disks")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1386,6 +1437,7 @@ pub struct ListTagsForResourceInput {
 
 /// <p>ListTagsForResourceOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTagsForResourceOutput {
     /// <p>An opaque string that indicates the position at which to stop returning the list of tags.</p>
     #[serde(rename = "Marker")]
@@ -1419,6 +1471,7 @@ pub struct ListTapesInput {
 
 /// <p><p>A JSON object containing the following fields:</p> <ul> <li> <p> <a>ListTapesOutput$Marker</a> </p> </li> <li> <p> <a>ListTapesOutput$VolumeInfos</a> </p> </li> </ul></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTapesOutput {
     /// <p>A string that indicates the position at which to begin returning the next list of tapes. Use the marker in your next request to continue pagination of tapes. If there are no more tapes to list, this element does not appear in the response body.</p>
     #[serde(rename = "Marker")]
@@ -1439,6 +1492,7 @@ pub struct ListVolumeInitiatorsInput {
 
 /// <p>ListVolumeInitiatorsOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListVolumeInitiatorsOutput {
     /// <p>The host names and port numbers of all iSCSI initiators that are connected to the gateway.</p>
     #[serde(rename = "Initiators")]
@@ -1453,6 +1507,7 @@ pub struct ListVolumeRecoveryPointsInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListVolumeRecoveryPointsOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1479,6 +1534,7 @@ pub struct ListVolumesInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListVolumesOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1514,6 +1570,7 @@ pub struct NFSFileShareDefaults {
 
 /// <p>The Unix file permissions and ownership information assigned, by default, to native S3 objects when file gateway discovers them in S3 buckets. This operation is only supported in file gateways.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct NFSFileShareInfo {
     #[serde(rename = "ClientList")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1575,6 +1632,7 @@ pub struct NFSFileShareInfo {
 
 /// <p>Describes a gateway's network interface.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct NetworkInterface {
     /// <p>The Internet Protocol version 4 (IPv4) address of the interface.</p>
     #[serde(rename = "Ipv4Address")]
@@ -1597,6 +1655,7 @@ pub struct NotifyWhenUploadedInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct NotifyWhenUploadedOutput {
     #[serde(rename = "FileShareARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1613,6 +1672,7 @@ pub struct RefreshCacheInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RefreshCacheOutput {
     #[serde(rename = "FileShareARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1632,6 +1692,7 @@ pub struct RemoveTagsFromResourceInput {
 
 /// <p>RemoveTagsFromResourceOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RemoveTagsFromResourceOutput {
     /// <p>The Amazon Resource Name (ARN) of the resource that the tags were removed from.</p>
     #[serde(rename = "ResourceARN")]
@@ -1646,6 +1707,7 @@ pub struct ResetCacheInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResetCacheOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1665,6 +1727,7 @@ pub struct RetrieveTapeArchiveInput {
 
 /// <p>RetrieveTapeArchiveOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RetrieveTapeArchiveOutput {
     /// <p>The Amazon Resource Name (ARN) of the retrieved virtual tape.</p>
     #[serde(rename = "TapeARN")]
@@ -1684,6 +1747,7 @@ pub struct RetrieveTapeRecoveryPointInput {
 
 /// <p>RetrieveTapeRecoveryPointOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RetrieveTapeRecoveryPointOutput {
     /// <p>The Amazon Resource Name (ARN) of the virtual tape for which the recovery point was retrieved.</p>
     #[serde(rename = "TapeARN")]
@@ -1693,6 +1757,7 @@ pub struct RetrieveTapeRecoveryPointOutput {
 
 /// <p>The Windows file permissions and ownership information assigned, by default, to native S3 objects when file gateway discovers them in S3 buckets. This operation is only supported for file gateways.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SMBFileShareInfo {
     #[serde(rename = "Authentication")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1766,6 +1831,7 @@ pub struct SetLocalConsolePasswordInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SetLocalConsolePasswordOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1784,6 +1850,7 @@ pub struct SetSMBGuestPasswordInput {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SetSMBGuestPasswordOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1799,6 +1866,7 @@ pub struct ShutdownGatewayInput {
 
 /// <p>A JSON object containing the of the gateway that was shut down.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ShutdownGatewayOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1814,6 +1882,7 @@ pub struct StartGatewayInput {
 
 /// <p>A JSON object containing the of the gateway that was restarted.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartGatewayOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1831,6 +1900,7 @@ pub struct StorageGatewayError {
 
 /// <p>Describes an iSCSI stored volume.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StorediSCSIVolume {
     /// <p>The date the volume was created. Volumes created prior to March 28, 2017 don’t have this time stamp.</p>
     #[serde(rename = "CreatedDate")]
@@ -1895,6 +1965,7 @@ pub struct Tag {
 
 /// <p>Describes a virtual tape object.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Tape {
     #[serde(rename = "KMSKey")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1935,6 +2006,7 @@ pub struct Tape {
 
 /// <p>Represents a virtual tape that is archived in the virtual tape shelf (VTS).</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TapeArchive {
     /// <p>The time that the archiving of the virtual tape was completed.</p> <p>The default time stamp format is in the ISO8601 extended YYYY-MM-DD'T'HH:MM:SS'Z' format.</p>
     #[serde(rename = "CompletionTime")]
@@ -1975,6 +2047,7 @@ pub struct TapeArchive {
 
 /// <p>Describes a virtual tape.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TapeInfo {
     /// <p>The Amazon Resource Name (ARN) of the gateway. Use the <a>ListGateways</a> operation to return a list of gateways for your account and region.</p>
     #[serde(rename = "GatewayARN")]
@@ -2000,6 +2073,7 @@ pub struct TapeInfo {
 
 /// <p>Describes a recovery point.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TapeRecoveryPointInfo {
     /// <p>The Amazon Resource Name (ARN) of the virtual tape.</p>
     #[serde(rename = "TapeARN")]
@@ -2035,6 +2109,7 @@ pub struct UpdateBandwidthRateLimitInput {
 
 /// <p>A JSON object containing the of the gateway whose throttle information was updated.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateBandwidthRateLimitOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2061,6 +2136,7 @@ pub struct UpdateChapCredentialsInput {
 
 /// <p>A JSON object containing the following fields:</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateChapCredentialsOutput {
     /// <p>The iSCSI initiator that connects to the target. This is the same initiator name specified in the request.</p>
     #[serde(rename = "InitiatorName")]
@@ -2086,6 +2162,7 @@ pub struct UpdateGatewayInformationInput {
 
 /// <p>A JSON object containing the ARN of the gateway that was updated.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateGatewayInformationOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2104,6 +2181,7 @@ pub struct UpdateGatewaySoftwareNowInput {
 
 /// <p>A JSON object containing the of the gateway that was updated.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateGatewaySoftwareNowOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2128,6 +2206,7 @@ pub struct UpdateMaintenanceStartTimeInput {
 
 /// <p>A JSON object containing the of the gateway whose maintenance start time is updated.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateMaintenanceStartTimeOutput {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2184,6 +2263,7 @@ pub struct UpdateNFSFileShareInput {
 
 /// <p>UpdateNFSFileShareOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateNFSFileShareOutput {
     /// <p>The Amazon Resource Name (ARN) of the updated file share. </p>
     #[serde(rename = "FileShareARN")]
@@ -2237,6 +2317,7 @@ pub struct UpdateSMBFileShareInput {
 
 /// <p>UpdateSMBFileShareOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateSMBFileShareOutput {
     /// <p>The Amazon Resource Name (ARN) of the updated SMB file share. </p>
     #[serde(rename = "FileShareARN")]
@@ -2264,6 +2345,7 @@ pub struct UpdateSnapshotScheduleInput {
 
 /// <p>A JSON object containing the of the updated storage volume.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateSnapshotScheduleOutput {
     /// <p><p/></p>
     #[serde(rename = "VolumeARN")]
@@ -2283,6 +2365,7 @@ pub struct UpdateVTLDeviceTypeInput {
 
 /// <p>UpdateVTLDeviceTypeOutput</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateVTLDeviceTypeOutput {
     /// <p>The Amazon Resource Name (ARN) of the medium changer you have selected.</p>
     #[serde(rename = "VTLDeviceARN")]
@@ -2292,6 +2375,7 @@ pub struct UpdateVTLDeviceTypeOutput {
 
 /// <p>Represents a device object associated with a tape gateway.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VTLDevice {
     /// <p>A list of iSCSI information about a VTL device.</p>
     #[serde(rename = "DeviceiSCSIAttributes")]
@@ -2314,6 +2398,7 @@ pub struct VTLDevice {
 
 /// <p>Describes a storage volume object.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VolumeInfo {
     #[serde(rename = "GatewayARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2340,6 +2425,7 @@ pub struct VolumeInfo {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VolumeRecoveryPointInfo {
     #[serde(rename = "VolumeARN")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2357,6 +2443,7 @@ pub struct VolumeRecoveryPointInfo {
 
 /// <p>Lists iSCSI information about a volume.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VolumeiSCSIAttributes {
     /// <p>Indicates whether mutual CHAP is enabled for the iSCSI target.</p>
     #[serde(rename = "ChapEnabled")]

--- a/rusoto/services/support/src/generated.rs
+++ b/rusoto/services/support/src/generated.rs
@@ -42,6 +42,7 @@ pub struct AddAttachmentsToSetRequest {
 
 /// <p>The ID and expiry time of the attachment set returned by the <a>AddAttachmentsToSet</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddAttachmentsToSetResponse {
     /// <p>The ID of the attachment set. If an <code>attachmentSetId</code> was not specified, a new attachment set is created, and the ID of the set is returned in the response. If an <code>attachmentSetId</code> was specified, the attachments are added to the specified set, if it exists.</p>
     #[serde(rename = "attachmentSetId")]
@@ -75,6 +76,7 @@ pub struct AddCommunicationToCaseRequest {
 
 /// <p>The result of the <a>AddCommunicationToCase</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddCommunicationToCaseResponse {
     /// <p>True if <a>AddCommunicationToCase</a> succeeds. Otherwise, returns an error.</p>
     #[serde(rename = "result")]
@@ -101,6 +103,7 @@ pub struct Attachment {
 
 /// <p>The file name and ID of an attachment to a case communication. You can use the ID to retrieve the attachment with the <a>DescribeAttachment</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AttachmentDetails {
     /// <p>The ID of the attachment.</p>
     #[serde(rename = "attachmentId")]
@@ -114,6 +117,7 @@ pub struct AttachmentDetails {
 
 /// <p><p>A JSON-formatted object that contains the metadata for a support case. It is contained the response from a <a>DescribeCases</a> request. <b>CaseDetails</b> contains the following fields:</p> <ul> <li> <p> <b>caseId.</b> The AWS Support case ID requested or returned in the call. The case ID is an alphanumeric string formatted as shown in this example: case-<i>12345678910-2013-c4c1d2bf33c5cf47</i>.</p> </li> <li> <p> <b>categoryCode.</b> The category of problem for the AWS Support case. Corresponds to the CategoryCode values returned by a call to <a>DescribeServices</a>.</p> </li> <li> <p> <b>displayId.</b> The identifier for the case on pages in the AWS Support Center.</p> </li> <li> <p> <b>language.</b> The ISO 639-1 code for the language in which AWS provides support. AWS Support currently supports English (&quot;en&quot;) and Japanese (&quot;ja&quot;). Language parameters must be passed explicitly for operations that take them.</p> </li> <li> <p> <b>recentCommunications.</b> One or more <a>Communication</a> objects. Fields of these objects are <code>attachments</code>, <code>body</code>, <code>caseId</code>, <code>submittedBy</code>, and <code>timeCreated</code>.</p> </li> <li> <p> <b>nextToken.</b> A resumption point for pagination.</p> </li> <li> <p> <b>serviceCode.</b> The identifier for the AWS service that corresponds to the service code defined in the call to <a>DescribeServices</a>.</p> </li> <li> <p> <b>severityCode. </b>The severity code assigned to the case. Contains one of the values returned by the call to <a>DescribeSeverityLevels</a>.</p> </li> <li> <p> <b>status.</b> The status of the case in the AWS Support Center.</p> </li> <li> <p> <b>subject.</b> The subject line of the case.</p> </li> <li> <p> <b>submittedBy.</b> The email address of the account that submitted the case.</p> </li> <li> <p> <b>timeCreated.</b> The time the case was created, in ISO-8601 format.</p> </li> </ul></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CaseDetails {
     /// <p>The AWS Support case ID requested or returned in the call. The case ID is an alphanumeric string formatted as shown in this example: case-<i>12345678910-2013-c4c1d2bf33c5cf47</i> </p>
     #[serde(rename = "caseId")]
@@ -167,6 +171,7 @@ pub struct CaseDetails {
 
 /// <p>A JSON-formatted name/value pair that represents the category name and category code of the problem, selected from the <a>DescribeServices</a> response for each AWS service.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Category {
     /// <p>The category code for the support case.</p>
     #[serde(rename = "code")]
@@ -180,6 +185,7 @@ pub struct Category {
 
 /// <p>A communication associated with an AWS Support case. The communication consists of the case ID, the message body, attachment information, the account email address, and the date and time of the communication.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Communication {
     /// <p>Information about the attachments to the case communication.</p>
     #[serde(rename = "attachmentSet")]
@@ -244,6 +250,7 @@ pub struct CreateCaseRequest {
 
 /// <p>The AWS Support case ID returned by a successful completion of the <a>CreateCase</a> operation. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateCaseResponse {
     /// <p>The AWS Support case ID requested or returned in the call. The case ID is an alphanumeric string formatted as shown in this example: case-<i>12345678910-2013-c4c1d2bf33c5cf47</i> </p>
     #[serde(rename = "caseId")]
@@ -260,6 +267,7 @@ pub struct DescribeAttachmentRequest {
 
 /// <p>The content and file name of the attachment returned by the <a>DescribeAttachment</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeAttachmentResponse {
     /// <p>The attachment content and file name.</p>
     #[serde(rename = "attachment")]
@@ -310,6 +318,7 @@ pub struct DescribeCasesRequest {
 
 /// <p>Returns an array of <a>CaseDetails</a> objects and a <code>nextToken</code> that defines a point for pagination in the result set.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeCasesResponse {
     /// <p>The details for the cases that match the request.</p>
     #[serde(rename = "cases")]
@@ -347,6 +356,7 @@ pub struct DescribeCommunicationsRequest {
 
 /// <p>The communications returned by the <a>DescribeCommunications</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeCommunicationsResponse {
     /// <p>The communications for the case.</p>
     #[serde(rename = "communications")]
@@ -373,6 +383,7 @@ pub struct DescribeServicesRequest {
 
 /// <p>The list of AWS services returned by the <a>DescribeServices</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeServicesResponse {
     /// <p>A JSON-formatted list of AWS services.</p>
     #[serde(rename = "services")]
@@ -391,6 +402,7 @@ pub struct DescribeSeverityLevelsRequest {
 
 /// <p>The list of severity levels returned by the <a>DescribeSeverityLevels</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeSeverityLevelsResponse {
     /// <p>The available severity levels for the support case. Available severity levels are defined by your service level agreement with AWS.</p>
     #[serde(rename = "severityLevels")]
@@ -408,6 +420,7 @@ pub struct DescribeTrustedAdvisorCheckRefreshStatusesRequest {
 
 /// <p>The statuses of the Trusted Advisor checks returned by the <a>DescribeTrustedAdvisorCheckRefreshStatuses</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeTrustedAdvisorCheckRefreshStatusesResponse {
     /// <p>The refresh status of the specified Trusted Advisor checks.</p>
     #[serde(rename = "statuses")]
@@ -428,6 +441,7 @@ pub struct DescribeTrustedAdvisorCheckResultRequest {
 
 /// <p>The result of the Trusted Advisor check returned by the <a>DescribeTrustedAdvisorCheckResult</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeTrustedAdvisorCheckResultResponse {
     /// <p>The detailed results of the Trusted Advisor check.</p>
     #[serde(rename = "result")]
@@ -445,6 +459,7 @@ pub struct DescribeTrustedAdvisorCheckSummariesRequest {
 
 /// <p>The summaries of the Trusted Advisor checks returned by the <a>DescribeTrustedAdvisorCheckSummaries</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeTrustedAdvisorCheckSummariesResponse {
     /// <p>The summary information for the requested Trusted Advisor checks.</p>
     #[serde(rename = "summaries")]
@@ -461,6 +476,7 @@ pub struct DescribeTrustedAdvisorChecksRequest {
 
 /// <p>Information about the Trusted Advisor checks returned by the <a>DescribeTrustedAdvisorChecks</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeTrustedAdvisorChecksResponse {
     /// <p>Information about all available Trusted Advisor checks.</p>
     #[serde(rename = "checks")]
@@ -469,6 +485,7 @@ pub struct DescribeTrustedAdvisorChecksResponse {
 
 /// <p>The five most recent communications associated with the case.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RecentCaseCommunications {
     /// <p>The five most recent communications associated with the case.</p>
     #[serde(rename = "communications")]
@@ -490,6 +507,7 @@ pub struct RefreshTrustedAdvisorCheckRequest {
 
 /// <p>The current refresh status of a Trusted Advisor check.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RefreshTrustedAdvisorCheckResponse {
     /// <p>The current refresh status for a check, including the amount of time until the check is eligible for refresh.</p>
     #[serde(rename = "status")]
@@ -507,6 +525,7 @@ pub struct ResolveCaseRequest {
 
 /// <p>The status of the case returned by the <a>ResolveCase</a> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResolveCaseResponse {
     /// <p>The status of the case after the <a>ResolveCase</a> request was processed.</p>
     #[serde(rename = "finalCaseStatus")]
@@ -520,6 +539,7 @@ pub struct ResolveCaseResponse {
 
 /// <p>Information about an AWS service returned by the <a>DescribeServices</a> operation. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Service {
     /// <p>A list of categories that describe the type of support issue a case describes. Categories consist of a category name and a category code. Category names and codes are passed to AWS Support when you call <a>CreateCase</a>.</p>
     #[serde(rename = "categories")]
@@ -537,6 +557,7 @@ pub struct Service {
 
 /// <p>A code and name pair that represent a severity level that can be applied to a support case.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SeverityLevel {
     /// <p>One of four values: "low," "medium," "high," and "urgent". These values correspond to response times returned to the caller in <code>severityLevel.name</code>. </p>
     #[serde(rename = "code")]
@@ -550,6 +571,7 @@ pub struct SeverityLevel {
 
 /// <p>The container for summary information that relates to the category of the Trusted Advisor check.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TrustedAdvisorCategorySpecificSummary {
     /// <p>The summary information about cost savings for a Trusted Advisor check that is in the Cost Optimizing category.</p>
     #[serde(rename = "costOptimizing")]
@@ -559,6 +581,7 @@ pub struct TrustedAdvisorCategorySpecificSummary {
 
 /// <p>The description and metadata for a Trusted Advisor check.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TrustedAdvisorCheckDescription {
     /// <p>The category of the Trusted Advisor check.</p>
     #[serde(rename = "category")]
@@ -579,6 +602,7 @@ pub struct TrustedAdvisorCheckDescription {
 
 /// <p>The refresh status of a Trusted Advisor check.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TrustedAdvisorCheckRefreshStatus {
     /// <p>The unique identifier for the Trusted Advisor check.</p>
     #[serde(rename = "checkId")]
@@ -593,6 +617,7 @@ pub struct TrustedAdvisorCheckRefreshStatus {
 
 /// <p>The results of a Trusted Advisor check returned by <a>DescribeTrustedAdvisorCheckResult</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TrustedAdvisorCheckResult {
     /// <p>Summary information that relates to the category of the check. Cost Optimizing is the only category that is currently supported.</p>
     #[serde(rename = "categorySpecificSummary")]
@@ -615,6 +640,7 @@ pub struct TrustedAdvisorCheckResult {
 
 /// <p>A summary of a Trusted Advisor check result, including the alert status, last refresh, and number of resources examined.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TrustedAdvisorCheckSummary {
     /// <p>Summary information that relates to the category of the check. Cost Optimizing is the only category that is currently supported.</p>
     #[serde(rename = "categorySpecificSummary")]
@@ -638,6 +664,7 @@ pub struct TrustedAdvisorCheckSummary {
 
 /// <p>The estimated cost savings that might be realized if the recommended actions are taken.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TrustedAdvisorCostOptimizingSummary {
     /// <p>The estimated monthly savings that might be realized if the recommended actions are taken.</p>
     #[serde(rename = "estimatedMonthlySavings")]
@@ -649,6 +676,7 @@ pub struct TrustedAdvisorCostOptimizingSummary {
 
 /// <p>Contains information about a resource identified by a Trusted Advisor check.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TrustedAdvisorResourceDetail {
     /// <p>Specifies whether the AWS resource was ignored by Trusted Advisor because it was marked as suppressed by the user.</p>
     #[serde(rename = "isSuppressed")]
@@ -671,6 +699,7 @@ pub struct TrustedAdvisorResourceDetail {
 
 /// <p>Details about AWS resources that were analyzed in a call to Trusted Advisor <a>DescribeTrustedAdvisorCheckSummaries</a>. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TrustedAdvisorResourcesSummary {
     /// <p>The number of AWS resources that were flagged (listed) by the Trusted Advisor check.</p>
     #[serde(rename = "resourcesFlagged")]

--- a/rusoto/services/swf/src/generated.rs
+++ b/rusoto/services/swf/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>Unit of work sent to an activity worker.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActivityTask {
     /// <p>The unique ID of the task.</p>
     #[serde(rename = "activityId")]
@@ -54,6 +55,7 @@ pub struct ActivityTask {
 
 /// <p>Provides the details of the <code>ActivityTaskCancelRequested</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActivityTaskCancelRequestedEventAttributes {
     /// <p>The unique ID of the task.</p>
     #[serde(rename = "activityId")]
@@ -65,6 +67,7 @@ pub struct ActivityTaskCancelRequestedEventAttributes {
 
 /// <p>Provides the details of the <code>ActivityTaskCanceled</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActivityTaskCanceledEventAttributes {
     /// <p>Details of the cancellation.</p>
     #[serde(rename = "details")]
@@ -84,6 +87,7 @@ pub struct ActivityTaskCanceledEventAttributes {
 
 /// <p>Provides the details of the <code>ActivityTaskCompleted</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActivityTaskCompletedEventAttributes {
     /// <p>The results of the activity task.</p>
     #[serde(rename = "result")]
@@ -99,6 +103,7 @@ pub struct ActivityTaskCompletedEventAttributes {
 
 /// <p>Provides the details of the <code>ActivityTaskFailed</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActivityTaskFailedEventAttributes {
     /// <p>The details of the failure.</p>
     #[serde(rename = "details")]
@@ -118,6 +123,7 @@ pub struct ActivityTaskFailedEventAttributes {
 
 /// <p>Provides the details of the <code>ActivityTaskScheduled</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActivityTaskScheduledEventAttributes {
     /// <p>The unique ID of the activity task.</p>
     #[serde(rename = "activityId")]
@@ -163,6 +169,7 @@ pub struct ActivityTaskScheduledEventAttributes {
 
 /// <p>Provides the details of the <code>ActivityTaskStarted</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActivityTaskStartedEventAttributes {
     /// <p>Identity of the worker that was assigned this task. This aids diagnostics when problems arise. The form of this identity is user defined.</p>
     #[serde(rename = "identity")]
@@ -175,6 +182,7 @@ pub struct ActivityTaskStartedEventAttributes {
 
 /// <p>Status information about an activity task.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActivityTaskStatus {
     /// <p>Set to <code>true</code> if cancellation of the task is requested.</p>
     #[serde(rename = "cancelRequested")]
@@ -183,6 +191,7 @@ pub struct ActivityTaskStatus {
 
 /// <p>Provides the details of the <code>ActivityTaskTimedOut</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActivityTaskTimedOutEventAttributes {
     /// <p>Contains the content of the <code>details</code> parameter for the last call made by the activity to <code>RecordActivityTaskHeartbeat</code>.</p>
     #[serde(rename = "details")]
@@ -212,6 +221,7 @@ pub struct ActivityType {
 
 /// <p>Configuration settings registered with the activity type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActivityTypeConfiguration {
     /// <p> The default maximum time, in seconds, before which a worker processing a task must report progress by calling <a>RecordActivityTaskHeartbeat</a>.</p> <p>You can specify this value only when <i>registering</i> an activity type. The registered default value can be overridden when you schedule a task through the <code>ScheduleActivityTask</code> <a>Decision</a>. If the activity worker subsequently attempts to record a heartbeat or returns a result, the activity worker receives an <code>UnknownResource</code> fault. In this case, Amazon SWF no longer considers the activity task to be valid; the activity worker should clean up the activity task.</p> <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>
     #[serde(rename = "defaultTaskHeartbeatTimeout")]
@@ -241,6 +251,7 @@ pub struct ActivityTypeConfiguration {
 
 /// <p>Detailed information about an activity type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActivityTypeDetail {
     /// <p>The configuration settings registered with the activity type.</p>
     #[serde(rename = "configuration")]
@@ -252,6 +263,7 @@ pub struct ActivityTypeDetail {
 
 /// <p>Detailed information about an activity type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActivityTypeInfo {
     /// <p>The <a>ActivityType</a> type structure representing the activity type.</p>
     #[serde(rename = "activityType")]
@@ -274,6 +286,7 @@ pub struct ActivityTypeInfo {
 
 /// <p>Contains a paginated list of activity type information structures.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActivityTypeInfos {
     /// <p>If a <code>NextPageToken</code> was returned by a previous call, there are more results available. To retrieve the next page of results, make the call again using the returned token in <code>nextPageToken</code>. Keep all other arguments unchanged.</p> <p>The configured <code>maximumPageSize</code> determines how many results can be returned in a single call.</p>
     #[serde(rename = "nextPageToken")]
@@ -294,6 +307,7 @@ pub struct CancelTimerDecisionAttributes {
 
 /// <p>Provides the details of the <code>CancelTimerFailed</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CancelTimerFailedEventAttributes {
     /// <p><p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note></p>
     #[serde(rename = "cause")]
@@ -317,6 +331,7 @@ pub struct CancelWorkflowExecutionDecisionAttributes {
 
 /// <p>Provides the details of the <code>CancelWorkflowExecutionFailed</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CancelWorkflowExecutionFailedEventAttributes {
     /// <p><p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note></p>
     #[serde(rename = "cause")]
@@ -328,6 +343,7 @@ pub struct CancelWorkflowExecutionFailedEventAttributes {
 
 /// <p>Provide details of the <code>ChildWorkflowExecutionCanceled</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ChildWorkflowExecutionCanceledEventAttributes {
     /// <p>Details of the cancellation (if provided).</p>
     #[serde(rename = "details")]
@@ -349,6 +365,7 @@ pub struct ChildWorkflowExecutionCanceledEventAttributes {
 
 /// <p>Provides the details of the <code>ChildWorkflowExecutionCompleted</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ChildWorkflowExecutionCompletedEventAttributes {
     /// <p>The ID of the <code>StartChildWorkflowExecutionInitiated</code> event corresponding to the <code>StartChildWorkflowExecution</code> <a>Decision</a> to start this child workflow execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "initiatedEventId")]
@@ -370,6 +387,7 @@ pub struct ChildWorkflowExecutionCompletedEventAttributes {
 
 /// <p>Provides the details of the <code>ChildWorkflowExecutionFailed</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ChildWorkflowExecutionFailedEventAttributes {
     /// <p>The details of the failure (if provided).</p>
     #[serde(rename = "details")]
@@ -395,6 +413,7 @@ pub struct ChildWorkflowExecutionFailedEventAttributes {
 
 /// <p>Provides the details of the <code>ChildWorkflowExecutionStarted</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ChildWorkflowExecutionStartedEventAttributes {
     /// <p>The ID of the <code>StartChildWorkflowExecutionInitiated</code> event corresponding to the <code>StartChildWorkflowExecution</code> <a>Decision</a> to start this child workflow execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "initiatedEventId")]
@@ -409,6 +428,7 @@ pub struct ChildWorkflowExecutionStartedEventAttributes {
 
 /// <p>Provides the details of the <code>ChildWorkflowExecutionTerminated</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ChildWorkflowExecutionTerminatedEventAttributes {
     /// <p>The ID of the <code>StartChildWorkflowExecutionInitiated</code> event corresponding to the <code>StartChildWorkflowExecution</code> <a>Decision</a> to start this child workflow execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "initiatedEventId")]
@@ -426,6 +446,7 @@ pub struct ChildWorkflowExecutionTerminatedEventAttributes {
 
 /// <p>Provides the details of the <code>ChildWorkflowExecutionTimedOut</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ChildWorkflowExecutionTimedOutEventAttributes {
     /// <p>The ID of the <code>StartChildWorkflowExecutionInitiated</code> event corresponding to the <code>StartChildWorkflowExecution</code> <a>Decision</a> to start this child workflow execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "initiatedEventId")]
@@ -463,6 +484,7 @@ pub struct CompleteWorkflowExecutionDecisionAttributes {
 
 /// <p>Provides the details of the <code>CompleteWorkflowExecutionFailed</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CompleteWorkflowExecutionFailedEventAttributes {
     /// <p><p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note></p>
     #[serde(rename = "cause")]
@@ -515,6 +537,7 @@ pub struct ContinueAsNewWorkflowExecutionDecisionAttributes {
 
 /// <p>Provides the details of the <code>ContinueAsNewWorkflowExecutionFailed</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ContinueAsNewWorkflowExecutionFailedEventAttributes {
     /// <p><p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note></p>
     #[serde(rename = "cause")]
@@ -668,6 +691,7 @@ pub struct Decision {
 
 /// <p>A structure that represents a decision task. Decision tasks are sent to deciders in order for them to make decisions.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DecisionTask {
     /// <p>A paginated list of history events of the workflow execution. The decider uses this during the processing of the decision task.</p>
     #[serde(rename = "events")]
@@ -696,6 +720,7 @@ pub struct DecisionTask {
 
 /// <p>Provides the details of the <code>DecisionTaskCompleted</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DecisionTaskCompletedEventAttributes {
     /// <p>User defined context for the workflow execution.</p>
     #[serde(rename = "executionContext")]
@@ -711,6 +736,7 @@ pub struct DecisionTaskCompletedEventAttributes {
 
 /// <p>Provides details about the <code>DecisionTaskScheduled</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DecisionTaskScheduledEventAttributes {
     /// <p>The maximum duration for this decision task. The task is considered timed out if it doesn't completed within this duration.</p> <p>The duration is specified in seconds, an integer greater than or equal to <code>0</code>. You can use <code>NONE</code> to specify unlimited duration.</p>
     #[serde(rename = "startToCloseTimeout")]
@@ -727,6 +753,7 @@ pub struct DecisionTaskScheduledEventAttributes {
 
 /// <p>Provides the details of the <code>DecisionTaskStarted</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DecisionTaskStartedEventAttributes {
     /// <p>Identity of the decider making the request. This enables diagnostic tracing when problems arise. The form of this identity is user defined.</p>
     #[serde(rename = "identity")]
@@ -739,6 +766,7 @@ pub struct DecisionTaskStartedEventAttributes {
 
 /// <p>Provides the details of the <code>DecisionTaskTimedOut</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DecisionTaskTimedOutEventAttributes {
     /// <p>The ID of the <code>DecisionTaskScheduled</code> event that was recorded when this decision task was scheduled. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "scheduledEventId")]
@@ -817,6 +845,7 @@ pub struct DescribeWorkflowTypeInput {
 
 /// <p>Contains the configuration settings of a domain.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DomainConfiguration {
     /// <p>The retention period for workflow executions in this domain.</p>
     #[serde(rename = "workflowExecutionRetentionPeriodInDays")]
@@ -825,6 +854,7 @@ pub struct DomainConfiguration {
 
 /// <p>Contains details of a domain.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DomainDetail {
     /// <p>The domain configuration. Currently, this includes only the domain's retention period.</p>
     #[serde(rename = "configuration")]
@@ -836,6 +866,7 @@ pub struct DomainDetail {
 
 /// <p>Contains general information about a domain.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DomainInfo {
     /// <p>The description of the domain provided through <a>RegisterDomain</a>.</p>
     #[serde(rename = "description")]
@@ -851,6 +882,7 @@ pub struct DomainInfo {
 
 /// <p>Contains a paginated collection of DomainInfo structures.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DomainInfos {
     /// <p>A list of DomainInfo structures.</p>
     #[serde(rename = "domainInfos")]
@@ -875,6 +907,7 @@ pub struct ExecutionTimeFilter {
 
 /// <p>Provides the details of the <code>ExternalWorkflowExecutionCancelRequested</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ExternalWorkflowExecutionCancelRequestedEventAttributes {
     /// <p>The ID of the <code>RequestCancelExternalWorkflowExecutionInitiated</code> event corresponding to the <code>RequestCancelExternalWorkflowExecution</code> decision to cancel this external workflow execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "initiatedEventId")]
@@ -886,6 +919,7 @@ pub struct ExternalWorkflowExecutionCancelRequestedEventAttributes {
 
 /// <p>Provides the details of the <code>ExternalWorkflowExecutionSignaled</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ExternalWorkflowExecutionSignaledEventAttributes {
     /// <p>The ID of the <code>SignalExternalWorkflowExecutionInitiated</code> event corresponding to the <code>SignalExternalWorkflowExecution</code> decision to request this signal. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "initiatedEventId")]
@@ -910,6 +944,7 @@ pub struct FailWorkflowExecutionDecisionAttributes {
 
 /// <p>Provides the details of the <code>FailWorkflowExecutionFailed</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FailWorkflowExecutionFailedEventAttributes {
     /// <p><p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note></p>
     #[serde(rename = "cause")]
@@ -943,6 +978,7 @@ pub struct GetWorkflowExecutionHistoryInput {
 
 /// <p>Paginated representation of a workflow history for a workflow execution. This is the up to date, complete and authoritative record of the events related to all tasks and events in the life of the workflow execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct History {
     /// <p>The list of history events.</p>
     #[serde(rename = "events")]
@@ -955,6 +991,7 @@ pub struct History {
 
 /// <p><p>Event within a workflow execution. A history event can be one of these types:</p> <ul> <li> <p> <code>ActivityTaskCancelRequested</code> – A <code>RequestCancelActivityTask</code> decision was received by the system.</p> </li> <li> <p> <code>ActivityTaskCanceled</code> – The activity task was successfully canceled.</p> </li> <li> <p> <code>ActivityTaskCompleted</code> – An activity worker successfully completed an activity task by calling <a>RespondActivityTaskCompleted</a>.</p> </li> <li> <p> <code>ActivityTaskFailed</code> – An activity worker failed an activity task by calling <a>RespondActivityTaskFailed</a>.</p> </li> <li> <p> <code>ActivityTaskScheduled</code> – An activity task was scheduled for execution.</p> </li> <li> <p> <code>ActivityTaskStarted</code> – The scheduled activity task was dispatched to a worker.</p> </li> <li> <p> <code>ActivityTaskTimedOut</code> – The activity task timed out.</p> </li> <li> <p> <code>CancelTimerFailed</code> – Failed to process CancelTimer decision. This happens when the decision isn&#39;t configured properly, for example no timer exists with the specified timer Id.</p> </li> <li> <p> <code>CancelWorkflowExecutionFailed</code> – A request to cancel a workflow execution failed.</p> </li> <li> <p> <code>ChildWorkflowExecutionCanceled</code> – A child workflow execution, started by this workflow execution, was canceled and closed.</p> </li> <li> <p> <code>ChildWorkflowExecutionCompleted</code> – A child workflow execution, started by this workflow execution, completed successfully and was closed.</p> </li> <li> <p> <code>ChildWorkflowExecutionFailed</code> – A child workflow execution, started by this workflow execution, failed to complete successfully and was closed.</p> </li> <li> <p> <code>ChildWorkflowExecutionStarted</code> – A child workflow execution was successfully started.</p> </li> <li> <p> <code>ChildWorkflowExecutionTerminated</code> – A child workflow execution, started by this workflow execution, was terminated.</p> </li> <li> <p> <code>ChildWorkflowExecutionTimedOut</code> – A child workflow execution, started by this workflow execution, timed out and was closed.</p> </li> <li> <p> <code>CompleteWorkflowExecutionFailed</code> – The workflow execution failed to complete.</p> </li> <li> <p> <code>ContinueAsNewWorkflowExecutionFailed</code> – The workflow execution failed to complete after being continued as a new workflow execution.</p> </li> <li> <p> <code>DecisionTaskCompleted</code> – The decider successfully completed a decision task by calling <a>RespondDecisionTaskCompleted</a>.</p> </li> <li> <p> <code>DecisionTaskScheduled</code> – A decision task was scheduled for the workflow execution.</p> </li> <li> <p> <code>DecisionTaskStarted</code> – The decision task was dispatched to a decider.</p> </li> <li> <p> <code>DecisionTaskTimedOut</code> – The decision task timed out.</p> </li> <li> <p> <code>ExternalWorkflowExecutionCancelRequested</code> – Request to cancel an external workflow execution was successfully delivered to the target execution.</p> </li> <li> <p> <code>ExternalWorkflowExecutionSignaled</code> – A signal, requested by this workflow execution, was successfully delivered to the target external workflow execution.</p> </li> <li> <p> <code>FailWorkflowExecutionFailed</code> – A request to mark a workflow execution as failed, itself failed.</p> </li> <li> <p> <code>MarkerRecorded</code> – A marker was recorded in the workflow history as the result of a <code>RecordMarker</code> decision.</p> </li> <li> <p> <code>RecordMarkerFailed</code> – A <code>RecordMarker</code> decision was returned as failed.</p> </li> <li> <p> <code>RequestCancelActivityTaskFailed</code> – Failed to process RequestCancelActivityTask decision. This happens when the decision isn&#39;t configured properly.</p> </li> <li> <p> <code>RequestCancelExternalWorkflowExecutionFailed</code> – Request to cancel an external workflow execution failed.</p> </li> <li> <p> <code>RequestCancelExternalWorkflowExecutionInitiated</code> – A request was made to request the cancellation of an external workflow execution.</p> </li> <li> <p> <code>ScheduleActivityTaskFailed</code> – Failed to process ScheduleActivityTask decision. This happens when the decision isn&#39;t configured properly, for example the activity type specified isn&#39;t registered.</p> </li> <li> <p> <code>SignalExternalWorkflowExecutionFailed</code> – The request to signal an external workflow execution failed.</p> </li> <li> <p> <code>SignalExternalWorkflowExecutionInitiated</code> – A request to signal an external workflow was made.</p> </li> <li> <p> <code>StartActivityTaskFailed</code> – A scheduled activity task failed to start.</p> </li> <li> <p> <code>StartChildWorkflowExecutionFailed</code> – Failed to process StartChildWorkflowExecution decision. This happens when the decision isn&#39;t configured properly, for example the workflow type specified isn&#39;t registered.</p> </li> <li> <p> <code>StartChildWorkflowExecutionInitiated</code> – A request was made to start a child workflow execution.</p> </li> <li> <p> <code>StartTimerFailed</code> – Failed to process StartTimer decision. This happens when the decision isn&#39;t configured properly, for example a timer already exists with the specified timer Id.</p> </li> <li> <p> <code>TimerCanceled</code> – A timer, previously started for this workflow execution, was successfully canceled.</p> </li> <li> <p> <code>TimerFired</code> – A timer, previously started for this workflow execution, fired.</p> </li> <li> <p> <code>TimerStarted</code> – A timer was started for the workflow execution due to a <code>StartTimer</code> decision.</p> </li> <li> <p> <code>WorkflowExecutionCancelRequested</code> – A request to cancel this workflow execution was made.</p> </li> <li> <p> <code>WorkflowExecutionCanceled</code> – The workflow execution was successfully canceled and closed.</p> </li> <li> <p> <code>WorkflowExecutionCompleted</code> – The workflow execution was closed due to successful completion.</p> </li> <li> <p> <code>WorkflowExecutionContinuedAsNew</code> – The workflow execution was closed and a new execution of the same type was created with the same workflowId.</p> </li> <li> <p> <code>WorkflowExecutionFailed</code> – The workflow execution closed due to a failure.</p> </li> <li> <p> <code>WorkflowExecutionSignaled</code> – An external signal was received for the workflow execution.</p> </li> <li> <p> <code>WorkflowExecutionStarted</code> – The workflow execution was started.</p> </li> <li> <p> <code>WorkflowExecutionTerminated</code> – The workflow execution was terminated.</p> </li> <li> <p> <code>WorkflowExecutionTimedOut</code> – The workflow execution was closed because a time out was exceeded.</p> </li> </ul></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct HistoryEvent {
     /// <p>If the event is of type <code>ActivityTaskcancelRequested</code> then this member is set and provides detailed information about the event. It isn't set for other event types.</p>
     #[serde(rename = "activityTaskCancelRequestedEventAttributes")]
@@ -1216,6 +1253,7 @@ pub struct HistoryEvent {
 
 /// <p>Provides the details of the <code>LambdaFunctionCompleted</code> event. It isn't set for other event types.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LambdaFunctionCompletedEventAttributes {
     /// <p>The results of the Lambda task.</p>
     #[serde(rename = "result")]
@@ -1231,6 +1269,7 @@ pub struct LambdaFunctionCompletedEventAttributes {
 
 /// <p>Provides the details of the <code>LambdaFunctionFailed</code> event. It isn't set for other event types.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LambdaFunctionFailedEventAttributes {
     /// <p>The details of the failure.</p>
     #[serde(rename = "details")]
@@ -1250,6 +1289,7 @@ pub struct LambdaFunctionFailedEventAttributes {
 
 /// <p>Provides the details of the <code>LambdaFunctionScheduled</code> event. It isn't set for other event types.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LambdaFunctionScheduledEventAttributes {
     /// <p>Data attached to the event that the decider can use in subsequent workflow tasks. This data isn't sent to the Lambda task.</p>
     #[serde(rename = "control")]
@@ -1276,6 +1316,7 @@ pub struct LambdaFunctionScheduledEventAttributes {
 
 /// <p>Provides the details of the <code>LambdaFunctionStarted</code> event. It isn't set for other event types.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LambdaFunctionStartedEventAttributes {
     /// <p>The ID of the <code>LambdaFunctionScheduled</code> event that was recorded when this activity task was scheduled. To help diagnose issues, use this information to trace back the chain of events leading up to this event.</p>
     #[serde(rename = "scheduledEventId")]
@@ -1284,6 +1325,7 @@ pub struct LambdaFunctionStartedEventAttributes {
 
 /// <p>Provides details of the <code>LambdaFunctionTimedOut</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct LambdaFunctionTimedOutEventAttributes {
     /// <p>The ID of the <code>LambdaFunctionScheduled</code> event that was recorded when this activity task was scheduled. To help diagnose issues, use this information to trace back the chain of events leading up to this event.</p>
     #[serde(rename = "scheduledEventId")]
@@ -1447,6 +1489,7 @@ pub struct ListWorkflowTypesInput {
 
 /// <p>Provides the details of the <code>MarkerRecorded</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct MarkerRecordedEventAttributes {
     /// <p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the <code>RecordMarker</code> decision that requested this marker. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "decisionTaskCompletedEventId")]
@@ -1462,6 +1505,7 @@ pub struct MarkerRecordedEventAttributes {
 
 /// <p>Contains the count of tasks in a task list.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PendingTaskCount {
     /// <p>The number of tasks in the task list.</p>
     #[serde(rename = "count")]
@@ -1537,6 +1581,7 @@ pub struct RecordMarkerDecisionAttributes {
 
 /// <p>Provides the details of the <code>RecordMarkerFailed</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RecordMarkerFailedEventAttributes {
     /// <p><p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note></p>
     #[serde(rename = "cause")]
@@ -1655,6 +1700,7 @@ pub struct RequestCancelActivityTaskDecisionAttributes {
 
 /// <p>Provides the details of the <code>RequestCancelActivityTaskFailed</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RequestCancelActivityTaskFailedEventAttributes {
     /// <p>The activityId provided in the <code>RequestCancelActivityTask</code> decision that failed.</p>
     #[serde(rename = "activityId")]
@@ -1685,6 +1731,7 @@ pub struct RequestCancelExternalWorkflowExecutionDecisionAttributes {
 
 /// <p>Provides the details of the <code>RequestCancelExternalWorkflowExecutionFailed</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RequestCancelExternalWorkflowExecutionFailedEventAttributes {
     /// <p><p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note></p>
     #[serde(rename = "cause")]
@@ -1710,6 +1757,7 @@ pub struct RequestCancelExternalWorkflowExecutionFailedEventAttributes {
 
 /// <p>Provides the details of the <code>RequestCancelExternalWorkflowExecutionInitiated</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RequestCancelExternalWorkflowExecutionInitiatedEventAttributes {
     /// <p>Data attached to the event that can be used by the decider in subsequent workflow tasks.</p>
     #[serde(rename = "control")]
@@ -1796,6 +1844,7 @@ pub struct RespondDecisionTaskCompletedInput {
 
 /// <p>Specifies the <code>runId</code> of a workflow execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Run {
     /// <p>The <code>runId</code> of a workflow execution. This ID is generated by the service and can be used to uniquely identify the workflow execution within a domain.</p>
     #[serde(rename = "runId")]
@@ -1848,6 +1897,7 @@ pub struct ScheduleActivityTaskDecisionAttributes {
 
 /// <p>Provides the details of the <code>ScheduleActivityTaskFailed</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ScheduleActivityTaskFailedEventAttributes {
     /// <p>The activityId provided in the <code>ScheduleActivityTask</code> decision that failed.</p>
     #[serde(rename = "activityId")]
@@ -1888,6 +1938,7 @@ pub struct ScheduleLambdaFunctionDecisionAttributes {
 
 /// <p>Provides the details of the <code>ScheduleLambdaFunctionFailed</code> event. It isn't set for other event types.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ScheduleLambdaFunctionFailedEventAttributes {
     /// <p><p>The cause of the failure. To help diagnose issues, use this information to trace back the chain of events leading up to this event.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note></p>
     #[serde(rename = "cause")]
@@ -1928,6 +1979,7 @@ pub struct SignalExternalWorkflowExecutionDecisionAttributes {
 
 /// <p>Provides the details of the <code>SignalExternalWorkflowExecutionFailed</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SignalExternalWorkflowExecutionFailedEventAttributes {
     /// <p><p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note></p>
     #[serde(rename = "cause")]
@@ -1953,6 +2005,7 @@ pub struct SignalExternalWorkflowExecutionFailedEventAttributes {
 
 /// <p>Provides the details of the <code>SignalExternalWorkflowExecutionInitiated</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SignalExternalWorkflowExecutionInitiatedEventAttributes {
     /// <p>Data attached to the event that can be used by the decider in subsequent decision tasks.</p>
     #[serde(rename = "control")]
@@ -2047,6 +2100,7 @@ pub struct StartChildWorkflowExecutionDecisionAttributes {
 
 /// <p>Provides the details of the <code>StartChildWorkflowExecutionFailed</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartChildWorkflowExecutionFailedEventAttributes {
     /// <p><p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>When <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision fails because it lacks sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html"> Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note></p>
     #[serde(rename = "cause")]
@@ -2071,6 +2125,7 @@ pub struct StartChildWorkflowExecutionFailedEventAttributes {
 
 /// <p>Provides the details of the <code>StartChildWorkflowExecutionInitiated</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartChildWorkflowExecutionInitiatedEventAttributes {
     /// <p><p>The policy to use for the child workflow executions if this execution gets terminated by explicitly calling the <a>TerminateWorkflowExecution</a> action or due to an expired timeout.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul></p>
     #[serde(rename = "childPolicy")]
@@ -2119,6 +2174,7 @@ pub struct StartChildWorkflowExecutionInitiatedEventAttributes {
 
 /// <p>Provides the details of the <code>StartLambdaFunctionFailed</code> event. It isn't set for other event types.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartLambdaFunctionFailedEventAttributes {
     /// <p><p>The cause of the failure. To help diagnose issues, use this information to trace back the chain of events leading up to this event.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision failed because the IAM role attached to the execution lacked sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/lambda-task.html">Lambda Tasks</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note></p>
     #[serde(rename = "cause")]
@@ -2151,6 +2207,7 @@ pub struct StartTimerDecisionAttributes {
 
 /// <p>Provides the details of the <code>StartTimerFailed</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartTimerFailedEventAttributes {
     /// <p><p>The cause of the failure. This information is generated by the system and can be useful for diagnostic purposes.</p> <note> <p>If <code>cause</code> is set to <code>OPERATION<em>NOT</em>PERMITTED</code>, the decision failed because it lacked sufficient permissions. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p> </note></p>
     #[serde(rename = "cause")]
@@ -2252,6 +2309,7 @@ pub struct TerminateWorkflowExecutionInput {
 
 /// <p> Provides the details of the <code>TimerCanceled</code> event. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TimerCanceledEventAttributes {
     /// <p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the <code>CancelTimer</code> decision to cancel this timer. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "decisionTaskCompletedEventId")]
@@ -2266,6 +2324,7 @@ pub struct TimerCanceledEventAttributes {
 
 /// <p>Provides the details of the <code>TimerFired</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TimerFiredEventAttributes {
     /// <p>The ID of the <code>TimerStarted</code> event that was recorded when this timer was started. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "startedEventId")]
@@ -2277,6 +2336,7 @@ pub struct TimerFiredEventAttributes {
 
 /// <p>Provides the details of the <code>TimerStarted</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TimerStartedEventAttributes {
     /// <p>Data attached to the event that can be used by the decider in subsequent workflow tasks.</p>
     #[serde(rename = "control")]
@@ -2306,6 +2366,7 @@ pub struct WorkflowExecution {
 
 /// <p>Provides the details of the <code>WorkflowExecutionCancelRequested</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WorkflowExecutionCancelRequestedEventAttributes {
     /// <p>If set, indicates that the request to cancel the workflow execution was automatically generated, and specifies the cause. This happens if the parent workflow execution times out or is terminated, and the child policy is set to cancel child executions.</p>
     #[serde(rename = "cause")]
@@ -2323,6 +2384,7 @@ pub struct WorkflowExecutionCancelRequestedEventAttributes {
 
 /// <p>Provides the details of the <code>WorkflowExecutionCanceled</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WorkflowExecutionCanceledEventAttributes {
     /// <p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the <code>CancelWorkflowExecution</code> decision for this cancellation request. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "decisionTaskCompletedEventId")]
@@ -2335,6 +2397,7 @@ pub struct WorkflowExecutionCanceledEventAttributes {
 
 /// <p>Provides the details of the <code>WorkflowExecutionCompleted</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WorkflowExecutionCompletedEventAttributes {
     /// <p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the <code>CompleteWorkflowExecution</code> decision to complete this execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "decisionTaskCompletedEventId")]
@@ -2347,6 +2410,7 @@ pub struct WorkflowExecutionCompletedEventAttributes {
 
 /// <p>The configuration settings for a workflow execution including timeout values, tasklist etc. These configuration settings are determined from the defaults specified when registering the workflow type and those specified when starting the workflow execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WorkflowExecutionConfiguration {
     /// <p><p>The policy to use for the child workflow executions if this workflow execution is terminated, by calling the <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul></p>
     #[serde(rename = "childPolicy")]
@@ -2372,6 +2436,7 @@ pub struct WorkflowExecutionConfiguration {
 
 /// <p>Provides the details of the <code>WorkflowExecutionContinuedAsNew</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WorkflowExecutionContinuedAsNewEventAttributes {
     /// <p><p>The policy to use for the child workflow executions of the new execution if it is terminated by calling the <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul></p>
     #[serde(rename = "childPolicy")]
@@ -2416,6 +2481,7 @@ pub struct WorkflowExecutionContinuedAsNewEventAttributes {
 
 /// <p>Contains the count of workflow executions returned from <a>CountOpenWorkflowExecutions</a> or <a>CountClosedWorkflowExecutions</a> </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WorkflowExecutionCount {
     /// <p>The number of workflow executions.</p>
     #[serde(rename = "count")]
@@ -2428,6 +2494,7 @@ pub struct WorkflowExecutionCount {
 
 /// <p>Contains details about a workflow execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WorkflowExecutionDetail {
     /// <p>The configuration settings for this workflow execution including timeout values, tasklist etc.</p>
     #[serde(rename = "executionConfiguration")]
@@ -2450,6 +2517,7 @@ pub struct WorkflowExecutionDetail {
 
 /// <p>Provides the details of the <code>WorkflowExecutionFailed</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WorkflowExecutionFailedEventAttributes {
     /// <p>The ID of the <code>DecisionTaskCompleted</code> event corresponding to the decision task that resulted in the <code>FailWorkflowExecution</code> decision to fail this execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event.</p>
     #[serde(rename = "decisionTaskCompletedEventId")]
@@ -2474,6 +2542,7 @@ pub struct WorkflowExecutionFilter {
 
 /// <p>Contains information about a workflow execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WorkflowExecutionInfo {
     /// <p>Set to true if a cancellation is requested for this workflow execution.</p>
     #[serde(rename = "cancelRequested")]
@@ -2511,6 +2580,7 @@ pub struct WorkflowExecutionInfo {
 
 /// <p>Contains a paginated list of information about workflow executions.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WorkflowExecutionInfos {
     /// <p>The list of workflow information structures.</p>
     #[serde(rename = "executionInfos")]
@@ -2523,6 +2593,7 @@ pub struct WorkflowExecutionInfos {
 
 /// <p>Contains the counts of open tasks, child workflow executions and timers for a workflow execution.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WorkflowExecutionOpenCounts {
     /// <p>The count of activity tasks whose status is <code>OPEN</code>.</p>
     #[serde(rename = "openActivityTasks")]
@@ -2544,6 +2615,7 @@ pub struct WorkflowExecutionOpenCounts {
 
 /// <p>Provides the details of the <code>WorkflowExecutionSignaled</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WorkflowExecutionSignaledEventAttributes {
     /// <p>The ID of the <code>SignalExternalWorkflowExecutionInitiated</code> event corresponding to the <code>SignalExternalWorkflow</code> decision to signal this workflow execution.The source event with this ID can be found in the history of the source workflow execution. This information can be useful for diagnosing problems by tracing back the chain of events leading up to this event. This field is set only if the signal was initiated by another workflow execution.</p>
     #[serde(rename = "externalInitiatedEventId")]
@@ -2564,6 +2636,7 @@ pub struct WorkflowExecutionSignaledEventAttributes {
 
 /// <p>Provides details of <code>WorkflowExecutionStarted</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WorkflowExecutionStartedEventAttributes {
     /// <p><p>The policy to use for the child workflow executions if this workflow execution is terminated, by calling the <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul></p>
     #[serde(rename = "childPolicy")]
@@ -2614,6 +2687,7 @@ pub struct WorkflowExecutionStartedEventAttributes {
 
 /// <p>Provides the details of the <code>WorkflowExecutionTerminated</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WorkflowExecutionTerminatedEventAttributes {
     /// <p>If set, indicates that the workflow execution was automatically terminated, and specifies the cause. This happens if the parent workflow execution times out or is terminated and the child policy is set to terminate child executions.</p>
     #[serde(rename = "cause")]
@@ -2634,6 +2708,7 @@ pub struct WorkflowExecutionTerminatedEventAttributes {
 
 /// <p>Provides the details of the <code>WorkflowExecutionTimedOut</code> event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WorkflowExecutionTimedOutEventAttributes {
     /// <p><p>The policy used for the child workflow executions of this workflow execution.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul></p>
     #[serde(rename = "childPolicy")]
@@ -2656,6 +2731,7 @@ pub struct WorkflowType {
 
 /// <p>The configuration settings of a workflow type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WorkflowTypeConfiguration {
     /// <p><p> The default policy to use for the child workflow executions when a workflow execution of this type is terminated, by calling the <a>TerminateWorkflowExecution</a> action explicitly or due to an expired timeout. This default can be overridden when starting a workflow execution using the <a>StartWorkflowExecution</a> action or the <code>StartChildWorkflowExecution</code> <a>Decision</a>.</p> <p>The supported child policies are:</p> <ul> <li> <p> <code>TERMINATE</code> – The child executions are terminated.</p> </li> <li> <p> <code>REQUEST_CANCEL</code> – A request to cancel is attempted for each child execution by recording a <code>WorkflowExecutionCancelRequested</code> event in its history. It is up to the decider to take appropriate actions when it receives an execution history with this event.</p> </li> <li> <p> <code>ABANDON</code> – No action is taken. The child executions continue to run.</p> </li> </ul></p>
     #[serde(rename = "defaultChildPolicy")]
@@ -2685,6 +2761,7 @@ pub struct WorkflowTypeConfiguration {
 
 /// <p>Contains details about a workflow type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WorkflowTypeDetail {
     /// <p>Configuration settings of the workflow type registered through <a>RegisterWorkflowType</a> </p>
     #[serde(rename = "configuration")]
@@ -2708,6 +2785,7 @@ pub struct WorkflowTypeFilter {
 
 /// <p>Contains information about a workflow type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WorkflowTypeInfo {
     /// <p>The date when this type was registered.</p>
     #[serde(rename = "creationDate")]
@@ -2730,6 +2808,7 @@ pub struct WorkflowTypeInfo {
 
 /// <p>Contains a paginated list of information structures about workflow types.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WorkflowTypeInfos {
     /// <p>If a <code>NextPageToken</code> was returned by a previous call, there are more results available. To retrieve the next page of results, make the call again using the returned token in <code>nextPageToken</code>. Keep all other arguments unchanged.</p> <p>The configured <code>maximumPageSize</code> determines how many results can be returned in a single call.</p>
     #[serde(rename = "nextPageToken")]

--- a/rusoto/services/transcribe/src/generated.rs
+++ b/rusoto/services/transcribe/src/generated.rs
@@ -42,6 +42,7 @@ pub struct CreateVocabularyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateVocabularyResponse {
     /// <p>If the <code>VocabularyState</code> field is <code>FAILED</code>, this field contains information about why the job failed.</p>
     #[serde(rename = "FailureReason")]
@@ -80,6 +81,7 @@ pub struct GetTranscriptionJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetTranscriptionJobResponse {
     /// <p>An object that contains the results of the transcription job.</p>
     #[serde(rename = "TranscriptionJob")]
@@ -95,6 +97,7 @@ pub struct GetVocabularyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetVocabularyResponse {
     /// <p>The S3 location where the vocabulary is stored. Use this URI to get the contents of the vocabulary. The URI is available for a limited time.</p>
     #[serde(rename = "DownloadUri")]
@@ -143,6 +146,7 @@ pub struct ListTranscriptionJobsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListTranscriptionJobsResponse {
     /// <p>The <code>ListTranscriptionJobs</code> operation returns a page of jobs at a time. The maximum size of the page is set by the <code>MaxResults</code> parameter. If there are more jobs in the list than the page size, Amazon Transcribe returns the <code>NextPage</code> token. Include the token in the next request to the <code>ListTranscriptionJobs</code> operation to return in the next page of jobs.</p>
     #[serde(rename = "NextToken")]
@@ -179,6 +183,7 @@ pub struct ListVocabulariesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListVocabulariesResponse {
     /// <p>The <code>ListVocabularies</code> operation returns a page of vocabularies at a time. The maximum size of the page is set by the <code>MaxResults</code> parameter. If there are more jobs in the list than the page size, Amazon Transcribe returns the <code>NextPage</code> token. Include the token in the next request to the <code>ListVocabularies</code> operation to return in the next page of jobs.</p>
     #[serde(rename = "NextToken")]
@@ -253,6 +258,7 @@ pub struct StartTranscriptionJobRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartTranscriptionJobResponse {
     /// <p>An object containing details of the asynchronous transcription job.</p>
     #[serde(rename = "TranscriptionJob")]
@@ -262,6 +268,7 @@ pub struct StartTranscriptionJobResponse {
 
 /// <p>Identifies the location of a transcription.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Transcript {
     /// <p>The location where the transcription is stored.</p> <p>Use this URI to access the transcription. If you specified an S3 bucket in the <code>OutputBucketName</code> field when you created the job, this is the URI of that bucket. If you chose to store the transcription in Amazon Transcribe, this is a shareable URL that provides secure access to that location.</p>
     #[serde(rename = "TranscriptFileUri")]
@@ -271,6 +278,7 @@ pub struct Transcript {
 
 /// <p>Describes an asynchronous transcription job that was created with the <code>StartTranscriptionJob</code> operation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TranscriptionJob {
     /// <p>A timestamp that shows when the job was completed.</p>
     #[serde(rename = "CompletionTime")]
@@ -320,6 +328,7 @@ pub struct TranscriptionJob {
 
 /// <p>Provides a summary of information about a transcription job.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TranscriptionJobSummary {
     /// <p>A timestamp that shows when the job was completed.</p>
     #[serde(rename = "CompletionTime")]
@@ -365,6 +374,7 @@ pub struct UpdateVocabularyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateVocabularyResponse {
     /// <p>The language code of the vocabulary entries.</p>
     #[serde(rename = "LanguageCode")]
@@ -386,6 +396,7 @@ pub struct UpdateVocabularyResponse {
 
 /// <p>Provides information about a custom vocabulary.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct VocabularyInfo {
     /// <p>The language code of the vocabulary entries.</p>
     #[serde(rename = "LanguageCode")]

--- a/rusoto/services/translate/src/generated.rs
+++ b/rusoto/services/translate/src/generated.rs
@@ -42,6 +42,7 @@ pub struct TranslateTextRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TranslateTextResponse {
     /// <p>The language code for the language of the input text. </p>
     #[serde(rename = "SourceLanguageCode")]

--- a/rusoto/services/waf-regional/src/generated.rs
+++ b/rusoto/services/waf-regional/src/generated.rs
@@ -62,10 +62,12 @@ pub struct AssociateWebACLRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociateWebACLResponse {}
 
 /// <p>In a <a>GetByteMatchSet</a> request, <code>ByteMatchSet</code> is a complex type that contains the <code>ByteMatchSetId</code> and <code>Name</code> of a <code>ByteMatchSet</code>, and the values that you specified when you updated the <code>ByteMatchSet</code>. </p> <p>A complex type that contains <code>ByteMatchTuple</code> objects, which specify the parts of web requests that you want AWS WAF to inspect and the values that you want AWS WAF to search for. If a <code>ByteMatchSet</code> contains more than one <code>ByteMatchTuple</code> object, a request needs to match the settings in only one <code>ByteMatchTuple</code> to be considered a match.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ByteMatchSet {
     /// <p>The <code>ByteMatchSetId</code> for a <code>ByteMatchSet</code>. You use <code>ByteMatchSetId</code> to get information about a <code>ByteMatchSet</code> (see <a>GetByteMatchSet</a>), update a <code>ByteMatchSet</code> (see <a>UpdateByteMatchSet</a>), insert a <code>ByteMatchSet</code> into a <code>Rule</code> or delete one from a <code>Rule</code> (see <a>UpdateRule</a>), and delete a <code>ByteMatchSet</code> from AWS WAF (see <a>DeleteByteMatchSet</a>).</p> <p> <code>ByteMatchSetId</code> is returned by <a>CreateByteMatchSet</a> and by <a>ListByteMatchSets</a>.</p>
     #[serde(rename = "ByteMatchSetId")]
@@ -81,6 +83,7 @@ pub struct ByteMatchSet {
 
 /// <p>Returned by <a>ListByteMatchSets</a>. Each <code>ByteMatchSetSummary</code> object includes the <code>Name</code> and <code>ByteMatchSetId</code> for one <a>ByteMatchSet</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ByteMatchSetSummary {
     /// <p>The <code>ByteMatchSetId</code> for a <code>ByteMatchSet</code>. You use <code>ByteMatchSetId</code> to get information about a <code>ByteMatchSet</code>, update a <code>ByteMatchSet</code>, remove a <code>ByteMatchSet</code> from a <code>Rule</code>, and delete a <code>ByteMatchSet</code> from AWS WAF.</p> <p> <code>ByteMatchSetId</code> is returned by <a>CreateByteMatchSet</a> and by <a>ListByteMatchSets</a>.</p>
     #[serde(rename = "ByteMatchSetId")]
@@ -134,6 +137,7 @@ pub struct CreateByteMatchSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateByteMatchSetResponse {
     /// <p>A <a>ByteMatchSet</a> that contains no <code>ByteMatchTuple</code> objects.</p>
     #[serde(rename = "ByteMatchSet")]
@@ -156,6 +160,7 @@ pub struct CreateGeoMatchSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateGeoMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateGeoMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -178,6 +183,7 @@ pub struct CreateIPSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateIPSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateIPSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -209,6 +215,7 @@ pub struct CreateRateBasedRuleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateRateBasedRuleResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateRateBasedRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -231,6 +238,7 @@ pub struct CreateRegexMatchSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateRegexMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateRegexMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -253,6 +261,7 @@ pub struct CreateRegexPatternSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateRegexPatternSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateRegexPatternSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -278,6 +287,7 @@ pub struct CreateRuleGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateRuleGroupResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateRuleGroup</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -303,6 +313,7 @@ pub struct CreateRuleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateRuleResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -325,6 +336,7 @@ pub struct CreateSizeConstraintSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateSizeConstraintSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateSizeConstraintSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -349,6 +361,7 @@ pub struct CreateSqlInjectionMatchSetRequest {
 
 /// <p>The response to a <code>CreateSqlInjectionMatchSet</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateSqlInjectionMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateSqlInjectionMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -377,6 +390,7 @@ pub struct CreateWebACLRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateWebACLResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateWebACL</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -401,6 +415,7 @@ pub struct CreateXssMatchSetRequest {
 
 /// <p>The response to a <code>CreateXssMatchSet</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateXssMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateXssMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -423,6 +438,7 @@ pub struct DeleteByteMatchSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteByteMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteByteMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -441,6 +457,7 @@ pub struct DeleteGeoMatchSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteGeoMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteGeoMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -459,6 +476,7 @@ pub struct DeleteIPSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteIPSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteIPSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -474,6 +492,7 @@ pub struct DeletePermissionPolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeletePermissionPolicyResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -487,6 +506,7 @@ pub struct DeleteRateBasedRuleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteRateBasedRuleResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteRateBasedRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -505,6 +525,7 @@ pub struct DeleteRegexMatchSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteRegexMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteRegexMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -523,6 +544,7 @@ pub struct DeleteRegexPatternSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteRegexPatternSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteRegexPatternSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -541,6 +563,7 @@ pub struct DeleteRuleGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteRuleGroupResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteRuleGroup</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -559,6 +582,7 @@ pub struct DeleteRuleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteRuleResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -577,6 +601,7 @@ pub struct DeleteSizeConstraintSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteSizeConstraintSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteSizeConstraintSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -597,6 +622,7 @@ pub struct DeleteSqlInjectionMatchSetRequest {
 
 /// <p>The response to a request to delete a <a>SqlInjectionMatchSet</a> from AWS WAF.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteSqlInjectionMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteSqlInjectionMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -615,6 +641,7 @@ pub struct DeleteWebACLRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteWebACLResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteWebACL</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -635,6 +662,7 @@ pub struct DeleteXssMatchSetRequest {
 
 /// <p>The response to a request to delete an <a>XssMatchSet</a> from AWS WAF.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteXssMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteXssMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -650,6 +678,7 @@ pub struct DisassociateWebACLRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisassociateWebACLResponse {}
 
 /// <p>Specifies where in a web request to look for <code>TargetString</code>.</p>
@@ -677,6 +706,7 @@ pub struct GeoMatchConstraint {
 
 /// <p>Contains one or more countries that AWS WAF will search for.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GeoMatchSet {
     /// <p>An array of <a>GeoMatchConstraint</a> objects, which contain the country that you want AWS WAF to search for.</p>
     #[serde(rename = "GeoMatchConstraints")]
@@ -692,6 +722,7 @@ pub struct GeoMatchSet {
 
 /// <p>Contains the identifier and the name of the <code>GeoMatchSet</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GeoMatchSetSummary {
     /// <p>The <code>GeoMatchSetId</code> for an <a>GeoMatchSet</a>. You can use <code>GeoMatchSetId</code> in a <a>GetGeoMatchSet</a> request to get detailed information about an <a>GeoMatchSet</a>.</p>
     #[serde(rename = "GeoMatchSetId")]
@@ -720,6 +751,7 @@ pub struct GetByteMatchSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetByteMatchSetResponse {
     /// <p><p>Information about the <a>ByteMatchSet</a> that you specified in the <code>GetByteMatchSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>ByteMatchSet</a>: Contains <code>ByteMatchSetId</code>, <code>ByteMatchTuples</code>, and <code>Name</code> </p> </li> <li> <p> <code>ByteMatchTuples</code>: Contains an array of <a>ByteMatchTuple</a> objects. Each <code>ByteMatchTuple</code> object contains <a>FieldToMatch</a>, <code>PositionalConstraint</code>, <code>TargetString</code>, and <code>TextTransformation</code> </p> </li> <li> <p> <a>FieldToMatch</a>: Contains <code>Data</code> and <code>Type</code> </p> </li> </ul></p>
     #[serde(rename = "ByteMatchSet")]
@@ -731,6 +763,7 @@ pub struct GetByteMatchSetResponse {
 pub struct GetChangeTokenRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetChangeTokenResponse {
     /// <p>The <code>ChangeToken</code> that you used in the request. Use this value in a <code>GetChangeTokenStatus</code> request to get the current status of the request. </p>
     #[serde(rename = "ChangeToken")]
@@ -746,6 +779,7 @@ pub struct GetChangeTokenStatusRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetChangeTokenStatusResponse {
     /// <p>The status of the change token.</p>
     #[serde(rename = "ChangeTokenStatus")]
@@ -761,6 +795,7 @@ pub struct GetGeoMatchSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetGeoMatchSetResponse {
     /// <p>Information about the <a>GeoMatchSet</a> that you specified in the <code>GetGeoMatchSet</code> request. This includes the <code>Type</code>, which for a <code>GeoMatchContraint</code> is always <code>Country</code>, as well as the <code>Value</code>, which is the identifier for a specific country.</p>
     #[serde(rename = "GeoMatchSet")]
@@ -776,6 +811,7 @@ pub struct GetIPSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetIPSetResponse {
     /// <p><p>Information about the <a>IPSet</a> that you specified in the <code>GetIPSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>IPSet</a>: Contains <code>IPSetDescriptors</code>, <code>IPSetId</code>, and <code>Name</code> </p> </li> <li> <p> <code>IPSetDescriptors</code>: Contains an array of <a>IPSetDescriptor</a> objects. Each <code>IPSetDescriptor</code> object contains <code>Type</code> and <code>Value</code> </p> </li> </ul></p>
     #[serde(rename = "IPSet")]
@@ -791,6 +827,7 @@ pub struct GetPermissionPolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetPermissionPolicyResponse {
     /// <p>The IAM policy attached to the specified RuleGroup.</p>
     #[serde(rename = "Policy")]
@@ -810,6 +847,7 @@ pub struct GetRateBasedRuleManagedKeysRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetRateBasedRuleManagedKeysResponse {
     /// <p>An array of IP addresses that currently are blocked by the specified <a>RateBasedRule</a>. </p>
     #[serde(rename = "ManagedKeys")]
@@ -829,6 +867,7 @@ pub struct GetRateBasedRuleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetRateBasedRuleResponse {
     /// <p>Information about the <a>RateBasedRule</a> that you specified in the <code>GetRateBasedRule</code> request.</p>
     #[serde(rename = "Rule")]
@@ -844,6 +883,7 @@ pub struct GetRegexMatchSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetRegexMatchSetResponse {
     /// <p>Information about the <a>RegexMatchSet</a> that you specified in the <code>GetRegexMatchSet</code> request. For more information, see <a>RegexMatchTuple</a>.</p>
     #[serde(rename = "RegexMatchSet")]
@@ -859,6 +899,7 @@ pub struct GetRegexPatternSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetRegexPatternSetResponse {
     /// <p>Information about the <a>RegexPatternSet</a> that you specified in the <code>GetRegexPatternSet</code> request, including the identifier of the pattern set and the regular expression patterns you want AWS WAF to search for. </p>
     #[serde(rename = "RegexPatternSet")]
@@ -874,6 +915,7 @@ pub struct GetRuleGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetRuleGroupResponse {
     /// <p>Information about the <a>RuleGroup</a> that you specified in the <code>GetRuleGroup</code> request. </p>
     #[serde(rename = "RuleGroup")]
@@ -889,6 +931,7 @@ pub struct GetRuleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetRuleResponse {
     /// <p><p>Information about the <a>Rule</a> that you specified in the <code>GetRule</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>Rule</a>: Contains <code>MetricName</code>, <code>Name</code>, an array of <code>Predicate</code> objects, and <code>RuleId</code> </p> </li> <li> <p> <a>Predicate</a>: Each <code>Predicate</code> object contains <code>DataId</code>, <code>Negated</code>, and <code>Type</code> </p> </li> </ul></p>
     #[serde(rename = "Rule")]
@@ -913,6 +956,7 @@ pub struct GetSampledRequestsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetSampledRequestsResponse {
     /// <p>The total number of requests from which <code>GetSampledRequests</code> got a sample of <code>MaxItems</code> requests. If <code>PopulationSize</code> is less than <code>MaxItems</code>, the sample includes every request that your AWS resource received during the specified time range.</p>
     #[serde(rename = "PopulationSize")]
@@ -936,6 +980,7 @@ pub struct GetSizeConstraintSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetSizeConstraintSetResponse {
     /// <p><p>Information about the <a>SizeConstraintSet</a> that you specified in the <code>GetSizeConstraintSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>SizeConstraintSet</a>: Contains <code>SizeConstraintSetId</code>, <code>SizeConstraints</code>, and <code>Name</code> </p> </li> <li> <p> <code>SizeConstraints</code>: Contains an array of <a>SizeConstraint</a> objects. Each <code>SizeConstraint</code> object contains <a>FieldToMatch</a>, <code>TextTransformation</code>, <code>ComparisonOperator</code>, and <code>Size</code> </p> </li> <li> <p> <a>FieldToMatch</a>: Contains <code>Data</code> and <code>Type</code> </p> </li> </ul></p>
     #[serde(rename = "SizeConstraintSet")]
@@ -953,6 +998,7 @@ pub struct GetSqlInjectionMatchSetRequest {
 
 /// <p>The response to a <a>GetSqlInjectionMatchSet</a> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetSqlInjectionMatchSetResponse {
     /// <p><p>Information about the <a>SqlInjectionMatchSet</a> that you specified in the <code>GetSqlInjectionMatchSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>SqlInjectionMatchSet</a>: Contains <code>Name</code>, <code>SqlInjectionMatchSetId</code>, and an array of <code>SqlInjectionMatchTuple</code> objects</p> </li> <li> <p> <a>SqlInjectionMatchTuple</a>: Each <code>SqlInjectionMatchTuple</code> object contains <code>FieldToMatch</code> and <code>TextTransformation</code> </p> </li> <li> <p> <a>FieldToMatch</a>: Contains <code>Data</code> and <code>Type</code> </p> </li> </ul></p>
     #[serde(rename = "SqlInjectionMatchSet")]
@@ -968,6 +1014,7 @@ pub struct GetWebACLForResourceRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetWebACLForResourceResponse {
     /// <p>Information about the web ACL that you specified in the <code>GetWebACLForResource</code> request. If there is no associated resource, a null WebACLSummary is returned.</p>
     #[serde(rename = "WebACLSummary")]
@@ -983,6 +1030,7 @@ pub struct GetWebACLRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetWebACLResponse {
     /// <p><p>Information about the <a>WebACL</a> that you specified in the <code>GetWebACL</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>WebACL</a>: Contains <code>DefaultAction</code>, <code>MetricName</code>, <code>Name</code>, an array of <code>Rule</code> objects, and <code>WebACLId</code> </p> </li> <li> <p> <code>DefaultAction</code> (Data type is <a>WafAction</a>): Contains <code>Type</code> </p> </li> <li> <p> <code>Rules</code>: Contains an array of <code>ActivatedRule</code> objects, which contain <code>Action</code>, <code>Priority</code>, and <code>RuleId</code> </p> </li> <li> <p> <code>Action</code>: Contains <code>Type</code> </p> </li> </ul></p>
     #[serde(rename = "WebACL")]
@@ -1000,6 +1048,7 @@ pub struct GetXssMatchSetRequest {
 
 /// <p>The response to a <a>GetXssMatchSet</a> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetXssMatchSetResponse {
     /// <p><p>Information about the <a>XssMatchSet</a> that you specified in the <code>GetXssMatchSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>XssMatchSet</a>: Contains <code>Name</code>, <code>XssMatchSetId</code>, and an array of <code>XssMatchTuple</code> objects</p> </li> <li> <p> <a>XssMatchTuple</a>: Each <code>XssMatchTuple</code> object contains <code>FieldToMatch</code> and <code>TextTransformation</code> </p> </li> <li> <p> <a>FieldToMatch</a>: Contains <code>Data</code> and <code>Type</code> </p> </li> </ul></p>
     #[serde(rename = "XssMatchSet")]
@@ -1009,6 +1058,7 @@ pub struct GetXssMatchSetResponse {
 
 /// <p>The response from a <a>GetSampledRequests</a> request includes an <code>HTTPHeader</code> complex type that appears as <code>Headers</code> in the response syntax. <code>HTTPHeader</code> contains the names and values of all of the headers that appear in one of the web requests that were returned by <code>GetSampledRequests</code>. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct HTTPHeader {
     /// <p>The name of one of the headers in the sampled web request.</p>
     #[serde(rename = "Name")]
@@ -1022,6 +1072,7 @@ pub struct HTTPHeader {
 
 /// <p>The response from a <a>GetSampledRequests</a> request includes an <code>HTTPRequest</code> complex type that appears as <code>Request</code> in the response syntax. <code>HTTPRequest</code> contains information about one of the web requests that were returned by <code>GetSampledRequests</code>. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct HTTPRequest {
     /// <p><p>The IP address that the request originated from. If the <code>WebACL</code> is associated with a CloudFront distribution, this is the value of one of the following fields in CloudFront access logs:</p> <ul> <li> <p> <code>c-ip</code>, if the viewer did not use an HTTP proxy or a load balancer to send the request</p> </li> <li> <p> <code>x-forwarded-for</code>, if the viewer did use an HTTP proxy or a load balancer to send the request</p> </li> </ul></p>
     #[serde(rename = "ClientIP")]
@@ -1051,6 +1102,7 @@ pub struct HTTPRequest {
 
 /// <p>Contains one or more IP addresses or blocks of IP addresses specified in Classless Inter-Domain Routing (CIDR) notation. AWS WAF supports /8, /16, /24, and /32 IP address ranges for IPv4, and /24, /32, /48, /56, /64 and /128 for IPv6.</p> <p>To specify an individual IP address, you specify the four-part IP address followed by a <code>/32</code>, for example, 192.0.2.0/31. To block a range of IP addresses, you can specify a <code>/128</code>, <code>/64</code>, <code>/56</code>, <code>/48</code>, <code>/32</code>, <code>/24</code>, <code>/16</code>, or <code>/8</code> CIDR. For more information about CIDR notation, see the Wikipedia entry <a href="https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing">Classless Inter-Domain Routing</a>. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct IPSet {
     /// <p>The IP address type (<code>IPV4</code> or <code>IPV6</code>) and the IP address range (in CIDR notation) that web requests originate from. If the <code>WebACL</code> is associated with a CloudFront distribution and the viewer did not use an HTTP proxy or a load balancer to send the request, this is the value of the c-ip field in the CloudFront access logs.</p>
     #[serde(rename = "IPSetDescriptors")]
@@ -1077,6 +1129,7 @@ pub struct IPSetDescriptor {
 
 /// <p>Contains the identifier and the name of the <code>IPSet</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct IPSetSummary {
     /// <p>The <code>IPSetId</code> for an <a>IPSet</a>. You can use <code>IPSetId</code> in a <a>GetIPSet</a> request to get detailed information about an <a>IPSet</a>.</p>
     #[serde(rename = "IPSetId")]
@@ -1114,6 +1167,7 @@ pub struct ListActivatedRulesInRuleGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListActivatedRulesInRuleGroupResponse {
     /// <p>An array of <code>ActivatedRules</code> objects.</p>
     #[serde(rename = "ActivatedRules")]
@@ -1138,6 +1192,7 @@ pub struct ListByteMatchSetsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListByteMatchSetsResponse {
     /// <p>An array of <a>ByteMatchSetSummary</a> objects.</p>
     #[serde(rename = "ByteMatchSets")]
@@ -1162,6 +1217,7 @@ pub struct ListGeoMatchSetsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListGeoMatchSetsResponse {
     /// <p>An array of <a>GeoMatchSetSummary</a> objects.</p>
     #[serde(rename = "GeoMatchSets")]
@@ -1186,6 +1242,7 @@ pub struct ListIPSetsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListIPSetsResponse {
     /// <p>An array of <a>IPSetSummary</a> objects.</p>
     #[serde(rename = "IPSets")]
@@ -1210,6 +1267,7 @@ pub struct ListRateBasedRulesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListRateBasedRulesResponse {
     /// <p>If you have more <code>Rules</code> than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>Rules</code>, submit another <code>ListRateBasedRules</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1234,6 +1292,7 @@ pub struct ListRegexMatchSetsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListRegexMatchSetsResponse {
     /// <p>If you have more <code>RegexMatchSet</code> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>RegexMatchSet</code> objects, submit another <code>ListRegexMatchSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1258,6 +1317,7 @@ pub struct ListRegexPatternSetsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListRegexPatternSetsResponse {
     /// <p>If you have more <code>RegexPatternSet</code> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>RegexPatternSet</code> objects, submit another <code>ListRegexPatternSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1277,6 +1337,7 @@ pub struct ListResourcesForWebACLRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListResourcesForWebACLResponse {
     /// <p>An array of ARNs (Amazon Resource Names) of the resources associated with the specified web ACL. An array with zero elements is returned if there are no resources associated with the web ACL.</p>
     #[serde(rename = "ResourceArns")]
@@ -1297,6 +1358,7 @@ pub struct ListRuleGroupsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListRuleGroupsResponse {
     /// <p>If you have more <code>RuleGroups</code> than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>RuleGroups</code>, submit another <code>ListRuleGroups</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1321,6 +1383,7 @@ pub struct ListRulesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListRulesResponse {
     /// <p>If you have more <code>Rules</code> than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>Rules</code>, submit another <code>ListRules</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1345,6 +1408,7 @@ pub struct ListSizeConstraintSetsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListSizeConstraintSetsResponse {
     /// <p>If you have more <code>SizeConstraintSet</code> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>SizeConstraintSet</code> objects, submit another <code>ListSizeConstraintSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1371,6 +1435,7 @@ pub struct ListSqlInjectionMatchSetsRequest {
 
 /// <p>The response to a <a>ListSqlInjectionMatchSets</a> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListSqlInjectionMatchSetsResponse {
     /// <p>If you have more <a>SqlInjectionMatchSet</a> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>SqlInjectionMatchSet</code> objects, submit another <code>ListSqlInjectionMatchSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1395,6 +1460,7 @@ pub struct ListSubscribedRuleGroupsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListSubscribedRuleGroupsResponse {
     /// <p>If you have more objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more objects, submit another <code>ListSubscribedRuleGroups</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1419,6 +1485,7 @@ pub struct ListWebACLsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListWebACLsResponse {
     /// <p>If you have more <code>WebACL</code> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>WebACL</code> objects, submit another <code>ListWebACLs</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1445,6 +1512,7 @@ pub struct ListXssMatchSetsRequest {
 
 /// <p>The response to a <a>ListXssMatchSets</a> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListXssMatchSetsResponse {
     /// <p>If you have more <a>XssMatchSet</a> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>XssMatchSet</code> objects, submit another <code>ListXssMatchSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1481,10 +1549,12 @@ pub struct PutPermissionPolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutPermissionPolicyResponse {}
 
 /// <p>A <code>RateBasedRule</code> is identical to a regular <a>Rule</a>, with one addition: a <code>RateBasedRule</code> counts the number of requests that arrive from a specified IP address every five minutes. For example, based on recent requests that you've seen from an attacker, you might create a <code>RateBasedRule</code> that includes the following conditions: </p> <ul> <li> <p>The requests come from 192.0.2.44.</p> </li> <li> <p>They contain the value <code>BadBot</code> in the <code>User-Agent</code> header.</p> </li> </ul> <p>In the rule, you also define the rate limit as 15,000.</p> <p>Requests that meet both of these conditions and exceed 15,000 requests every five minutes trigger the rule's action (block or count), which is defined in the web ACL.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RateBasedRule {
     /// <p>The <code>Predicates</code> object contains one <code>Predicate</code> element for each <a>ByteMatchSet</a>, <a>IPSet</a>, or <a>SqlInjectionMatchSet</a> object that you want to include in a <code>RateBasedRule</code>.</p>
     #[serde(rename = "MatchPredicates")]
@@ -1510,6 +1580,7 @@ pub struct RateBasedRule {
 
 /// <p>In a <a>GetRegexMatchSet</a> request, <code>RegexMatchSet</code> is a complex type that contains the <code>RegexMatchSetId</code> and <code>Name</code> of a <code>RegexMatchSet</code>, and the values that you specified when you updated the <code>RegexMatchSet</code>.</p> <p> The values are contained in a <code>RegexMatchTuple</code> object, which specify the parts of web requests that you want AWS WAF to inspect and the values that you want AWS WAF to search for. If a <code>RegexMatchSet</code> contains more than one <code>RegexMatchTuple</code> object, a request needs to match the settings in only one <code>ByteMatchTuple</code> to be considered a match.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegexMatchSet {
     /// <p>A friendly name or description of the <a>RegexMatchSet</a>. You can't change <code>Name</code> after you create a <code>RegexMatchSet</code>.</p>
     #[serde(rename = "Name")]
@@ -1527,6 +1598,7 @@ pub struct RegexMatchSet {
 
 /// <p>Returned by <a>ListRegexMatchSets</a>. Each <code>RegexMatchSetSummary</code> object includes the <code>Name</code> and <code>RegexMatchSetId</code> for one <a>RegexMatchSet</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegexMatchSetSummary {
     /// <p>A friendly name or description of the <a>RegexMatchSet</a>. You can't change <code>Name</code> after you create a <code>RegexMatchSet</code>.</p>
     #[serde(rename = "Name")]
@@ -1563,6 +1635,7 @@ pub struct RegexMatchTuple {
 
 /// <p>The <code>RegexPatternSet</code> specifies the regular expression (regex) pattern that you want AWS WAF to search for, such as <code>B[a@]dB[o0]t</code>. You can then configure AWS WAF to reject those requests.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegexPatternSet {
     /// <p>A friendly name or description of the <a>RegexPatternSet</a>. You can't change <code>Name</code> after you create a <code>RegexPatternSet</code>.</p>
     #[serde(rename = "Name")]
@@ -1578,6 +1651,7 @@ pub struct RegexPatternSet {
 
 /// <p>Returned by <a>ListRegexPatternSets</a>. Each <code>RegexPatternSetSummary</code> object includes the <code>Name</code> and <code>RegexPatternSetId</code> for one <a>RegexPatternSet</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegexPatternSetSummary {
     /// <p>A friendly name or description of the <a>RegexPatternSet</a>. You can't change <code>Name</code> after you create a <code>RegexPatternSet</code>.</p>
     #[serde(rename = "Name")]
@@ -1600,6 +1674,7 @@ pub struct RegexPatternSetUpdate {
 
 /// <p>A combination of <a>ByteMatchSet</a>, <a>IPSet</a>, and/or <a>SqlInjectionMatchSet</a> objects that identify the web requests that you want to allow, block, or count. For example, you might create a <code>Rule</code> that includes the following predicates:</p> <ul> <li> <p>An <code>IPSet</code> that causes AWS WAF to search for web requests that originate from the IP address <code>192.0.2.44</code> </p> </li> <li> <p>A <code>ByteMatchSet</code> that causes AWS WAF to search for web requests for which the value of the <code>User-Agent</code> header is <code>BadBot</code>.</p> </li> </ul> <p>To match the settings in this <code>Rule</code>, a request must originate from <code>192.0.2.44</code> AND include a <code>User-Agent</code> header for which the value is <code>BadBot</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Rule {
     /// <p>A friendly name or description for the metrics for this <code>Rule</code>. The name can contain only alphanumeric characters (A-Z, a-z, 0-9); the name can't contain whitespace. You can't change <code>MetricName</code> after you create the <code>Rule</code>.</p>
     #[serde(rename = "MetricName")]
@@ -1619,6 +1694,7 @@ pub struct Rule {
 
 /// <p><p>A collection of predefined rules that you can add to a web ACL.</p> <p>Rule groups are subject to the following limits:</p> <ul> <li> <p>Three rule groups per account. You can request an increase to this limit by contacting customer support.</p> </li> <li> <p>One rule group per web ACL.</p> </li> <li> <p>Ten rules per rule group.</p> </li> </ul></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RuleGroup {
     /// <p>A friendly name or description for the metrics for this <code>RuleGroup</code>. The name can contain only alphanumeric characters (A-Z, a-z, 0-9); the name can't contain whitespace. You can't change the name of the metric after you create the <code>RuleGroup</code>.</p>
     #[serde(rename = "MetricName")]
@@ -1635,6 +1711,7 @@ pub struct RuleGroup {
 
 /// <p>Contains the identifier and the friendly name or description of the <code>RuleGroup</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RuleGroupSummary {
     /// <p>A friendly name or description of the <a>RuleGroup</a>. You can't change the name of a <code>RuleGroup</code> after you create it.</p>
     #[serde(rename = "Name")]
@@ -1657,6 +1734,7 @@ pub struct RuleGroupUpdate {
 
 /// <p>Contains the identifier and the friendly name or description of the <code>Rule</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RuleSummary {
     /// <p>A friendly name or description of the <a>Rule</a>. You can't change the name of a <code>Rule</code> after you create it.</p>
     #[serde(rename = "Name")]
@@ -1679,6 +1757,7 @@ pub struct RuleUpdate {
 
 /// <p>The response from a <a>GetSampledRequests</a> request includes a <code>SampledHTTPRequests</code> complex type that appears as <code>SampledRequests</code> in the response syntax. <code>SampledHTTPRequests</code> contains one <code>SampledHTTPRequest</code> object for each web request that is returned by <code>GetSampledRequests</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SampledHTTPRequest {
     /// <p>The action for the <code>Rule</code> that the request matched: <code>ALLOW</code>, <code>BLOCK</code>, or <code>COUNT</code>.</p>
     #[serde(rename = "Action")]
@@ -1719,6 +1798,7 @@ pub struct SizeConstraint {
 
 /// <p>A complex type that contains <code>SizeConstraint</code> objects, which specify the parts of web requests that you want AWS WAF to inspect the size of. If a <code>SizeConstraintSet</code> contains more than one <code>SizeConstraint</code> object, a request only needs to match one constraint to be considered a match.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SizeConstraintSet {
     /// <p>The name, if any, of the <code>SizeConstraintSet</code>.</p>
     #[serde(rename = "Name")]
@@ -1734,6 +1814,7 @@ pub struct SizeConstraintSet {
 
 /// <p>The <code>Id</code> and <code>Name</code> of a <code>SizeConstraintSet</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SizeConstraintSetSummary {
     /// <p>The name of the <code>SizeConstraintSet</code>, if any.</p>
     #[serde(rename = "Name")]
@@ -1756,6 +1837,7 @@ pub struct SizeConstraintSetUpdate {
 
 /// <p>A complex type that contains <code>SqlInjectionMatchTuple</code> objects, which specify the parts of web requests that you want AWS WAF to inspect for snippets of malicious SQL code and, if you want AWS WAF to inspect a header, the name of the header. If a <code>SqlInjectionMatchSet</code> contains more than one <code>SqlInjectionMatchTuple</code> object, a request needs to include snippets of SQL code in only one of the specified parts of the request to be considered a match.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SqlInjectionMatchSet {
     /// <p>The name, if any, of the <code>SqlInjectionMatchSet</code>.</p>
     #[serde(rename = "Name")]
@@ -1771,6 +1853,7 @@ pub struct SqlInjectionMatchSet {
 
 /// <p>The <code>Id</code> and <code>Name</code> of a <code>SqlInjectionMatchSet</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SqlInjectionMatchSetSummary {
     /// <p>The name of the <code>SqlInjectionMatchSet</code>, if any, specified by <code>Id</code>.</p>
     #[serde(rename = "Name")]
@@ -1804,6 +1887,7 @@ pub struct SqlInjectionMatchTuple {
 
 /// <p>A summary of the rule groups you are subscribed to.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SubscribedRuleGroupSummary {
     /// <p>A friendly name or description for the metrics for this <code>RuleGroup</code>. The name can contain only alphanumeric characters (A-Z, a-z, 0-9); the name can't contain whitespace. You can't change the name of the metric after you create the <code>RuleGroup</code>.</p>
     #[serde(rename = "MetricName")]
@@ -1841,6 +1925,7 @@ pub struct UpdateByteMatchSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateByteMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateByteMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1862,6 +1947,7 @@ pub struct UpdateGeoMatchSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateGeoMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateGeoMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1883,6 +1969,7 @@ pub struct UpdateIPSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateIPSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateIPSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1907,6 +1994,7 @@ pub struct UpdateRateBasedRuleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateRateBasedRuleResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateRateBasedRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1928,6 +2016,7 @@ pub struct UpdateRegexMatchSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateRegexMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateRegexMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1949,6 +2038,7 @@ pub struct UpdateRegexPatternSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateRegexPatternSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateRegexPatternSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1970,6 +2060,7 @@ pub struct UpdateRuleGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateRuleGroupResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateRuleGroup</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1991,6 +2082,7 @@ pub struct UpdateRuleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateRuleResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -2012,6 +2104,7 @@ pub struct UpdateSizeConstraintSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateSizeConstraintSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateSizeConstraintSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -2035,6 +2128,7 @@ pub struct UpdateSqlInjectionMatchSetRequest {
 
 /// <p>The response to an <a>UpdateSqlInjectionMatchSets</a> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateSqlInjectionMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateSqlInjectionMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -2061,6 +2155,7 @@ pub struct UpdateWebACLRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateWebACLResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateWebACL</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -2084,6 +2179,7 @@ pub struct UpdateXssMatchSetRequest {
 
 /// <p>The response to an <a>UpdateXssMatchSets</a> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateXssMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateXssMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -2109,6 +2205,7 @@ pub struct WafOverrideAction {
 
 /// <p>Contains the <code>Rules</code> that identify the requests that you want to allow, block, or count. In a <code>WebACL</code>, you also specify a default action (<code>ALLOW</code> or <code>BLOCK</code>), and the action for each <code>Rule</code> that you add to a <code>WebACL</code>, for example, block requests from specified IP addresses or block requests from specified referrers. You also associate the <code>WebACL</code> with a CloudFront distribution to identify the requests that you want AWS WAF to filter. If you add more than one <code>Rule</code> to a <code>WebACL</code>, a request needs to match only one of the specifications to be allowed, blocked, or counted. For more information, see <a>UpdateWebACL</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WebACL {
     /// <p>The action to perform if none of the <code>Rules</code> contained in the <code>WebACL</code> match. The action is specified by the <a>WafAction</a> object.</p>
     #[serde(rename = "DefaultAction")]
@@ -2131,6 +2228,7 @@ pub struct WebACL {
 
 /// <p>Contains the identifier and the name or description of the <a>WebACL</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WebACLSummary {
     /// <p>A friendly name or description of the <a>WebACL</a>. You can't change the name of a <code>WebACL</code> after you create it.</p>
     #[serde(rename = "Name")]
@@ -2153,6 +2251,7 @@ pub struct WebACLUpdate {
 
 /// <p>A complex type that contains <code>XssMatchTuple</code> objects, which specify the parts of web requests that you want AWS WAF to inspect for cross-site scripting attacks and, if you want AWS WAF to inspect a header, the name of the header. If a <code>XssMatchSet</code> contains more than one <code>XssMatchTuple</code> object, a request needs to include cross-site scripting attacks in only one of the specified parts of the request to be considered a match.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct XssMatchSet {
     /// <p>The name, if any, of the <code>XssMatchSet</code>.</p>
     #[serde(rename = "Name")]
@@ -2168,6 +2267,7 @@ pub struct XssMatchSet {
 
 /// <p>The <code>Id</code> and <code>Name</code> of an <code>XssMatchSet</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct XssMatchSetSummary {
     /// <p>The name of the <code>XssMatchSet</code>, if any, specified by <code>Id</code>.</p>
     #[serde(rename = "Name")]

--- a/rusoto/services/waf/src/generated.rs
+++ b/rusoto/services/waf/src/generated.rs
@@ -53,6 +53,7 @@ pub struct ActivatedRule {
 
 /// <p>In a <a>GetByteMatchSet</a> request, <code>ByteMatchSet</code> is a complex type that contains the <code>ByteMatchSetId</code> and <code>Name</code> of a <code>ByteMatchSet</code>, and the values that you specified when you updated the <code>ByteMatchSet</code>. </p> <p>A complex type that contains <code>ByteMatchTuple</code> objects, which specify the parts of web requests that you want AWS WAF to inspect and the values that you want AWS WAF to search for. If a <code>ByteMatchSet</code> contains more than one <code>ByteMatchTuple</code> object, a request needs to match the settings in only one <code>ByteMatchTuple</code> to be considered a match.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ByteMatchSet {
     /// <p>The <code>ByteMatchSetId</code> for a <code>ByteMatchSet</code>. You use <code>ByteMatchSetId</code> to get information about a <code>ByteMatchSet</code> (see <a>GetByteMatchSet</a>), update a <code>ByteMatchSet</code> (see <a>UpdateByteMatchSet</a>), insert a <code>ByteMatchSet</code> into a <code>Rule</code> or delete one from a <code>Rule</code> (see <a>UpdateRule</a>), and delete a <code>ByteMatchSet</code> from AWS WAF (see <a>DeleteByteMatchSet</a>).</p> <p> <code>ByteMatchSetId</code> is returned by <a>CreateByteMatchSet</a> and by <a>ListByteMatchSets</a>.</p>
     #[serde(rename = "ByteMatchSetId")]
@@ -68,6 +69,7 @@ pub struct ByteMatchSet {
 
 /// <p>Returned by <a>ListByteMatchSets</a>. Each <code>ByteMatchSetSummary</code> object includes the <code>Name</code> and <code>ByteMatchSetId</code> for one <a>ByteMatchSet</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ByteMatchSetSummary {
     /// <p>The <code>ByteMatchSetId</code> for a <code>ByteMatchSet</code>. You use <code>ByteMatchSetId</code> to get information about a <code>ByteMatchSet</code>, update a <code>ByteMatchSet</code>, remove a <code>ByteMatchSet</code> from a <code>Rule</code>, and delete a <code>ByteMatchSet</code> from AWS WAF.</p> <p> <code>ByteMatchSetId</code> is returned by <a>CreateByteMatchSet</a> and by <a>ListByteMatchSets</a>.</p>
     #[serde(rename = "ByteMatchSetId")]
@@ -121,6 +123,7 @@ pub struct CreateByteMatchSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateByteMatchSetResponse {
     /// <p>A <a>ByteMatchSet</a> that contains no <code>ByteMatchTuple</code> objects.</p>
     #[serde(rename = "ByteMatchSet")]
@@ -143,6 +146,7 @@ pub struct CreateGeoMatchSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateGeoMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateGeoMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -165,6 +169,7 @@ pub struct CreateIPSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateIPSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateIPSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -196,6 +201,7 @@ pub struct CreateRateBasedRuleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateRateBasedRuleResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateRateBasedRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -218,6 +224,7 @@ pub struct CreateRegexMatchSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateRegexMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateRegexMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -240,6 +247,7 @@ pub struct CreateRegexPatternSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateRegexPatternSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateRegexPatternSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -265,6 +273,7 @@ pub struct CreateRuleGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateRuleGroupResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateRuleGroup</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -290,6 +299,7 @@ pub struct CreateRuleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateRuleResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -312,6 +322,7 @@ pub struct CreateSizeConstraintSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateSizeConstraintSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateSizeConstraintSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -336,6 +347,7 @@ pub struct CreateSqlInjectionMatchSetRequest {
 
 /// <p>The response to a <code>CreateSqlInjectionMatchSet</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateSqlInjectionMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateSqlInjectionMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -364,6 +376,7 @@ pub struct CreateWebACLRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateWebACLResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateWebACL</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -388,6 +401,7 @@ pub struct CreateXssMatchSetRequest {
 
 /// <p>The response to a <code>CreateXssMatchSet</code> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateXssMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>CreateXssMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -410,6 +424,7 @@ pub struct DeleteByteMatchSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteByteMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteByteMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -428,6 +443,7 @@ pub struct DeleteGeoMatchSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteGeoMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteGeoMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -446,6 +462,7 @@ pub struct DeleteIPSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteIPSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteIPSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -461,6 +478,7 @@ pub struct DeletePermissionPolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeletePermissionPolicyResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -474,6 +492,7 @@ pub struct DeleteRateBasedRuleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteRateBasedRuleResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteRateBasedRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -492,6 +511,7 @@ pub struct DeleteRegexMatchSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteRegexMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteRegexMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -510,6 +530,7 @@ pub struct DeleteRegexPatternSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteRegexPatternSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteRegexPatternSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -528,6 +549,7 @@ pub struct DeleteRuleGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteRuleGroupResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteRuleGroup</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -546,6 +568,7 @@ pub struct DeleteRuleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteRuleResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -564,6 +587,7 @@ pub struct DeleteSizeConstraintSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteSizeConstraintSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteSizeConstraintSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -584,6 +608,7 @@ pub struct DeleteSqlInjectionMatchSetRequest {
 
 /// <p>The response to a request to delete a <a>SqlInjectionMatchSet</a> from AWS WAF.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteSqlInjectionMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteSqlInjectionMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -602,6 +627,7 @@ pub struct DeleteWebACLRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteWebACLResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteWebACL</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -622,6 +648,7 @@ pub struct DeleteXssMatchSetRequest {
 
 /// <p>The response to a request to delete an <a>XssMatchSet</a> from AWS WAF.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteXssMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>DeleteXssMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -654,6 +681,7 @@ pub struct GeoMatchConstraint {
 
 /// <p>Contains one or more countries that AWS WAF will search for.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GeoMatchSet {
     /// <p>An array of <a>GeoMatchConstraint</a> objects, which contain the country that you want AWS WAF to search for.</p>
     #[serde(rename = "GeoMatchConstraints")]
@@ -669,6 +697,7 @@ pub struct GeoMatchSet {
 
 /// <p>Contains the identifier and the name of the <code>GeoMatchSet</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GeoMatchSetSummary {
     /// <p>The <code>GeoMatchSetId</code> for an <a>GeoMatchSet</a>. You can use <code>GeoMatchSetId</code> in a <a>GetGeoMatchSet</a> request to get detailed information about an <a>GeoMatchSet</a>.</p>
     #[serde(rename = "GeoMatchSetId")]
@@ -697,6 +726,7 @@ pub struct GetByteMatchSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetByteMatchSetResponse {
     /// <p><p>Information about the <a>ByteMatchSet</a> that you specified in the <code>GetByteMatchSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>ByteMatchSet</a>: Contains <code>ByteMatchSetId</code>, <code>ByteMatchTuples</code>, and <code>Name</code> </p> </li> <li> <p> <code>ByteMatchTuples</code>: Contains an array of <a>ByteMatchTuple</a> objects. Each <code>ByteMatchTuple</code> object contains <a>FieldToMatch</a>, <code>PositionalConstraint</code>, <code>TargetString</code>, and <code>TextTransformation</code> </p> </li> <li> <p> <a>FieldToMatch</a>: Contains <code>Data</code> and <code>Type</code> </p> </li> </ul></p>
     #[serde(rename = "ByteMatchSet")]
@@ -708,6 +738,7 @@ pub struct GetByteMatchSetResponse {
 pub struct GetChangeTokenRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetChangeTokenResponse {
     /// <p>The <code>ChangeToken</code> that you used in the request. Use this value in a <code>GetChangeTokenStatus</code> request to get the current status of the request. </p>
     #[serde(rename = "ChangeToken")]
@@ -723,6 +754,7 @@ pub struct GetChangeTokenStatusRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetChangeTokenStatusResponse {
     /// <p>The status of the change token.</p>
     #[serde(rename = "ChangeTokenStatus")]
@@ -738,6 +770,7 @@ pub struct GetGeoMatchSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetGeoMatchSetResponse {
     /// <p>Information about the <a>GeoMatchSet</a> that you specified in the <code>GetGeoMatchSet</code> request. This includes the <code>Type</code>, which for a <code>GeoMatchContraint</code> is always <code>Country</code>, as well as the <code>Value</code>, which is the identifier for a specific country.</p>
     #[serde(rename = "GeoMatchSet")]
@@ -753,6 +786,7 @@ pub struct GetIPSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetIPSetResponse {
     /// <p><p>Information about the <a>IPSet</a> that you specified in the <code>GetIPSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>IPSet</a>: Contains <code>IPSetDescriptors</code>, <code>IPSetId</code>, and <code>Name</code> </p> </li> <li> <p> <code>IPSetDescriptors</code>: Contains an array of <a>IPSetDescriptor</a> objects. Each <code>IPSetDescriptor</code> object contains <code>Type</code> and <code>Value</code> </p> </li> </ul></p>
     #[serde(rename = "IPSet")]
@@ -768,6 +802,7 @@ pub struct GetPermissionPolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetPermissionPolicyResponse {
     /// <p>The IAM policy attached to the specified RuleGroup.</p>
     #[serde(rename = "Policy")]
@@ -787,6 +822,7 @@ pub struct GetRateBasedRuleManagedKeysRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetRateBasedRuleManagedKeysResponse {
     /// <p>An array of IP addresses that currently are blocked by the specified <a>RateBasedRule</a>. </p>
     #[serde(rename = "ManagedKeys")]
@@ -806,6 +842,7 @@ pub struct GetRateBasedRuleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetRateBasedRuleResponse {
     /// <p>Information about the <a>RateBasedRule</a> that you specified in the <code>GetRateBasedRule</code> request.</p>
     #[serde(rename = "Rule")]
@@ -821,6 +858,7 @@ pub struct GetRegexMatchSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetRegexMatchSetResponse {
     /// <p>Information about the <a>RegexMatchSet</a> that you specified in the <code>GetRegexMatchSet</code> request. For more information, see <a>RegexMatchTuple</a>.</p>
     #[serde(rename = "RegexMatchSet")]
@@ -836,6 +874,7 @@ pub struct GetRegexPatternSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetRegexPatternSetResponse {
     /// <p>Information about the <a>RegexPatternSet</a> that you specified in the <code>GetRegexPatternSet</code> request, including the identifier of the pattern set and the regular expression patterns you want AWS WAF to search for. </p>
     #[serde(rename = "RegexPatternSet")]
@@ -851,6 +890,7 @@ pub struct GetRuleGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetRuleGroupResponse {
     /// <p>Information about the <a>RuleGroup</a> that you specified in the <code>GetRuleGroup</code> request. </p>
     #[serde(rename = "RuleGroup")]
@@ -866,6 +906,7 @@ pub struct GetRuleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetRuleResponse {
     /// <p><p>Information about the <a>Rule</a> that you specified in the <code>GetRule</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>Rule</a>: Contains <code>MetricName</code>, <code>Name</code>, an array of <code>Predicate</code> objects, and <code>RuleId</code> </p> </li> <li> <p> <a>Predicate</a>: Each <code>Predicate</code> object contains <code>DataId</code>, <code>Negated</code>, and <code>Type</code> </p> </li> </ul></p>
     #[serde(rename = "Rule")]
@@ -890,6 +931,7 @@ pub struct GetSampledRequestsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetSampledRequestsResponse {
     /// <p>The total number of requests from which <code>GetSampledRequests</code> got a sample of <code>MaxItems</code> requests. If <code>PopulationSize</code> is less than <code>MaxItems</code>, the sample includes every request that your AWS resource received during the specified time range.</p>
     #[serde(rename = "PopulationSize")]
@@ -913,6 +955,7 @@ pub struct GetSizeConstraintSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetSizeConstraintSetResponse {
     /// <p><p>Information about the <a>SizeConstraintSet</a> that you specified in the <code>GetSizeConstraintSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>SizeConstraintSet</a>: Contains <code>SizeConstraintSetId</code>, <code>SizeConstraints</code>, and <code>Name</code> </p> </li> <li> <p> <code>SizeConstraints</code>: Contains an array of <a>SizeConstraint</a> objects. Each <code>SizeConstraint</code> object contains <a>FieldToMatch</a>, <code>TextTransformation</code>, <code>ComparisonOperator</code>, and <code>Size</code> </p> </li> <li> <p> <a>FieldToMatch</a>: Contains <code>Data</code> and <code>Type</code> </p> </li> </ul></p>
     #[serde(rename = "SizeConstraintSet")]
@@ -930,6 +973,7 @@ pub struct GetSqlInjectionMatchSetRequest {
 
 /// <p>The response to a <a>GetSqlInjectionMatchSet</a> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetSqlInjectionMatchSetResponse {
     /// <p><p>Information about the <a>SqlInjectionMatchSet</a> that you specified in the <code>GetSqlInjectionMatchSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>SqlInjectionMatchSet</a>: Contains <code>Name</code>, <code>SqlInjectionMatchSetId</code>, and an array of <code>SqlInjectionMatchTuple</code> objects</p> </li> <li> <p> <a>SqlInjectionMatchTuple</a>: Each <code>SqlInjectionMatchTuple</code> object contains <code>FieldToMatch</code> and <code>TextTransformation</code> </p> </li> <li> <p> <a>FieldToMatch</a>: Contains <code>Data</code> and <code>Type</code> </p> </li> </ul></p>
     #[serde(rename = "SqlInjectionMatchSet")]
@@ -945,6 +989,7 @@ pub struct GetWebACLRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetWebACLResponse {
     /// <p><p>Information about the <a>WebACL</a> that you specified in the <code>GetWebACL</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>WebACL</a>: Contains <code>DefaultAction</code>, <code>MetricName</code>, <code>Name</code>, an array of <code>Rule</code> objects, and <code>WebACLId</code> </p> </li> <li> <p> <code>DefaultAction</code> (Data type is <a>WafAction</a>): Contains <code>Type</code> </p> </li> <li> <p> <code>Rules</code>: Contains an array of <code>ActivatedRule</code> objects, which contain <code>Action</code>, <code>Priority</code>, and <code>RuleId</code> </p> </li> <li> <p> <code>Action</code>: Contains <code>Type</code> </p> </li> </ul></p>
     #[serde(rename = "WebACL")]
@@ -962,6 +1007,7 @@ pub struct GetXssMatchSetRequest {
 
 /// <p>The response to a <a>GetXssMatchSet</a> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetXssMatchSetResponse {
     /// <p><p>Information about the <a>XssMatchSet</a> that you specified in the <code>GetXssMatchSet</code> request. For more information, see the following topics:</p> <ul> <li> <p> <a>XssMatchSet</a>: Contains <code>Name</code>, <code>XssMatchSetId</code>, and an array of <code>XssMatchTuple</code> objects</p> </li> <li> <p> <a>XssMatchTuple</a>: Each <code>XssMatchTuple</code> object contains <code>FieldToMatch</code> and <code>TextTransformation</code> </p> </li> <li> <p> <a>FieldToMatch</a>: Contains <code>Data</code> and <code>Type</code> </p> </li> </ul></p>
     #[serde(rename = "XssMatchSet")]
@@ -971,6 +1017,7 @@ pub struct GetXssMatchSetResponse {
 
 /// <p>The response from a <a>GetSampledRequests</a> request includes an <code>HTTPHeader</code> complex type that appears as <code>Headers</code> in the response syntax. <code>HTTPHeader</code> contains the names and values of all of the headers that appear in one of the web requests that were returned by <code>GetSampledRequests</code>. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct HTTPHeader {
     /// <p>The name of one of the headers in the sampled web request.</p>
     #[serde(rename = "Name")]
@@ -984,6 +1031,7 @@ pub struct HTTPHeader {
 
 /// <p>The response from a <a>GetSampledRequests</a> request includes an <code>HTTPRequest</code> complex type that appears as <code>Request</code> in the response syntax. <code>HTTPRequest</code> contains information about one of the web requests that were returned by <code>GetSampledRequests</code>. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct HTTPRequest {
     /// <p><p>The IP address that the request originated from. If the <code>WebACL</code> is associated with a CloudFront distribution, this is the value of one of the following fields in CloudFront access logs:</p> <ul> <li> <p> <code>c-ip</code>, if the viewer did not use an HTTP proxy or a load balancer to send the request</p> </li> <li> <p> <code>x-forwarded-for</code>, if the viewer did use an HTTP proxy or a load balancer to send the request</p> </li> </ul></p>
     #[serde(rename = "ClientIP")]
@@ -1013,6 +1061,7 @@ pub struct HTTPRequest {
 
 /// <p>Contains one or more IP addresses or blocks of IP addresses specified in Classless Inter-Domain Routing (CIDR) notation. AWS WAF supports /8, /16, /24, and /32 IP address ranges for IPv4, and /24, /32, /48, /56, /64 and /128 for IPv6.</p> <p>To specify an individual IP address, you specify the four-part IP address followed by a <code>/32</code>, for example, 192.0.2.0/31. To block a range of IP addresses, you can specify a <code>/128</code>, <code>/64</code>, <code>/56</code>, <code>/48</code>, <code>/32</code>, <code>/24</code>, <code>/16</code>, or <code>/8</code> CIDR. For more information about CIDR notation, see the Wikipedia entry <a href="https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing">Classless Inter-Domain Routing</a>. </p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct IPSet {
     /// <p>The IP address type (<code>IPV4</code> or <code>IPV6</code>) and the IP address range (in CIDR notation) that web requests originate from. If the <code>WebACL</code> is associated with a CloudFront distribution and the viewer did not use an HTTP proxy or a load balancer to send the request, this is the value of the c-ip field in the CloudFront access logs.</p>
     #[serde(rename = "IPSetDescriptors")]
@@ -1039,6 +1088,7 @@ pub struct IPSetDescriptor {
 
 /// <p>Contains the identifier and the name of the <code>IPSet</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct IPSetSummary {
     /// <p>The <code>IPSetId</code> for an <a>IPSet</a>. You can use <code>IPSetId</code> in a <a>GetIPSet</a> request to get detailed information about an <a>IPSet</a>.</p>
     #[serde(rename = "IPSetId")]
@@ -1076,6 +1126,7 @@ pub struct ListActivatedRulesInRuleGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListActivatedRulesInRuleGroupResponse {
     /// <p>An array of <code>ActivatedRules</code> objects.</p>
     #[serde(rename = "ActivatedRules")]
@@ -1100,6 +1151,7 @@ pub struct ListByteMatchSetsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListByteMatchSetsResponse {
     /// <p>An array of <a>ByteMatchSetSummary</a> objects.</p>
     #[serde(rename = "ByteMatchSets")]
@@ -1124,6 +1176,7 @@ pub struct ListGeoMatchSetsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListGeoMatchSetsResponse {
     /// <p>An array of <a>GeoMatchSetSummary</a> objects.</p>
     #[serde(rename = "GeoMatchSets")]
@@ -1148,6 +1201,7 @@ pub struct ListIPSetsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListIPSetsResponse {
     /// <p>An array of <a>IPSetSummary</a> objects.</p>
     #[serde(rename = "IPSets")]
@@ -1172,6 +1226,7 @@ pub struct ListRateBasedRulesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListRateBasedRulesResponse {
     /// <p>If you have more <code>Rules</code> than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>Rules</code>, submit another <code>ListRateBasedRules</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1196,6 +1251,7 @@ pub struct ListRegexMatchSetsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListRegexMatchSetsResponse {
     /// <p>If you have more <code>RegexMatchSet</code> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>RegexMatchSet</code> objects, submit another <code>ListRegexMatchSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1220,6 +1276,7 @@ pub struct ListRegexPatternSetsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListRegexPatternSetsResponse {
     /// <p>If you have more <code>RegexPatternSet</code> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>RegexPatternSet</code> objects, submit another <code>ListRegexPatternSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1244,6 +1301,7 @@ pub struct ListRuleGroupsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListRuleGroupsResponse {
     /// <p>If you have more <code>RuleGroups</code> than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>RuleGroups</code>, submit another <code>ListRuleGroups</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1268,6 +1326,7 @@ pub struct ListRulesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListRulesResponse {
     /// <p>If you have more <code>Rules</code> than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>Rules</code>, submit another <code>ListRules</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1292,6 +1351,7 @@ pub struct ListSizeConstraintSetsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListSizeConstraintSetsResponse {
     /// <p>If you have more <code>SizeConstraintSet</code> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>SizeConstraintSet</code> objects, submit another <code>ListSizeConstraintSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1318,6 +1378,7 @@ pub struct ListSqlInjectionMatchSetsRequest {
 
 /// <p>The response to a <a>ListSqlInjectionMatchSets</a> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListSqlInjectionMatchSetsResponse {
     /// <p>If you have more <a>SqlInjectionMatchSet</a> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>SqlInjectionMatchSet</code> objects, submit another <code>ListSqlInjectionMatchSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1342,6 +1403,7 @@ pub struct ListSubscribedRuleGroupsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListSubscribedRuleGroupsResponse {
     /// <p>If you have more objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more objects, submit another <code>ListSubscribedRuleGroups</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1366,6 +1428,7 @@ pub struct ListWebACLsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListWebACLsResponse {
     /// <p>If you have more <code>WebACL</code> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>WebACL</code> objects, submit another <code>ListWebACLs</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1392,6 +1455,7 @@ pub struct ListXssMatchSetsRequest {
 
 /// <p>The response to a <a>ListXssMatchSets</a> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ListXssMatchSetsResponse {
     /// <p>If you have more <a>XssMatchSet</a> objects than the number that you specified for <code>Limit</code> in the request, the response includes a <code>NextMarker</code> value. To list more <code>XssMatchSet</code> objects, submit another <code>ListXssMatchSets</code> request, and specify the <code>NextMarker</code> value from the response in the <code>NextMarker</code> value in the next request.</p>
     #[serde(rename = "NextMarker")]
@@ -1428,10 +1492,12 @@ pub struct PutPermissionPolicyRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutPermissionPolicyResponse {}
 
 /// <p>A <code>RateBasedRule</code> is identical to a regular <a>Rule</a>, with one addition: a <code>RateBasedRule</code> counts the number of requests that arrive from a specified IP address every five minutes. For example, based on recent requests that you've seen from an attacker, you might create a <code>RateBasedRule</code> that includes the following conditions: </p> <ul> <li> <p>The requests come from 192.0.2.44.</p> </li> <li> <p>They contain the value <code>BadBot</code> in the <code>User-Agent</code> header.</p> </li> </ul> <p>In the rule, you also define the rate limit as 15,000.</p> <p>Requests that meet both of these conditions and exceed 15,000 requests every five minutes trigger the rule's action (block or count), which is defined in the web ACL.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RateBasedRule {
     /// <p>The <code>Predicates</code> object contains one <code>Predicate</code> element for each <a>ByteMatchSet</a>, <a>IPSet</a>, or <a>SqlInjectionMatchSet</a> object that you want to include in a <code>RateBasedRule</code>.</p>
     #[serde(rename = "MatchPredicates")]
@@ -1457,6 +1523,7 @@ pub struct RateBasedRule {
 
 /// <p>In a <a>GetRegexMatchSet</a> request, <code>RegexMatchSet</code> is a complex type that contains the <code>RegexMatchSetId</code> and <code>Name</code> of a <code>RegexMatchSet</code>, and the values that you specified when you updated the <code>RegexMatchSet</code>.</p> <p> The values are contained in a <code>RegexMatchTuple</code> object, which specify the parts of web requests that you want AWS WAF to inspect and the values that you want AWS WAF to search for. If a <code>RegexMatchSet</code> contains more than one <code>RegexMatchTuple</code> object, a request needs to match the settings in only one <code>ByteMatchTuple</code> to be considered a match.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegexMatchSet {
     /// <p>A friendly name or description of the <a>RegexMatchSet</a>. You can't change <code>Name</code> after you create a <code>RegexMatchSet</code>.</p>
     #[serde(rename = "Name")]
@@ -1474,6 +1541,7 @@ pub struct RegexMatchSet {
 
 /// <p>Returned by <a>ListRegexMatchSets</a>. Each <code>RegexMatchSetSummary</code> object includes the <code>Name</code> and <code>RegexMatchSetId</code> for one <a>RegexMatchSet</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegexMatchSetSummary {
     /// <p>A friendly name or description of the <a>RegexMatchSet</a>. You can't change <code>Name</code> after you create a <code>RegexMatchSet</code>.</p>
     #[serde(rename = "Name")]
@@ -1510,6 +1578,7 @@ pub struct RegexMatchTuple {
 
 /// <p>The <code>RegexPatternSet</code> specifies the regular expression (regex) pattern that you want AWS WAF to search for, such as <code>B[a@]dB[o0]t</code>. You can then configure AWS WAF to reject those requests.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegexPatternSet {
     /// <p>A friendly name or description of the <a>RegexPatternSet</a>. You can't change <code>Name</code> after you create a <code>RegexPatternSet</code>.</p>
     #[serde(rename = "Name")]
@@ -1525,6 +1594,7 @@ pub struct RegexPatternSet {
 
 /// <p>Returned by <a>ListRegexPatternSets</a>. Each <code>RegexPatternSetSummary</code> object includes the <code>Name</code> and <code>RegexPatternSetId</code> for one <a>RegexPatternSet</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RegexPatternSetSummary {
     /// <p>A friendly name or description of the <a>RegexPatternSet</a>. You can't change <code>Name</code> after you create a <code>RegexPatternSet</code>.</p>
     #[serde(rename = "Name")]
@@ -1547,6 +1617,7 @@ pub struct RegexPatternSetUpdate {
 
 /// <p>A combination of <a>ByteMatchSet</a>, <a>IPSet</a>, and/or <a>SqlInjectionMatchSet</a> objects that identify the web requests that you want to allow, block, or count. For example, you might create a <code>Rule</code> that includes the following predicates:</p> <ul> <li> <p>An <code>IPSet</code> that causes AWS WAF to search for web requests that originate from the IP address <code>192.0.2.44</code> </p> </li> <li> <p>A <code>ByteMatchSet</code> that causes AWS WAF to search for web requests for which the value of the <code>User-Agent</code> header is <code>BadBot</code>.</p> </li> </ul> <p>To match the settings in this <code>Rule</code>, a request must originate from <code>192.0.2.44</code> AND include a <code>User-Agent</code> header for which the value is <code>BadBot</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Rule {
     /// <p>A friendly name or description for the metrics for this <code>Rule</code>. The name can contain only alphanumeric characters (A-Z, a-z, 0-9); the name can't contain whitespace. You can't change <code>MetricName</code> after you create the <code>Rule</code>.</p>
     #[serde(rename = "MetricName")]
@@ -1566,6 +1637,7 @@ pub struct Rule {
 
 /// <p><p>A collection of predefined rules that you can add to a web ACL.</p> <p>Rule groups are subject to the following limits:</p> <ul> <li> <p>Three rule groups per account. You can request an increase to this limit by contacting customer support.</p> </li> <li> <p>One rule group per web ACL.</p> </li> <li> <p>Ten rules per rule group.</p> </li> </ul></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RuleGroup {
     /// <p>A friendly name or description for the metrics for this <code>RuleGroup</code>. The name can contain only alphanumeric characters (A-Z, a-z, 0-9); the name can't contain whitespace. You can't change the name of the metric after you create the <code>RuleGroup</code>.</p>
     #[serde(rename = "MetricName")]
@@ -1582,6 +1654,7 @@ pub struct RuleGroup {
 
 /// <p>Contains the identifier and the friendly name or description of the <code>RuleGroup</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RuleGroupSummary {
     /// <p>A friendly name or description of the <a>RuleGroup</a>. You can't change the name of a <code>RuleGroup</code> after you create it.</p>
     #[serde(rename = "Name")]
@@ -1604,6 +1677,7 @@ pub struct RuleGroupUpdate {
 
 /// <p>Contains the identifier and the friendly name or description of the <code>Rule</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RuleSummary {
     /// <p>A friendly name or description of the <a>Rule</a>. You can't change the name of a <code>Rule</code> after you create it.</p>
     #[serde(rename = "Name")]
@@ -1626,6 +1700,7 @@ pub struct RuleUpdate {
 
 /// <p>The response from a <a>GetSampledRequests</a> request includes a <code>SampledHTTPRequests</code> complex type that appears as <code>SampledRequests</code> in the response syntax. <code>SampledHTTPRequests</code> contains one <code>SampledHTTPRequest</code> object for each web request that is returned by <code>GetSampledRequests</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SampledHTTPRequest {
     /// <p>The action for the <code>Rule</code> that the request matched: <code>ALLOW</code>, <code>BLOCK</code>, or <code>COUNT</code>.</p>
     #[serde(rename = "Action")]
@@ -1666,6 +1741,7 @@ pub struct SizeConstraint {
 
 /// <p>A complex type that contains <code>SizeConstraint</code> objects, which specify the parts of web requests that you want AWS WAF to inspect the size of. If a <code>SizeConstraintSet</code> contains more than one <code>SizeConstraint</code> object, a request only needs to match one constraint to be considered a match.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SizeConstraintSet {
     /// <p>The name, if any, of the <code>SizeConstraintSet</code>.</p>
     #[serde(rename = "Name")]
@@ -1681,6 +1757,7 @@ pub struct SizeConstraintSet {
 
 /// <p>The <code>Id</code> and <code>Name</code> of a <code>SizeConstraintSet</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SizeConstraintSetSummary {
     /// <p>The name of the <code>SizeConstraintSet</code>, if any.</p>
     #[serde(rename = "Name")]
@@ -1703,6 +1780,7 @@ pub struct SizeConstraintSetUpdate {
 
 /// <p>A complex type that contains <code>SqlInjectionMatchTuple</code> objects, which specify the parts of web requests that you want AWS WAF to inspect for snippets of malicious SQL code and, if you want AWS WAF to inspect a header, the name of the header. If a <code>SqlInjectionMatchSet</code> contains more than one <code>SqlInjectionMatchTuple</code> object, a request needs to include snippets of SQL code in only one of the specified parts of the request to be considered a match.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SqlInjectionMatchSet {
     /// <p>The name, if any, of the <code>SqlInjectionMatchSet</code>.</p>
     #[serde(rename = "Name")]
@@ -1718,6 +1796,7 @@ pub struct SqlInjectionMatchSet {
 
 /// <p>The <code>Id</code> and <code>Name</code> of a <code>SqlInjectionMatchSet</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SqlInjectionMatchSetSummary {
     /// <p>The name of the <code>SqlInjectionMatchSet</code>, if any, specified by <code>Id</code>.</p>
     #[serde(rename = "Name")]
@@ -1751,6 +1830,7 @@ pub struct SqlInjectionMatchTuple {
 
 /// <p>A summary of the rule groups you are subscribed to.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct SubscribedRuleGroupSummary {
     /// <p>A friendly name or description for the metrics for this <code>RuleGroup</code>. The name can contain only alphanumeric characters (A-Z, a-z, 0-9); the name can't contain whitespace. You can't change the name of the metric after you create the <code>RuleGroup</code>.</p>
     #[serde(rename = "MetricName")]
@@ -1788,6 +1868,7 @@ pub struct UpdateByteMatchSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateByteMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateByteMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1809,6 +1890,7 @@ pub struct UpdateGeoMatchSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateGeoMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateGeoMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1830,6 +1912,7 @@ pub struct UpdateIPSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateIPSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateIPSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1854,6 +1937,7 @@ pub struct UpdateRateBasedRuleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateRateBasedRuleResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateRateBasedRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1875,6 +1959,7 @@ pub struct UpdateRegexMatchSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateRegexMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateRegexMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1896,6 +1981,7 @@ pub struct UpdateRegexPatternSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateRegexPatternSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateRegexPatternSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1917,6 +2003,7 @@ pub struct UpdateRuleGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateRuleGroupResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateRuleGroup</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1938,6 +2025,7 @@ pub struct UpdateRuleRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateRuleResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateRule</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1959,6 +2047,7 @@ pub struct UpdateSizeConstraintSetRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateSizeConstraintSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateSizeConstraintSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -1982,6 +2071,7 @@ pub struct UpdateSqlInjectionMatchSetRequest {
 
 /// <p>The response to an <a>UpdateSqlInjectionMatchSets</a> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateSqlInjectionMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateSqlInjectionMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -2008,6 +2098,7 @@ pub struct UpdateWebACLRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateWebACLResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateWebACL</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -2031,6 +2122,7 @@ pub struct UpdateXssMatchSetRequest {
 
 /// <p>The response to an <a>UpdateXssMatchSets</a> request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateXssMatchSetResponse {
     /// <p>The <code>ChangeToken</code> that you used to submit the <code>UpdateXssMatchSet</code> request. You can also use this value to query the status of the request. For more information, see <a>GetChangeTokenStatus</a>.</p>
     #[serde(rename = "ChangeToken")]
@@ -2056,6 +2148,7 @@ pub struct WafOverrideAction {
 
 /// <p>Contains the <code>Rules</code> that identify the requests that you want to allow, block, or count. In a <code>WebACL</code>, you also specify a default action (<code>ALLOW</code> or <code>BLOCK</code>), and the action for each <code>Rule</code> that you add to a <code>WebACL</code>, for example, block requests from specified IP addresses or block requests from specified referrers. You also associate the <code>WebACL</code> with a CloudFront distribution to identify the requests that you want AWS WAF to filter. If you add more than one <code>Rule</code> to a <code>WebACL</code>, a request needs to match only one of the specifications to be allowed, blocked, or counted. For more information, see <a>UpdateWebACL</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WebACL {
     /// <p>The action to perform if none of the <code>Rules</code> contained in the <code>WebACL</code> match. The action is specified by the <a>WafAction</a> object.</p>
     #[serde(rename = "DefaultAction")]
@@ -2078,6 +2171,7 @@ pub struct WebACL {
 
 /// <p>Contains the identifier and the name or description of the <a>WebACL</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WebACLSummary {
     /// <p>A friendly name or description of the <a>WebACL</a>. You can't change the name of a <code>WebACL</code> after you create it.</p>
     #[serde(rename = "Name")]
@@ -2100,6 +2194,7 @@ pub struct WebACLUpdate {
 
 /// <p>A complex type that contains <code>XssMatchTuple</code> objects, which specify the parts of web requests that you want AWS WAF to inspect for cross-site scripting attacks and, if you want AWS WAF to inspect a header, the name of the header. If a <code>XssMatchSet</code> contains more than one <code>XssMatchTuple</code> object, a request needs to include cross-site scripting attacks in only one of the specified parts of the request to be considered a match.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct XssMatchSet {
     /// <p>The name, if any, of the <code>XssMatchSet</code>.</p>
     #[serde(rename = "Name")]
@@ -2115,6 +2210,7 @@ pub struct XssMatchSet {
 
 /// <p>The <code>Id</code> and <code>Name</code> of an <code>XssMatchSet</code>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct XssMatchSetSummary {
     /// <p>The name of the <code>XssMatchSet</code>, if any, specified by <code>Id</code>.</p>
     #[serde(rename = "Name")]

--- a/rusoto/services/workdocs/src/generated.rs
+++ b/rusoto/services/workdocs/src/generated.rs
@@ -55,6 +55,7 @@ pub struct ActivateUserRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ActivateUserResponse {
     /// <p>The user information.</p>
     #[serde(rename = "User")]
@@ -64,6 +65,7 @@ pub struct ActivateUserResponse {
 
 /// <p>Describes the activity information.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Activity {
     /// <p>Metadata of the commenting activity. This is an optional field and is filled for commenting activities.</p>
     #[serde(rename = "CommentMetadata")]
@@ -118,6 +120,7 @@ pub struct AddResourcePermissionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AddResourcePermissionsResponse {
     /// <p>The share results.</p>
     #[serde(rename = "ShareResults")]
@@ -127,6 +130,7 @@ pub struct AddResourcePermissionsResponse {
 
 /// <p>Describes a comment.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Comment {
     /// <p>The ID of the comment.</p>
     #[serde(rename = "CommentId")]
@@ -167,6 +171,7 @@ pub struct Comment {
 
 /// <p>Describes the metadata of a comment.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CommentMetadata {
     /// <p>The ID of the comment.</p>
     #[serde(rename = "CommentId")]
@@ -224,6 +229,7 @@ pub struct CreateCommentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateCommentResponse {
     /// <p>The comment that has been created.</p>
     #[serde(rename = "Comment")]
@@ -250,6 +256,7 @@ pub struct CreateCustomMetadataRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateCustomMetadataResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -268,6 +275,7 @@ pub struct CreateFolderRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateFolderResponse {
     /// <p>The metadata of the folder.</p>
     #[serde(rename = "Metadata")]
@@ -290,6 +298,7 @@ pub struct CreateLabelsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateLabelsResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -309,6 +318,7 @@ pub struct CreateNotificationSubscriptionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateNotificationSubscriptionResponse {
     /// <p>The subscription.</p>
     #[serde(rename = "Subscription")]
@@ -353,6 +363,7 @@ pub struct CreateUserRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateUserResponse {
     /// <p>The user information.</p>
     #[serde(rename = "User")]
@@ -412,6 +423,7 @@ pub struct DeleteCustomMetadataRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteCustomMetadataResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -467,6 +479,7 @@ pub struct DeleteLabelsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteLabelsResponse {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -523,6 +536,7 @@ pub struct DescribeActivitiesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeActivitiesResponse {
     /// <p>The marker for the next set of results.</p>
     #[serde(rename = "Marker")]
@@ -557,6 +571,7 @@ pub struct DescribeCommentsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeCommentsResponse {
     /// <p>The list of comments for the specified document version.</p>
     #[serde(rename = "Comments")]
@@ -596,6 +611,7 @@ pub struct DescribeDocumentVersionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeDocumentVersionsResponse {
     /// <p>The document versions.</p>
     #[serde(rename = "DocumentVersions")]
@@ -643,6 +659,7 @@ pub struct DescribeFolderContentsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeFolderContentsResponse {
     /// <p>The documents in the specified folder.</p>
     #[serde(rename = "Documents")]
@@ -682,6 +699,7 @@ pub struct DescribeGroupsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeGroupsResponse {
     /// <p>The list of groups.</p>
     #[serde(rename = "Groups")]
@@ -709,6 +727,7 @@ pub struct DescribeNotificationSubscriptionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeNotificationSubscriptionsResponse {
     /// <p>The marker to use when requesting the next set of results. If there are no additional results, the string is empty.</p>
     #[serde(rename = "Marker")]
@@ -744,6 +763,7 @@ pub struct DescribeResourcePermissionsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeResourcePermissionsResponse {
     /// <p>The marker to use when requesting the next set of results. If there are no additional results, the string is empty.</p>
     #[serde(rename = "Marker")]
@@ -771,6 +791,7 @@ pub struct DescribeRootFoldersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeRootFoldersResponse {
     /// <p>The user's special folders.</p>
     #[serde(rename = "Folders")]
@@ -827,6 +848,7 @@ pub struct DescribeUsersRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeUsersResponse {
     /// <p>The marker to use when requesting the next set of results. If there are no additional results, the string is empty.</p>
     #[serde(rename = "Marker")]
@@ -840,6 +862,7 @@ pub struct DescribeUsersResponse {
 
 /// <p>Describes the document.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DocumentMetadata {
     /// <p>The time when the document was created.</p>
     #[serde(rename = "CreatedTimestamp")]
@@ -877,6 +900,7 @@ pub struct DocumentMetadata {
 
 /// <p>Describes a version of a document.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DocumentVersionMetadata {
     /// <p>The timestamp when the content of the document was originally created.</p>
     #[serde(rename = "ContentCreatedTimestamp")]
@@ -934,6 +958,7 @@ pub struct DocumentVersionMetadata {
 
 /// <p>Describes a folder.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FolderMetadata {
     /// <p>The time when the folder was created.</p>
     #[serde(rename = "CreatedTimestamp")]
@@ -989,6 +1014,7 @@ pub struct GetCurrentUserRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetCurrentUserResponse {
     /// <p>Metadata of the user.</p>
     #[serde(rename = "User")]
@@ -1020,6 +1046,7 @@ pub struct GetDocumentPathRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDocumentPathResponse {
     /// <p>The path information.</p>
     #[serde(rename = "Path")]
@@ -1043,6 +1070,7 @@ pub struct GetDocumentRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDocumentResponse {
     /// <p>The custom metadata on the document.</p>
     #[serde(rename = "CustomMetadata")]
@@ -1077,6 +1105,7 @@ pub struct GetDocumentVersionRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetDocumentVersionResponse {
     /// <p>The custom metadata on the document version.</p>
     #[serde(rename = "CustomMetadata")]
@@ -1112,6 +1141,7 @@ pub struct GetFolderPathRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetFolderPathResponse {
     /// <p>The path information.</p>
     #[serde(rename = "Path")]
@@ -1135,6 +1165,7 @@ pub struct GetFolderRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetFolderResponse {
     /// <p>The custom metadata on the folder.</p>
     #[serde(rename = "CustomMetadata")]
@@ -1148,6 +1179,7 @@ pub struct GetFolderResponse {
 
 /// <p>Describes the metadata of a user group.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GroupMetadata {
     /// <p>The ID of the user group.</p>
     #[serde(rename = "Id")]
@@ -1195,6 +1227,7 @@ pub struct InitiateDocumentVersionUploadRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct InitiateDocumentVersionUploadResponse {
     /// <p>The document metadata.</p>
     #[serde(rename = "Metadata")]
@@ -1221,6 +1254,7 @@ pub struct NotificationOptions {
 
 /// <p>Describes the users or user groups.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Participants {
     /// <p>The list of user groups.</p>
     #[serde(rename = "Groups")]
@@ -1234,6 +1268,7 @@ pub struct Participants {
 
 /// <p>Describes the permissions.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PermissionInfo {
     /// <p>The role of the user.</p>
     #[serde(rename = "Role")]
@@ -1247,6 +1282,7 @@ pub struct PermissionInfo {
 
 /// <p>Describes a resource.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Principal {
     /// <p>The ID of the resource.</p>
     #[serde(rename = "Id")]
@@ -1293,6 +1329,7 @@ pub struct RemoveResourcePermissionRequest {
 
 /// <p>Describes the metadata of a resource.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResourceMetadata {
     /// <p>The ID of the resource.</p>
     #[serde(rename = "Id")]
@@ -1326,6 +1363,7 @@ pub struct ResourceMetadata {
 
 /// <p>Describes the path information of a resource.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResourcePath {
     /// <p>The components of the resource path.</p>
     #[serde(rename = "Components")]
@@ -1335,6 +1373,7 @@ pub struct ResourcePath {
 
 /// <p>Describes the resource path.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ResourcePathComponent {
     /// <p>The ID of the resource path.</p>
     #[serde(rename = "Id")]
@@ -1362,6 +1401,7 @@ pub struct SharePrincipal {
 
 /// <p>Describes the share results of a resource.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ShareResult {
     /// <p>The ID of the principal.</p>
     #[serde(rename = "PrincipalId")]
@@ -1400,6 +1440,7 @@ pub struct StorageRuleType {
 
 /// <p>Describes a subscription.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Subscription {
     /// <p>The endpoint of the subscription.</p>
     #[serde(rename = "EndPoint")]
@@ -1519,6 +1560,7 @@ pub struct UpdateUserRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateUserResponse {
     /// <p>The user information.</p>
     #[serde(rename = "User")]
@@ -1528,6 +1570,7 @@ pub struct UpdateUserResponse {
 
 /// <p>Describes the upload.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UploadMetadata {
     /// <p>The signed headers.</p>
     #[serde(rename = "SignedHeaders")]
@@ -1541,6 +1584,7 @@ pub struct UploadMetadata {
 
 /// <p>Describes a user.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct User {
     /// <p>The time when the user was created.</p>
     #[serde(rename = "CreatedTimestamp")]
@@ -1606,6 +1650,7 @@ pub struct User {
 
 /// <p>Describes the metadata of the user.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UserMetadata {
     /// <p>The email address of the user.</p>
     #[serde(rename = "EmailAddress")]
@@ -1631,6 +1676,7 @@ pub struct UserMetadata {
 
 /// <p>Describes the storage for a user.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UserStorageMetadata {
     /// <p>The storage for a user.</p>
     #[serde(rename = "StorageRule")]

--- a/rusoto/services/workspaces/src/generated.rs
+++ b/rusoto/services/workspaces/src/generated.rs
@@ -39,6 +39,7 @@ pub struct AssociateIpGroupsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AssociateIpGroupsResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -52,10 +53,12 @@ pub struct AuthorizeIpRulesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AuthorizeIpRulesResult {}
 
 /// <p>Information about the compute type.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ComputeType {
     /// <p>The compute type.</p>
     #[serde(rename = "Name")]
@@ -79,6 +82,7 @@ pub struct CreateIpGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateIpGroupResult {
     /// <p>The ID of the group.</p>
     #[serde(rename = "GroupId")]
@@ -97,6 +101,7 @@ pub struct CreateTagsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateTagsResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -107,6 +112,7 @@ pub struct CreateWorkspacesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct CreateWorkspacesResult {
     /// <p>Information about the WorkSpaces that could not be created.</p>
     #[serde(rename = "FailedRequests")]
@@ -120,6 +126,7 @@ pub struct CreateWorkspacesResult {
 
 /// <p>Information about defaults used to create a WorkSpace.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DefaultWorkspaceCreationProperties {
     /// <p>The identifier of any security groups to apply to WorkSpaces when they are created.</p>
     #[serde(rename = "CustomSecurityGroupId")]
@@ -151,6 +158,7 @@ pub struct DeleteIpGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteIpGroupResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -164,6 +172,7 @@ pub struct DeleteTagsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DeleteTagsResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -183,6 +192,7 @@ pub struct DescribeIpGroupsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeIpGroupsResult {
     /// <p>The token to use to retrieve the next set of results, or null if there are no more results available. This token is valid for one day and must be used within that time frame.</p>
     #[serde(rename = "NextToken")]
@@ -202,6 +212,7 @@ pub struct DescribeTagsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeTagsResult {
     /// <p>The tags.</p>
     #[serde(rename = "TagList")]
@@ -226,6 +237,7 @@ pub struct DescribeWorkspaceBundlesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeWorkspaceBundlesResult {
     /// <p>Information about the bundles.</p>
     #[serde(rename = "Bundles")]
@@ -250,6 +262,7 @@ pub struct DescribeWorkspaceDirectoriesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeWorkspaceDirectoriesResult {
     /// <p>Information about the directories.</p>
     #[serde(rename = "Directories")]
@@ -274,6 +287,7 @@ pub struct DescribeWorkspacesConnectionStatusRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeWorkspacesConnectionStatusResult {
     /// <p>The token to use to retrieve the next set of results, or null if there are no more results available.</p>
     #[serde(rename = "NextToken")]
@@ -314,6 +328,7 @@ pub struct DescribeWorkspacesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DescribeWorkspacesResult {
     /// <p>The token to use to retrieve the next set of results, or null if there are no more results available. This token is valid for one day and must be used within that time frame.</p>
     #[serde(rename = "NextToken")]
@@ -336,10 +351,12 @@ pub struct DisassociateIpGroupsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct DisassociateIpGroupsResult {}
 
 /// <p>Information about a WorkSpace that could not be created.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FailedCreateWorkspaceRequest {
     /// <p>The error code.</p>
     #[serde(rename = "ErrorCode")]
@@ -357,6 +374,7 @@ pub struct FailedCreateWorkspaceRequest {
 
 /// <p>Information about a WorkSpace that could not be rebooted (<a>RebootWorkspaces</a>), rebuilt (<a>RebuildWorkspaces</a>), terminated (<a>TerminateWorkspaces</a>), started (<a>StartWorkspaces</a>), or stopped (<a>StopWorkspaces</a>).</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FailedWorkspaceChangeRequest {
     /// <p>The error code.</p>
     #[serde(rename = "ErrorCode")]
@@ -387,6 +405,7 @@ pub struct IpRuleItem {
 
 /// <p>Information about a WorkSpace modification.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ModificationState {
     /// <p>The resource.</p>
     #[serde(rename = "Resource")]
@@ -409,6 +428,7 @@ pub struct ModifyWorkspacePropertiesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ModifyWorkspacePropertiesResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -422,6 +442,7 @@ pub struct ModifyWorkspaceStateRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ModifyWorkspaceStateResult {}
 
 /// <p>Information used to reboot a WorkSpace.</p>
@@ -440,6 +461,7 @@ pub struct RebootWorkspacesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RebootWorkspacesResult {
     /// <p>Information about the WorkSpaces that could not be rebooted.</p>
     #[serde(rename = "FailedRequests")]
@@ -463,6 +485,7 @@ pub struct RebuildWorkspacesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RebuildWorkspacesResult {
     /// <p>Information about the WorkSpace if it could not be rebuilt.</p>
     #[serde(rename = "FailedRequests")]
@@ -481,10 +504,12 @@ pub struct RevokeIpRulesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RevokeIpRulesResult {}
 
 /// <p>Information about the root volume for a WorkSpace bundle.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct RootStorage {
     /// <p>The size of the root volume.</p>
     #[serde(rename = "Capacity")]
@@ -509,6 +534,7 @@ pub struct StartWorkspacesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StartWorkspacesResult {
     /// <p>Information about the WorkSpaces that could not be started.</p>
     #[serde(rename = "FailedRequests")]
@@ -533,6 +559,7 @@ pub struct StopWorkspacesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct StopWorkspacesResult {
     /// <p>Information about the WorkSpaces that could not be stopped.</p>
     #[serde(rename = "FailedRequests")]
@@ -568,6 +595,7 @@ pub struct TerminateWorkspacesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TerminateWorkspacesResult {
     /// <p>Information about the WorkSpaces that could not be terminated.</p>
     #[serde(rename = "FailedRequests")]
@@ -586,10 +614,12 @@ pub struct UpdateRulesOfIpGroupRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UpdateRulesOfIpGroupResult {}
 
 /// <p>Information about the user storage for a WorkSpace bundle.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UserStorage {
     /// <p>The size of the user storage.</p>
     #[serde(rename = "Capacity")]
@@ -599,6 +629,7 @@ pub struct UserStorage {
 
 /// <p>Information about a WorkSpace.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Workspace {
     /// <p>The identifier of the bundle used to create the WorkSpace.</p>
     #[serde(rename = "BundleId")]
@@ -664,6 +695,7 @@ pub struct Workspace {
 
 /// <p>Information about a WorkSpace bundle.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WorkspaceBundle {
     /// <p>The bundle identifier.</p>
     #[serde(rename = "BundleId")]
@@ -697,6 +729,7 @@ pub struct WorkspaceBundle {
 
 /// <p>Describes the connection status of a WorkSpace.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WorkspaceConnectionStatus {
     /// <p>The connection state of the WorkSpace. The connection state is unknown if the WorkSpace is stopped.</p>
     #[serde(rename = "ConnectionState")]
@@ -718,6 +751,7 @@ pub struct WorkspaceConnectionStatus {
 
 /// <p>Information about an AWS Directory Service directory for use with Amazon WorkSpaces.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WorkspaceDirectory {
     /// <p>The directory alias.</p>
     #[serde(rename = "Alias")]
@@ -834,6 +868,7 @@ pub struct WorkspaceRequest {
 
 /// <p>Information about an IP access control group.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct WorkspacesIpGroup {
     /// <p>The description of the group.</p>
     #[serde(rename = "groupDesc")]

--- a/rusoto/services/xray/src/generated.rs
+++ b/rusoto/services/xray/src/generated.rs
@@ -30,6 +30,7 @@ use serde_json::from_slice;
 use serde_json::Value as SerdeJsonValue;
 /// <p>An alias for an edge.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Alias {
     /// <p>The canonical name of the alias.</p>
     #[serde(rename = "Name")]
@@ -47,6 +48,7 @@ pub struct Alias {
 
 /// <p>Value of a segment annotation. Has one of three value types: Number, Boolean or String.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct AnnotationValue {
     /// <p>Value for a Boolean annotation.</p>
     #[serde(rename = "BooleanValue")]
@@ -103,6 +105,7 @@ pub struct BatchGetTracesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct BatchGetTracesResult {
     /// <p>Pagination token. Not used.</p>
     #[serde(rename = "NextToken")]
@@ -120,6 +123,7 @@ pub struct BatchGetTracesResult {
 
 /// <p>Information about a connection between two services.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Edge {
     /// <p>Aliases for the edge.</p>
     #[serde(rename = "Aliases")]
@@ -149,6 +153,7 @@ pub struct Edge {
 
 /// <p>Response statistics for an edge.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EdgeStatistics {
     /// <p>Information about requests that failed with a 4xx Client Error status code.</p>
     #[serde(rename = "ErrorStatistics")]
@@ -174,6 +179,7 @@ pub struct EdgeStatistics {
 
 /// <p>A configuration document that specifies encryption configuration settings.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct EncryptionConfig {
     /// <p>The ID of the customer master key (CMK) used for encryption, if applicable.</p>
     #[serde(rename = "KeyId")]
@@ -191,6 +197,7 @@ pub struct EncryptionConfig {
 
 /// <p>Information about requests that failed with a 4xx Client Error status code.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ErrorStatistics {
     /// <p>The number of requests that failed with untracked 4xx Client Error status codes.</p>
     #[serde(rename = "OtherCount")]
@@ -208,6 +215,7 @@ pub struct ErrorStatistics {
 
 /// <p>Information about requests that failed with a 5xx Server Error status code.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct FaultStatistics {
     /// <p>The number of requests that failed with untracked 5xx Server Error status codes.</p>
     #[serde(rename = "OtherCount")]
@@ -223,6 +231,7 @@ pub struct FaultStatistics {
 pub struct GetEncryptionConfigRequest {}
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetEncryptionConfigResult {
     /// <p>The encryption configuration document.</p>
     #[serde(rename = "EncryptionConfig")]
@@ -245,6 +254,7 @@ pub struct GetServiceGraphRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetServiceGraphResult {
     /// <p>The end of the time frame for which the graph was generated.</p>
     #[serde(rename = "EndTime")]
@@ -276,6 +286,7 @@ pub struct GetTraceGraphRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetTraceGraphResult {
     /// <p>Pagination token. Not used.</p>
     #[serde(rename = "NextToken")]
@@ -310,6 +321,7 @@ pub struct GetTraceSummariesRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct GetTraceSummariesResult {
     /// <p>The start time of this page of results.</p>
     #[serde(rename = "ApproximateTime")]
@@ -331,6 +343,7 @@ pub struct GetTraceSummariesResult {
 
 /// <p>An entry in a histogram for a statistic. A histogram maps the range of observed values on the X axis, and the prevalence of each value on the Y axis.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct HistogramEntry {
     /// <p>The prevalence of the entry.</p>
     #[serde(rename = "Count")]
@@ -344,6 +357,7 @@ pub struct HistogramEntry {
 
 /// <p>Information about an HTTP request.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Http {
     /// <p>The IP address of the requestor.</p>
     #[serde(rename = "ClientIp")]
@@ -379,6 +393,7 @@ pub struct PutEncryptionConfigRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutEncryptionConfigResult {
     /// <p>The new encryption configuration.</p>
     #[serde(rename = "EncryptionConfig")]
@@ -406,6 +421,7 @@ pub struct PutTelemetryRecordsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutTelemetryRecordsResult {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -416,6 +432,7 @@ pub struct PutTraceSegmentsRequest {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct PutTraceSegmentsResult {
     /// <p>Segments that failed processing.</p>
     #[serde(rename = "UnprocessedTraceSegments")]
@@ -425,6 +442,7 @@ pub struct PutTraceSegmentsResult {
 
 /// <p>A segment from a trace that has been ingested by the X-Ray service. The segment can be compiled from documents uploaded with <a>PutTraceSegments</a>, or an <code>inferred</code> segment for a downstream service, generated from a subsegment sent by the service that called it.</p> <p>For the full segment document schema, see <a href="https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html">AWS X-Ray Segment Documents</a> in the <i>AWS X-Ray Developer Guide</i>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Segment {
     /// <p>The segment document.</p>
     #[serde(rename = "Document")]
@@ -438,6 +456,7 @@ pub struct Segment {
 
 /// <p>Information about an application that processed requests, users that made requests, or downstream services, resources and applications that an application used.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Service {
     /// <p>Identifier of the AWS account in which the service runs.</p>
     #[serde(rename = "AccountId")]
@@ -495,6 +514,7 @@ pub struct Service {
 
 /// <p><p/></p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ServiceId {
     /// <p><p/></p>
     #[serde(rename = "AccountId")]
@@ -516,6 +536,7 @@ pub struct ServiceId {
 
 /// <p>Response statistics for a service.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ServiceStatistics {
     /// <p>Information about requests that failed with a 4xx Client Error status code.</p>
     #[serde(rename = "ErrorStatistics")]
@@ -569,6 +590,7 @@ pub struct TelemetryRecord {
 
 /// <p>A collection of segment documents with matching trace IDs.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct Trace {
     /// <p>The length of time in seconds between the start time of the root segment and the end time of the last segment that completed.</p>
     #[serde(rename = "Duration")]
@@ -586,6 +608,7 @@ pub struct Trace {
 
 /// <p>Metadata generated from the segment documents in a trace.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TraceSummary {
     /// <p>Annotations from the trace's segment documents.</p>
     #[serde(rename = "Annotations")]
@@ -635,6 +658,7 @@ pub struct TraceSummary {
 
 /// <p>Information about a user recorded in segment documents.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct TraceUser {
     /// <p>Services that the user's request hit.</p>
     #[serde(rename = "ServiceIds")]
@@ -648,6 +672,7 @@ pub struct TraceUser {
 
 /// <p>Information about a segment that failed processing.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct UnprocessedTraceSegment {
     /// <p>The error that caused processing to fail.</p>
     #[serde(rename = "ErrorCode")]
@@ -665,6 +690,7 @@ pub struct UnprocessedTraceSegment {
 
 /// <p>Information about a segment annotation.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
+#[cfg_attr(test, derive(Serialize))]
 pub struct ValueWithServiceIds {
     /// <p>Values of the annotation.</p>
     #[serde(rename = "AnnotationValue")]


### PR DESCRIPTION
fixes: #1171

this enables more straightforward mock testing services with json protocols.

care was taken not to introduce code size increase outside of a test run with `cfg_attr`

an example of a mock test that uses new mock interface can be found [here](https://github.com/rusoto/rusoto/pull/1177/files#diff-4c04359d687f100df13f757a6c8f23feR10)

