### PR TITLE
Enable passthrough parsing of payload members

### DIFF
--- a/integration_tests/docker_test_run.py
+++ b/integration_tests/docker_test_run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import argparse
 import time
 import requests

--- a/integration_tests/tests/s3.rs
+++ b/integration_tests/tests/s3.rs
@@ -232,14 +232,14 @@ fn test_multipart_upload(client: &TestClient, bucket: &str, filename: &str) {
     // https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPartCopy.html
     let create_multipart_req2 = CreateMultipartUploadRequest {
         bucket: bucket.to_owned(),
-        key: "multipartfilename".to_owned(),
+        key: filename.to_owned(),
         ..Default::default()
     };
     let upload_multi_response = client.create_multipart_upload(create_multipart_req2).sync().expect("Couldn't create multipart upload2");
     println!("{:#?}", upload_multi_response);
     let upload_id2 = upload_multi_response.upload_id.unwrap();
     let upload_part_copy_req = UploadPartCopyRequest {
-        key: "multipartfilename".to_owned(),
+        key: filename.to_owned(),
         bucket: bucket.to_owned(),
         part_number: 1,
         upload_id: upload_id2.clone(),
@@ -250,7 +250,7 @@ fn test_multipart_upload(client: &TestClient, bucket: &str, filename: &str) {
     println!("copy response: {:#?}", copy_response);
 
     let upload_part_copy_req2 = UploadPartCopyRequest {
-        key: "multipartfilename".to_owned(),
+        key: filename.to_owned(),
         bucket: bucket.to_owned(),
         part_number: 2,
         upload_id: upload_id2.clone(),
@@ -258,7 +258,7 @@ fn test_multipart_upload(client: &TestClient, bucket: &str, filename: &str) {
         ..Default::default()
     };
     let copy_response2 = client.upload_part_copy(upload_part_copy_req2).sync().expect("Should have had copy part work");
-    println!("copy response2: {:#?}", copy_response);
+    println!("copy response2: {:#?}", copy_response2);
 
     // complete the upload_part_copy upload:
     let completed_parts_2 = vec!(
@@ -274,7 +274,7 @@ fn test_multipart_upload(client: &TestClient, bucket: &str, filename: &str) {
     let completed_upload2 = CompletedMultipartUpload { parts: Some(completed_parts_2) };
     let complete_req2 = CompleteMultipartUploadRequest {
         bucket: bucket.to_owned(),
-        key: "multipartfilename".to_owned(),
+        key: filename.to_owned(),
         upload_id: upload_id2.to_owned(),
         multipart_upload: Some(completed_upload2),
         ..Default::default()

--- a/integration_tests/tests/s3.rs
+++ b/integration_tests/tests/s3.rs
@@ -25,7 +25,8 @@ use rusoto_s3::{S3, S3Client, HeadObjectRequest, CopyObjectRequest, GetObjectErr
                  PutObjectRequest, DeleteObjectRequest, PutBucketCorsRequest, CORSConfiguration,
                  CORSRule, CreateBucketRequest, DeleteBucketRequest, CreateMultipartUploadRequest,
                  UploadPartRequest, CompleteMultipartUploadRequest, CompletedMultipartUpload,
-                 CompletedPart, ListObjectsRequest, ListObjectsV2Request, StreamingBody, DeleteBucketError};
+                 CompletedPart, ListObjectsRequest, ListObjectsV2Request, StreamingBody, DeleteBucketError,
+                 UploadPartCopyRequest};
 
 type TestClient = S3Client;
 
@@ -226,6 +227,61 @@ fn test_multipart_upload(client: &TestClient, bucket: &str, filename: &str) {
 
     let response = client.complete_multipart_upload(complete_req).sync().expect("Couldn't complete multipart upload");
     println!("{:#?}", response);
+
+    // Add copy upload part to this test
+    // https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPartCopy.html
+    let create_multipart_req2 = CreateMultipartUploadRequest {
+        bucket: bucket.to_owned(),
+        key: "multipartfilename".to_owned(),
+        ..Default::default()
+    };
+    let upload_multi_response = client.create_multipart_upload(create_multipart_req2).sync().expect("Couldn't create multipart upload2");
+    println!("{:#?}", upload_multi_response);
+    let upload_id2 = upload_multi_response.upload_id.unwrap();
+    let upload_part_copy_req = UploadPartCopyRequest {
+        key: "multipartfilename".to_owned(),
+        bucket: bucket.to_owned(),
+        part_number: 1,
+        upload_id: upload_id2.clone(),
+        copy_source: format!("{}/{}", bucket, filename).to_owned(),
+        ..Default::default()
+    };
+    let copy_response = client.upload_part_copy(upload_part_copy_req).sync().expect("Should have had copy part work");
+    println!("copy response: {:#?}", copy_response);
+
+    let upload_part_copy_req2 = UploadPartCopyRequest {
+        key: "multipartfilename".to_owned(),
+        bucket: bucket.to_owned(),
+        part_number: 2,
+        upload_id: upload_id2.clone(),
+        copy_source: format!("{}/{}", bucket, filename).to_owned(),
+        ..Default::default()
+    };
+    let copy_response2 = client.upload_part_copy(upload_part_copy_req2).sync().expect("Should have had copy part work");
+    println!("copy response2: {:#?}", copy_response);
+
+    // complete the upload_part_copy upload:
+    let completed_parts_2 = vec!(
+        CompletedPart {
+            e_tag: copy_response.copy_part_result.unwrap().e_tag.clone(),
+            part_number: Some(1),
+        },
+        CompletedPart {
+            e_tag: copy_response2.copy_part_result.unwrap().e_tag.clone(),
+            part_number: Some(2),
+        }
+    );
+    let completed_upload2 = CompletedMultipartUpload { parts: Some(completed_parts_2) };
+    let complete_req2 = CompleteMultipartUploadRequest {
+        bucket: bucket.to_owned(),
+        key: "multipartfilename".to_owned(),
+        upload_id: upload_id2.to_owned(),
+        multipart_upload: Some(completed_upload2),
+        ..Default::default()
+    };
+
+    let response2 = client.complete_multipart_upload(complete_req2).sync().expect("Couldn't complete multipart upload2");
+    println!("{:#?}", response2);
 
     // delete the completed file
     test_delete_object(client, bucket, filename);

--- a/rusoto/core/src/signature.rs
+++ b/rusoto/core/src/signature.rs
@@ -249,7 +249,7 @@ impl SignedRequest {
         self.remove_header("X-Amz-Content-Sha256");
 
         self.remove_header("X-Amz-Date");
-        
+
         self.remove_header("Content-Type");
 
         if let Some(ref token) = *creds.token() {
@@ -276,7 +276,7 @@ impl SignedRequest {
         self.params.put("X-Amz-Date", current_time_fmted);
 
         self.canonical_query_string = build_canonical_query_string(&self.params);
-        
+
         debug!("canonical_uri: {:?}", self.canonical_uri);
         debug!("canonical_headers: {:?}", canonical_headers);
         debug!("signed_headers: {:?}", signed_headers);
@@ -380,7 +380,7 @@ impl SignedRequest {
                                             canonical_headers,
                                             signed_headers,
                                             &to_hexdigest(""));
-                (Some(to_hexdigest("")), None)
+                (Some(to_hexdigest("")), Some(0))
             }
             Some(SignedRequestPayload::Buffer(ref payload)) => {
                 let (digest, len) = digest_payload(&payload);

--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -1460,39 +1460,15 @@ impl CreateCloudFrontOriginAccessIdentityResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateCloudFrontOriginAccessIdentityResult, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = CreateCloudFrontOriginAccessIdentityResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
+        obj.cloud_front_origin_access_identity =
+            match CloudFrontOriginAccessIdentityDeserializer::deserialize(
+                "CloudFrontOriginAccessIdentity",
+                stack,
+            ) {
+                Ok(payload) => Some(payload),
+                Err(_) => None,
             };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CloudFrontOriginAccessIdentity" => {
-                        obj.cloud_front_origin_access_identity = Some(try!(
-                            CloudFrontOriginAccessIdentityDeserializer::deserialize(
-                                "CloudFrontOriginAccessIdentity",
-                                stack
-                            )
-                        ));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
 
         Ok(obj)
     }
@@ -1522,37 +1498,11 @@ impl CreateDistributionResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateDistributionResult, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = CreateDistributionResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Distribution" => {
-                        obj.distribution = Some(try!(DistributionDeserializer::deserialize(
-                            "Distribution",
-                            stack
-                        )));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
+        obj.distribution = match DistributionDeserializer::deserialize("Distribution", stack) {
+            Ok(payload) => Some(payload),
+            Err(_) => None,
+        };
 
         Ok(obj)
     }
@@ -1582,37 +1532,11 @@ impl CreateDistributionWithTagsResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateDistributionWithTagsResult, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = CreateDistributionWithTagsResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Distribution" => {
-                        obj.distribution = Some(try!(DistributionDeserializer::deserialize(
-                            "Distribution",
-                            stack
-                        )));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
+        obj.distribution = match DistributionDeserializer::deserialize("Distribution", stack) {
+            Ok(payload) => Some(payload),
+            Err(_) => None,
+        };
 
         Ok(obj)
     }
@@ -1642,37 +1566,11 @@ impl CreateInvalidationResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateInvalidationResult, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = CreateInvalidationResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Invalidation" => {
-                        obj.invalidation = Some(try!(InvalidationDeserializer::deserialize(
-                            "Invalidation",
-                            stack
-                        )));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
+        obj.invalidation = match InvalidationDeserializer::deserialize("Invalidation", stack) {
+            Ok(payload) => Some(payload),
+            Err(_) => None,
+        };
 
         Ok(obj)
     }
@@ -1702,38 +1600,12 @@ impl CreateStreamingDistributionResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateStreamingDistributionResult, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = CreateStreamingDistributionResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
+        obj.streaming_distribution =
+            match StreamingDistributionDeserializer::deserialize("StreamingDistribution", stack) {
+                Ok(payload) => Some(payload),
+                Err(_) => None,
             };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "StreamingDistribution" => {
-                        obj.streaming_distribution =
-                            Some(try!(StreamingDistributionDeserializer::deserialize(
-                                "StreamingDistribution",
-                                stack
-                            )));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
 
         Ok(obj)
     }
@@ -1762,38 +1634,12 @@ impl CreateStreamingDistributionWithTagsResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateStreamingDistributionWithTagsResult, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = CreateStreamingDistributionWithTagsResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
+        obj.streaming_distribution =
+            match StreamingDistributionDeserializer::deserialize("StreamingDistribution", stack) {
+                Ok(payload) => Some(payload),
+                Err(_) => None,
             };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "StreamingDistribution" => {
-                        obj.streaming_distribution =
-                            Some(try!(StreamingDistributionDeserializer::deserialize(
-                                "StreamingDistribution",
-                                stack
-                            )));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
 
         Ok(obj)
     }
@@ -3476,39 +3322,15 @@ impl GetCloudFrontOriginAccessIdentityConfigResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetCloudFrontOriginAccessIdentityConfigResult, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = GetCloudFrontOriginAccessIdentityConfigResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
+        obj.cloud_front_origin_access_identity_config =
+            match CloudFrontOriginAccessIdentityConfigDeserializer::deserialize(
+                "CloudFrontOriginAccessIdentityConfig",
+                stack,
+            ) {
+                Ok(payload) => Some(payload),
+                Err(_) => None,
             };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CloudFrontOriginAccessIdentityConfig" => {
-                        obj.cloud_front_origin_access_identity_config = Some(try!(
-                            CloudFrontOriginAccessIdentityConfigDeserializer::deserialize(
-                                "CloudFrontOriginAccessIdentityConfig",
-                                stack
-                            )
-                        ));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
 
         Ok(obj)
     }
@@ -3536,39 +3358,15 @@ impl GetCloudFrontOriginAccessIdentityResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetCloudFrontOriginAccessIdentityResult, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = GetCloudFrontOriginAccessIdentityResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
+        obj.cloud_front_origin_access_identity =
+            match CloudFrontOriginAccessIdentityDeserializer::deserialize(
+                "CloudFrontOriginAccessIdentity",
+                stack,
+            ) {
+                Ok(payload) => Some(payload),
+                Err(_) => None,
             };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CloudFrontOriginAccessIdentity" => {
-                        obj.cloud_front_origin_access_identity = Some(try!(
-                            CloudFrontOriginAccessIdentityDeserializer::deserialize(
-                                "CloudFrontOriginAccessIdentity",
-                                stack
-                            )
-                        ));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
 
         Ok(obj)
     }
@@ -3596,38 +3394,12 @@ impl GetDistributionConfigResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetDistributionConfigResult, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = GetDistributionConfigResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
+        obj.distribution_config =
+            match DistributionConfigDeserializer::deserialize("DistributionConfig", stack) {
+                Ok(payload) => Some(payload),
+                Err(_) => None,
             };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DistributionConfig" => {
-                        obj.distribution_config =
-                            Some(try!(DistributionConfigDeserializer::deserialize(
-                                "DistributionConfig",
-                                stack
-                            )));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
 
         Ok(obj)
     }
@@ -3655,37 +3427,11 @@ impl GetDistributionResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetDistributionResult, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = GetDistributionResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Distribution" => {
-                        obj.distribution = Some(try!(DistributionDeserializer::deserialize(
-                            "Distribution",
-                            stack
-                        )));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
+        obj.distribution = match DistributionDeserializer::deserialize("Distribution", stack) {
+            Ok(payload) => Some(payload),
+            Err(_) => None,
+        };
 
         Ok(obj)
     }
@@ -3713,37 +3459,11 @@ impl GetInvalidationResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetInvalidationResult, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = GetInvalidationResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Invalidation" => {
-                        obj.invalidation = Some(try!(InvalidationDeserializer::deserialize(
-                            "Invalidation",
-                            stack
-                        )));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
+        obj.invalidation = match InvalidationDeserializer::deserialize("Invalidation", stack) {
+            Ok(payload) => Some(payload),
+            Err(_) => None,
+        };
 
         Ok(obj)
     }
@@ -3771,38 +3491,15 @@ impl GetStreamingDistributionConfigResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetStreamingDistributionConfigResult, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = GetStreamingDistributionConfigResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
+        obj.streaming_distribution_config =
+            match StreamingDistributionConfigDeserializer::deserialize(
+                "StreamingDistributionConfig",
+                stack,
+            ) {
+                Ok(payload) => Some(payload),
+                Err(_) => None,
             };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "StreamingDistributionConfig" => {
-                        obj.streaming_distribution_config =
-                            Some(try!(StreamingDistributionConfigDeserializer::deserialize(
-                                "StreamingDistributionConfig",
-                                stack
-                            )));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
 
         Ok(obj)
     }
@@ -3830,38 +3527,12 @@ impl GetStreamingDistributionResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetStreamingDistributionResult, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = GetStreamingDistributionResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
+        obj.streaming_distribution =
+            match StreamingDistributionDeserializer::deserialize("StreamingDistribution", stack) {
+                Ok(payload) => Some(payload),
+                Err(_) => None,
             };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "StreamingDistribution" => {
-                        obj.streaming_distribution =
-                            Some(try!(StreamingDistributionDeserializer::deserialize(
-                                "StreamingDistribution",
-                                stack
-                            )));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
 
         Ok(obj)
     }
@@ -4813,39 +4484,15 @@ impl ListCloudFrontOriginAccessIdentitiesResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListCloudFrontOriginAccessIdentitiesResult, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = ListCloudFrontOriginAccessIdentitiesResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
+        obj.cloud_front_origin_access_identity_list =
+            match CloudFrontOriginAccessIdentityListDeserializer::deserialize(
+                "CloudFrontOriginAccessIdentityList",
+                stack,
+            ) {
+                Ok(payload) => Some(payload),
+                Err(_) => None,
             };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CloudFrontOriginAccessIdentityList" => {
-                        obj.cloud_front_origin_access_identity_list = Some(try!(
-                            CloudFrontOriginAccessIdentityListDeserializer::deserialize(
-                                "CloudFrontOriginAccessIdentityList",
-                                stack
-                            )
-                        ));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
 
         Ok(obj)
     }
