### PR TITLE
Only test against stable, beta and nightly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ osx_image: xcode9.4
 cache:
   directories:
     - ~/.cargo
-# run builds for all the trains (and more)
+# run builds for all the trains
 rust:
-  - 1.26.1 # test against minimum Rust version supported
   - stable
   - beta
   - nightly

--- a/README.md
+++ b/README.md
@@ -33,12 +33,6 @@ You may be looking for:
 * [API documentation][api-documentation]
 * [Getting help with Rusoto][rusoto-help]
 
-## Requirements
-
-Rust 1.26.1 or later is required.
-
-On Linux, OpenSSL is required.
-
 ## Installation
 
 Rusoto is available on [crates.io](https://crates.io/crates/rusoto_core).

--- a/rusoto/core/README.md
+++ b/rusoto/core/README.md
@@ -29,12 +29,6 @@ You may be looking for:
 * [API documentation][api-documentation]
 * [Getting help with Rusoto][rusoto-help]
 
-## Requirements
-
-Rust 1.26.1 or later is required.
-
-On Linux, OpenSSL is required unless `features=["rustls"]` is used.
-
 ## Installation
 
 Rusoto is available on [crates.io](https://crates.io/crates/rusoto_core).


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

* Drop automated testing against versions of Rust before `stable`

From https://github.com/rusoto/rusoto/issues/1166 this change will let us support running `clippy` using the `stable` release of Rust. 🎉 A bonus is reducing the turnaround time for TravisCI.

An open question: should we bump our minimum to just what `clippy` needs to keep some backwards compatibility testing?