### PR TITLE
Fix a malformed SNS Publish API request when it has message attributes

### DIFF
--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -1638,7 +1638,7 @@ impl MessageAttributeMapSerializer {
         obj: &::std::collections::HashMap<String, MessageAttributeValue>,
     ) {
         for (index, (key, value)) in obj.iter().enumerate() {
-            let prefix = format!("{}.{}", name, index + 1);
+            let prefix = format!("{}.entry.{}", name, index + 1);
             params.put(&format!("{}.{}", prefix, "Name"), &key);
             MessageAttributeValueSerializer::serialize(
                 params,

--- a/service_crategen/src/commands/generate/codegen/query.rs
+++ b/service_crategen/src/commands/generate/codegen/query.rs
@@ -197,10 +197,18 @@ fn list_member_format(service: &Service, flattened: bool) -> String {
 fn generate_map_serializer(service: &Service, shape: &Shape) -> String {
     let mut parts = Vec::new();
 
+    let prefix_snip: String;
+    if service.service_id() == Some("SNS") && shape.value.is_some() && shape.value.as_ref().unwrap().shape == "MessageAttributeValue" {
+        prefix_snip = "let prefix = format!(\"{}.entry.{}\", name, index+1);".to_string();
+    } else {
+        prefix_snip = "let prefix = format!(\"{}.{}\", name, index+1);".to_string();
+    }
+
     // the key is always a string type
     parts.push(format!("for (index, (key, value)) in obj.iter().enumerate() {{
-            let prefix = format!(\"{{}}.{{}}\", name, index+1);
+            {prefix_snip}
             params.put(&format!(\"{{}}.{{}}\", prefix, \"{key_name}\"), &key);",
+            prefix_snip = prefix_snip,
             key_name = key_name(service, shape),
         ));
 


### PR DESCRIPTION
I found a malformed request when I make an SNS Publish API request with message attributes. It can be reproduced by following code.

https://github.com/mozamimy/rusoto_test

```
$ TOPIC_ARN=arn:aws:sns:ap-northeast-1:1234567890:xxxxxxxxxx RUST_LOG=debug cargo run

# snip

[2018-12-02T03:42:34Z DEBUG rusoto_core::request] Full request:
 method: POST
 final_uri: https://sns.ap-northeast-1.amazonaws.com/
 payload: Action=Publish&Message=test&MessageAttributes.1.Name=Foo&MessageAttributes.1.Value.DataType=String&MessageAttributes.1.Value.StringValue=Bar&TopicArn=arn%3Aaws%3Asns%3Aap-northeast-1%3A1234567890%3Axxxxxxxxxx&Version=2010-03-31

# snip 

[2018-12-02T03:42:34Z DEBUG hyper::client::pool] pooling idle connection for "https://sns.ap-northeast-1.amazonaws.com"
Unknown(BufferedHttpResponse { status: 400, body: [60, 69, 114, 114, 111, 114, 82, 101, 115, 112, 111, 110, 115, 101, 32, 120, 109, 108, 110, 115, 61, 34, 104, 116, 116, 112, 58, 47, 47, 115, 110, 115, 46, 97, 109, 97, 122, 111, 110, 97, 119, 115, 46, 99, 111, 109, 47, 100, 111, 99, 47, 50, 48, 49, 48, 45, 48, 51, 45, 51, 49, 47, 34, 62, 10, 32, 32, 60, 69, 114, 114, 111, 114, 62, 10, 32, 32, 32, 32, 60, 84, 121, 112, 101, 62, 83, 101, 110, 100, 101, 114, 60, 47, 84, 121, 112, 101, 62, 10, 32, 32, 32, 32, 60, 67, 111, 100, 101, 62, 77, 97, 108, 102, 111, 114, 109, 101, 100, 73, 110, 112, 117, 116, 60, 47, 67, 111, 100, 101, 62, 10, 32, 32, 32, 32, 60, 77, 101, 115, 115, 97, 103, 101, 62, 84, 111, 112, 32, 108, 101, 118, 101, 108, 32, 101, 108, 101, 109, 101, 110, 116, 32, 109, 97, 121, 32, 110, 111, 116, 32, 98, 101, 32, 116, 114, 101, 97, 116, 101, 100, 32, 97, 115, 32, 97, 32, 108, 105, 115, 116, 60, 47, 77, 101, 115, 115, 97, 103, 101, 62, 10, 32, 32, 60, 47, 69, 114, 114, 111, 114, 62, 10, 32, 32, 60, 82, 101, 113, 117, 101, 115, 116, 73, 100, 62, 50, 101, 49, 49, 57, 102, 101, 53, 45, 53, 49, 55, 55, 45, 53, 54, 53, 50, 45, 57, 97, 99, 99, 45, 99, 98, 57, 56, 48, 55, 57, 100, 101, 97, 54, 98, 60, 47, 82, 101, 113, 117, 101, 115, 116, 73, 100, 62, 10, 60, 47, 69, 114, 114, 111, 114, 82, 101, 115, 112, 111, 110, 115, 101, 62, 10], headers: Headers({"x-amzn-requestid": "2e119fe5-5177-5652-9acc-cb98079dea6b", "content-type": "text/xml", "content-length": "291", "date": "Sun, 02 Dec 2018 03:42:34 GMT"}) })
```

According to [Publish - Amazon Simple Notification Service](https://docs.aws.amazon.com/ja_jp/sns/latest/api/API_Publish.html), the payload shoud be like following snippet.

```
 payload: Action=Publish&Message=test&MessageAttributes.entry.1.Name=Foo&MessageAttributes.entry.1.Value.DataType=String&MessageAttributes.entry.1.Value.StringValue=Bar&TopicArn=arn%3Aaws%3Asns%3Aap-northeast-1%3A1234567890%3Axxxxxxxxxx&Version=2010-03-31
```

Therefore, I'm trying to create a patch which fixes it. I'm not used to rusoto code generating codes, so I'm unconfident that this change is preferred to fix the problem. It may be little shortsighted and a dirty hack..