### PR TITLE
integration tests for newer services

### DIFF
--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -575,6 +575,22 @@ path = "../rusoto/services/workspaces"
 optional = true
 path = "../rusoto/services/xray"
 
+[dependencies.rusoto_amplify]
+optional = true
+path = "../rusoto/services/amplify"
+
+[dependencies.rusoto_apigatewaymanagementapi]
+optional = true
+path = "../rusoto/services/apigatewaymanagementapi"
+
+[dependencies.rusoto_apigatewayv2]
+optional = true
+path = "../rusoto/services/apigatewayv2"
+
+[dependencies.rusoto_ram]
+optional = true
+path = "../rusoto/services/ram"
+
 [dev-dependencies]
 env_logger = "0.5"
 futures = "0.1.16"
@@ -722,7 +738,11 @@ all = [
 		"workdocs",
 		"workmail",
 		"workspaces",
-		"xray"
+		"xray",
+		"amplify",
+		"apigatewaymanagementapi",
+		"apigatewayv2",
+		"ram"
 	]
 acm = ["rusoto_acm"]
 acm-pca = ["rusoto_acm_pca"]
@@ -862,6 +882,10 @@ workmail = ["rusoto_workmail"]
 workspaces = ["rusoto_workspaces"]
 workdocs = ["rusoto_workdocs"]
 xray = ["rusoto_xray"]
+amplify = ["rusoto_amplify"]
+apigatewaymanagementapi = ["rusoto_apigatewaymanagementapi"]
+apigatewayv2 = ["rusoto_apigatewayv2"]
+ram = ["rusoto_ram"]
 nightly-testing = ["rusoto_core/nightly-testing"]
 disable_ceph_unsupported = []
 disable_minio_unsupported = []

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -14,6 +14,12 @@ Specific service tests can be run using their feature flags.  To run the S3 test
 
 To run multiple service tests, add the feature flags: `cargo test --features "ecs ec2"`.
 
+There will be a lot of tests in the cargo test output. To limit this output when targetting runs of specific tests you may wish to you cargo tests's `--test <testname>` filter. You can use this flag more than once for more than one test.
+
+```sh
+cargo test --features "amplify ram" --test amplify --test ram -- --nocapture
+```
+
 #### Running S3 tests against Minio or Ceph
 
 Dependencies:

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -14,7 +14,7 @@ Specific service tests can be run using their feature flags.  To run the S3 test
 
 To run multiple service tests, add the feature flags: `cargo test --features "ecs ec2"`.
 
-There will be a lot of tests in the cargo test output. To limit this output when targetting runs of specific tests you may wish to you cargo tests's `--test <testname>` filter. You can use this flag more than once for more than one test.
+There will be a lot of tests in the cargo test output. To limit this output when targetting runs of specific tests you may wish to use cargo test's `--test <testname>` filter. You can use this flag more than once for more than one test.
 
 ```sh
 cargo test --features "amplify ram" --test amplify --test ram -- --nocapture

--- a/integration_tests/tests/amplify.rs
+++ b/integration_tests/tests/amplify.rs
@@ -1,0 +1,14 @@
+#![cfg(feature = "amplify")]
+
+extern crate rusoto_amplify;
+extern crate rusoto_core;
+
+use rusoto_amplify::{Amplify, AmplifyClient};
+use rusoto_core::Region;
+
+#[test]
+fn should_work() {
+    let client = AmplifyClient::new(Region::UsEast1);
+    let response = client.list_apps(Default::default()).sync();
+    println!("response is {:#?}", response);
+}

--- a/integration_tests/tests/amplify.rs
+++ b/integration_tests/tests/amplify.rs
@@ -9,6 +9,9 @@ use rusoto_core::Region;
 #[test]
 fn should_work() {
     let client = AmplifyClient::new(Region::UsEast1);
-    let response = client.list_apps(Default::default()).sync();
+    let response = client
+        .list_apps(Default::default())
+        .sync()
+        .expect("expected an ok response");
     println!("response is {:#?}", response);
 }

--- a/integration_tests/tests/apigatewaymanagementapi.rs
+++ b/integration_tests/tests/apigatewaymanagementapi.rs
@@ -1,0 +1,32 @@
+#![cfg(feature = "apigatewaymanagementapi")]
+
+extern crate rusoto_apigatewaymanagementapi;
+extern crate rusoto_core;
+
+use rusoto_apigatewaymanagementapi::{
+    ApiGatewayManagementApi, ApiGatewayManagementApiClient, PostToConnectionRequest,
+};
+use rusoto_core::Region;
+
+#[test]
+fn should_work() {
+    // post_to_connection is a bit like invoke using the following method
+    // https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-call-api.html
+    // except this is intended for websocket connection postings over rest
+    //
+    // you will need to set the endpoint for this client
+    // typically in the form `https://{api-id}.execute-api.{region}.amazonaws.com/{stage}` as
+    // documented here
+    // https://docs.aws.amazon.com/cli/latest/reference/apigatewaymanagementapi/index.html#cli-aws-apigatewaymanagementapi
+    let client = ApiGatewayManagementApiClient::new(Region::Custom {
+        name: "us-east1".to_owned(),
+        endpoint: "https://123.execute-api.us-east1.amazonaws.com/dev/".to_owned(),
+    });
+    let response = client
+        .post_to_connection(PostToConnectionRequest {
+            connection_id: "bogus".into(),
+            ..PostToConnectionRequest::default()
+        })
+        .sync();
+    println!("response is {:#?}", response);
+}

