### PR TITLE
Mock dispatcher can simulate communication errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Remove unneeded muts in Glacier codegen
 - Add Eu-North-1 Region
 - Fix bug in SNS publish message action
+- Mock can simulate communications errors
 
 ## [0.36.0] - 2018-12-04
 

--- a/rusoto/core/src/request.rs
+++ b/rusoto/core/src/request.rs
@@ -163,10 +163,17 @@ impl HttpResponse {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 /// An error produced when invalid request types are sent.
 pub struct HttpDispatchError {
     message: String,
+}
+
+impl HttpDispatchError {
+  /// Construct a new HttpDispatchError for testing purposes
+  pub fn new(message: String) -> HttpDispatchError {
+    HttpDispatchError { message: message }
+  }
 }
 
 impl Error for HttpDispatchError {


### PR DESCRIPTION
When a service encounters network errors, it will return HttpDispatchError. I want my application to do retries and to manage a queue of Cloudwatch metrics to submit. `rusoto_mock` suits testing this use case quite well.

Since many services have "batch" API calls (e.g. ECR, XRay, Cloudwatch), I think a project using Rusoto will frequently end up with a vector of submissions to manage and you need to ensure that you retry properly on some errors and fail on others, popping/retaining your submissions accordingly. In my case, I'm trying to submit metrics to Cloudwatch.

Notes:
- In order to be able to actually use `with_dispatch_error()` you need to construct an `HttpDispatchError`. I have thus introduced a `new()` method, but perhaps a `From<String>` would be more appropriate?