@@ -4875,36 +4522,12 @@ impl ListDistributionsByWebACLIdResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListDistributionsByWebACLIdResult, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = ListDistributionsByWebACLIdResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
+        obj.distribution_list =
+            match DistributionListDeserializer::deserialize("DistributionList", stack) {
+                Ok(payload) => Some(payload),
+                Err(_) => None,
             };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DistributionList" => {
-                        obj.distribution_list = Some(try!(
-                            DistributionListDeserializer::deserialize("DistributionList", stack)
-                        ));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
 
         Ok(obj)
     }
@@ -4932,36 +4555,12 @@ impl ListDistributionsResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListDistributionsResult, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = ListDistributionsResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
+        obj.distribution_list =
+            match DistributionListDeserializer::deserialize("DistributionList", stack) {
+                Ok(payload) => Some(payload),
+                Err(_) => None,
             };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DistributionList" => {
-                        obj.distribution_list = Some(try!(
-                            DistributionListDeserializer::deserialize("DistributionList", stack)
-                        ));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
 
         Ok(obj)
     }
@@ -4991,36 +4590,12 @@ impl ListInvalidationsResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListInvalidationsResult, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = ListInvalidationsResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
+        obj.invalidation_list =
+            match InvalidationListDeserializer::deserialize("InvalidationList", stack) {
+                Ok(payload) => Some(payload),
+                Err(_) => None,
             };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "InvalidationList" => {
-                        obj.invalidation_list = Some(try!(
-                            InvalidationListDeserializer::deserialize("InvalidationList", stack)
-                        ));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
 
         Ok(obj)
     }