--- a/integration_tests/tests/apigatewaymanagementapi.rs
+++ b/integration_tests/tests/apigatewaymanagementapi.rs
@@ -28,5 +28,7 @@ fn should_work() {
             ..PostToConnectionRequest::default()
         })
         .sync();
+    // we expect an error because we're posting to an apigw that does not exist
+    assert!(response.is_err());
     println!("response is {:#?}", response);
 }

--- a/integration_tests/tests/apigatewayv2.rs
+++ b/integration_tests/tests/apigatewayv2.rs
@@ -9,6 +9,9 @@ use rusoto_core::Region;
 #[test]
 fn should_work() {
     let client = ApiGatewayV2Client::new(Region::UsEast1);
-    let response = client.get_apis(Default::default()).sync();
+    let response = client
+        .get_apis(Default::default())
+        .sync()
+        .expect("expected an ok response");
     println!("response is {:#?}", response);
 }

--- a/integration_tests/tests/apigatewayv2.rs
+++ b/integration_tests/tests/apigatewayv2.rs
@@ -1,0 +1,14 @@
+#![cfg(feature = "apigatewayv2")]
+
+extern crate rusoto_apigatewayv2;
+extern crate rusoto_core;
+
+use rusoto_apigatewayv2::{ApiGatewayV2, ApiGatewayV2Client};
+use rusoto_core::Region;
+
+#[test]
+fn should_work() {
+    let client = ApiGatewayV2Client::new(Region::UsEast1);
+    let response = client.get_apis(Default::default()).sync();
+    println!("response is {:#?}", response);
+}

--- a/integration_tests/tests/ram.rs
+++ b/integration_tests/tests/ram.rs
@@ -1,0 +1,19 @@
+#![cfg(feature = "ram")]
+
+extern crate rusoto_core;
+extern crate rusoto_ram;
+
+use rusoto_core::Region;
+use rusoto_ram::{ListResourcesRequest, Ram, RamClient};
+
+#[test]
+fn should_list_skills() {
+    let client = RamClient::new(Region::UsEast1);
+    let response = client
+        .list_resources(ListResourcesRequest {
+            resource_owner: "SELF".into(),
+            ..ListResourcesRequest::default()
+        })
+        .sync();
+    println!("response is {:#?}", response);
+}

--- a/integration_tests/tests/ram.rs
+++ b/integration_tests/tests/ram.rs
@@ -7,7 +7,7 @@ use rusoto_core::Region;
 use rusoto_ram::{ListResourcesRequest, Ram, RamClient};
 
 #[test]
-fn should_list_skills() {
+fn should_work() {
     let client = RamClient::new(Region::UsEast1);
     let response = client
         .list_resources(ListResourcesRequest {

--- a/integration_tests/tests/ram.rs
+++ b/integration_tests/tests/ram.rs
@@ -14,6 +14,7 @@ fn should_work() {
             resource_owner: "SELF".into(),
             ..ListResourcesRequest::default()
         })
-        .sync();
+        .sync()
+        .expect("expected an ok response");
     println!("response is {:#?}", response);
 }


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

this is a quick followup to https://github.com/rusoto/rusoto/pull/1296 adding from what I gather what mvps for smoke testing clients of the new services

note that the api gateway management api is a bit unique in that it requires you to set an endpoint that maps back to an existing api gateway -- https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/apigatewaymanagementapi/AmazonApiGatewayManagementApiClient.html

 luckily this is possible via rusotos custom regions. this wasn't a super in depth test as you can see but I plan on doing a bit more testing locally to validate that this indeed works. I wanted to kick of the review process early.

side note: this is my first experience working on rusotos integration testing hardness. I was very tempted to reformat the Cargo.toml file for this but held myself back to keep a small diff.

I may follow up on that in a separate pull.

