### PR TITLE
Fix #1256: duplicated Content-Type header in SageMaker Runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Rusoto changes
 
 ## [Unreleased]
+- Fix duplicated Content-Type header in SageMaker Runtime
 - Switch from `try!` to `?` operator
-
 - Remove unneeded muts in Glacier codegen
 - Add Eu-North-1 Region
 - Fix bug in SNS publish message action

--- a/rusoto/services/sagemaker-runtime/src/generated.rs
+++ b/rusoto/services/sagemaker-runtime/src/generated.rs
@@ -112,17 +112,17 @@ impl InvokeEndpointError {
 
             match error_type {
                 "InternalFailure" => {
-                    return InvokeEndpointError::InternalFailure(String::from(error_message));
+                    return InvokeEndpointError::InternalFailure(String::from(error_message))
                 }
                 "ModelError" => return InvokeEndpointError::ModelError(String::from(error_message)),
                 "ServiceUnavailable" => {
-                    return InvokeEndpointError::ServiceUnavailable(String::from(error_message));
+                    return InvokeEndpointError::ServiceUnavailable(String::from(error_message))
                 }
                 "ValidationError" => {
-                    return InvokeEndpointError::ValidationError(String::from(error_message));
+                    return InvokeEndpointError::ValidationError(String::from(error_message))
                 }
                 "ValidationException" => {
-                    return InvokeEndpointError::Validation(error_message.to_string());
+                    return InvokeEndpointError::Validation(error_message.to_string())
                 }
                 _ => {}
             }

--- a/rusoto/services/sagemaker-runtime/src/generated.rs
+++ b/rusoto/services/sagemaker-runtime/src/generated.rs
@@ -112,17 +112,17 @@ impl InvokeEndpointError {
 
             match error_type {
                 "InternalFailure" => {
-                    return InvokeEndpointError::InternalFailure(String::from(error_message))
+                    return InvokeEndpointError::InternalFailure(String::from(error_message));
                 }
                 "ModelError" => return InvokeEndpointError::ModelError(String::from(error_message)),
                 "ServiceUnavailable" => {
-                    return InvokeEndpointError::ServiceUnavailable(String::from(error_message))
+                    return InvokeEndpointError::ServiceUnavailable(String::from(error_message));
                 }
                 "ValidationError" => {
-                    return InvokeEndpointError::ValidationError(String::from(error_message))
+                    return InvokeEndpointError::ValidationError(String::from(error_message));
                 }
                 "ValidationException" => {
-                    return InvokeEndpointError::Validation(error_message.to_string())
+                    return InvokeEndpointError::Validation(error_message.to_string());
                 }
                 _ => {}
             }
@@ -226,7 +226,9 @@ impl SageMakerRuntime for SageMakerRuntimeClient {
         );
 
         let mut request = SignedRequest::new("POST", "sagemaker", &self.region, &request_uri);
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
+        if input.content_type.is_none() {
+            request.set_content_type("application/x-amz-json-1.1".to_owned());
+        }
 
         request.set_endpoint_prefix("runtime.sagemaker".to_string());
         let encoded = Some(input.body.to_owned());

--- a/service_crategen/src/commands/generate/codegen/rest_json.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_json.rs
@@ -92,7 +92,7 @@ impl GenerateProtocol for RestJsonGenerator {
                 ).unwrap_or_else(|| "".to_string()),
                 load_payload = generate_payload(service, input_shape).unwrap_or_else(|| "".to_string()),
                 load_params = rest_request_generator::generate_params_loading_string(service, operation).unwrap_or_else(|| "".to_string()),
-                default_headers = generate_default_headers(service).unwrap_or_else(|| "".to_string()),
+                default_headers = generate_default_headers(service),
                 set_headers = generate_headers(service).unwrap_or_else(|| "".to_string()),
             )?
         }
@@ -146,13 +146,14 @@ fn generate_headers(service: &Service) -> Option<String> {
 }
 
 // SageMaker Runtime allows to overwrite content-type
-fn generate_default_headers(service: &Service) -> Option<String> {
+fn generate_default_headers(service: &Service) -> String {
     if service.full_name() == "Amazon SageMaker Runtime" {
-        return Some("if input.content_type.is_none() {
-                         request.set_content_type(\"application/x-amz-json-1.1\".to_owned());
-                     }".to_string());
+        return "if input.content_type.is_none() {
+                    request.set_content_type(\"application/x-amz-json-1.1\".to_owned());
+                }"
+                .to_string();
     }
-    Some("request.set_content_type(\"application/x-amz-json-1.1\".to_owned());".to_string())
+    "request.set_content_type(\"application/x-amz-json-1.1\".to_owned());".to_string()
 }
 
 // IoT has an endpoint_prefix and a signing_name that differ


### PR DESCRIPTION
As I described in #1256, setting `rusoto_sagemaker_runtime::InvokeEndpointInput.content_type` produces two `content-type` headers which is not correct.