### PR TITLE
Add special case decoding for IAM policy documents

### DIFF
--- a/rusoto/core/src/signature.rs
+++ b/rusoto/core/src/signature.rs
@@ -686,7 +686,8 @@ fn encode_uri_strict(uri: &str) -> String {
 }
 
 #[inline]
-fn decode_uri(uri: &str) -> String {
+#[doc(hidden)]
+pub fn decode_uri(uri: &str) -> String {
     let decoder = percent_decode(uri.as_bytes());
     if let Ok(decoded) = decoder.decode_utf8() {
         decoded.to_string()

--- a/rusoto/services/acm-pca/src/generated.rs
+++ b/rusoto/services/acm-pca/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/acm/src/generated.rs
+++ b/rusoto/services/acm/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/alexaforbusiness/src/generated.rs
+++ b/rusoto/services/alexaforbusiness/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/apigateway/src/generated.rs
+++ b/rusoto/services/apigateway/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/application-autoscaling/src/generated.rs
+++ b/rusoto/services/application-autoscaling/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/appstream/src/generated.rs
+++ b/rusoto/services/appstream/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/appsync/src/generated.rs
+++ b/rusoto/services/appsync/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/athena/src/generated.rs
+++ b/rusoto/services/athena/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/autoscaling-plans/src/generated.rs
+++ b/rusoto/services/autoscaling-plans/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/autoscaling/src/generated.rs
+++ b/rusoto/services/autoscaling/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/batch/src/generated.rs
+++ b/rusoto/services/batch/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/budgets/src/generated.rs
+++ b/rusoto/services/budgets/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/ce/src/generated.rs
+++ b/rusoto/services/ce/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/cloud9/src/generated.rs
+++ b/rusoto/services/cloud9/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/clouddirectory/src/generated.rs
+++ b/rusoto/services/clouddirectory/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/cloudformation/src/generated.rs
+++ b/rusoto/services/cloudformation/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/cloudhsm/src/generated.rs
+++ b/rusoto/services/cloudhsm/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/cloudhsmv2/src/generated.rs
+++ b/rusoto/services/cloudhsmv2/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/cloudsearch/src/generated.rs
+++ b/rusoto/services/cloudsearch/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/cloudsearchdomain/src/generated.rs
+++ b/rusoto/services/cloudsearchdomain/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/cloudtrail/src/generated.rs
+++ b/rusoto/services/cloudtrail/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/cloudwatch/src/generated.rs
+++ b/rusoto/services/cloudwatch/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/codebuild/src/generated.rs
+++ b/rusoto/services/codebuild/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/codecommit/src/generated.rs
+++ b/rusoto/services/codecommit/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/codedeploy/src/generated.rs
+++ b/rusoto/services/codedeploy/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/codepipeline/src/generated.rs
+++ b/rusoto/services/codepipeline/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/codestar/src/generated.rs
+++ b/rusoto/services/codestar/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/cognito-identity/src/generated.rs
+++ b/rusoto/services/cognito-identity/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/cognito-idp/src/generated.rs
+++ b/rusoto/services/cognito-idp/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/cognito-sync/src/generated.rs
+++ b/rusoto/services/cognito-sync/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/comprehend/src/generated.rs
+++ b/rusoto/services/comprehend/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/config/src/generated.rs
+++ b/rusoto/services/config/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/connect/src/generated.rs
+++ b/rusoto/services/connect/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/cur/src/generated.rs
+++ b/rusoto/services/cur/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/datapipeline/src/generated.rs
+++ b/rusoto/services/datapipeline/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/dax/src/generated.rs
+++ b/rusoto/services/dax/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/devicefarm/src/generated.rs
+++ b/rusoto/services/devicefarm/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/directconnect/src/generated.rs
+++ b/rusoto/services/directconnect/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/discovery/src/generated.rs
+++ b/rusoto/services/discovery/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/dms/src/generated.rs
+++ b/rusoto/services/dms/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/ds/src/generated.rs
+++ b/rusoto/services/ds/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/dynamodb/src/generated.rs
+++ b/rusoto/services/dynamodb/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/dynamodbstreams/src/generated.rs
+++ b/rusoto/services/dynamodbstreams/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/ec2/src/generated.rs
+++ b/rusoto/services/ec2/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/ecr/src/generated.rs
+++ b/rusoto/services/ecr/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/ecs/src/generated.rs
+++ b/rusoto/services/ecs/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/efs/src/generated.rs
+++ b/rusoto/services/efs/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/eks/src/generated.rs
+++ b/rusoto/services/eks/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/elasticache/src/generated.rs
+++ b/rusoto/services/elasticache/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/elasticbeanstalk/src/generated.rs
+++ b/rusoto/services/elasticbeanstalk/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/elastictranscoder/src/generated.rs
+++ b/rusoto/services/elastictranscoder/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/elb/src/generated.rs
+++ b/rusoto/services/elb/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/elbv2/src/generated.rs
+++ b/rusoto/services/elbv2/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/emr/src/generated.rs
+++ b/rusoto/services/emr/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/events/src/generated.rs
+++ b/rusoto/services/events/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/firehose/src/generated.rs
+++ b/rusoto/services/firehose/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/fms/src/generated.rs
+++ b/rusoto/services/fms/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/gamelift/src/generated.rs
+++ b/rusoto/services/gamelift/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/glacier/src/generated.rs
+++ b/rusoto/services/glacier/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/glue/src/generated.rs
+++ b/rusoto/services/glue/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/greengrass/src/generated.rs
+++ b/rusoto/services/greengrass/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/guardduty/src/generated.rs
+++ b/rusoto/services/guardduty/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/health/src/generated.rs
+++ b/rusoto/services/health/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/iam/src/generated.rs
+++ b/rusoto/services/iam/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 
@@ -8615,7 +8618,7 @@ impl PolicyDocumentTypeDeserializer {
         stack: &mut T,
     ) -> Result<String, XmlParseError> {
         start_element(tag_name, stack)?;
-        let obj = characters(stack)?;
+        let obj = decode_uri(&characters(stack)?);
         end_element(tag_name, stack)?;
 
         Ok(obj)

--- a/rusoto/services/importexport/src/generated.rs
+++ b/rusoto/services/importexport/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/inspector/src/generated.rs
+++ b/rusoto/services/inspector/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/iot-data/src/generated.rs
+++ b/rusoto/services/iot-data/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/iot-jobs-data/src/generated.rs
+++ b/rusoto/services/iot-jobs-data/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/iot/src/generated.rs
+++ b/rusoto/services/iot/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/iot1click-devices/src/generated.rs
+++ b/rusoto/services/iot1click-devices/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/iot1click-projects/src/generated.rs
+++ b/rusoto/services/iot1click-projects/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/iotanalytics/src/generated.rs
+++ b/rusoto/services/iotanalytics/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/kinesis-video-archived-media/src/generated.rs
+++ b/rusoto/services/kinesis-video-archived-media/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/kinesis-video-media/src/generated.rs
+++ b/rusoto/services/kinesis-video-media/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/kinesis/src/generated.rs
+++ b/rusoto/services/kinesis/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/kinesisanalytics/src/generated.rs
+++ b/rusoto/services/kinesisanalytics/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/kinesisvideo/src/generated.rs
+++ b/rusoto/services/kinesisvideo/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/kms/src/generated.rs
+++ b/rusoto/services/kms/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/lambda/src/generated.rs
+++ b/rusoto/services/lambda/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/lex-models/src/generated.rs
+++ b/rusoto/services/lex-models/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/lex-runtime/src/generated.rs
+++ b/rusoto/services/lex-runtime/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/lightsail/src/generated.rs
+++ b/rusoto/services/lightsail/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/logs/src/generated.rs
+++ b/rusoto/services/logs/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/machinelearning/src/generated.rs
+++ b/rusoto/services/machinelearning/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/macie/src/generated.rs
+++ b/rusoto/services/macie/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/marketplace-entitlement/src/generated.rs
+++ b/rusoto/services/marketplace-entitlement/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/marketplacecommerceanalytics/src/generated.rs
+++ b/rusoto/services/marketplacecommerceanalytics/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/mediaconvert/src/generated.rs
+++ b/rusoto/services/mediaconvert/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/medialive/src/generated.rs
+++ b/rusoto/services/medialive/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/mediapackage/src/generated.rs
+++ b/rusoto/services/mediapackage/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/mediastore/src/generated.rs
+++ b/rusoto/services/mediastore/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/mediatailor/src/generated.rs
+++ b/rusoto/services/mediatailor/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/meteringmarketplace/src/generated.rs
+++ b/rusoto/services/meteringmarketplace/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/mgh/src/generated.rs
+++ b/rusoto/services/mgh/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/mobile/src/generated.rs
+++ b/rusoto/services/mobile/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/mq/src/generated.rs
+++ b/rusoto/services/mq/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/mturk/src/generated.rs
+++ b/rusoto/services/mturk/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/neptune/src/generated.rs
+++ b/rusoto/services/neptune/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/opsworks/src/generated.rs
+++ b/rusoto/services/opsworks/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/opsworkscm/src/generated.rs
+++ b/rusoto/services/opsworkscm/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/organizations/src/generated.rs
+++ b/rusoto/services/organizations/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/pi/src/generated.rs
+++ b/rusoto/services/pi/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/polly/src/generated.rs
+++ b/rusoto/services/polly/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/pricing/src/generated.rs
+++ b/rusoto/services/pricing/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/rds/src/generated.rs
+++ b/rusoto/services/rds/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/redshift/src/generated.rs
+++ b/rusoto/services/redshift/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/rekognition/src/generated.rs
+++ b/rusoto/services/rekognition/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/resource-groups/src/generated.rs
+++ b/rusoto/services/resource-groups/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/resourcegroupstaggingapi/src/generated.rs
+++ b/rusoto/services/resourcegroupstaggingapi/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/route53/src/generated.rs
+++ b/rusoto/services/route53/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/route53domains/src/generated.rs
+++ b/rusoto/services/route53domains/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/sagemaker-runtime/src/generated.rs
+++ b/rusoto/services/sagemaker-runtime/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/sagemaker/src/generated.rs
+++ b/rusoto/services/sagemaker/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/sdb/src/generated.rs
+++ b/rusoto/services/sdb/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/secretsmanager/src/generated.rs
+++ b/rusoto/services/secretsmanager/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/serverlessrepo/src/generated.rs
+++ b/rusoto/services/serverlessrepo/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/servicecatalog/src/generated.rs
+++ b/rusoto/services/servicecatalog/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/servicediscovery/src/generated.rs
+++ b/rusoto/services/servicediscovery/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/ses/src/generated.rs
+++ b/rusoto/services/ses/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/shield/src/generated.rs
+++ b/rusoto/services/shield/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/sms/src/generated.rs
+++ b/rusoto/services/sms/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/snowball/src/generated.rs
+++ b/rusoto/services/snowball/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/sqs/src/generated.rs
+++ b/rusoto/services/sqs/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/ssm/src/generated.rs
+++ b/rusoto/services/ssm/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/stepfunctions/src/generated.rs
+++ b/rusoto/services/stepfunctions/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/storagegateway/src/generated.rs
+++ b/rusoto/services/storagegateway/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/sts/src/generated.rs
+++ b/rusoto/services/sts/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/support/src/generated.rs
+++ b/rusoto/services/support/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/swf/src/generated.rs
+++ b/rusoto/services/swf/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/transcribe/src/generated.rs
+++ b/rusoto/services/transcribe/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/translate/src/generated.rs
+++ b/rusoto/services/translate/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/waf-regional/src/generated.rs
+++ b/rusoto/services/waf-regional/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/waf/src/generated.rs
+++ b/rusoto/services/waf/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/workdocs/src/generated.rs
+++ b/rusoto/services/workdocs/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/workmail/src/generated.rs
+++ b/rusoto/services/workmail/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/workspaces/src/generated.rs
+++ b/rusoto/services/workspaces/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/rusoto/services/xray/src/generated.rs
+++ b/rusoto/services/xray/src/generated.rs
@@ -21,6 +21,9 @@ use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
 use rusoto_core::{Client, RusotoFuture};
 
+#[allow(unused_imports)]
+use rusoto_core::signature::decode_uri;
+
 use rusoto_core::credential::{CredentialsError, ProvideAwsCredentials};
 use rusoto_core::request::HttpDispatchError;
 

--- a/service_crategen/src/commands/generate/codegen/mod.rs
+++ b/service_crategen/src/commands/generate/codegen/mod.rs
@@ -137,6 +137,9 @@ where
         use rusoto_core::region;
         use rusoto_core::{{Client, RusotoFuture}};
 
+        #[allow(unused_imports)]
+        use rusoto_core::signature::decode_uri;
+
         use rusoto_core::request::HttpDispatchError;
         use rusoto_core::credential::{{CredentialsError, ProvideAwsCredentials}};
     "

--- a/service_crategen/src/commands/generate/codegen/xml_payload_parser.rs
+++ b/service_crategen/src/commands/generate/codegen/xml_payload_parser.rs
@@ -245,7 +245,12 @@ fn generate_deserializer_body(name: &str, shape: &Shape, service: &Service) -> S
         ShapeType::List => generate_list_deserializer(shape, service),
         ShapeType::Map => generate_map_deserializer(shape),
         ShapeType::Structure => generate_struct_deserializer(name, service, shape),
-        _ => generate_primitive_deserializer(shape),
+
+        // For mysterious historical reasons, all policies returned by the IAM APIs are URI-encoded, and
+        // they all use this shape name so we're able to match on this safely. botocore does the same
+        // thing to ensure a consistent user experience. Other services that handle IAM policies don't
+        // need the same treatment.
+        _ => generate_primitive_deserializer(shape, name == "PolicyDocumentType"),
     }
 }
 
@@ -370,8 +375,9 @@ fn generate_map_deserializer(shape: &Shape) -> String {
     }
 }
 
-fn generate_primitive_deserializer(shape: &Shape) -> String {
+fn generate_primitive_deserializer(shape: &Shape, percent_decode: bool) -> String {
     let statement = match shape.shape_type {
+        ShapeType::String if percent_decode => "decode_uri(&characters(stack)?)",
         ShapeType::String | ShapeType::Timestamp => "characters(stack)?",
         ShapeType::Integer | ShapeType::Long => {
             "i64::from_str(characters(stack)?.as_ref()).unwrap()"


### PR DESCRIPTION
This mirrors what botocore does to normalize IAM API responses and saves users from needing to URI-decode every policy its actions return.

When I reran the code generator, the diffs were super noisy because I think someone made a change to its semicolon behavior without committing those diffs back to master, so I peeled out only the codegen diffs that my change caused for this PR. Let me know if I should do it differently! This is actually my first ever rust PR 😄 

Tested manually, but I was thinking that depending on your test environment I could query for a managed policy version document and make sure it looks like JSON rather than a mess of percent signs. Let me know if you'd like me to add such a test.

Fixes #1287

### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Add special case for percent-decoding policy documents returned by the IAM APIs