### PR TITLE
Skeptic tests updated for new Rusoto release

### DIFF
--- a/skeptical/Cargo.toml
+++ b/skeptical/Cargo.toml
@@ -5,11 +5,11 @@ authors = ["Matthew Mayer <matthewkmayer@gmail.com>"]
 build = "build.rs"
 
 [dependencies]
-rusoto_core = "0.34"
-rusoto_dynamodb = "0.34"
-rusoto_s3 = "0.34"
-rusoto_ec2 = "0.34"
-rusoto_sts = "0.34"
+rusoto_core = "0.35"
+rusoto_dynamodb = "0.35"
+rusoto_s3 = "0.35"
+rusoto_ec2 = "0.35"
+rusoto_sts = "0.35"
 env_logger = "0.5"
 
 [build-dependencies]


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Updated the skeptic tests to use the most recent release of Rusoto.