### PR TITLE
update rustfmt install instructions

### DIFF
--- a/service_crategen/README.md
+++ b/service_crategen/README.md
@@ -8,12 +8,12 @@ In order to run the service generator, first make sure that the botocore submodu
 $ git submodule update --init
 ```
 
-The service generator uses the `stable` version of `rustfmt` to format the generated code nicely.
+The service generator uses the `stable` version of [`rustfmt`](https://github.com/rust-lang/rustfmt) to format the generated code nicely.
 
 Install the `rustfmt` component via `rustup`:
 
 ```bash
-$ rustup component add --toolchain stable rustfmt-preview
+$ rustup component add --toolchain stable rustfmt
 ```
 
 From the `service_crategen` directory, call:


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Note sure if this is worth calling out but this change updates the install instructions for rustfmt so contributors don't accidentally install and run and old version. This instructions reflect stabilizations that happened around [this time](https://blog.rust-lang.org/2018/12/17/Rust-2018-dev-tools.html#rustfmt)
