### PR TITLE
Skip serializing blobs when they are Option::None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add Connect service
 - Add MediaTailor support
 - Add ByteStream struct to core
+- Skip serializing blobs when they are `Option::None`
 
 ## [0.35.0] - 2018-10-31
 

--- a/rusoto/services/acm/src/generated.rs
+++ b/rusoto/services/acm/src/generated.rs
@@ -338,6 +338,7 @@ pub struct ImportCertificateRequest {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub certificate_chain: Option<Vec<u8>>,
     /// <p>The private key that matches the public key in the certificate.</p>
     #[serde(rename = "PrivateKey")]

--- a/rusoto/services/clouddirectory/src/generated.rs
+++ b/rusoto/services/clouddirectory/src/generated.rs
@@ -2726,6 +2726,7 @@ pub struct TypedAttributeValue {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub binary_value: Option<Vec<u8>>,
     /// <p>A Boolean data value.</p>
     #[serde(rename = "BooleanValue")]

--- a/rusoto/services/cloudtrail/src/generated.rs
+++ b/rusoto/services/cloudtrail/src/generated.rs
@@ -470,6 +470,7 @@ pub struct PublicKey {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<Vec<u8>>,
 }
 

--- a/rusoto/services/cognito-idp/src/generated.rs
+++ b/rusoto/services/cognito-idp/src/generated.rs
@@ -2804,6 +2804,7 @@ pub struct SetUICustomizationRequest {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub image_file: Option<Vec<u8>>,
     /// <p>The user pool ID for the user pool.</p>
     #[serde(rename = "UserPoolId")]

--- a/rusoto/services/directconnect/src/generated.rs
+++ b/rusoto/services/directconnect/src/generated.rs
@@ -964,6 +964,7 @@ pub struct Loa {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub loa_content: Option<Vec<u8>>,
     #[serde(rename = "loaContentType")]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/rusoto/services/dms/src/generated.rs
+++ b/rusoto/services/dms/src/generated.rs
@@ -103,6 +103,7 @@ pub struct Certificate {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub certificate_wallet: Option<Vec<u8>>,
     /// <p>The key length of the cryptographic algorithm being used.</p>
     #[serde(rename = "KeyLength")]
@@ -1270,6 +1271,7 @@ pub struct ImportCertificateMessage {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub certificate_wallet: Option<Vec<u8>>,
     /// <p>The tags associated with the certificate.</p>
     #[serde(rename = "Tags")]

--- a/rusoto/services/dynamodb/src/custom/custom_tests.rs
+++ b/rusoto/services/dynamodb/src/custom/custom_tests.rs
@@ -1,0 +1,33 @@
+use ::{AttributeValue};
+
+#[test]
+fn attribute_value_default_is_empty() {
+    let all_default = AttributeValue{
+        ..Default::default()
+    };
+
+    let serialized = serde_json::to_string(&all_default).unwrap();
+    assert_eq!(&serialized, "{}");
+}
+
+#[test]
+fn attribute_value_with_blob_contains_only_blob() {
+    let all_default = AttributeValue{
+        b: Some("foo".bytes().collect()),
+        ..Default::default()
+    };
+
+    let serialized = serde_json::to_string(&all_default).unwrap();
+    assert_eq!(&serialized, r#"{"B":"Zm9v"}"#);
+}
+
+#[test]
+fn attribute_value_with_number_contains_only_number() {
+    let all_default = AttributeValue{
+        n: Some(1234.to_string()),
+        ..Default::default()
+    };
+
+    let serialized = serde_json::to_string(&all_default).unwrap();
+    assert_eq!(&serialized, r#"{"N":"1234"}"#);
+}

--- a/rusoto/services/dynamodb/src/custom/mod.rs
+++ b/rusoto/services/dynamodb/src/custom/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(test)]
+mod custom_tests;

--- a/rusoto/services/dynamodb/src/generated.rs
+++ b/rusoto/services/dynamodb/src/generated.rs
@@ -49,6 +49,7 @@ pub struct AttributeValue {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub b: Option<Vec<u8>>,
     /// <p>An attribute of type Boolean. For example:</p> <p> <code>"BOOL": true</code> </p>
     #[serde(rename = "BOOL")]

--- a/rusoto/services/dynamodbstreams/src/generated.rs
+++ b/rusoto/services/dynamodbstreams/src/generated.rs
@@ -39,6 +39,7 @@ pub struct AttributeValue {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub b: Option<Vec<u8>>,
     /// <p>A Boolean data type.</p>
     #[serde(rename = "BOOL")]

--- a/rusoto/services/glacier/src/generated.rs
+++ b/rusoto/services/glacier/src/generated.rs
@@ -1183,6 +1183,7 @@ pub struct UploadArchiveInput {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<Vec<u8>>,
     /// <p>The SHA256 tree hash of the data being uploaded.</p>
     #[serde(rename = "checksum")]
@@ -1232,6 +1233,7 @@ pub struct UploadMultipartPartInput {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<Vec<u8>>,
     /// <p>The SHA256 tree hash of the data being uploaded.</p>
     #[serde(rename = "checksum")]

--- a/rusoto/services/iot/src/generated.rs
+++ b/rusoto/services/iot/src/generated.rs
@@ -847,6 +847,7 @@ pub struct CodeSigningSignature {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub inline_document: Option<Vec<u8>>,
     /// <p>A stream of the code signing signature.</p>
     #[serde(rename = "stream")]

--- a/rusoto/services/kms/src/generated.rs
+++ b/rusoto/services/kms/src/generated.rs
@@ -185,6 +185,7 @@ pub struct DecryptResponse {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub plaintext: Option<Vec<u8>>,
 }
 
@@ -283,6 +284,7 @@ pub struct EncryptResponse {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ciphertext_blob: Option<Vec<u8>>,
     /// <p>The ID of the key used during encryption.</p>
     #[serde(rename = "KeyId")]
@@ -323,6 +325,7 @@ pub struct GenerateDataKeyResponse {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ciphertext_blob: Option<Vec<u8>>,
     /// <p>The identifier of the CMK under which the data encryption key was generated and encrypted.</p>
     #[serde(rename = "KeyId")]
@@ -335,6 +338,7 @@ pub struct GenerateDataKeyResponse {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub plaintext: Option<Vec<u8>>,
 }
 
@@ -371,6 +375,7 @@ pub struct GenerateDataKeyWithoutPlaintextResponse {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ciphertext_blob: Option<Vec<u8>>,
     /// <p>The identifier of the CMK under which the data encryption key was generated and encrypted.</p>
     #[serde(rename = "KeyId")]
@@ -396,6 +401,7 @@ pub struct GenerateRandomResponse {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub plaintext: Option<Vec<u8>>,
 }
 
@@ -457,6 +463,7 @@ pub struct GetParametersForImportResponse {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub import_token: Option<Vec<u8>>,
     /// <p>The identifier of the CMK to use in a subsequent <a>ImportKeyMaterial</a> request. This is the same CMK specified in the <code>GetParametersForImport</code> request.</p>
     #[serde(rename = "KeyId")]
@@ -473,6 +480,7 @@ pub struct GetParametersForImportResponse {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub public_key: Option<Vec<u8>>,
 }
 
@@ -864,6 +872,7 @@ pub struct ReEncryptResponse {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ciphertext_blob: Option<Vec<u8>>,
     /// <p>Unique identifier of the CMK used to reencrypt the data.</p>
     #[serde(rename = "KeyId")]

--- a/rusoto/services/lambda/src/generated.rs
+++ b/rusoto/services/lambda/src/generated.rs
@@ -412,6 +412,7 @@ pub struct FunctionCode {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub zip_file: Option<Vec<u8>>,
 }
 
@@ -638,6 +639,7 @@ pub struct InvocationRequest {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub payload: Option<Vec<u8>>,
     /// <p>You can use this optional parameter to specify a Lambda function version or alias name. If you specify a function version, the API uses the qualified function ARN to invoke a specific Lambda function. If you specify an alias name, the API uses the alias ARN to invoke the Lambda function version to which the alias points.</p> <p>If you don't provide this parameter, then the API uses unqualified function ARN which results in invocation of the <code>$LATEST</code> version.</p>
     #[serde(rename = "Qualifier")]
@@ -1005,6 +1007,7 @@ pub struct UpdateFunctionCodeRequest {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub zip_file: Option<Vec<u8>>,
 }
 

--- a/rusoto/services/rekognition/src/generated.rs
+++ b/rusoto/services/rekognition/src/generated.rs
@@ -1000,6 +1000,7 @@ pub struct Image {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bytes: Option<Vec<u8>>,
     /// <p>Identifies an S3 object as the image source.</p>
     #[serde(rename = "S3Object")]

--- a/rusoto/services/secretsmanager/src/generated.rs
+++ b/rusoto/services/secretsmanager/src/generated.rs
@@ -76,6 +76,7 @@ pub struct CreateSecretRequest {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub secret_binary: Option<Vec<u8>>,
     /// <p>(Optional) Specifies text data that you want to encrypt and store in this new version of the secret.</p> <p>Either <code>SecretString</code> or <code>SecretBinary</code> must have a value, but not both. They cannot both be empty.</p> <p>If you create a secret by using the Secrets Manager console then Secrets Manager puts the protected secret text in only the <code>SecretString</code> parameter. The Secrets Manager console stores the information as a JSON structure of key/value pairs that the Lambda rotation function knows how to parse.</p> <p>For storing multiple values, we recommend that you use a JSON text string argument and specify key/value pairs. For information on how to format a JSON parameter for the various command line tool environments, see <a href="http://docs.aws.amazon.com/cli/latest/userguide/cli-using-param.html#cli-using-param-json">Using JSON for Parameters</a> in the <i>AWS CLI User Guide</i>. For example:</p> <p> <code>[{"username":"bob"},{"password":"abc123xyz456"}]</code> </p> <p>If your command-line tool or SDK requires quotation marks around the parameter, you should use single quotes to avoid confusion with the double quotes required in the JSON text. </p>
     #[serde(rename = "SecretString")]
@@ -322,6 +323,7 @@ pub struct GetSecretValueResponse {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub secret_binary: Option<Vec<u8>>,
     /// <p>The decrypted part of the protected secret information that was originally provided as a string.</p> <p>If you create this secret by using the Secrets Manager console then only the <code>SecretString</code> parameter contains data. Secrets Manager stores the information as a JSON structure of key/value pairs that the Lambda rotation function knows how to parse.</p> <p>If you store custom information in the secret by using the <a>CreateSecret</a>, <a>UpdateSecret</a>, or <a>PutSecretValue</a> API operations instead of the Secrets Manager console, or by using the <b>Other secret type</b> in the console, then you must code your Lambda rotation function to parse and interpret those values.</p>
     #[serde(rename = "SecretString")]
@@ -438,6 +440,7 @@ pub struct PutSecretValueRequest {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub secret_binary: Option<Vec<u8>>,
     /// <p>Specifies the secret to which you want to add a new version. You can specify either the Amazon Resource Name (ARN) or the friendly name of the secret. The secret must already exist.</p>
     #[serde(rename = "SecretId")]
@@ -672,6 +675,7 @@ pub struct UpdateSecretRequest {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub secret_binary: Option<Vec<u8>>,
     /// <p>Specifies the secret that you want to update or to which you want to add a new version. You can specify either the Amazon Resource Name (ARN) or the friendly name of the secret.</p>
     #[serde(rename = "SecretId")]

--- a/rusoto/services/ssm/src/generated.rs
+++ b/rusoto/services/ssm/src/generated.rs
@@ -4439,6 +4439,7 @@ pub struct MaintenanceWindowLambdaParameters {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub payload: Option<Vec<u8>>,
     /// <p>(Optional) Specify a Lambda function version or alias name. If you specify a function version, the action uses the qualified function ARN to invoke a specific Lambda function. If you specify an alias name, the action uses the alias ARN to invoke the Lambda function version to which the alias points.</p>
     #[serde(rename = "Qualifier")]

--- a/rusoto/services/support/src/generated.rs
+++ b/rusoto/services/support/src/generated.rs
@@ -94,6 +94,7 @@ pub struct Attachment {
         serialize_with = "::rusoto_core::serialization::SerdeBlob::serialize_blob",
         default
     )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<Vec<u8>>,
     /// <p>The name of the attachment file.</p>
     #[serde(rename = "fileName")]

--- a/service_crategen/src/commands/generate/codegen/mod.rs
+++ b/service_crategen/src/commands/generate/codegen/mod.rs
@@ -449,9 +449,11 @@ fn generate_struct_fields<P: GenerateProtocol>(service: &Service,
                             default,
                         )]".to_owned()
                     );
-                } else if !shape.required(member_name) {
-                    lines.push("#[serde(skip_serializing_if=\"Option::is_none\")]".to_owned());
                 }
+            }
+
+            if !shape.required(member_name) {
+                lines.push("#[serde(skip_serializing_if=\"Option::is_none\")]".to_owned());
             }
         }
 


### PR DESCRIPTION
At present:

```rust
use rusoto_dynamodb::AttributeValue;

AttributeValue{ bool: Some(true, ..Default::default() }
// serializes as {"B":null,"BOOL":true}

AttributeValue{ n: Some("1234".to_string()), ..Default::default() }
// serializes as {"B":null,"N":"1234"}

AttributeValue{ s: Some("foo".to_string()), ..Default::default() }
// serializes as {"B":null,"S":"foo"}
```

The code generator was emitting `#[serde]` attributes for blobs, and for optional values, but it wasn't specifically handling optional blobs.

With this changeset, [every field in `rusoto_dynamodb::AttributeValue`](https://github.com/rusoto/rusoto/blob/4a26a14f7bca95ec378b0ca3aed3715e454716c9/rusoto/services/dynamodb/src/generated.rs#L44-L90) uses `skip_serializing_if`, thus:

```rust
AttributeValue{ bool: Some(true, ..Default::default() }
// serializes as {"BOOL":true}

AttributeValue{ n: Some("1234".to_string()), ..Default::default() }
// serializes as {"N":"1234"}

AttributeValue{ s: Some("foo".to_string()), ..Default::default() }
// serializes as {"S":"foo"}
```

The first commit adds failing tests, the second commit updates the code generator, the third commit commits the updated code, and the fourth commit updates the changelog.