@@ -5048,38 +4623,14 @@ impl ListStreamingDistributionsResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListStreamingDistributionsResult, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = ListStreamingDistributionsResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "StreamingDistributionList" => {
-                        obj.streaming_distribution_list =
-                            Some(try!(StreamingDistributionListDeserializer::deserialize(
-                                "StreamingDistributionList",
-                                stack
-                            )));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
+        obj.streaming_distribution_list = match StreamingDistributionListDeserializer::deserialize(
+            "StreamingDistributionList",
+            stack,
+        ) {
+            Ok(payload) => Some(payload),
+            Err(_) => None,
+        };
 
         Ok(obj)
     }
@@ -5105,34 +4656,8 @@ impl ListTagsForResourceResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListTagsForResourceResult, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = ListTagsForResourceResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Tags" => {
-                        obj.tags = try!(TagsDeserializer::deserialize("Tags", stack));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
+        obj.tags = try!(TagsDeserializer::deserialize("Tags", stack));
 
         Ok(obj)
     }
@@ -7912,39 +7437,15 @@ impl UpdateCloudFrontOriginAccessIdentityResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UpdateCloudFrontOriginAccessIdentityResult, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = UpdateCloudFrontOriginAccessIdentityResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
+        obj.cloud_front_origin_access_identity =
+            match CloudFrontOriginAccessIdentityDeserializer::deserialize(
+                "CloudFrontOriginAccessIdentity",
+                stack,
+            ) {
+                Ok(payload) => Some(payload),
+                Err(_) => None,
             };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CloudFrontOriginAccessIdentity" => {
-                        obj.cloud_front_origin_access_identity = Some(try!(
-                            CloudFrontOriginAccessIdentityDeserializer::deserialize(
-                                "CloudFrontOriginAccessIdentity",
-                                stack
-                            )
-                        ));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
 
         Ok(obj)
     }
@@ -7976,37 +7477,11 @@ impl UpdateDistributionResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UpdateDistributionResult, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = UpdateDistributionResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Distribution" => {
-                        obj.distribution = Some(try!(DistributionDeserializer::deserialize(
-                            "Distribution",
-                            stack
-                        )));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
+        obj.distribution = match DistributionDeserializer::deserialize("Distribution", stack) {
+            Ok(payload) => Some(payload),
+            Err(_) => None,
+        };
 
         Ok(obj)
     }
@@ -8038,38 +7513,12 @@ impl UpdateStreamingDistributionResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UpdateStreamingDistributionResult, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = UpdateStreamingDistributionResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
+        obj.streaming_distribution =
+            match StreamingDistributionDeserializer::deserialize("StreamingDistribution", stack) {
+                Ok(payload) => Some(payload),
+                Err(_) => None,
             };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "StreamingDistribution" => {
-                        obj.streaming_distribution =
-                            Some(try!(StreamingDistributionDeserializer::deserialize(
-                                "StreamingDistribution",
-                                stack
-                            )));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
 
         Ok(obj)
     }

--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -1460,17 +1460,15 @@ impl CreateCloudFrontOriginAccessIdentityResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateCloudFrontOriginAccessIdentityResult, XmlParseError> {
-        let mut obj = CreateCloudFrontOriginAccessIdentityResult::default();
-        obj.cloud_front_origin_access_identity =
-            match CloudFrontOriginAccessIdentityDeserializer::deserialize(
-                "CloudFrontOriginAccessIdentity",
-                stack,
-            ) {
-                Ok(payload) => Some(payload),
-                Err(_) => None,
-            };
-
-        Ok(obj)
+        Ok(CreateCloudFrontOriginAccessIdentityResult {
+            cloud_front_origin_access_identity: Some(try!(
+                CloudFrontOriginAccessIdentityDeserializer::deserialize(
+                    "CloudFrontOriginAccessIdentity",
+                    stack
+                )
+            )),
+            ..CreateCloudFrontOriginAccessIdentityResult::default()
+        })
     }
 }
 /// <p>The request to create a new distribution.</p>
