### PR TITLE
updating hyper to 0.12.16 and increasing http request buffer size to 2MB

### DIFF
--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -26,7 +26,7 @@ rustc_version = "0.2.1"
 [dependencies]
 futures = "0.1.16"
 hmac = "0.5.0"
-hyper = "0.12.16"
+hyper = "0.12"
 hyper-tls = { version = "0.3.0", optional = true }
 hyper-rustls = { version = "0.14.0", optional = true }
 lazy_static = "1.0"

--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -26,7 +26,7 @@ rustc_version = "0.2.1"
 [dependencies]
 futures = "0.1.16"
 hmac = "0.5.0"
-hyper = "0.12.0"
+hyper = "0.12.16"
 hyper-tls = { version = "0.3.0", optional = true }
 hyper-rustls = { version = "0.14.0", optional = true }
 lazy_static = "1.0"

--- a/rusoto/core/src/lib.rs
+++ b/rusoto/core/src/lib.rs
@@ -52,7 +52,7 @@ pub mod xmlerror;
 pub mod xmlutil;
 
 pub use credential::{ProvideAwsCredentials, DefaultCredentialsProvider, CredentialsError};
-pub use request::{DispatchSignedRequest, HttpClient, HttpDispatchError};
+pub use request::{DispatchSignedRequest, HttpConfig, HttpClient, HttpDispatchError};
 pub use region::Region;
 pub use future::RusotoFuture;
 pub use stream::ByteStream;

--- a/rusoto/core/src/request.rs
+++ b/rusoto/core/src/request.rs
@@ -372,6 +372,11 @@ pub struct HttpConfig {
 }
 
 impl HttpConfig {
+
+    /// Create a new HttpConfig
+    pub fn new() -> HttpConfig {
+        HttpConfig { read_buf_size: None }
+    }
     /// Sets the size of the read buffer for inbound data
     /// A larger buffer size might result in better performance
     /// by requiring fewer copies out of the socket buffer. 

--- a/rusoto/core/src/request.rs
+++ b/rusoto/core/src/request.rs
@@ -33,6 +33,8 @@ use log::Level::Debug;
 use signature::{SignedRequest, SignedRequestPayload};
 use stream::ByteStream;
 
+const READ_BUF_SIZE : usize = 1024 * 1024 * 2;
+
 // Pulls in the statically generated rustc version.
 include!(concat!(env!("OUT_DIR"), "/user_agent_vars.rs"));
 
@@ -329,6 +331,7 @@ where
     /// Allows for a custom connector to be used with the HttpClient
     pub fn from_connector(connector: C) -> Self {
         let inner = HyperClient::builder()
+            .http1_read_buf_exact_size(READ_BUF_SIZE)
             .build(connector);
 
         HttpClient {

--- a/rusoto/core/src/request.rs
+++ b/rusoto/core/src/request.rs
@@ -33,8 +33,6 @@ use log::Level::Debug;
 use signature::{SignedRequest, SignedRequestPayload};
 use stream::ByteStream;
 
-const READ_BUF_SIZE : usize = 1024 * 1024 * 2;
-
 // Pulls in the statically generated rustc version.
 include!(concat!(env!("OUT_DIR"), "/user_agent_vars.rs"));
 
@@ -321,6 +319,25 @@ impl HttpClient {
 
         Ok(Self::from_connector(connector))
     }
+
+    /// Create a tls-enabled http client.
+    pub fn new_with_config(config: HttpConfig) -> Result<Self, TlsError> {
+        #[cfg(feature="native-tls")]
+        let connector = match HttpsConnector::new(4) {
+            Ok(connector) => connector,
+            Err(tls_error) => {
+                return Err(TlsError {
+                    message: format!("Couldn't create NativeTlsClient: {}", tls_error),
+                })
+            }
+        };
+
+        #[cfg(feature="rustls")]
+        let connector = HttpsConnector::new(4);
+
+        Ok(Self::from_connector_with_config(connector, config))
+    }
+
 }
 
 impl<C> HttpClient<C>
@@ -329,14 +346,37 @@ where
     C::Future: 'static
 {
     /// Allows for a custom connector to be used with the HttpClient
-    pub fn from_connector(connector: C) -> Self {
-        let inner = HyperClient::builder()
-            .http1_read_buf_exact_size(READ_BUF_SIZE)
-            .build(connector);
+    pub fn from_connector(connector:C) -> Self {
+        let inner = HyperClient::builder().build(connector);
+        HttpClient {
+            inner
+        }
+    }
+
+    /// Allows for a custom connector to be used with the HttpClient
+    /// with extra configuration options
+    pub fn from_connector_with_config(connector: C, config: HttpConfig) -> Self {
+        let mut builder = HyperClient::builder();
+        config.read_buf_size.map(|sz| builder.http1_read_buf_exact_size(sz));
+        let inner = builder.build(connector);
 
         HttpClient {
             inner
         }
+    }
+}
+
+/// Configuration options for the HTTP Client
+pub struct HttpConfig {
+    read_buf_size: Option<usize>,
+}
+
+impl HttpConfig {
+    /// Sets the size of the read buffer for inbound data
+    /// A larger buffer size might result in better performance
+    /// by requiring fewer copies out of the socket buffer. 
+    pub fn read_buf_size(&mut self, sz: usize) {
+        self.read_buf_size = Some(sz);
     }
 }
 


### PR DESCRIPTION
Updated hyper dependency to v0.12.16 and increased the http request buffer size to 2MB. 