@@ -1498,13 +1496,13 @@ impl CreateDistributionResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateDistributionResult, XmlParseError> {
-        let mut obj = CreateDistributionResult::default();
-        obj.distribution = match DistributionDeserializer::deserialize("Distribution", stack) {
-            Ok(payload) => Some(payload),
-            Err(_) => None,
-        };
-
-        Ok(obj)
+        Ok(CreateDistributionResult {
+            distribution: Some(try!(DistributionDeserializer::deserialize(
+                "Distribution",
+                stack
+            ))),
+            ..CreateDistributionResult::default()
+        })
     }
 }
 /// <p>The request to create a new distribution with tags. </p>
@@ -1532,13 +1530,13 @@ impl CreateDistributionWithTagsResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateDistributionWithTagsResult, XmlParseError> {
-        let mut obj = CreateDistributionWithTagsResult::default();
-        obj.distribution = match DistributionDeserializer::deserialize("Distribution", stack) {
-            Ok(payload) => Some(payload),
-            Err(_) => None,
-        };
-
-        Ok(obj)
+        Ok(CreateDistributionWithTagsResult {
+            distribution: Some(try!(DistributionDeserializer::deserialize(
+                "Distribution",
+                stack
+            ))),
+            ..CreateDistributionWithTagsResult::default()
+        })
     }
 }
 /// <p>The request to create an invalidation.</p>
@@ -1566,13 +1564,13 @@ impl CreateInvalidationResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateInvalidationResult, XmlParseError> {
-        let mut obj = CreateInvalidationResult::default();
-        obj.invalidation = match InvalidationDeserializer::deserialize("Invalidation", stack) {
-            Ok(payload) => Some(payload),
-            Err(_) => None,
-        };
-
-        Ok(obj)
+        Ok(CreateInvalidationResult {
+            invalidation: Some(try!(InvalidationDeserializer::deserialize(
+                "Invalidation",
+                stack
+            ))),
+            ..CreateInvalidationResult::default()
+        })
     }
 }
 /// <p>The request to create a new streaming distribution.</p>
@@ -1600,14 +1598,13 @@ impl CreateStreamingDistributionResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateStreamingDistributionResult, XmlParseError> {
-        let mut obj = CreateStreamingDistributionResult::default();
-        obj.streaming_distribution =
-            match StreamingDistributionDeserializer::deserialize("StreamingDistribution", stack) {
-                Ok(payload) => Some(payload),
-                Err(_) => None,
-            };
-
-        Ok(obj)
+        Ok(CreateStreamingDistributionResult {
+            streaming_distribution: Some(try!(StreamingDistributionDeserializer::deserialize(
+                "StreamingDistribution",
+                stack
+            ))),
+            ..CreateStreamingDistributionResult::default()
+        })
     }
 }
 /// <p>The request to create a new streaming distribution with tags.</p>
@@ -1634,14 +1631,13 @@ impl CreateStreamingDistributionWithTagsResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateStreamingDistributionWithTagsResult, XmlParseError> {
-        let mut obj = CreateStreamingDistributionWithTagsResult::default();
-        obj.streaming_distribution =
-            match StreamingDistributionDeserializer::deserialize("StreamingDistribution", stack) {
-                Ok(payload) => Some(payload),
-                Err(_) => None,
-            };
-
-        Ok(obj)
+        Ok(CreateStreamingDistributionWithTagsResult {
+            streaming_distribution: Some(try!(StreamingDistributionDeserializer::deserialize(
+                "StreamingDistribution",
+                stack
+            ))),
+            ..CreateStreamingDistributionWithTagsResult::default()
+        })
     }
 }
 /// <p>A complex type that controls:</p> <ul> <li> <p>Whether CloudFront replaces HTTP status codes in the 4xx and 5xx range with custom error messages before returning the response to the viewer. </p> </li> <li> <p>How long CloudFront caches HTTP status codes in the 4xx and 5xx range.</p> </li> </ul> <p>For more information about custom error pages, see <a href="http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/custom-error-pages.html">Customizing Error Responses</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>
@@ -3322,17 +3318,15 @@ impl GetCloudFrontOriginAccessIdentityConfigResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetCloudFrontOriginAccessIdentityConfigResult, XmlParseError> {
-        let mut obj = GetCloudFrontOriginAccessIdentityConfigResult::default();
-        obj.cloud_front_origin_access_identity_config =
-            match CloudFrontOriginAccessIdentityConfigDeserializer::deserialize(
-                "CloudFrontOriginAccessIdentityConfig",
-                stack,
-            ) {
-                Ok(payload) => Some(payload),
-                Err(_) => None,
-            };
-
-        Ok(obj)
+        Ok(GetCloudFrontOriginAccessIdentityConfigResult {
+            cloud_front_origin_access_identity_config: Some(try!(
+                CloudFrontOriginAccessIdentityConfigDeserializer::deserialize(
+                    "CloudFrontOriginAccessIdentityConfig",
+                    stack
+                )
+            )),
+            ..GetCloudFrontOriginAccessIdentityConfigResult::default()
+        })
     }
 }
 /// <p>The request to get an origin access identity's information.</p>
@@ -3358,17 +3352,15 @@ impl GetCloudFrontOriginAccessIdentityResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetCloudFrontOriginAccessIdentityResult, XmlParseError> {
-        let mut obj = GetCloudFrontOriginAccessIdentityResult::default();
-        obj.cloud_front_origin_access_identity =
-            match CloudFrontOriginAccessIdentityDeserializer::deserialize(
-                "CloudFrontOriginAccessIdentity",
-                stack,
-            ) {
-                Ok(payload) => Some(payload),
-                Err(_) => None,
-            };
-
-        Ok(obj)
+        Ok(GetCloudFrontOriginAccessIdentityResult {
+            cloud_front_origin_access_identity: Some(try!(
+                CloudFrontOriginAccessIdentityDeserializer::deserialize(
+                    "CloudFrontOriginAccessIdentity",
+                    stack
+                )
+            )),
+            ..GetCloudFrontOriginAccessIdentityResult::default()
+        })
     }
 }
 /// <p>The request to get a distribution configuration.</p>
@@ -3394,14 +3386,13 @@ impl GetDistributionConfigResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetDistributionConfigResult, XmlParseError> {
-        let mut obj = GetDistributionConfigResult::default();
-        obj.distribution_config =
-            match DistributionConfigDeserializer::deserialize("DistributionConfig", stack) {
-                Ok(payload) => Some(payload),
-                Err(_) => None,
-            };
-
-        Ok(obj)
+        Ok(GetDistributionConfigResult {
+            distribution_config: Some(try!(DistributionConfigDeserializer::deserialize(
+                "DistributionConfig",
+                stack
+            ))),
+            ..GetDistributionConfigResult::default()
+        })
     }
 }
 /// <p>The request to get a distribution's information.</p>
@@ -3427,13 +3418,13 @@ impl GetDistributionResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetDistributionResult, XmlParseError> {
-        let mut obj = GetDistributionResult::default();
-        obj.distribution = match DistributionDeserializer::deserialize("Distribution", stack) {
-            Ok(payload) => Some(payload),
-            Err(_) => None,
-        };
-
-        Ok(obj)
+        Ok(GetDistributionResult {
+            distribution: Some(try!(DistributionDeserializer::deserialize(
+                "Distribution",
+                stack
+            ))),
+            ..GetDistributionResult::default()
+        })
     }
 }
 /// <p>The request to get an invalidation's information. </p>
@@ -3459,13 +3450,13 @@ impl GetInvalidationResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetInvalidationResult, XmlParseError> {
-        let mut obj = GetInvalidationResult::default();
-        obj.invalidation = match InvalidationDeserializer::deserialize("Invalidation", stack) {
-            Ok(payload) => Some(payload),
-            Err(_) => None,
-        };
-
-        Ok(obj)
+        Ok(GetInvalidationResult {
+            invalidation: Some(try!(InvalidationDeserializer::deserialize(
+                "Invalidation",
+                stack
+            ))),
+            ..GetInvalidationResult::default()
+        })
     }
 }
 /// <p>To request to get a streaming distribution configuration.</p>
@@ -3491,17 +3482,15 @@ impl GetStreamingDistributionConfigResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetStreamingDistributionConfigResult, XmlParseError> {
-        let mut obj = GetStreamingDistributionConfigResult::default();
-        obj.streaming_distribution_config =
-            match StreamingDistributionConfigDeserializer::deserialize(
-                "StreamingDistributionConfig",
-                stack,
-            ) {
-                Ok(payload) => Some(payload),
-                Err(_) => None,
-            };
-
-        Ok(obj)
+        Ok(GetStreamingDistributionConfigResult {
+            streaming_distribution_config: Some(try!(
+                StreamingDistributionConfigDeserializer::deserialize(
+                    "StreamingDistributionConfig",
+                    stack
+                )
+            )),
+            ..GetStreamingDistributionConfigResult::default()
+        })
     }
 }
 /// <p>The request to get a streaming distribution's information.</p>
@@ -3527,14 +3516,13 @@ impl GetStreamingDistributionResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetStreamingDistributionResult, XmlParseError> {
-        let mut obj = GetStreamingDistributionResult::default();
-        obj.streaming_distribution =
-            match StreamingDistributionDeserializer::deserialize("StreamingDistribution", stack) {
-                Ok(payload) => Some(payload),
-                Err(_) => None,
-            };
-
-        Ok(obj)
+        Ok(GetStreamingDistributionResult {
+            streaming_distribution: Some(try!(StreamingDistributionDeserializer::deserialize(
+                "StreamingDistribution",
+                stack
+            ))),
+            ..GetStreamingDistributionResult::default()
+        })
     }
 }
 struct HeaderListDeserializer;
@@ -4484,17 +4472,15 @@ impl ListCloudFrontOriginAccessIdentitiesResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListCloudFrontOriginAccessIdentitiesResult, XmlParseError> {
-        let mut obj = ListCloudFrontOriginAccessIdentitiesResult::default();
-        obj.cloud_front_origin_access_identity_list =
-            match CloudFrontOriginAccessIdentityListDeserializer::deserialize(
-                "CloudFrontOriginAccessIdentityList",
-                stack,
-            ) {
-                Ok(payload) => Some(payload),
-                Err(_) => None,
-            };
-
-        Ok(obj)
+        Ok(ListCloudFrontOriginAccessIdentitiesResult {
+            cloud_front_origin_access_identity_list: Some(try!(
+                CloudFrontOriginAccessIdentityListDeserializer::deserialize(
+                    "CloudFrontOriginAccessIdentityList",
+                    stack
+                )
+            )),
+            ..ListCloudFrontOriginAccessIdentitiesResult::default()
+        })
     }
 }
 /// <p>The request to list distributions that are associated with a specified AWS WAF web ACL. </p>
@@ -4522,14 +4508,13 @@ impl ListDistributionsByWebACLIdResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListDistributionsByWebACLIdResult, XmlParseError> {
-        let mut obj = ListDistributionsByWebACLIdResult::default();
-        obj.distribution_list =
-            match DistributionListDeserializer::deserialize("DistributionList", stack) {
-                Ok(payload) => Some(payload),
-                Err(_) => None,
-            };
-
-        Ok(obj)
+        Ok(ListDistributionsByWebACLIdResult {
+            distribution_list: Some(try!(DistributionListDeserializer::deserialize(
+                "DistributionList",
+                stack
+            ))),
+            ..ListDistributionsByWebACLIdResult::default()
+        })
     }
 }
 /// <p>The request to list your distributions. </p>
@@ -4555,14 +4540,13 @@ impl ListDistributionsResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListDistributionsResult, XmlParseError> {
-        let mut obj = ListDistributionsResult::default();
-        obj.distribution_list =
-            match DistributionListDeserializer::deserialize("DistributionList", stack) {
-                Ok(payload) => Some(payload),
-                Err(_) => None,
-            };
-
-        Ok(obj)
+        Ok(ListDistributionsResult {
+            distribution_list: Some(try!(DistributionListDeserializer::deserialize(
+                "DistributionList",
+                stack
+            ))),
+            ..ListDistributionsResult::default()
+        })
     }
 }
 /// <p>The request to list invalidations. </p>
@@ -4590,14 +4574,13 @@ impl ListInvalidationsResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListInvalidationsResult, XmlParseError> {
-        let mut obj = ListInvalidationsResult::default();
-        obj.invalidation_list =
-            match InvalidationListDeserializer::deserialize("InvalidationList", stack) {
-                Ok(payload) => Some(payload),
-                Err(_) => None,
-            };
-
-        Ok(obj)
+        Ok(ListInvalidationsResult {
+            invalidation_list: Some(try!(InvalidationListDeserializer::deserialize(
+                "InvalidationList",
+                stack
+            ))),
+            ..ListInvalidationsResult::default()
+        })
     }
 }
 /// <p>The request to list your streaming distributions. </p>
@@ -4623,16 +4606,15 @@ impl ListStreamingDistributionsResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListStreamingDistributionsResult, XmlParseError> {
-        let mut obj = ListStreamingDistributionsResult::default();
-        obj.streaming_distribution_list = match StreamingDistributionListDeserializer::deserialize(
-            "StreamingDistributionList",
-            stack,
-        ) {
-            Ok(payload) => Some(payload),
-            Err(_) => None,
-        };
-
-        Ok(obj)
+        Ok(ListStreamingDistributionsResult {
+            streaming_distribution_list: Some(try!(
+                StreamingDistributionListDeserializer::deserialize(
+                    "StreamingDistributionList",
+                    stack
+                )
+            )),
+            ..ListStreamingDistributionsResult::default()
+        })
     }
 }
 /// <p> The request to list tags for a CloudFront resource.</p>
@@ -4656,10 +4638,10 @@ impl ListTagsForResourceResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListTagsForResourceResult, XmlParseError> {
-        let mut obj = ListTagsForResourceResult::default();
-        obj.tags = try!(TagsDeserializer::deserialize("Tags", stack));
-
-        Ok(obj)
+        Ok(ListTagsForResourceResult {
+            tags: try!(TagsDeserializer::deserialize("Tags", stack)),
+            ..ListTagsForResourceResult::default()
+        })
     }
 }
 struct LocationListDeserializer;
@@ -7437,17 +7419,15 @@ impl UpdateCloudFrontOriginAccessIdentityResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UpdateCloudFrontOriginAccessIdentityResult, XmlParseError> {
-        let mut obj = UpdateCloudFrontOriginAccessIdentityResult::default();
-        obj.cloud_front_origin_access_identity =
-            match CloudFrontOriginAccessIdentityDeserializer::deserialize(
-                "CloudFrontOriginAccessIdentity",
-                stack,
-            ) {
-                Ok(payload) => Some(payload),
-                Err(_) => None,
-            };
-
-        Ok(obj)
+        Ok(UpdateCloudFrontOriginAccessIdentityResult {
+            cloud_front_origin_access_identity: Some(try!(
+                CloudFrontOriginAccessIdentityDeserializer::deserialize(
+                    "CloudFrontOriginAccessIdentity",
+                    stack
+                )
+            )),
+            ..UpdateCloudFrontOriginAccessIdentityResult::default()
+        })
     }
 }
 /// <p>The request to update a distribution.</p>
@@ -7477,13 +7457,13 @@ impl UpdateDistributionResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UpdateDistributionResult, XmlParseError> {
-        let mut obj = UpdateDistributionResult::default();
-        obj.distribution = match DistributionDeserializer::deserialize("Distribution", stack) {
-            Ok(payload) => Some(payload),
-            Err(_) => None,
-        };
-
-        Ok(obj)
+        Ok(UpdateDistributionResult {
+            distribution: Some(try!(DistributionDeserializer::deserialize(
+                "Distribution",
+                stack
+            ))),
+            ..UpdateDistributionResult::default()
+        })
     }
 }
 /// <p>The request to update a streaming distribution.</p>
@@ -7513,14 +7493,13 @@ impl UpdateStreamingDistributionResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UpdateStreamingDistributionResult, XmlParseError> {
-        let mut obj = UpdateStreamingDistributionResult::default();
-        obj.streaming_distribution =
-            match StreamingDistributionDeserializer::deserialize("StreamingDistribution", stack) {
-                Ok(payload) => Some(payload),
-                Err(_) => None,
-            };
-
-        Ok(obj)
+        Ok(UpdateStreamingDistributionResult {
+            streaming_distribution: Some(try!(StreamingDistributionDeserializer::deserialize(
+                "StreamingDistribution",
+                stack
+            ))),
+            ..UpdateStreamingDistributionResult::default()
+        })
     }
 }
 /// <p>A complex type that specifies the following:</p> <ul> <li> <p>Whether you want viewers to use HTTP or HTTPS to request your objects.</p> </li> <li> <p>If you want viewers to use HTTPS, whether you're using an alternate domain name such as <code>example.com</code> or the CloudFront domain name for your distribution, such as <code>d111111abcdef8.cloudfront.net</code>.</p> </li> <li> <p>If you're using an alternate domain name, whether AWS Certificate Manager (ACM) provided the certificate, or you purchased a certificate from a third-party certificate authority and imported it into ACM or uploaded it to the IAM certificate store.</p> </li> </ul> <p>You must specify only one of the following values: </p> <ul> <li> <p> <a>ViewerCertificate$ACMCertificateArn</a> </p> </li> <li> <p> <a>ViewerCertificate$IAMCertificateId</a> </p> </li> <li> <p> <a>ViewerCertificate$CloudFrontDefaultCertificate</a> </p> </li> </ul> <p>Don't specify <code>false</code> for <code>CloudFrontDefaultCertificate</code>.</p> <p> <b>If you want viewers to use HTTP instead of HTTPS to request your objects</b>: Specify the following value:</p> <p> <code>&lt;CloudFrontDefaultCertificate&gt;true&lt;CloudFrontDefaultCertificate&gt;</code> </p> <p>In addition, specify <code>allow-all</code> for <code>ViewerProtocolPolicy</code> for all of your cache behaviors.</p> <p> <b>If you want viewers to use HTTPS to request your objects</b>: Choose the type of certificate that you want to use based on whether you're using an alternate domain name for your objects or the CloudFront domain name:</p> <ul> <li> <p> <b>If you're using an alternate domain name, such as example.com</b>: Specify one of the following values, depending on whether ACM provided your certificate or you purchased your certificate from third-party certificate authority:</p> <ul> <li> <p> <code>&lt;ACMCertificateArn&gt;<i>ARN for ACM SSL/TLS certificate</i>&lt;ACMCertificateArn&gt;</code> where <code> <i>ARN for ACM SSL/TLS certificate</i> </code> is the ARN for the ACM SSL/TLS certificate that you want to use for this distribution.</p> </li> <li> <p> <code>&lt;IAMCertificateId&gt;<i>IAM certificate ID</i>&lt;IAMCertificateId&gt;</code> where <code> <i>IAM certificate ID</i> </code> is the ID that IAM returned when you added the certificate to the IAM certificate store.</p> </li> </ul> <p>If you specify <code>ACMCertificateArn</code> or <code>IAMCertificateId</code>, you must also specify a value for <code>SSLSupportMethod</code>.</p> <p>If you choose to use an ACM certificate or a certificate in the IAM certificate store, we recommend that you use only an alternate domain name in your object URLs (<code>https://example.com/logo.jpg</code>). If you use the domain name that is associated with your CloudFront distribution (such as <code>https://d111111abcdef8.cloudfront.net/logo.jpg</code>) and the viewer supports <code>SNI</code>, then CloudFront behaves normally. However, if the browser does not support SNI, the user's experience depends on the value that you choose for <code>SSLSupportMethod</code>:</p> <ul> <li> <p> <code>vip</code>: The viewer displays a warning because there is a mismatch between the CloudFront domain name and the domain name in your SSL/TLS certificate.</p> </li> <li> <p> <code>sni-only</code>: CloudFront drops the connection with the browser without returning the object.</p> </li> </ul> </li> <li> <p> <b>If you're using the CloudFront domain name for your distribution, such as <code>d111111abcdef8.cloudfront.net</code> </b>: Specify the following value:</p> <p> <code>&lt;CloudFrontDefaultCertificate&gt;true&lt;CloudFrontDefaultCertificate&gt; </code> </p> </li> </ul> <p>If you want viewers to use HTTPS, you must also specify one of the following values in your cache behaviors:</p> <ul> <li> <p> <code> &lt;ViewerProtocolPolicy&gt;https-only&lt;ViewerProtocolPolicy&gt;</code> </p> </li> <li> <p> <code>&lt;ViewerProtocolPolicy&gt;redirect-to-https&lt;ViewerProtocolPolicy&gt;</code> </p> </li> </ul> <p>You can also optionally require that CloudFront use HTTPS to communicate with your origin by specifying one of the following values for the applicable origins:</p> <ul> <li> <p> <code>&lt;OriginProtocolPolicy&gt;https-only&lt;OriginProtocolPolicy&gt; </code> </p> </li> <li> <p> <code>&lt;OriginProtocolPolicy&gt;match-viewer&lt;OriginProtocolPolicy&gt; </code> </p> </li> </ul> <p>For more information, see <a href="http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/SecureConnections.html#CNAMEsAndHTTPS">Using Alternate Domain Names and HTTPS</a> in the <i>Amazon CloudFront Developer Guide</i>.</p>

--- a/rusoto/services/s3/src/custom/custom_tests.rs
+++ b/rusoto/services/s3/src/custom/custom_tests.rs
@@ -30,7 +30,7 @@ fn test_multipart_upload_copy_response() {
         .sync()
         .unwrap();
     assert!(result.copy_part_result.is_some(), "Should have result in etag field");
-    assert_eq!(result.copy_part_result.unwrap().e_tag.unwrap(), "9a9d1bbe80188883302bff764b4cb321");
+    assert_eq!(result.copy_part_result.unwrap().e_tag.unwrap(), "\"9a9d1bbe80188883302bff764b4cb321\"");
 }
 
 #[test]
@@ -88,7 +88,7 @@ fn initiate_multipart_upload_happy_path() {
 fn complete_multipart_upload_happy_path() {
     let body = MockResponseReader::read_response("test_resources/custom", "s3_complete_multipart_upload.xml");
     let mock = MockRequestDispatcher::with_status(200).with_body(&body);
-    
+
     let client = S3Client::new_with(mock, MockCredentialsProvider, Region::UsEast1);
     let result = client.complete_multipart_upload(CompleteMultipartUploadRequest {
         bucket: "example-bucket".to_owned(),
@@ -111,7 +111,7 @@ fn complete_multipart_upload_happy_path() {
 fn list_multipart_upload_happy_path() {
     let body = MockResponseReader::read_response("test_resources/custom", "s3_list_multipart_uploads.xml");
     let mock = MockRequestDispatcher::with_status(200).with_body(&body);
-    
+
     let client = S3Client::new_with(mock, MockCredentialsProvider, Region::UsEast1);
     let result = client.list_multipart_uploads(ListMultipartUploadsRequest {
         bucket: "example-bucket".to_owned(),
@@ -367,7 +367,7 @@ fn should_serialize_complicated_request() {
 fn should_parse_location_constraint() {
     let body = MockResponseReader::read_response("test_resources/generated/valid", "s3-get-bucket-location.xml");
     let mock = MockRequestDispatcher::with_status(200).with_body(&body);
-    
+
     let client = S3Client::new_with(mock, MockCredentialsProvider, Region::UsEast1);
     let result = client.get_bucket_location(GetBucketLocationRequest {
         bucket: "example-bucket".to_owned()

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -2511,36 +2511,12 @@ impl CopyObjectOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CopyObjectOutput, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = CopyObjectOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
+        obj.copy_object_result =
+            match CopyObjectResultDeserializer::deserialize("CopyObjectResult", stack) {
+                Ok(payload) => Some(payload),
+                Err(_) => None,
             };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CopyObjectResult" => {
-                        obj.copy_object_result = Some(try!(
-                            CopyObjectResultDeserializer::deserialize("CopyObjectResult", stack)
-                        ));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
 
         Ok(obj)
     }
@@ -4779,38 +4755,14 @@ impl GetBucketAnalyticsConfigurationOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetBucketAnalyticsConfigurationOutput, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = GetBucketAnalyticsConfigurationOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AnalyticsConfiguration" => {
-                        obj.analytics_configuration =
-                            Some(try!(AnalyticsConfigurationDeserializer::deserialize(
-                                "AnalyticsConfiguration",
-                                stack
-                            )));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
+        obj.analytics_configuration = match AnalyticsConfigurationDeserializer::deserialize(
+            "AnalyticsConfiguration",
+            stack,
+        ) {
+            Ok(payload) => Some(payload),
+            Err(_) => None,
+        };
 
         Ok(obj)
     }
@@ -4894,39 +4846,15 @@ impl GetBucketEncryptionOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetBucketEncryptionOutput, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = GetBucketEncryptionOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
+        obj.server_side_encryption_configuration =
+            match ServerSideEncryptionConfigurationDeserializer::deserialize(
+                "ServerSideEncryptionConfiguration",
+                stack,
+            ) {
+                Ok(payload) => Some(payload),
+                Err(_) => None,
             };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "ServerSideEncryptionConfiguration" => {
-                        obj.server_side_encryption_configuration = Some(try!(
-                            ServerSideEncryptionConfigurationDeserializer::deserialize(
-                                "ServerSideEncryptionConfiguration",
-                                stack
-                            )
-                        ));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
 
         Ok(obj)
     }
@@ -4950,38 +4878,14 @@ impl GetBucketInventoryConfigurationOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetBucketInventoryConfigurationOutput, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = GetBucketInventoryConfigurationOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "InventoryConfiguration" => {
-                        obj.inventory_configuration =
-                            Some(try!(InventoryConfigurationDeserializer::deserialize(
-                                "InventoryConfiguration",
-                                stack
-                            )));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
+        obj.inventory_configuration = match InventoryConfigurationDeserializer::deserialize(
+            "InventoryConfiguration",
+            stack,
+        ) {
+            Ok(payload) => Some(payload),
+            Err(_) => None,
+        };
 
         Ok(obj)
     }
@@ -5199,38 +5103,12 @@ impl GetBucketMetricsConfigurationOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetBucketMetricsConfigurationOutput, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = GetBucketMetricsConfigurationOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
+        obj.metrics_configuration =
+            match MetricsConfigurationDeserializer::deserialize("MetricsConfiguration", stack) {
+                Ok(payload) => Some(payload),
+                Err(_) => None,
             };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "MetricsConfiguration" => {
-                        obj.metrics_configuration =
-                            Some(try!(MetricsConfigurationDeserializer::deserialize(
-                                "MetricsConfiguration",
-                                stack
-                            )));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
 
         Ok(obj)
     }
@@ -5272,38 +5150,14 @@ impl GetBucketReplicationOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetBucketReplicationOutput, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = GetBucketReplicationOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "ReplicationConfiguration" => {
-                        obj.replication_configuration =
-                            Some(try!(ReplicationConfigurationDeserializer::deserialize(
-                                "ReplicationConfiguration",
-                                stack
-                            )));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
+        obj.replication_configuration = match ReplicationConfigurationDeserializer::deserialize(
+            "ReplicationConfiguration",
+            stack,
+        ) {
+            Ok(payload) => Some(payload),
+            Err(_) => None,
+        };
 
         Ok(obj)
     }
@@ -14248,38 +14102,12 @@ impl SelectObjectContentOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<SelectObjectContentOutput, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = SelectObjectContentOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
+        obj.payload =
+            match SelectObjectContentEventStreamDeserializer::deserialize("Payload", stack) {
+                Ok(payload) => Some(payload),
+                Err(_) => None,
             };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Payload" => {
-                        obj.payload = Some(try!(
-                            SelectObjectContentEventStreamDeserializer::deserialize(
-                                "Payload", stack
-                            )
-                        ));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
 
         Ok(obj)
     }
@@ -16311,37 +16139,12 @@ impl UploadPartCopyOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UploadPartCopyOutput, XmlParseError> {
-        try!(start_element(tag_name, stack));
-
         let mut obj = UploadPartCopyOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
+        obj.copy_part_result =
+            match CopyPartResultDeserializer::deserialize("CopyPartResult", stack) {
+                Ok(payload) => Some(payload),
+                Err(_) => None,
             };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CopyPartResult" => {
-                        obj.copy_part_result = Some(try!(CopyPartResultDeserializer::deserialize(
-                            "CopyPartResult",
-                            stack
-                        )));
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        try!(end_element(tag_name, stack));
 
         Ok(obj)
     }

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -2511,14 +2511,13 @@ impl CopyObjectOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CopyObjectOutput, XmlParseError> {
-        let mut obj = CopyObjectOutput::default();
-        obj.copy_object_result =
-            match CopyObjectResultDeserializer::deserialize("CopyObjectResult", stack) {
-                Ok(payload) => Some(payload),
-                Err(_) => None,
-            };
-
-        Ok(obj)
+        Ok(CopyObjectOutput {
+            copy_object_result: Some(try!(CopyObjectResultDeserializer::deserialize(
+                "CopyObjectResult",
+                stack
+            ))),
+            ..CopyObjectOutput::default()
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -4755,16 +4754,13 @@ impl GetBucketAnalyticsConfigurationOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetBucketAnalyticsConfigurationOutput, XmlParseError> {
-        let mut obj = GetBucketAnalyticsConfigurationOutput::default();
-        obj.analytics_configuration = match AnalyticsConfigurationDeserializer::deserialize(
-            "AnalyticsConfiguration",
-            stack,
-        ) {
-            Ok(payload) => Some(payload),
-            Err(_) => None,
-        };
-
-        Ok(obj)
+        Ok(GetBucketAnalyticsConfigurationOutput {
+            analytics_configuration: Some(try!(AnalyticsConfigurationDeserializer::deserialize(
+                "AnalyticsConfiguration",
+                stack
+            ))),
+            ..GetBucketAnalyticsConfigurationOutput::default()
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -4846,17 +4842,15 @@ impl GetBucketEncryptionOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetBucketEncryptionOutput, XmlParseError> {
-        let mut obj = GetBucketEncryptionOutput::default();
-        obj.server_side_encryption_configuration =
-            match ServerSideEncryptionConfigurationDeserializer::deserialize(
-                "ServerSideEncryptionConfiguration",
-                stack,
-            ) {
-                Ok(payload) => Some(payload),
-                Err(_) => None,
-            };
-
-        Ok(obj)
+        Ok(GetBucketEncryptionOutput {
+            server_side_encryption_configuration: Some(try!(
+                ServerSideEncryptionConfigurationDeserializer::deserialize(
+                    "ServerSideEncryptionConfiguration",
+                    stack
+                )
+            )),
+            ..GetBucketEncryptionOutput::default()
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -4878,16 +4872,13 @@ impl GetBucketInventoryConfigurationOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetBucketInventoryConfigurationOutput, XmlParseError> {
-        let mut obj = GetBucketInventoryConfigurationOutput::default();
-        obj.inventory_configuration = match InventoryConfigurationDeserializer::deserialize(
-            "InventoryConfiguration",
-            stack,
-        ) {
-            Ok(payload) => Some(payload),
-            Err(_) => None,
-        };
-
-        Ok(obj)
+        Ok(GetBucketInventoryConfigurationOutput {
+            inventory_configuration: Some(try!(InventoryConfigurationDeserializer::deserialize(
+                "InventoryConfiguration",
+                stack
+            ))),
+            ..GetBucketInventoryConfigurationOutput::default()
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -5103,14 +5094,13 @@ impl GetBucketMetricsConfigurationOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetBucketMetricsConfigurationOutput, XmlParseError> {
-        let mut obj = GetBucketMetricsConfigurationOutput::default();
-        obj.metrics_configuration =
-            match MetricsConfigurationDeserializer::deserialize("MetricsConfiguration", stack) {
-                Ok(payload) => Some(payload),
-                Err(_) => None,
-            };
-
-        Ok(obj)
+        Ok(GetBucketMetricsConfigurationOutput {
+            metrics_configuration: Some(try!(MetricsConfigurationDeserializer::deserialize(
+                "MetricsConfiguration",
+                stack
+            ))),
+            ..GetBucketMetricsConfigurationOutput::default()
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -5150,16 +5140,15 @@ impl GetBucketReplicationOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetBucketReplicationOutput, XmlParseError> {
-        let mut obj = GetBucketReplicationOutput::default();
-        obj.replication_configuration = match ReplicationConfigurationDeserializer::deserialize(
-            "ReplicationConfiguration",
-            stack,
-        ) {
-            Ok(payload) => Some(payload),
-            Err(_) => None,
-        };
-
-        Ok(obj)
+        Ok(GetBucketReplicationOutput {
+            replication_configuration: Some(try!(
+                ReplicationConfigurationDeserializer::deserialize(
+                    "ReplicationConfiguration",
+                    stack
+                )
+            )),
+            ..GetBucketReplicationOutput::default()
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -14102,14 +14091,12 @@ impl SelectObjectContentOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<SelectObjectContentOutput, XmlParseError> {
-        let mut obj = SelectObjectContentOutput::default();
-        obj.payload =
-            match SelectObjectContentEventStreamDeserializer::deserialize("Payload", stack) {
-                Ok(payload) => Some(payload),
-                Err(_) => None,
-            };
-
-        Ok(obj)
+        Ok(SelectObjectContentOutput {
+            payload: Some(try!(
+                SelectObjectContentEventStreamDeserializer::deserialize("Payload", stack)
+            )),
+            ..SelectObjectContentOutput::default()
+        })
     }
 }
 /// <p>Request to filter the contents of an Amazon S3 object based on a simple Structured Query Language (SQL) statement. In the request, along with the SQL expression, you must also specify a data serialization format (JSON or CSV) of the object. Amazon S3 uses this to parse object data into records, and returns only records that match the specified SQL expression. You must also specify the data serialization format for the response. For more information, go to <a href="http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectSELECTContent.html">S3Select API Documentation</a>.</p>
@@ -16139,14 +16126,13 @@ impl UploadPartCopyOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UploadPartCopyOutput, XmlParseError> {
-        let mut obj = UploadPartCopyOutput::default();
-        obj.copy_part_result =
-            match CopyPartResultDeserializer::deserialize("CopyPartResult", stack) {
-                Ok(payload) => Some(payload),
-                Err(_) => None,
-            };
-
-        Ok(obj)
+        Ok(UploadPartCopyOutput {
+            copy_part_result: Some(try!(CopyPartResultDeserializer::deserialize(
+                "CopyPartResult",
+                stack
+            ))),
+            ..UploadPartCopyOutput::default()
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]

--- a/service_crategen/src/commands/generate/codegen/xml_payload_parser.rs
+++ b/service_crategen/src/commands/generate/codegen/xml_payload_parser.rs
@@ -357,8 +357,8 @@ fn generate_struct_deserializer(name: &str, service: &Service, shape: &Shape) ->
             .get(payload_member_name)
             .expect("failed to get payload member");
 
-        let deserialize = format!("{payload_shape}Deserializer::deserialize(\"{name}\", stack)",
-                                  name = name,
+        let deserialize = format!("{payload_shape}Deserializer::deserialize(\"{payload_member_name}\", stack)",
+                                  payload_member_name = payload_member_name,
                                   payload_shape = payload_member.shape);
 
         let unwrapping = if shape.required(payload_member_name) {


### PR DESCRIPTION
This fixes #1187, although that is just one of the symptoms here afaict.

The issue appears to be that (currently) struct deserializers don't handle the case where the actual XML body represents a member field.

In the linked issue, the `UploadPartCopyOutputDeserializer` is trying to look for the `CopyPartResult` tag in the XML before parsing - in actuality, the XML is already the `CopyPartResult` tag instance, and so `UploadPartCopyOutputDeserializer` simply needs to pass directly through to `CopyPartResult`.

That's what this PR does; in the case there's a payload, it delegates straight through to the appropriate deserializer. I'm not sure if this is perfect, but all tests appear to pass as far as I can tell.

It does mean that there's a bunch of redundancy here; it's possible to hijack `xml_body_parser` to do this passthrough directly (and thus not even need `UploadPartCopyOutputDeserializer`). I have this working locally as well, but I'm unsure of how to avoid generating the deserializers - so I went this route instead. I'm sure we can clean it up in future though and skip the unnecessary deserializers.

