### PR TITLE
Reduce generated xml deserializer logic

### DIFF
--- a/rusoto/services/cloudformation/src/generated.rs
+++ b/rusoto/services/cloudformation/src/generated.rs
@@ -25,20 +25,15 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
 use rusoto_core::xmlutil::{
-    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+    characters, deserialize_elements, end_element, find_start_element, peek_at_name, skip_tree,
+    start_element,
 };
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;
-use xml::reader::XmlEvent;
 use xml::EventReader;
 
-enum DeserializerNext {
-    Close,
-    Skip,
-    Element(String),
-}
 struct AccountDeserializer;
 impl AccountDeserializer {
     #[allow(unused_variables)]
@@ -69,43 +64,21 @@ impl AccountGateResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AccountGateResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AccountGateResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, AccountGateResult, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Status" => {
+                    obj.status = Some(AccountGateStatusDeserializer::deserialize("Status", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Status" => {
-                        obj.status =
-                            Some(AccountGateStatusDeserializer::deserialize("Status", stack)?);
-                    }
-                    "StatusReason" => {
-                        obj.status_reason = Some(AccountGateStatusReasonDeserializer::deserialize(
-                            "StatusReason",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "StatusReason" => {
+                    obj.status_reason = Some(AccountGateStatusReasonDeserializer::deserialize(
+                        "StatusReason",
+                        stack,
+                    )?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct AccountGateStatusDeserializer;
@@ -152,39 +125,18 @@ impl AccountLimitDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AccountLimit, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AccountLimit::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, AccountLimit, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Name" => {
+                    obj.name = Some(LimitNameDeserializer::deserialize("Name", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Name" => {
-                        obj.name = Some(LimitNameDeserializer::deserialize("Name", stack)?);
-                    }
-                    "Value" => {
-                        obj.value = Some(LimitValueDeserializer::deserialize("Value", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Value" => {
+                    obj.value = Some(LimitValueDeserializer::deserialize("Value", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct AccountLimitListDeserializer;
@@ -194,37 +146,14 @@ impl AccountLimitListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<AccountLimit>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(AccountLimitDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(AccountLimitDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -260,37 +189,14 @@ impl AllowedValuesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(AllowedValueDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(AllowedValueDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ArnDeserializer;
@@ -353,37 +259,14 @@ impl CapabilitiesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(CapabilityDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(CapabilityDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -456,42 +339,21 @@ impl ChangeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Change, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Change::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Change, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "ResourceChange" => {
+                    obj.resource_change = Some(ResourceChangeDeserializer::deserialize(
+                        "ResourceChange",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "ResourceChange" => {
-                        obj.resource_change = Some(ResourceChangeDeserializer::deserialize(
-                            "ResourceChange",
-                            stack,
-                        )?);
-                    }
-                    "Type" => {
-                        obj.type_ = Some(ChangeTypeDeserializer::deserialize("Type", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Type" => {
+                    obj.type_ = Some(ChangeTypeDeserializer::deserialize("Type", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ChangeActionDeserializer;
@@ -571,37 +433,14 @@ impl ChangeSetSummariesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<ChangeSetSummary>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(ChangeSetSummaryDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(ChangeSetSummaryDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>The <code>ChangeSetSummary</code> structure describes a change set, its status, and the stack with which it's associated.</p>
@@ -634,76 +473,53 @@ impl ChangeSetSummaryDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ChangeSetSummary, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ChangeSetSummary::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ChangeSetSummary, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "ChangeSetId" => {
+                    obj.change_set_id =
+                        Some(ChangeSetIdDeserializer::deserialize("ChangeSetId", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "ChangeSetId" => {
-                        obj.change_set_id =
-                            Some(ChangeSetIdDeserializer::deserialize("ChangeSetId", stack)?);
-                    }
-                    "ChangeSetName" => {
-                        obj.change_set_name = Some(ChangeSetNameDeserializer::deserialize(
-                            "ChangeSetName",
-                            stack,
-                        )?);
-                    }
-                    "CreationTime" => {
-                        obj.creation_time = Some(CreationTimeDeserializer::deserialize(
-                            "CreationTime",
-                            stack,
-                        )?);
-                    }
-                    "Description" => {
-                        obj.description =
-                            Some(DescriptionDeserializer::deserialize("Description", stack)?);
-                    }
-                    "ExecutionStatus" => {
-                        obj.execution_status = Some(ExecutionStatusDeserializer::deserialize(
-                            "ExecutionStatus",
-                            stack,
-                        )?);
-                    }
-                    "StackId" => {
-                        obj.stack_id = Some(StackIdDeserializer::deserialize("StackId", stack)?);
-                    }
-                    "StackName" => {
-                        obj.stack_name =
-                            Some(StackNameDeserializer::deserialize("StackName", stack)?);
-                    }
-                    "Status" => {
-                        obj.status =
-                            Some(ChangeSetStatusDeserializer::deserialize("Status", stack)?);
-                    }
-                    "StatusReason" => {
-                        obj.status_reason = Some(ChangeSetStatusReasonDeserializer::deserialize(
-                            "StatusReason",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "ChangeSetName" => {
+                    obj.change_set_name = Some(ChangeSetNameDeserializer::deserialize(
+                        "ChangeSetName",
+                        stack,
+                    )?);
                 }
+                "CreationTime" => {
+                    obj.creation_time = Some(CreationTimeDeserializer::deserialize(
+                        "CreationTime",
+                        stack,
+                    )?);
+                }
+                "Description" => {
+                    obj.description =
+                        Some(DescriptionDeserializer::deserialize("Description", stack)?);
+                }
+                "ExecutionStatus" => {
+                    obj.execution_status = Some(ExecutionStatusDeserializer::deserialize(
+                        "ExecutionStatus",
+                        stack,
+                    )?);
+                }
+                "StackId" => {
+                    obj.stack_id = Some(StackIdDeserializer::deserialize("StackId", stack)?);
+                }
+                "StackName" => {
+                    obj.stack_name = Some(StackNameDeserializer::deserialize("StackName", stack)?);
+                }
+                "Status" => {
+                    obj.status = Some(ChangeSetStatusDeserializer::deserialize("Status", stack)?);
+                }
+                "StatusReason" => {
+                    obj.status_reason = Some(ChangeSetStatusReasonDeserializer::deserialize(
+                        "StatusReason",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ChangeSourceDeserializer;
@@ -741,37 +557,14 @@ impl ChangesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Change>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(ChangeDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(ChangeDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ClientRequestTokenDeserializer;
@@ -977,39 +770,18 @@ impl CreateChangeSetOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateChangeSetOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateChangeSetOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CreateChangeSetOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Id" => {
+                    obj.id = Some(ChangeSetIdDeserializer::deserialize("Id", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Id" => {
-                        obj.id = Some(ChangeSetIdDeserializer::deserialize("Id", stack)?);
-                    }
-                    "StackId" => {
-                        obj.stack_id = Some(StackIdDeserializer::deserialize("StackId", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "StackId" => {
+                    obj.stack_id = Some(StackIdDeserializer::deserialize("StackId", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>The input for <a>CreateStack</a> action.</p>
@@ -1209,21 +981,11 @@ impl CreateStackInstancesOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateStackInstancesOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateStackInstancesOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateStackInstancesOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "OperationId" => {
                         obj.operation_id = Some(ClientRequestTokenDeserializer::deserialize(
                             "OperationId",
@@ -1231,17 +993,10 @@ impl CreateStackInstancesOutputDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>The output for a <a>CreateStack</a> action.</p>
@@ -1258,36 +1013,15 @@ impl CreateStackOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateStackOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateStackOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CreateStackOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "StackId" => {
+                    obj.stack_id = Some(StackIdDeserializer::deserialize("StackId", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "StackId" => {
-                        obj.stack_id = Some(StackIdDeserializer::deserialize("StackId", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -1381,37 +1115,16 @@ impl CreateStackSetOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateStackSetOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateStackSetOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CreateStackSetOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "StackSetId" => {
+                    obj.stack_set_id =
+                        Some(StackSetIdDeserializer::deserialize("StackSetId", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "StackSetId" => {
-                        obj.stack_set_id =
-                            Some(StackSetIdDeserializer::deserialize("StackSetId", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct CreationTimeDeserializer;
@@ -1580,21 +1293,11 @@ impl DeleteStackInstancesOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DeleteStackInstancesOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DeleteStackInstancesOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DeleteStackInstancesOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "OperationId" => {
                         obj.operation_id = Some(ClientRequestTokenDeserializer::deserialize(
                             "OperationId",
@@ -1602,17 +1305,10 @@ impl DeleteStackInstancesOutputDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -1708,52 +1404,25 @@ impl DescribeAccountLimitsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeAccountLimitsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeAccountLimitsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeAccountLimitsOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AccountLimits" => {
-                        obj.account_limits = match obj.account_limits {
-                            Some(ref mut existing) => {
-                                existing.extend(AccountLimitListDeserializer::deserialize(
-                                    "AccountLimits",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(AccountLimitListDeserializer::deserialize(
-                                "AccountLimits",
-                                stack,
-                            )?),
-                        };
+                        obj.account_limits.get_or_insert(vec![]).extend(
+                            AccountLimitListDeserializer::deserialize("AccountLimits", stack)?,
+                        );
                     }
                     "NextToken" => {
                         obj.next_token =
                             Some(NextTokenDeserializer::deserialize("NextToken", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>The input for the <a>DescribeChangeSet</a> action.</p>
@@ -1833,35 +1502,15 @@ impl DescribeChangeSetOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeChangeSetOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeChangeSetOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeChangeSetOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Capabilities" => {
-                        obj.capabilities = match obj.capabilities {
-                            Some(ref mut existing) => {
-                                existing.extend(CapabilitiesDeserializer::deserialize(
-                                    "Capabilities",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(CapabilitiesDeserializer::deserialize(
-                                "Capabilities",
-                                stack,
-                            )?),
-                        };
+                        obj.capabilities.get_or_insert(vec![]).extend(
+                            CapabilitiesDeserializer::deserialize("Capabilities", stack)?,
+                        );
                     }
                     "ChangeSetId" => {
                         obj.change_set_id =
@@ -1874,14 +1523,9 @@ impl DescribeChangeSetOutputDeserializer {
                         )?);
                     }
                     "Changes" => {
-                        obj.changes = match obj.changes {
-                            Some(ref mut existing) => {
-                                existing
-                                    .extend(ChangesDeserializer::deserialize("Changes", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ChangesDeserializer::deserialize("Changes", stack)?),
-                        };
+                        obj.changes
+                            .get_or_insert(vec![])
+                            .extend(ChangesDeserializer::deserialize("Changes", stack)?);
                     }
                     "CreationTime" => {
                         obj.creation_time = Some(CreationTimeDeserializer::deserialize(
@@ -1904,31 +1548,14 @@ impl DescribeChangeSetOutputDeserializer {
                             Some(NextTokenDeserializer::deserialize("NextToken", stack)?);
                     }
                     "NotificationARNs" => {
-                        obj.notification_ar_ns = match obj.notification_ar_ns {
-                            Some(ref mut existing) => {
-                                existing.extend(NotificationARNsDeserializer::deserialize(
-                                    "NotificationARNs",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(NotificationARNsDeserializer::deserialize(
-                                "NotificationARNs",
-                                stack,
-                            )?),
-                        };
+                        obj.notification_ar_ns.get_or_insert(vec![]).extend(
+                            NotificationARNsDeserializer::deserialize("NotificationARNs", stack)?,
+                        );
                     }
                     "Parameters" => {
-                        obj.parameters = match obj.parameters {
-                            Some(ref mut existing) => {
-                                existing.extend(ParametersDeserializer::deserialize(
-                                    "Parameters",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ParametersDeserializer::deserialize("Parameters", stack)?),
-                        };
+                        obj.parameters
+                            .get_or_insert(vec![])
+                            .extend(ParametersDeserializer::deserialize("Parameters", stack)?);
                     }
                     "RollbackConfiguration" => {
                         obj.rollback_configuration =
@@ -1955,26 +1582,15 @@ impl DescribeChangeSetOutputDeserializer {
                         )?);
                     }
                     "Tags" => {
-                        obj.tags = match obj.tags {
-                            Some(ref mut existing) => {
-                                existing.extend(TagsDeserializer::deserialize("Tags", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(TagsDeserializer::deserialize("Tags", stack)?),
-                        };
+                        obj.tags
+                            .get_or_insert(vec![])
+                            .extend(TagsDeserializer::deserialize("Tags", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -2024,21 +1640,11 @@ impl DescribeStackDriftDetectionStatusOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeStackDriftDetectionStatusOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeStackDriftDetectionStatusOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeStackDriftDetectionStatusOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DetectionStatus" => {
                         obj.detection_status = StackDriftDetectionStatusDeserializer::deserialize(
                             "DetectionStatus",
@@ -2079,17 +1685,10 @@ impl DescribeStackDriftDetectionStatusOutputDeserializer {
                         obj.timestamp = TimestampDeserializer::deserialize("Timestamp", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>The input for <a>DescribeStackEvents</a> action.</p>
@@ -2135,51 +1734,25 @@ impl DescribeStackEventsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeStackEventsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeStackEventsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeStackEventsOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "NextToken" => {
                         obj.next_token =
                             Some(NextTokenDeserializer::deserialize("NextToken", stack)?);
                     }
                     "StackEvents" => {
-                        obj.stack_events = match obj.stack_events {
-                            Some(ref mut existing) => {
-                                existing.extend(StackEventsDeserializer::deserialize(
-                                    "StackEvents",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => {
-                                Some(StackEventsDeserializer::deserialize("StackEvents", stack)?)
-                            }
-                        };
+                        obj.stack_events
+                            .get_or_insert(vec![])
+                            .extend(StackEventsDeserializer::deserialize("StackEvents", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -2229,21 +1802,11 @@ impl DescribeStackInstanceOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeStackInstanceOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeStackInstanceOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeStackInstanceOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "StackInstance" => {
                         obj.stack_instance = Some(StackInstanceDeserializer::deserialize(
                             "StackInstance",
@@ -2251,17 +1814,10 @@ impl DescribeStackInstanceOutputDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -2320,21 +1876,11 @@ impl DescribeStackResourceDriftsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeStackResourceDriftsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeStackResourceDriftsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeStackResourceDriftsOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "NextToken" => {
                         obj.next_token =
                             Some(NextTokenDeserializer::deserialize("NextToken", stack)?);
@@ -2348,17 +1894,10 @@ impl DescribeStackResourceDriftsOutputDeserializer {
                         );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>The input for <a>DescribeStackResource</a> action.</p>
@@ -2401,21 +1940,11 @@ impl DescribeStackResourceOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeStackResourceOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeStackResourceOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeStackResourceOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "StackResourceDetail" => {
                         obj.stack_resource_detail =
                             Some(StackResourceDetailDeserializer::deserialize(
@@ -2424,17 +1953,10 @@ impl DescribeStackResourceOutputDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>The input for <a>DescribeStackResources</a> action.</p>
@@ -2483,48 +2005,21 @@ impl DescribeStackResourcesOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeStackResourcesOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeStackResourcesOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeStackResourcesOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "StackResources" => {
-                        obj.stack_resources = match obj.stack_resources {
-                            Some(ref mut existing) => {
-                                existing.extend(StackResourcesDeserializer::deserialize(
-                                    "StackResources",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(StackResourcesDeserializer::deserialize(
-                                "StackResources",
-                                stack,
-                            )?),
-                        };
+                        obj.stack_resources.get_or_insert(vec![]).extend(
+                            StackResourcesDeserializer::deserialize("StackResources", stack)?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -2587,21 +2082,11 @@ impl DescribeStackSetOperationOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeStackSetOperationOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeStackSetOperationOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeStackSetOperationOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "StackSetOperation" => {
                         obj.stack_set_operation = Some(StackSetOperationDeserializer::deserialize(
                             "StackSetOperation",
@@ -2609,17 +2094,10 @@ impl DescribeStackSetOperationOutputDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -2635,36 +2113,15 @@ impl DescribeStackSetOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeStackSetOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeStackSetOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DescribeStackSetOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "StackSet" => {
+                    obj.stack_set = Some(StackSetDeserializer::deserialize("StackSet", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "StackSet" => {
-                        obj.stack_set = Some(StackSetDeserializer::deserialize("StackSet", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>The input for <a>DescribeStacks</a> action.</p>
@@ -2710,46 +2167,20 @@ impl DescribeStacksOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeStacksOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeStacksOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DescribeStacksOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "NextToken" => {
+                    obj.next_token = Some(NextTokenDeserializer::deserialize("NextToken", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "NextToken" => {
-                        obj.next_token =
-                            Some(NextTokenDeserializer::deserialize("NextToken", stack)?);
-                    }
-                    "Stacks" => {
-                        obj.stacks = match obj.stacks {
-                            Some(ref mut existing) => {
-                                existing.extend(StacksDeserializer::deserialize("Stacks", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(StacksDeserializer::deserialize("Stacks", stack)?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Stacks" => {
+                    obj.stacks
+                        .get_or_insert(vec![])
+                        .extend(StacksDeserializer::deserialize("Stacks", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct DescriptionDeserializer;
@@ -2807,40 +2238,18 @@ impl DetectStackDriftOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DetectStackDriftOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DetectStackDriftOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DetectStackDriftOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "StackDriftDetectionId" => {
+                    obj.stack_drift_detection_id = StackDriftDetectionIdDeserializer::deserialize(
+                        "StackDriftDetectionId",
+                        stack,
+                    )?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "StackDriftDetectionId" => {
-                        obj.stack_drift_detection_id =
-                            StackDriftDetectionIdDeserializer::deserialize(
-                                "StackDriftDetectionId",
-                                stack,
-                            )?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -2881,21 +2290,11 @@ impl DetectStackResourceDriftOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DetectStackResourceDriftOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DetectStackResourceDriftOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DetectStackResourceDriftOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "StackResourceDrift" => {
                         obj.stack_resource_drift = StackResourceDriftDeserializer::deserialize(
                             "StackResourceDrift",
@@ -2903,17 +2302,10 @@ impl DetectStackResourceDriftOutputDeserializer {
                         )?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct DifferenceTypeDeserializer;
@@ -3008,36 +2400,19 @@ impl EstimateTemplateCostOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<EstimateTemplateCostOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = EstimateTemplateCostOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, EstimateTemplateCostOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Url" => {
                         obj.url = Some(UrlDeserializer::deserialize("Url", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct EvaluationTypeDeserializer;
@@ -3167,43 +2542,22 @@ impl ExportDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Export, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Export::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Export, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "ExportingStackId" => {
+                    obj.exporting_stack_id =
+                        Some(StackIdDeserializer::deserialize("ExportingStackId", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "ExportingStackId" => {
-                        obj.exporting_stack_id =
-                            Some(StackIdDeserializer::deserialize("ExportingStackId", stack)?);
-                    }
-                    "Name" => {
-                        obj.name = Some(ExportNameDeserializer::deserialize("Name", stack)?);
-                    }
-                    "Value" => {
-                        obj.value = Some(ExportValueDeserializer::deserialize("Value", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Name" => {
+                    obj.name = Some(ExportNameDeserializer::deserialize("Name", stack)?);
                 }
+                "Value" => {
+                    obj.value = Some(ExportValueDeserializer::deserialize("Value", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ExportNameDeserializer;
@@ -3241,37 +2595,14 @@ impl ExportsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Export>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(ExportDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(ExportDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct FailureToleranceCountDeserializer;
@@ -3336,39 +2667,18 @@ impl GetStackPolicyOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetStackPolicyOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetStackPolicyOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, GetStackPolicyOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "StackPolicyBody" => {
+                    obj.stack_policy_body = Some(StackPolicyBodyDeserializer::deserialize(
+                        "StackPolicyBody",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "StackPolicyBody" => {
-                        obj.stack_policy_body = Some(StackPolicyBodyDeserializer::deserialize(
-                            "StackPolicyBody",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>The input for a <a>GetTemplate</a> action.</p>
@@ -3419,54 +2729,23 @@ impl GetTemplateOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetTemplateOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetTemplateOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, GetTemplateOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "StagesAvailable" => {
+                    obj.stages_available.get_or_insert(vec![]).extend(
+                        StageListDeserializer::deserialize("StagesAvailable", stack)?,
+                    );
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "StagesAvailable" => {
-                        obj.stages_available = match obj.stages_available {
-                            Some(ref mut existing) => {
-                                existing.extend(StageListDeserializer::deserialize(
-                                    "StagesAvailable",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(StageListDeserializer::deserialize(
-                                "StagesAvailable",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "TemplateBody" => {
-                        obj.template_body = Some(TemplateBodyDeserializer::deserialize(
-                            "TemplateBody",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "TemplateBody" => {
+                    obj.template_body = Some(TemplateBodyDeserializer::deserialize(
+                        "TemplateBody",
+                        stack,
+                    )?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>The input for the <a>GetTemplateSummary</a> action.</p>
@@ -3534,35 +2813,15 @@ impl GetTemplateSummaryOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetTemplateSummaryOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetTemplateSummaryOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetTemplateSummaryOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Capabilities" => {
-                        obj.capabilities = match obj.capabilities {
-                            Some(ref mut existing) => {
-                                existing.extend(CapabilitiesDeserializer::deserialize(
-                                    "Capabilities",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(CapabilitiesDeserializer::deserialize(
-                                "Capabilities",
-                                stack,
-                            )?),
-                        };
+                        obj.capabilities.get_or_insert(vec![]).extend(
+                            CapabilitiesDeserializer::deserialize("Capabilities", stack)?,
+                        );
                     }
                     "CapabilitiesReason" => {
                         obj.capabilities_reason =
@@ -3572,19 +2831,9 @@ impl GetTemplateSummaryOutputDeserializer {
                             )?);
                     }
                     "DeclaredTransforms" => {
-                        obj.declared_transforms = match obj.declared_transforms {
-                            Some(ref mut existing) => {
-                                existing.extend(TransformsListDeserializer::deserialize(
-                                    "DeclaredTransforms",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(TransformsListDeserializer::deserialize(
-                                "DeclaredTransforms",
-                                stack,
-                            )?),
-                        };
+                        obj.declared_transforms.get_or_insert(vec![]).extend(
+                            TransformsListDeserializer::deserialize("DeclaredTransforms", stack)?,
+                        );
                     }
                     "Description" => {
                         obj.description =
@@ -3594,50 +2843,23 @@ impl GetTemplateSummaryOutputDeserializer {
                         obj.metadata = Some(MetadataDeserializer::deserialize("Metadata", stack)?);
                     }
                     "Parameters" => {
-                        obj.parameters = match obj.parameters {
-                            Some(ref mut existing) => {
-                                existing.extend(ParameterDeclarationsDeserializer::deserialize(
-                                    "Parameters",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ParameterDeclarationsDeserializer::deserialize(
-                                "Parameters",
-                                stack,
-                            )?),
-                        };
+                        obj.parameters.get_or_insert(vec![]).extend(
+                            ParameterDeclarationsDeserializer::deserialize("Parameters", stack)?,
+                        );
                     }
                     "ResourceTypes" => {
-                        obj.resource_types = match obj.resource_types {
-                            Some(ref mut existing) => {
-                                existing.extend(ResourceTypesDeserializer::deserialize(
-                                    "ResourceTypes",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ResourceTypesDeserializer::deserialize(
-                                "ResourceTypes",
-                                stack,
-                            )?),
-                        };
+                        obj.resource_types.get_or_insert(vec![]).extend(
+                            ResourceTypesDeserializer::deserialize("ResourceTypes", stack)?,
+                        );
                     }
                     "Version" => {
                         obj.version = Some(VersionDeserializer::deserialize("Version", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct ImportsDeserializer;
@@ -3647,37 +2869,14 @@ impl ImportsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(StackNameDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(StackNameDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct KeyDeserializer;
@@ -3777,52 +2976,20 @@ impl ListChangeSetsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListChangeSetsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListChangeSetsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ListChangeSetsOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "NextToken" => {
+                    obj.next_token = Some(NextTokenDeserializer::deserialize("NextToken", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "NextToken" => {
-                        obj.next_token =
-                            Some(NextTokenDeserializer::deserialize("NextToken", stack)?);
-                    }
-                    "Summaries" => {
-                        obj.summaries = match obj.summaries {
-                            Some(ref mut existing) => {
-                                existing.extend(ChangeSetSummariesDeserializer::deserialize(
-                                    "Summaries",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ChangeSetSummariesDeserializer::deserialize(
-                                "Summaries",
-                                stack,
-                            )?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Summaries" => {
+                    obj.summaries.get_or_insert(vec![]).extend(
+                        ChangeSetSummariesDeserializer::deserialize("Summaries", stack)?,
+                    );
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -3861,47 +3028,20 @@ impl ListExportsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListExportsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListExportsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ListExportsOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Exports" => {
+                    obj.exports
+                        .get_or_insert(vec![])
+                        .extend(ExportsDeserializer::deserialize("Exports", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Exports" => {
-                        obj.exports = match obj.exports {
-                            Some(ref mut existing) => {
-                                existing
-                                    .extend(ExportsDeserializer::deserialize("Exports", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ExportsDeserializer::deserialize("Exports", stack)?),
-                        };
-                    }
-                    "NextToken" => {
-                        obj.next_token =
-                            Some(NextTokenDeserializer::deserialize("NextToken", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "NextToken" => {
+                    obj.next_token = Some(NextTokenDeserializer::deserialize("NextToken", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -3943,47 +3083,20 @@ impl ListImportsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListImportsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListImportsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ListImportsOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Imports" => {
+                    obj.imports
+                        .get_or_insert(vec![])
+                        .extend(ImportsDeserializer::deserialize("Imports", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Imports" => {
-                        obj.imports = match obj.imports {
-                            Some(ref mut existing) => {
-                                existing
-                                    .extend(ImportsDeserializer::deserialize("Imports", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ImportsDeserializer::deserialize("Imports", stack)?),
-                        };
-                    }
-                    "NextToken" => {
-                        obj.next_token =
-                            Some(NextTokenDeserializer::deserialize("NextToken", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "NextToken" => {
+                    obj.next_token = Some(NextTokenDeserializer::deserialize("NextToken", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -4052,52 +3165,25 @@ impl ListStackInstancesOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListStackInstancesOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListStackInstancesOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListStackInstancesOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "NextToken" => {
                         obj.next_token =
                             Some(NextTokenDeserializer::deserialize("NextToken", stack)?);
                     }
                     "Summaries" => {
-                        obj.summaries = match obj.summaries {
-                            Some(ref mut existing) => {
-                                existing.extend(StackInstanceSummariesDeserializer::deserialize(
-                                    "Summaries",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(StackInstanceSummariesDeserializer::deserialize(
-                                "Summaries",
-                                stack,
-                            )?),
-                        };
+                        obj.summaries.get_or_insert(vec![]).extend(
+                            StackInstanceSummariesDeserializer::deserialize("Summaries", stack)?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>The input for the <a>ListStackResource</a> action.</p>
@@ -4141,52 +3227,28 @@ impl ListStackResourcesOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListStackResourcesOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListStackResourcesOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListStackResourcesOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "NextToken" => {
                         obj.next_token =
                             Some(NextTokenDeserializer::deserialize("NextToken", stack)?);
                     }
                     "StackResourceSummaries" => {
-                        obj.stack_resource_summaries = match obj.stack_resource_summaries {
-                            Some(ref mut existing) => {
-                                existing.extend(StackResourceSummariesDeserializer::deserialize(
-                                    "StackResourceSummaries",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(StackResourceSummariesDeserializer::deserialize(
+                        obj.stack_resource_summaries.get_or_insert(vec![]).extend(
+                            StackResourceSummariesDeserializer::deserialize(
                                 "StackResourceSummaries",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -4242,56 +3304,28 @@ impl ListStackSetOperationResultsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListStackSetOperationResultsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListStackSetOperationResultsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListStackSetOperationResultsOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "NextToken" => {
                         obj.next_token =
                             Some(NextTokenDeserializer::deserialize("NextToken", stack)?);
                     }
                     "Summaries" => {
-                        obj.summaries = match obj.summaries {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    StackSetOperationResultSummariesDeserializer::deserialize(
-                                        "Summaries",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => {
-                                Some(StackSetOperationResultSummariesDeserializer::deserialize(
-                                    "Summaries",
-                                    stack,
-                                )?)
-                            }
-                        };
+                        obj.summaries.get_or_insert(vec![]).extend(
+                            StackSetOperationResultSummariesDeserializer::deserialize(
+                                "Summaries",
+                                stack,
+                            )?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -4344,54 +3378,28 @@ impl ListStackSetOperationsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListStackSetOperationsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListStackSetOperationsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListStackSetOperationsOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "NextToken" => {
                         obj.next_token =
                             Some(NextTokenDeserializer::deserialize("NextToken", stack)?);
                     }
                     "Summaries" => {
-                        obj.summaries = match obj.summaries {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    StackSetOperationSummariesDeserializer::deserialize(
-                                        "Summaries",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(StackSetOperationSummariesDeserializer::deserialize(
+                        obj.summaries.get_or_insert(vec![]).extend(
+                            StackSetOperationSummariesDeserializer::deserialize(
                                 "Summaries",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -4443,52 +3451,20 @@ impl ListStackSetsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListStackSetsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListStackSetsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ListStackSetsOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "NextToken" => {
+                    obj.next_token = Some(NextTokenDeserializer::deserialize("NextToken", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "NextToken" => {
-                        obj.next_token =
-                            Some(NextTokenDeserializer::deserialize("NextToken", stack)?);
-                    }
-                    "Summaries" => {
-                        obj.summaries = match obj.summaries {
-                            Some(ref mut existing) => {
-                                existing.extend(StackSetSummariesDeserializer::deserialize(
-                                    "Summaries",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(StackSetSummariesDeserializer::deserialize(
-                                "Summaries",
-                                stack,
-                            )?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Summaries" => {
+                    obj.summaries.get_or_insert(vec![]).extend(
+                        StackSetSummariesDeserializer::deserialize("Summaries", stack)?,
+                    );
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>The input for <a>ListStacks</a> action.</p>
@@ -4538,52 +3514,20 @@ impl ListStacksOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListStacksOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListStacksOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ListStacksOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "NextToken" => {
+                    obj.next_token = Some(NextTokenDeserializer::deserialize("NextToken", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "NextToken" => {
-                        obj.next_token =
-                            Some(NextTokenDeserializer::deserialize("NextToken", stack)?);
-                    }
-                    "StackSummaries" => {
-                        obj.stack_summaries = match obj.stack_summaries {
-                            Some(ref mut existing) => {
-                                existing.extend(StackSummariesDeserializer::deserialize(
-                                    "StackSummaries",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(StackSummariesDeserializer::deserialize(
-                                "StackSummaries",
-                                stack,
-                            )?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "StackSummaries" => {
+                    obj.stack_summaries.get_or_insert(vec![]).extend(
+                        StackSummariesDeserializer::deserialize("StackSummaries", stack)?,
+                    );
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct LogicalResourceIdDeserializer;
@@ -4717,37 +3661,14 @@ impl NotificationARNsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(NotificationARNDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(NotificationARNDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -4782,49 +3703,27 @@ impl OutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Output, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Output::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Output, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Description" => {
+                    obj.description =
+                        Some(DescriptionDeserializer::deserialize("Description", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Description" => {
-                        obj.description =
-                            Some(DescriptionDeserializer::deserialize("Description", stack)?);
-                    }
-                    "ExportName" => {
-                        obj.export_name =
-                            Some(ExportNameDeserializer::deserialize("ExportName", stack)?);
-                    }
-                    "OutputKey" => {
-                        obj.output_key =
-                            Some(OutputKeyDeserializer::deserialize("OutputKey", stack)?);
-                    }
-                    "OutputValue" => {
-                        obj.output_value =
-                            Some(OutputValueDeserializer::deserialize("OutputValue", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "ExportName" => {
+                    obj.export_name =
+                        Some(ExportNameDeserializer::deserialize("ExportName", stack)?);
                 }
+                "OutputKey" => {
+                    obj.output_key = Some(OutputKeyDeserializer::deserialize("OutputKey", stack)?);
+                }
+                "OutputValue" => {
+                    obj.output_value =
+                        Some(OutputValueDeserializer::deserialize("OutputValue", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct OutputKeyDeserializer;
@@ -4862,37 +3761,14 @@ impl OutputsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Output>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(OutputDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(OutputDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>The Parameter data type.</p>
@@ -4915,57 +3791,36 @@ impl ParameterDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Parameter, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Parameter::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Parameter, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "ParameterKey" => {
+                    obj.parameter_key = Some(ParameterKeyDeserializer::deserialize(
+                        "ParameterKey",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "ParameterKey" => {
-                        obj.parameter_key = Some(ParameterKeyDeserializer::deserialize(
-                            "ParameterKey",
-                            stack,
-                        )?);
-                    }
-                    "ParameterValue" => {
-                        obj.parameter_value = Some(ParameterValueDeserializer::deserialize(
-                            "ParameterValue",
-                            stack,
-                        )?);
-                    }
-                    "ResolvedValue" => {
-                        obj.resolved_value = Some(ParameterValueDeserializer::deserialize(
-                            "ResolvedValue",
-                            stack,
-                        )?);
-                    }
-                    "UsePreviousValue" => {
-                        obj.use_previous_value = Some(UsePreviousValueDeserializer::deserialize(
-                            "UsePreviousValue",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "ParameterValue" => {
+                    obj.parameter_value = Some(ParameterValueDeserializer::deserialize(
+                        "ParameterValue",
+                        stack,
+                    )?);
                 }
+                "ResolvedValue" => {
+                    obj.resolved_value = Some(ParameterValueDeserializer::deserialize(
+                        "ResolvedValue",
+                        stack,
+                    )?);
+                }
+                "UsePreviousValue" => {
+                    obj.use_previous_value = Some(UsePreviousValueDeserializer::deserialize(
+                        "UsePreviousValue",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -5010,48 +3865,17 @@ impl ParameterConstraintsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ParameterConstraints, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ParameterConstraints::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ParameterConstraints, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AllowedValues" => {
+                    obj.allowed_values.get_or_insert(vec![]).extend(
+                        AllowedValuesDeserializer::deserialize("AllowedValues", stack)?,
+                    );
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AllowedValues" => {
-                        obj.allowed_values = match obj.allowed_values {
-                            Some(ref mut existing) => {
-                                existing.extend(AllowedValuesDeserializer::deserialize(
-                                    "AllowedValues",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(AllowedValuesDeserializer::deserialize(
-                                "AllowedValues",
-                                stack,
-                            )?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>The ParameterDeclaration data type.</p>
@@ -5078,65 +3902,44 @@ impl ParameterDeclarationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ParameterDeclaration, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ParameterDeclaration::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ParameterDeclaration, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DefaultValue" => {
+                    obj.default_value = Some(ParameterValueDeserializer::deserialize(
+                        "DefaultValue",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DefaultValue" => {
-                        obj.default_value = Some(ParameterValueDeserializer::deserialize(
-                            "DefaultValue",
-                            stack,
-                        )?);
-                    }
-                    "Description" => {
-                        obj.description =
-                            Some(DescriptionDeserializer::deserialize("Description", stack)?);
-                    }
-                    "NoEcho" => {
-                        obj.no_echo = Some(NoEchoDeserializer::deserialize("NoEcho", stack)?);
-                    }
-                    "ParameterConstraints" => {
-                        obj.parameter_constraints =
-                            Some(ParameterConstraintsDeserializer::deserialize(
-                                "ParameterConstraints",
-                                stack,
-                            )?);
-                    }
-                    "ParameterKey" => {
-                        obj.parameter_key = Some(ParameterKeyDeserializer::deserialize(
-                            "ParameterKey",
-                            stack,
-                        )?);
-                    }
-                    "ParameterType" => {
-                        obj.parameter_type = Some(ParameterTypeDeserializer::deserialize(
-                            "ParameterType",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Description" => {
+                    obj.description =
+                        Some(DescriptionDeserializer::deserialize("Description", stack)?);
                 }
+                "NoEcho" => {
+                    obj.no_echo = Some(NoEchoDeserializer::deserialize("NoEcho", stack)?);
+                }
+                "ParameterConstraints" => {
+                    obj.parameter_constraints =
+                        Some(ParameterConstraintsDeserializer::deserialize(
+                            "ParameterConstraints",
+                            stack,
+                        )?);
+                }
+                "ParameterKey" => {
+                    obj.parameter_key = Some(ParameterKeyDeserializer::deserialize(
+                        "ParameterKey",
+                        stack,
+                    )?);
+                }
+                "ParameterType" => {
+                    obj.parameter_type = Some(ParameterTypeDeserializer::deserialize(
+                        "ParameterType",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ParameterDeclarationsDeserializer;
@@ -5146,39 +3949,16 @@ impl ParameterDeclarationsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<ParameterDeclaration>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(ParameterDeclarationDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(ParameterDeclarationDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ParameterKeyDeserializer;
@@ -5230,37 +4010,14 @@ impl ParametersDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Parameter>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(ParameterDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(ParameterDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -5296,41 +4053,18 @@ impl PhysicalResourceIdContextDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<PhysicalResourceIdContextKeyValuePair>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(
-                            PhysicalResourceIdContextKeyValuePairDeserializer::deserialize(
-                                "member", stack,
-                            )?,
-                        );
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(
+                    PhysicalResourceIdContextKeyValuePairDeserializer::deserialize(
+                        "member", stack,
+                    )?,
+                );
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Context information that enables AWS CloudFormation to uniquely identify a resource. AWS CloudFormation uses context key-value pairs in cases where a resource's logical and physical IDs are not enough to uniquely identify that resource. Each context key-value pair specifies a resource that contains the targeted resource.</p>
@@ -5349,21 +4083,11 @@ impl PhysicalResourceIdContextKeyValuePairDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<PhysicalResourceIdContextKeyValuePair, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = PhysicalResourceIdContextKeyValuePair::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, PhysicalResourceIdContextKeyValuePair, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Key" => {
                         obj.key = KeyDeserializer::deserialize("Key", stack)?;
                     }
@@ -5371,17 +4095,10 @@ impl PhysicalResourceIdContextKeyValuePairDeserializer {
                         obj.value = ValueDeserializer::deserialize("Value", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct PropertiesDeserializer;
@@ -5418,49 +4135,28 @@ impl PropertyDifferenceDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<PropertyDifference, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = PropertyDifference::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, PropertyDifference, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "ActualValue" => {
+                    obj.actual_value =
+                        PropertyValueDeserializer::deserialize("ActualValue", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "ActualValue" => {
-                        obj.actual_value =
-                            PropertyValueDeserializer::deserialize("ActualValue", stack)?;
-                    }
-                    "DifferenceType" => {
-                        obj.difference_type =
-                            DifferenceTypeDeserializer::deserialize("DifferenceType", stack)?;
-                    }
-                    "ExpectedValue" => {
-                        obj.expected_value =
-                            PropertyValueDeserializer::deserialize("ExpectedValue", stack)?;
-                    }
-                    "PropertyPath" => {
-                        obj.property_path =
-                            PropertyPathDeserializer::deserialize("PropertyPath", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "DifferenceType" => {
+                    obj.difference_type =
+                        DifferenceTypeDeserializer::deserialize("DifferenceType", stack)?;
                 }
+                "ExpectedValue" => {
+                    obj.expected_value =
+                        PropertyValueDeserializer::deserialize("ExpectedValue", stack)?;
+                }
+                "PropertyPath" => {
+                    obj.property_path =
+                        PropertyPathDeserializer::deserialize("PropertyPath", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PropertyDifferencesDeserializer;
@@ -5470,39 +4166,16 @@ impl PropertyDifferencesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<PropertyDifference>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(PropertyDifferenceDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(PropertyDifferenceDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PropertyNameDeserializer;
@@ -5582,37 +4255,14 @@ impl RegionListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(RegionDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(RegionDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -5695,81 +4345,47 @@ impl ResourceChangeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ResourceChange, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ResourceChange::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ResourceChange, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Action" => {
+                    obj.action = Some(ChangeActionDeserializer::deserialize("Action", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Action" => {
-                        obj.action = Some(ChangeActionDeserializer::deserialize("Action", stack)?);
-                    }
-                    "Details" => {
-                        obj.details = match obj.details {
-                            Some(ref mut existing) => {
-                                existing.extend(ResourceChangeDetailsDeserializer::deserialize(
-                                    "Details", stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ResourceChangeDetailsDeserializer::deserialize(
-                                "Details", stack,
-                            )?),
-                        };
-                    }
-                    "LogicalResourceId" => {
-                        obj.logical_resource_id = Some(LogicalResourceIdDeserializer::deserialize(
-                            "LogicalResourceId",
-                            stack,
-                        )?);
-                    }
-                    "PhysicalResourceId" => {
-                        obj.physical_resource_id =
-                            Some(PhysicalResourceIdDeserializer::deserialize(
-                                "PhysicalResourceId",
-                                stack,
-                            )?);
-                    }
-                    "Replacement" => {
-                        obj.replacement =
-                            Some(ReplacementDeserializer::deserialize("Replacement", stack)?);
-                    }
-                    "ResourceType" => {
-                        obj.resource_type = Some(ResourceTypeDeserializer::deserialize(
-                            "ResourceType",
-                            stack,
-                        )?);
-                    }
-                    "Scope" => {
-                        obj.scope = match obj.scope {
-                            Some(ref mut existing) => {
-                                existing.extend(ScopeDeserializer::deserialize("Scope", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ScopeDeserializer::deserialize("Scope", stack)?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Details" => {
+                    obj.details.get_or_insert(vec![]).extend(
+                        ResourceChangeDetailsDeserializer::deserialize("Details", stack)?,
+                    );
                 }
+                "LogicalResourceId" => {
+                    obj.logical_resource_id = Some(LogicalResourceIdDeserializer::deserialize(
+                        "LogicalResourceId",
+                        stack,
+                    )?);
+                }
+                "PhysicalResourceId" => {
+                    obj.physical_resource_id = Some(PhysicalResourceIdDeserializer::deserialize(
+                        "PhysicalResourceId",
+                        stack,
+                    )?);
+                }
+                "Replacement" => {
+                    obj.replacement =
+                        Some(ReplacementDeserializer::deserialize("Replacement", stack)?);
+                }
+                "ResourceType" => {
+                    obj.resource_type = Some(ResourceTypeDeserializer::deserialize(
+                        "ResourceType",
+                        stack,
+                    )?);
+                }
+                "Scope" => {
+                    obj.scope
+                        .get_or_insert(vec![])
+                        .extend(ScopeDeserializer::deserialize("Scope", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>For a resource with <code>Modify</code> as the action, the <code>ResourceChange</code> structure describes the changes AWS CloudFormation will make to that resource.</p>
@@ -5792,56 +4408,35 @@ impl ResourceChangeDetailDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ResourceChangeDetail, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ResourceChangeDetail::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ResourceChangeDetail, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CausingEntity" => {
+                    obj.causing_entity = Some(CausingEntityDeserializer::deserialize(
+                        "CausingEntity",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CausingEntity" => {
-                        obj.causing_entity = Some(CausingEntityDeserializer::deserialize(
-                            "CausingEntity",
-                            stack,
-                        )?);
-                    }
-                    "ChangeSource" => {
-                        obj.change_source = Some(ChangeSourceDeserializer::deserialize(
-                            "ChangeSource",
-                            stack,
-                        )?);
-                    }
-                    "Evaluation" => {
-                        obj.evaluation = Some(EvaluationTypeDeserializer::deserialize(
-                            "Evaluation",
-                            stack,
-                        )?);
-                    }
-                    "Target" => {
-                        obj.target = Some(ResourceTargetDefinitionDeserializer::deserialize(
-                            "Target", stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "ChangeSource" => {
+                    obj.change_source = Some(ChangeSourceDeserializer::deserialize(
+                        "ChangeSource",
+                        stack,
+                    )?);
                 }
+                "Evaluation" => {
+                    obj.evaluation = Some(EvaluationTypeDeserializer::deserialize(
+                        "Evaluation",
+                        stack,
+                    )?);
+                }
+                "Target" => {
+                    obj.target = Some(ResourceTargetDefinitionDeserializer::deserialize(
+                        "Target", stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ResourceChangeDetailsDeserializer;
@@ -5851,39 +4446,16 @@ impl ResourceChangeDetailsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<ResourceChangeDetail>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(ResourceChangeDetailDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(ResourceChangeDetailDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ResourcePropertiesDeserializer;
@@ -5946,21 +4518,11 @@ impl ResourceTargetDefinitionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ResourceTargetDefinition, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ResourceTargetDefinition::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ResourceTargetDefinition, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Attribute" => {
                         obj.attribute = Some(ResourceAttributeDeserializer::deserialize(
                             "Attribute",
@@ -5978,17 +4540,10 @@ impl ResourceTargetDefinitionDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct ResourceTypeDeserializer;
@@ -6012,37 +4567,14 @@ impl ResourceTypesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(ResourceTypeDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(ResourceTypeDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -6123,55 +4655,24 @@ impl RollbackConfigurationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<RollbackConfiguration, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = RollbackConfiguration::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, RollbackConfiguration, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "MonitoringTimeInMinutes" => {
+                    obj.monitoring_time_in_minutes =
+                        Some(MonitoringTimeInMinutesDeserializer::deserialize(
+                            "MonitoringTimeInMinutes",
+                            stack,
+                        )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "MonitoringTimeInMinutes" => {
-                        obj.monitoring_time_in_minutes =
-                            Some(MonitoringTimeInMinutesDeserializer::deserialize(
-                                "MonitoringTimeInMinutes",
-                                stack,
-                            )?);
-                    }
-                    "RollbackTriggers" => {
-                        obj.rollback_triggers = match obj.rollback_triggers {
-                            Some(ref mut existing) => {
-                                existing.extend(RollbackTriggersDeserializer::deserialize(
-                                    "RollbackTriggers",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(RollbackTriggersDeserializer::deserialize(
-                                "RollbackTriggers",
-                                stack,
-                            )?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "RollbackTriggers" => {
+                    obj.rollback_triggers.get_or_insert(vec![]).extend(
+                        RollbackTriggersDeserializer::deserialize("RollbackTriggers", stack)?,
+                    );
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -6216,39 +4717,18 @@ impl RollbackTriggerDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<RollbackTrigger, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = RollbackTrigger::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, RollbackTrigger, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Arn" => {
+                    obj.arn = ArnDeserializer::deserialize("Arn", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Arn" => {
-                        obj.arn = ArnDeserializer::deserialize("Arn", stack)?;
-                    }
-                    "Type" => {
-                        obj.type_ = TypeDeserializer::deserialize("Type", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Type" => {
+                    obj.type_ = TypeDeserializer::deserialize("Type", stack)?;
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -6273,37 +4753,14 @@ impl RollbackTriggersDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<RollbackTrigger>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(RollbackTriggerDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(RollbackTriggerDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -6325,37 +4782,14 @@ impl ScopeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(ResourceAttributeDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(ResourceAttributeDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>The input for the <a>SetStackPolicy</a> action.</p>
@@ -6476,176 +4910,117 @@ impl StackDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Stack, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Stack::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Stack, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Capabilities" => {
+                    obj.capabilities.get_or_insert(vec![]).extend(
+                        CapabilitiesDeserializer::deserialize("Capabilities", stack)?,
+                    );
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Capabilities" => {
-                        obj.capabilities = match obj.capabilities {
-                            Some(ref mut existing) => {
-                                existing.extend(CapabilitiesDeserializer::deserialize(
-                                    "Capabilities",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(CapabilitiesDeserializer::deserialize(
-                                "Capabilities",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "ChangeSetId" => {
-                        obj.change_set_id =
-                            Some(ChangeSetIdDeserializer::deserialize("ChangeSetId", stack)?);
-                    }
-                    "CreationTime" => {
-                        obj.creation_time =
-                            CreationTimeDeserializer::deserialize("CreationTime", stack)?;
-                    }
-                    "DeletionTime" => {
-                        obj.deletion_time = Some(DeletionTimeDeserializer::deserialize(
-                            "DeletionTime",
-                            stack,
-                        )?);
-                    }
-                    "Description" => {
-                        obj.description =
-                            Some(DescriptionDeserializer::deserialize("Description", stack)?);
-                    }
-                    "DisableRollback" => {
-                        obj.disable_rollback = Some(DisableRollbackDeserializer::deserialize(
-                            "DisableRollback",
-                            stack,
-                        )?);
-                    }
-                    "DriftInformation" => {
-                        obj.drift_information =
-                            Some(StackDriftInformationDeserializer::deserialize(
-                                "DriftInformation",
-                                stack,
-                            )?);
-                    }
-                    "EnableTerminationProtection" => {
-                        obj.enable_termination_protection =
-                            Some(EnableTerminationProtectionDeserializer::deserialize(
-                                "EnableTerminationProtection",
-                                stack,
-                            )?);
-                    }
-                    "LastUpdatedTime" => {
-                        obj.last_updated_time = Some(LastUpdatedTimeDeserializer::deserialize(
-                            "LastUpdatedTime",
-                            stack,
-                        )?);
-                    }
-                    "NotificationARNs" => {
-                        obj.notification_ar_ns = match obj.notification_ar_ns {
-                            Some(ref mut existing) => {
-                                existing.extend(NotificationARNsDeserializer::deserialize(
-                                    "NotificationARNs",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(NotificationARNsDeserializer::deserialize(
-                                "NotificationARNs",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "Outputs" => {
-                        obj.outputs = match obj.outputs {
-                            Some(ref mut existing) => {
-                                existing
-                                    .extend(OutputsDeserializer::deserialize("Outputs", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(OutputsDeserializer::deserialize("Outputs", stack)?),
-                        };
-                    }
-                    "Parameters" => {
-                        obj.parameters = match obj.parameters {
-                            Some(ref mut existing) => {
-                                existing.extend(ParametersDeserializer::deserialize(
-                                    "Parameters",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ParametersDeserializer::deserialize("Parameters", stack)?),
-                        };
-                    }
-                    "ParentId" => {
-                        obj.parent_id = Some(StackIdDeserializer::deserialize("ParentId", stack)?);
-                    }
-                    "RoleARN" => {
-                        obj.role_arn = Some(RoleARNDeserializer::deserialize("RoleARN", stack)?);
-                    }
-                    "RollbackConfiguration" => {
-                        obj.rollback_configuration =
-                            Some(RollbackConfigurationDeserializer::deserialize(
-                                "RollbackConfiguration",
-                                stack,
-                            )?);
-                    }
-                    "RootId" => {
-                        obj.root_id = Some(StackIdDeserializer::deserialize("RootId", stack)?);
-                    }
-                    "StackId" => {
-                        obj.stack_id = Some(StackIdDeserializer::deserialize("StackId", stack)?);
-                    }
-                    "StackName" => {
-                        obj.stack_name = StackNameDeserializer::deserialize("StackName", stack)?;
-                    }
-                    "StackStatus" => {
-                        obj.stack_status =
-                            StackStatusDeserializer::deserialize("StackStatus", stack)?;
-                    }
-                    "StackStatusReason" => {
-                        obj.stack_status_reason = Some(StackStatusReasonDeserializer::deserialize(
-                            "StackStatusReason",
-                            stack,
-                        )?);
-                    }
-                    "Tags" => {
-                        obj.tags = match obj.tags {
-                            Some(ref mut existing) => {
-                                existing.extend(TagsDeserializer::deserialize("Tags", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(TagsDeserializer::deserialize("Tags", stack)?),
-                        };
-                    }
-                    "TimeoutInMinutes" => {
-                        obj.timeout_in_minutes = Some(TimeoutMinutesDeserializer::deserialize(
-                            "TimeoutInMinutes",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "ChangeSetId" => {
+                    obj.change_set_id =
+                        Some(ChangeSetIdDeserializer::deserialize("ChangeSetId", stack)?);
                 }
+                "CreationTime" => {
+                    obj.creation_time =
+                        CreationTimeDeserializer::deserialize("CreationTime", stack)?;
+                }
+                "DeletionTime" => {
+                    obj.deletion_time = Some(DeletionTimeDeserializer::deserialize(
+                        "DeletionTime",
+                        stack,
+                    )?);
+                }
+                "Description" => {
+                    obj.description =
+                        Some(DescriptionDeserializer::deserialize("Description", stack)?);
+                }
+                "DisableRollback" => {
+                    obj.disable_rollback = Some(DisableRollbackDeserializer::deserialize(
+                        "DisableRollback",
+                        stack,
+                    )?);
+                }
+                "DriftInformation" => {
+                    obj.drift_information = Some(StackDriftInformationDeserializer::deserialize(
+                        "DriftInformation",
+                        stack,
+                    )?);
+                }
+                "EnableTerminationProtection" => {
+                    obj.enable_termination_protection =
+                        Some(EnableTerminationProtectionDeserializer::deserialize(
+                            "EnableTerminationProtection",
+                            stack,
+                        )?);
+                }
+                "LastUpdatedTime" => {
+                    obj.last_updated_time = Some(LastUpdatedTimeDeserializer::deserialize(
+                        "LastUpdatedTime",
+                        stack,
+                    )?);
+                }
+                "NotificationARNs" => {
+                    obj.notification_ar_ns.get_or_insert(vec![]).extend(
+                        NotificationARNsDeserializer::deserialize("NotificationARNs", stack)?,
+                    );
+                }
+                "Outputs" => {
+                    obj.outputs
+                        .get_or_insert(vec![])
+                        .extend(OutputsDeserializer::deserialize("Outputs", stack)?);
+                }
+                "Parameters" => {
+                    obj.parameters
+                        .get_or_insert(vec![])
+                        .extend(ParametersDeserializer::deserialize("Parameters", stack)?);
+                }
+                "ParentId" => {
+                    obj.parent_id = Some(StackIdDeserializer::deserialize("ParentId", stack)?);
+                }
+                "RoleARN" => {
+                    obj.role_arn = Some(RoleARNDeserializer::deserialize("RoleARN", stack)?);
+                }
+                "RollbackConfiguration" => {
+                    obj.rollback_configuration =
+                        Some(RollbackConfigurationDeserializer::deserialize(
+                            "RollbackConfiguration",
+                            stack,
+                        )?);
+                }
+                "RootId" => {
+                    obj.root_id = Some(StackIdDeserializer::deserialize("RootId", stack)?);
+                }
+                "StackId" => {
+                    obj.stack_id = Some(StackIdDeserializer::deserialize("StackId", stack)?);
+                }
+                "StackName" => {
+                    obj.stack_name = StackNameDeserializer::deserialize("StackName", stack)?;
+                }
+                "StackStatus" => {
+                    obj.stack_status = StackStatusDeserializer::deserialize("StackStatus", stack)?;
+                }
+                "StackStatusReason" => {
+                    obj.stack_status_reason = Some(StackStatusReasonDeserializer::deserialize(
+                        "StackStatusReason",
+                        stack,
+                    )?);
+                }
+                "Tags" => {
+                    obj.tags
+                        .get_or_insert(vec![])
+                        .extend(TagsDeserializer::deserialize("Tags", stack)?);
+                }
+                "TimeoutInMinutes" => {
+                    obj.timeout_in_minutes = Some(TimeoutMinutesDeserializer::deserialize(
+                        "TimeoutInMinutes",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct StackDriftDetectionIdDeserializer;
@@ -6706,43 +5081,22 @@ impl StackDriftInformationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<StackDriftInformation, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = StackDriftInformation::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, StackDriftInformation, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "LastCheckTimestamp" => {
+                    obj.last_check_timestamp = Some(TimestampDeserializer::deserialize(
+                        "LastCheckTimestamp",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "LastCheckTimestamp" => {
-                        obj.last_check_timestamp = Some(TimestampDeserializer::deserialize(
-                            "LastCheckTimestamp",
-                            stack,
-                        )?);
-                    }
-                    "StackDriftStatus" => {
-                        obj.stack_drift_status =
-                            StackDriftStatusDeserializer::deserialize("StackDriftStatus", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "StackDriftStatus" => {
+                    obj.stack_drift_status =
+                        StackDriftStatusDeserializer::deserialize("StackDriftStatus", stack)?;
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains information about whether the stack's actual configuration differs, or has <i>drifted</i>, from its expected configuration, as defined in the stack template and any values specified as template parameters. A stack is considered to have drifted if one or more of its resources have drifted.</p>
@@ -6761,21 +5115,11 @@ impl StackDriftInformationSummaryDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<StackDriftInformationSummary, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = StackDriftInformationSummary::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, StackDriftInformationSummary, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "LastCheckTimestamp" => {
                         obj.last_check_timestamp = Some(TimestampDeserializer::deserialize(
                             "LastCheckTimestamp",
@@ -6787,17 +5131,10 @@ impl StackDriftInformationSummaryDeserializer {
                             StackDriftStatusDeserializer::deserialize("StackDriftStatus", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct StackDriftStatusDeserializer;
@@ -6848,91 +5185,67 @@ impl StackEventDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<StackEvent, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = StackEvent::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, StackEvent, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "ClientRequestToken" => {
+                    obj.client_request_token = Some(ClientRequestTokenDeserializer::deserialize(
+                        "ClientRequestToken",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "ClientRequestToken" => {
-                        obj.client_request_token =
-                            Some(ClientRequestTokenDeserializer::deserialize(
-                                "ClientRequestToken",
-                                stack,
-                            )?);
-                    }
-                    "EventId" => {
-                        obj.event_id = EventIdDeserializer::deserialize("EventId", stack)?;
-                    }
-                    "LogicalResourceId" => {
-                        obj.logical_resource_id = Some(LogicalResourceIdDeserializer::deserialize(
-                            "LogicalResourceId",
-                            stack,
-                        )?);
-                    }
-                    "PhysicalResourceId" => {
-                        obj.physical_resource_id =
-                            Some(PhysicalResourceIdDeserializer::deserialize(
-                                "PhysicalResourceId",
-                                stack,
-                            )?);
-                    }
-                    "ResourceProperties" => {
-                        obj.resource_properties =
-                            Some(ResourcePropertiesDeserializer::deserialize(
-                                "ResourceProperties",
-                                stack,
-                            )?);
-                    }
-                    "ResourceStatus" => {
-                        obj.resource_status = Some(ResourceStatusDeserializer::deserialize(
-                            "ResourceStatus",
-                            stack,
-                        )?);
-                    }
-                    "ResourceStatusReason" => {
-                        obj.resource_status_reason =
-                            Some(ResourceStatusReasonDeserializer::deserialize(
-                                "ResourceStatusReason",
-                                stack,
-                            )?);
-                    }
-                    "ResourceType" => {
-                        obj.resource_type = Some(ResourceTypeDeserializer::deserialize(
-                            "ResourceType",
-                            stack,
-                        )?);
-                    }
-                    "StackId" => {
-                        obj.stack_id = StackIdDeserializer::deserialize("StackId", stack)?;
-                    }
-                    "StackName" => {
-                        obj.stack_name = StackNameDeserializer::deserialize("StackName", stack)?;
-                    }
-                    "Timestamp" => {
-                        obj.timestamp = TimestampDeserializer::deserialize("Timestamp", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "EventId" => {
+                    obj.event_id = EventIdDeserializer::deserialize("EventId", stack)?;
                 }
+                "LogicalResourceId" => {
+                    obj.logical_resource_id = Some(LogicalResourceIdDeserializer::deserialize(
+                        "LogicalResourceId",
+                        stack,
+                    )?);
+                }
+                "PhysicalResourceId" => {
+                    obj.physical_resource_id = Some(PhysicalResourceIdDeserializer::deserialize(
+                        "PhysicalResourceId",
+                        stack,
+                    )?);
+                }
+                "ResourceProperties" => {
+                    obj.resource_properties = Some(ResourcePropertiesDeserializer::deserialize(
+                        "ResourceProperties",
+                        stack,
+                    )?);
+                }
+                "ResourceStatus" => {
+                    obj.resource_status = Some(ResourceStatusDeserializer::deserialize(
+                        "ResourceStatus",
+                        stack,
+                    )?);
+                }
+                "ResourceStatusReason" => {
+                    obj.resource_status_reason =
+                        Some(ResourceStatusReasonDeserializer::deserialize(
+                            "ResourceStatusReason",
+                            stack,
+                        )?);
+                }
+                "ResourceType" => {
+                    obj.resource_type = Some(ResourceTypeDeserializer::deserialize(
+                        "ResourceType",
+                        stack,
+                    )?);
+                }
+                "StackId" => {
+                    obj.stack_id = StackIdDeserializer::deserialize("StackId", stack)?;
+                }
+                "StackName" => {
+                    obj.stack_name = StackNameDeserializer::deserialize("StackName", stack)?;
+                }
+                "Timestamp" => {
+                    obj.timestamp = TimestampDeserializer::deserialize("Timestamp", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct StackEventsDeserializer;
@@ -6942,37 +5255,14 @@ impl StackEventsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<StackEvent>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(StackEventDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(StackEventDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct StackIdDeserializer;
@@ -7015,70 +5305,39 @@ impl StackInstanceDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<StackInstance, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = StackInstance::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, StackInstance, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Account" => {
+                    obj.account = Some(AccountDeserializer::deserialize("Account", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Account" => {
-                        obj.account = Some(AccountDeserializer::deserialize("Account", stack)?);
-                    }
-                    "ParameterOverrides" => {
-                        obj.parameter_overrides = match obj.parameter_overrides {
-                            Some(ref mut existing) => {
-                                existing.extend(ParametersDeserializer::deserialize(
-                                    "ParameterOverrides",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ParametersDeserializer::deserialize(
-                                "ParameterOverrides",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "Region" => {
-                        obj.region = Some(RegionDeserializer::deserialize("Region", stack)?);
-                    }
-                    "StackId" => {
-                        obj.stack_id = Some(StackIdDeserializer::deserialize("StackId", stack)?);
-                    }
-                    "StackSetId" => {
-                        obj.stack_set_id =
-                            Some(StackSetIdDeserializer::deserialize("StackSetId", stack)?);
-                    }
-                    "Status" => {
-                        obj.status = Some(StackInstanceStatusDeserializer::deserialize(
-                            "Status", stack,
-                        )?);
-                    }
-                    "StatusReason" => {
-                        obj.status_reason =
-                            Some(ReasonDeserializer::deserialize("StatusReason", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "ParameterOverrides" => {
+                    obj.parameter_overrides.get_or_insert(vec![]).extend(
+                        ParametersDeserializer::deserialize("ParameterOverrides", stack)?,
+                    );
                 }
+                "Region" => {
+                    obj.region = Some(RegionDeserializer::deserialize("Region", stack)?);
+                }
+                "StackId" => {
+                    obj.stack_id = Some(StackIdDeserializer::deserialize("StackId", stack)?);
+                }
+                "StackSetId" => {
+                    obj.stack_set_id =
+                        Some(StackSetIdDeserializer::deserialize("StackSetId", stack)?);
+                }
+                "Status" => {
+                    obj.status = Some(StackInstanceStatusDeserializer::deserialize(
+                        "Status", stack,
+                    )?);
+                }
+                "StatusReason" => {
+                    obj.status_reason =
+                        Some(ReasonDeserializer::deserialize("StatusReason", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct StackInstanceStatusDeserializer;
@@ -7102,39 +5361,16 @@ impl StackInstanceSummariesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<StackInstanceSummary>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(StackInstanceSummaryDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(StackInstanceSummaryDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>The structure that contains summary information about a stack instance.</p>
@@ -7161,55 +5397,34 @@ impl StackInstanceSummaryDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<StackInstanceSummary, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = StackInstanceSummary::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, StackInstanceSummary, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Account" => {
+                    obj.account = Some(AccountDeserializer::deserialize("Account", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Account" => {
-                        obj.account = Some(AccountDeserializer::deserialize("Account", stack)?);
-                    }
-                    "Region" => {
-                        obj.region = Some(RegionDeserializer::deserialize("Region", stack)?);
-                    }
-                    "StackId" => {
-                        obj.stack_id = Some(StackIdDeserializer::deserialize("StackId", stack)?);
-                    }
-                    "StackSetId" => {
-                        obj.stack_set_id =
-                            Some(StackSetIdDeserializer::deserialize("StackSetId", stack)?);
-                    }
-                    "Status" => {
-                        obj.status = Some(StackInstanceStatusDeserializer::deserialize(
-                            "Status", stack,
-                        )?);
-                    }
-                    "StatusReason" => {
-                        obj.status_reason =
-                            Some(ReasonDeserializer::deserialize("StatusReason", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Region" => {
+                    obj.region = Some(RegionDeserializer::deserialize("Region", stack)?);
                 }
+                "StackId" => {
+                    obj.stack_id = Some(StackIdDeserializer::deserialize("StackId", stack)?);
+                }
+                "StackSetId" => {
+                    obj.stack_set_id =
+                        Some(StackSetIdDeserializer::deserialize("StackSetId", stack)?);
+                }
+                "Status" => {
+                    obj.status = Some(StackInstanceStatusDeserializer::deserialize(
+                        "Status", stack,
+                    )?);
+                }
+                "StatusReason" => {
+                    obj.status_reason =
+                        Some(ReasonDeserializer::deserialize("StatusReason", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct StackNameDeserializer;
@@ -7272,80 +5487,57 @@ impl StackResourceDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<StackResource, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = StackResource::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, StackResource, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Description" => {
+                    obj.description =
+                        Some(DescriptionDeserializer::deserialize("Description", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Description" => {
-                        obj.description =
-                            Some(DescriptionDeserializer::deserialize("Description", stack)?);
-                    }
-                    "DriftInformation" => {
-                        obj.drift_information =
-                            Some(StackResourceDriftInformationDeserializer::deserialize(
-                                "DriftInformation",
-                                stack,
-                            )?);
-                    }
-                    "LogicalResourceId" => {
-                        obj.logical_resource_id =
-                            LogicalResourceIdDeserializer::deserialize("LogicalResourceId", stack)?;
-                    }
-                    "PhysicalResourceId" => {
-                        obj.physical_resource_id =
-                            Some(PhysicalResourceIdDeserializer::deserialize(
-                                "PhysicalResourceId",
-                                stack,
-                            )?);
-                    }
-                    "ResourceStatus" => {
-                        obj.resource_status =
-                            ResourceStatusDeserializer::deserialize("ResourceStatus", stack)?;
-                    }
-                    "ResourceStatusReason" => {
-                        obj.resource_status_reason =
-                            Some(ResourceStatusReasonDeserializer::deserialize(
-                                "ResourceStatusReason",
-                                stack,
-                            )?);
-                    }
-                    "ResourceType" => {
-                        obj.resource_type =
-                            ResourceTypeDeserializer::deserialize("ResourceType", stack)?;
-                    }
-                    "StackId" => {
-                        obj.stack_id = Some(StackIdDeserializer::deserialize("StackId", stack)?);
-                    }
-                    "StackName" => {
-                        obj.stack_name =
-                            Some(StackNameDeserializer::deserialize("StackName", stack)?);
-                    }
-                    "Timestamp" => {
-                        obj.timestamp = TimestampDeserializer::deserialize("Timestamp", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "DriftInformation" => {
+                    obj.drift_information =
+                        Some(StackResourceDriftInformationDeserializer::deserialize(
+                            "DriftInformation",
+                            stack,
+                        )?);
                 }
+                "LogicalResourceId" => {
+                    obj.logical_resource_id =
+                        LogicalResourceIdDeserializer::deserialize("LogicalResourceId", stack)?;
+                }
+                "PhysicalResourceId" => {
+                    obj.physical_resource_id = Some(PhysicalResourceIdDeserializer::deserialize(
+                        "PhysicalResourceId",
+                        stack,
+                    )?);
+                }
+                "ResourceStatus" => {
+                    obj.resource_status =
+                        ResourceStatusDeserializer::deserialize("ResourceStatus", stack)?;
+                }
+                "ResourceStatusReason" => {
+                    obj.resource_status_reason =
+                        Some(ResourceStatusReasonDeserializer::deserialize(
+                            "ResourceStatusReason",
+                            stack,
+                        )?);
+                }
+                "ResourceType" => {
+                    obj.resource_type =
+                        ResourceTypeDeserializer::deserialize("ResourceType", stack)?;
+                }
+                "StackId" => {
+                    obj.stack_id = Some(StackIdDeserializer::deserialize("StackId", stack)?);
+                }
+                "StackName" => {
+                    obj.stack_name = Some(StackNameDeserializer::deserialize("StackName", stack)?);
+                }
+                "Timestamp" => {
+                    obj.timestamp = TimestampDeserializer::deserialize("Timestamp", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains detailed information about the specified stack resource.</p>
@@ -7382,84 +5574,61 @@ impl StackResourceDetailDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<StackResourceDetail, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = StackResourceDetail::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, StackResourceDetail, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Description" => {
+                    obj.description =
+                        Some(DescriptionDeserializer::deserialize("Description", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Description" => {
-                        obj.description =
-                            Some(DescriptionDeserializer::deserialize("Description", stack)?);
-                    }
-                    "DriftInformation" => {
-                        obj.drift_information =
-                            Some(StackResourceDriftInformationDeserializer::deserialize(
-                                "DriftInformation",
-                                stack,
-                            )?);
-                    }
-                    "LastUpdatedTimestamp" => {
-                        obj.last_updated_timestamp =
-                            TimestampDeserializer::deserialize("LastUpdatedTimestamp", stack)?;
-                    }
-                    "LogicalResourceId" => {
-                        obj.logical_resource_id =
-                            LogicalResourceIdDeserializer::deserialize("LogicalResourceId", stack)?;
-                    }
-                    "Metadata" => {
-                        obj.metadata = Some(MetadataDeserializer::deserialize("Metadata", stack)?);
-                    }
-                    "PhysicalResourceId" => {
-                        obj.physical_resource_id =
-                            Some(PhysicalResourceIdDeserializer::deserialize(
-                                "PhysicalResourceId",
-                                stack,
-                            )?);
-                    }
-                    "ResourceStatus" => {
-                        obj.resource_status =
-                            ResourceStatusDeserializer::deserialize("ResourceStatus", stack)?;
-                    }
-                    "ResourceStatusReason" => {
-                        obj.resource_status_reason =
-                            Some(ResourceStatusReasonDeserializer::deserialize(
-                                "ResourceStatusReason",
-                                stack,
-                            )?);
-                    }
-                    "ResourceType" => {
-                        obj.resource_type =
-                            ResourceTypeDeserializer::deserialize("ResourceType", stack)?;
-                    }
-                    "StackId" => {
-                        obj.stack_id = Some(StackIdDeserializer::deserialize("StackId", stack)?);
-                    }
-                    "StackName" => {
-                        obj.stack_name =
-                            Some(StackNameDeserializer::deserialize("StackName", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "DriftInformation" => {
+                    obj.drift_information =
+                        Some(StackResourceDriftInformationDeserializer::deserialize(
+                            "DriftInformation",
+                            stack,
+                        )?);
                 }
+                "LastUpdatedTimestamp" => {
+                    obj.last_updated_timestamp =
+                        TimestampDeserializer::deserialize("LastUpdatedTimestamp", stack)?;
+                }
+                "LogicalResourceId" => {
+                    obj.logical_resource_id =
+                        LogicalResourceIdDeserializer::deserialize("LogicalResourceId", stack)?;
+                }
+                "Metadata" => {
+                    obj.metadata = Some(MetadataDeserializer::deserialize("Metadata", stack)?);
+                }
+                "PhysicalResourceId" => {
+                    obj.physical_resource_id = Some(PhysicalResourceIdDeserializer::deserialize(
+                        "PhysicalResourceId",
+                        stack,
+                    )?);
+                }
+                "ResourceStatus" => {
+                    obj.resource_status =
+                        ResourceStatusDeserializer::deserialize("ResourceStatus", stack)?;
+                }
+                "ResourceStatusReason" => {
+                    obj.resource_status_reason =
+                        Some(ResourceStatusReasonDeserializer::deserialize(
+                            "ResourceStatusReason",
+                            stack,
+                        )?);
+                }
+                "ResourceType" => {
+                    obj.resource_type =
+                        ResourceTypeDeserializer::deserialize("ResourceType", stack)?;
+                }
+                "StackId" => {
+                    obj.stack_id = Some(StackIdDeserializer::deserialize("StackId", stack)?);
+                }
+                "StackName" => {
+                    obj.stack_name = Some(StackNameDeserializer::deserialize("StackName", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains the drift information for a resource that has been checked for drift. This includes actual and expected property values for resources in which AWS CloudFormation has detected drift. Only resource properties explicitly defined in the stack template are checked for drift. For more information, see <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift.html">Detecting Unregulated Configuration Changes to Stacks and Resources</a>.</p> <p>Resources that do not currently support drift detection cannot be checked. For a list of resources that support drift detection, see <a href="http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift-resource-list.html">Resources that Support Drift Detection</a>.</p> <p>Use <a>DetectStackResourceDrift</a> to detect drift on individual resources, or <a>DetectStackDrift</a> to detect drift on all resources in a given stack that support drift detection.</p>
@@ -7494,105 +5663,64 @@ impl StackResourceDriftDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<StackResourceDrift, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = StackResourceDrift::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, StackResourceDrift, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "ActualProperties" => {
+                    obj.actual_properties = Some(PropertiesDeserializer::deserialize(
+                        "ActualProperties",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "ActualProperties" => {
-                        obj.actual_properties = Some(PropertiesDeserializer::deserialize(
-                            "ActualProperties",
+                "ExpectedProperties" => {
+                    obj.expected_properties = Some(PropertiesDeserializer::deserialize(
+                        "ExpectedProperties",
+                        stack,
+                    )?);
+                }
+                "LogicalResourceId" => {
+                    obj.logical_resource_id =
+                        LogicalResourceIdDeserializer::deserialize("LogicalResourceId", stack)?;
+                }
+                "PhysicalResourceId" => {
+                    obj.physical_resource_id = Some(PhysicalResourceIdDeserializer::deserialize(
+                        "PhysicalResourceId",
+                        stack,
+                    )?);
+                }
+                "PhysicalResourceIdContext" => {
+                    obj.physical_resource_id_context
+                        .get_or_insert(vec![])
+                        .extend(PhysicalResourceIdContextDeserializer::deserialize(
+                            "PhysicalResourceIdContext",
                             stack,
                         )?);
-                    }
-                    "ExpectedProperties" => {
-                        obj.expected_properties = Some(PropertiesDeserializer::deserialize(
-                            "ExpectedProperties",
-                            stack,
-                        )?);
-                    }
-                    "LogicalResourceId" => {
-                        obj.logical_resource_id =
-                            LogicalResourceIdDeserializer::deserialize("LogicalResourceId", stack)?;
-                    }
-                    "PhysicalResourceId" => {
-                        obj.physical_resource_id =
-                            Some(PhysicalResourceIdDeserializer::deserialize(
-                                "PhysicalResourceId",
-                                stack,
-                            )?);
-                    }
-                    "PhysicalResourceIdContext" => {
-                        obj.physical_resource_id_context = match obj.physical_resource_id_context {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    PhysicalResourceIdContextDeserializer::deserialize(
-                                        "PhysicalResourceIdContext",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(PhysicalResourceIdContextDeserializer::deserialize(
-                                "PhysicalResourceIdContext",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "PropertyDifferences" => {
-                        obj.property_differences = match obj.property_differences {
-                            Some(ref mut existing) => {
-                                existing.extend(PropertyDifferencesDeserializer::deserialize(
-                                    "PropertyDifferences",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(PropertyDifferencesDeserializer::deserialize(
-                                "PropertyDifferences",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "ResourceType" => {
-                        obj.resource_type =
-                            ResourceTypeDeserializer::deserialize("ResourceType", stack)?;
-                    }
-                    "StackId" => {
-                        obj.stack_id = StackIdDeserializer::deserialize("StackId", stack)?;
-                    }
-                    "StackResourceDriftStatus" => {
-                        obj.stack_resource_drift_status =
-                            StackResourceDriftStatusDeserializer::deserialize(
-                                "StackResourceDriftStatus",
-                                stack,
-                            )?;
-                    }
-                    "Timestamp" => {
-                        obj.timestamp = TimestampDeserializer::deserialize("Timestamp", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                "PropertyDifferences" => {
+                    obj.property_differences.get_or_insert(vec![]).extend(
+                        PropertyDifferencesDeserializer::deserialize("PropertyDifferences", stack)?,
+                    );
+                }
+                "ResourceType" => {
+                    obj.resource_type =
+                        ResourceTypeDeserializer::deserialize("ResourceType", stack)?;
+                }
+                "StackId" => {
+                    obj.stack_id = StackIdDeserializer::deserialize("StackId", stack)?;
+                }
+                "StackResourceDriftStatus" => {
+                    obj.stack_resource_drift_status =
+                        StackResourceDriftStatusDeserializer::deserialize(
+                            "StackResourceDriftStatus",
+                            stack,
+                        )?;
+                }
+                "Timestamp" => {
+                    obj.timestamp = TimestampDeserializer::deserialize("Timestamp", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains information about whether the resource's actual configuration differs, or has <i>drifted</i>, from its expected configuration.</p>
@@ -7611,21 +5739,11 @@ impl StackResourceDriftInformationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<StackResourceDriftInformation, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = StackResourceDriftInformation::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, StackResourceDriftInformation, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "LastCheckTimestamp" => {
                         obj.last_check_timestamp = Some(TimestampDeserializer::deserialize(
                             "LastCheckTimestamp",
@@ -7640,17 +5758,10 @@ impl StackResourceDriftInformationDeserializer {
                             )?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Summarizes information about whether the resource's actual configuration differs, or has <i>drifted</i>, from its expected configuration.</p>
@@ -7669,21 +5780,11 @@ impl StackResourceDriftInformationSummaryDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<StackResourceDriftInformationSummary, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = StackResourceDriftInformationSummary::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, StackResourceDriftInformationSummary, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "LastCheckTimestamp" => {
                         obj.last_check_timestamp = Some(TimestampDeserializer::deserialize(
                             "LastCheckTimestamp",
@@ -7698,17 +5799,10 @@ impl StackResourceDriftInformationSummaryDeserializer {
                             )?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct StackResourceDriftStatusDeserializer;
@@ -7744,39 +5838,16 @@ impl StackResourceDriftsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<StackResourceDrift>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(StackResourceDriftDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(StackResourceDriftDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct StackResourceSummariesDeserializer;
@@ -7786,39 +5857,16 @@ impl StackResourceSummariesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<StackResourceSummary>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(StackResourceSummaryDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(StackResourceSummaryDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains high-level information about the specified stack resource.</p>
@@ -7847,71 +5895,49 @@ impl StackResourceSummaryDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<StackResourceSummary, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = StackResourceSummary::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, StackResourceSummary, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DriftInformation" => {
+                    obj.drift_information = Some(
+                        StackResourceDriftInformationSummaryDeserializer::deserialize(
+                            "DriftInformation",
+                            stack,
+                        )?,
+                    );
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DriftInformation" => {
-                        obj.drift_information = Some(
-                            StackResourceDriftInformationSummaryDeserializer::deserialize(
-                                "DriftInformation",
-                                stack,
-                            )?,
-                        );
-                    }
-                    "LastUpdatedTimestamp" => {
-                        obj.last_updated_timestamp =
-                            TimestampDeserializer::deserialize("LastUpdatedTimestamp", stack)?;
-                    }
-                    "LogicalResourceId" => {
-                        obj.logical_resource_id =
-                            LogicalResourceIdDeserializer::deserialize("LogicalResourceId", stack)?;
-                    }
-                    "PhysicalResourceId" => {
-                        obj.physical_resource_id =
-                            Some(PhysicalResourceIdDeserializer::deserialize(
-                                "PhysicalResourceId",
-                                stack,
-                            )?);
-                    }
-                    "ResourceStatus" => {
-                        obj.resource_status =
-                            ResourceStatusDeserializer::deserialize("ResourceStatus", stack)?;
-                    }
-                    "ResourceStatusReason" => {
-                        obj.resource_status_reason =
-                            Some(ResourceStatusReasonDeserializer::deserialize(
-                                "ResourceStatusReason",
-                                stack,
-                            )?);
-                    }
-                    "ResourceType" => {
-                        obj.resource_type =
-                            ResourceTypeDeserializer::deserialize("ResourceType", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "LastUpdatedTimestamp" => {
+                    obj.last_updated_timestamp =
+                        TimestampDeserializer::deserialize("LastUpdatedTimestamp", stack)?;
                 }
+                "LogicalResourceId" => {
+                    obj.logical_resource_id =
+                        LogicalResourceIdDeserializer::deserialize("LogicalResourceId", stack)?;
+                }
+                "PhysicalResourceId" => {
+                    obj.physical_resource_id = Some(PhysicalResourceIdDeserializer::deserialize(
+                        "PhysicalResourceId",
+                        stack,
+                    )?);
+                }
+                "ResourceStatus" => {
+                    obj.resource_status =
+                        ResourceStatusDeserializer::deserialize("ResourceStatus", stack)?;
+                }
+                "ResourceStatusReason" => {
+                    obj.resource_status_reason =
+                        Some(ResourceStatusReasonDeserializer::deserialize(
+                            "ResourceStatusReason",
+                            stack,
+                        )?);
+                }
+                "ResourceType" => {
+                    obj.resource_type =
+                        ResourceTypeDeserializer::deserialize("ResourceType", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct StackResourcesDeserializer;
@@ -7921,37 +5947,14 @@ impl StackResourcesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<StackResource>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(StackResourceDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(StackResourceDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>A structure that contains information about a stack set. A stack set enables you to provision stacks into AWS accounts and across regions by using a single CloudFormation template. In the stack set, you specify the template to use, as well as any parameters and capabilities that the template requires. </p>
@@ -7988,109 +5991,66 @@ impl StackSetDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<StackSet, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = StackSet::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, StackSet, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AdministrationRoleARN" => {
+                    obj.administration_role_arn = Some(RoleARNDeserializer::deserialize(
+                        "AdministrationRoleARN",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AdministrationRoleARN" => {
-                        obj.administration_role_arn = Some(RoleARNDeserializer::deserialize(
-                            "AdministrationRoleARN",
-                            stack,
-                        )?);
-                    }
-                    "Capabilities" => {
-                        obj.capabilities = match obj.capabilities {
-                            Some(ref mut existing) => {
-                                existing.extend(CapabilitiesDeserializer::deserialize(
-                                    "Capabilities",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(CapabilitiesDeserializer::deserialize(
-                                "Capabilities",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "Description" => {
-                        obj.description =
-                            Some(DescriptionDeserializer::deserialize("Description", stack)?);
-                    }
-                    "ExecutionRoleName" => {
-                        obj.execution_role_name = Some(ExecutionRoleNameDeserializer::deserialize(
-                            "ExecutionRoleName",
-                            stack,
-                        )?);
-                    }
-                    "Parameters" => {
-                        obj.parameters = match obj.parameters {
-                            Some(ref mut existing) => {
-                                existing.extend(ParametersDeserializer::deserialize(
-                                    "Parameters",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ParametersDeserializer::deserialize("Parameters", stack)?),
-                        };
-                    }
-                    "StackSetARN" => {
-                        obj.stack_set_arn =
-                            Some(StackSetARNDeserializer::deserialize("StackSetARN", stack)?);
-                    }
-                    "StackSetId" => {
-                        obj.stack_set_id =
-                            Some(StackSetIdDeserializer::deserialize("StackSetId", stack)?);
-                    }
-                    "StackSetName" => {
-                        obj.stack_set_name = Some(StackSetNameDeserializer::deserialize(
-                            "StackSetName",
-                            stack,
-                        )?);
-                    }
-                    "Status" => {
-                        obj.status =
-                            Some(StackSetStatusDeserializer::deserialize("Status", stack)?);
-                    }
-                    "Tags" => {
-                        obj.tags = match obj.tags {
-                            Some(ref mut existing) => {
-                                existing.extend(TagsDeserializer::deserialize("Tags", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(TagsDeserializer::deserialize("Tags", stack)?),
-                        };
-                    }
-                    "TemplateBody" => {
-                        obj.template_body = Some(TemplateBodyDeserializer::deserialize(
-                            "TemplateBody",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Capabilities" => {
+                    obj.capabilities.get_or_insert(vec![]).extend(
+                        CapabilitiesDeserializer::deserialize("Capabilities", stack)?,
+                    );
                 }
+                "Description" => {
+                    obj.description =
+                        Some(DescriptionDeserializer::deserialize("Description", stack)?);
+                }
+                "ExecutionRoleName" => {
+                    obj.execution_role_name = Some(ExecutionRoleNameDeserializer::deserialize(
+                        "ExecutionRoleName",
+                        stack,
+                    )?);
+                }
+                "Parameters" => {
+                    obj.parameters
+                        .get_or_insert(vec![])
+                        .extend(ParametersDeserializer::deserialize("Parameters", stack)?);
+                }
+                "StackSetARN" => {
+                    obj.stack_set_arn =
+                        Some(StackSetARNDeserializer::deserialize("StackSetARN", stack)?);
+                }
+                "StackSetId" => {
+                    obj.stack_set_id =
+                        Some(StackSetIdDeserializer::deserialize("StackSetId", stack)?);
+                }
+                "StackSetName" => {
+                    obj.stack_set_name = Some(StackSetNameDeserializer::deserialize(
+                        "StackSetName",
+                        stack,
+                    )?);
+                }
+                "Status" => {
+                    obj.status = Some(StackSetStatusDeserializer::deserialize("Status", stack)?);
+                }
+                "Tags" => {
+                    obj.tags
+                        .get_or_insert(vec![])
+                        .extend(TagsDeserializer::deserialize("Tags", stack)?);
+                }
+                "TemplateBody" => {
+                    obj.template_body = Some(TemplateBodyDeserializer::deserialize(
+                        "TemplateBody",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct StackSetARNDeserializer;
@@ -8167,88 +6127,67 @@ impl StackSetOperationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<StackSetOperation, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = StackSetOperation::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, StackSetOperation, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Action" => {
+                    obj.action = Some(StackSetOperationActionDeserializer::deserialize(
+                        "Action", stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Action" => {
-                        obj.action = Some(StackSetOperationActionDeserializer::deserialize(
-                            "Action", stack,
-                        )?);
-                    }
-                    "AdministrationRoleARN" => {
-                        obj.administration_role_arn = Some(RoleARNDeserializer::deserialize(
-                            "AdministrationRoleARN",
-                            stack,
-                        )?);
-                    }
-                    "CreationTimestamp" => {
-                        obj.creation_timestamp = Some(TimestampDeserializer::deserialize(
-                            "CreationTimestamp",
-                            stack,
-                        )?);
-                    }
-                    "EndTimestamp" => {
-                        obj.end_timestamp =
-                            Some(TimestampDeserializer::deserialize("EndTimestamp", stack)?);
-                    }
-                    "ExecutionRoleName" => {
-                        obj.execution_role_name = Some(ExecutionRoleNameDeserializer::deserialize(
-                            "ExecutionRoleName",
-                            stack,
-                        )?);
-                    }
-                    "OperationId" => {
-                        obj.operation_id = Some(ClientRequestTokenDeserializer::deserialize(
-                            "OperationId",
-                            stack,
-                        )?);
-                    }
-                    "OperationPreferences" => {
-                        obj.operation_preferences =
-                            Some(StackSetOperationPreferencesDeserializer::deserialize(
-                                "OperationPreferences",
-                                stack,
-                            )?);
-                    }
-                    "RetainStacks" => {
-                        obj.retain_stacks = Some(RetainStacksNullableDeserializer::deserialize(
-                            "RetainStacks",
-                            stack,
-                        )?);
-                    }
-                    "StackSetId" => {
-                        obj.stack_set_id =
-                            Some(StackSetIdDeserializer::deserialize("StackSetId", stack)?);
-                    }
-                    "Status" => {
-                        obj.status = Some(StackSetOperationStatusDeserializer::deserialize(
-                            "Status", stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "AdministrationRoleARN" => {
+                    obj.administration_role_arn = Some(RoleARNDeserializer::deserialize(
+                        "AdministrationRoleARN",
+                        stack,
+                    )?);
                 }
+                "CreationTimestamp" => {
+                    obj.creation_timestamp = Some(TimestampDeserializer::deserialize(
+                        "CreationTimestamp",
+                        stack,
+                    )?);
+                }
+                "EndTimestamp" => {
+                    obj.end_timestamp =
+                        Some(TimestampDeserializer::deserialize("EndTimestamp", stack)?);
+                }
+                "ExecutionRoleName" => {
+                    obj.execution_role_name = Some(ExecutionRoleNameDeserializer::deserialize(
+                        "ExecutionRoleName",
+                        stack,
+                    )?);
+                }
+                "OperationId" => {
+                    obj.operation_id = Some(ClientRequestTokenDeserializer::deserialize(
+                        "OperationId",
+                        stack,
+                    )?);
+                }
+                "OperationPreferences" => {
+                    obj.operation_preferences =
+                        Some(StackSetOperationPreferencesDeserializer::deserialize(
+                            "OperationPreferences",
+                            stack,
+                        )?);
+                }
+                "RetainStacks" => {
+                    obj.retain_stacks = Some(RetainStacksNullableDeserializer::deserialize(
+                        "RetainStacks",
+                        stack,
+                    )?);
+                }
+                "StackSetId" => {
+                    obj.stack_set_id =
+                        Some(StackSetIdDeserializer::deserialize("StackSetId", stack)?);
+                }
+                "Status" => {
+                    obj.status = Some(StackSetOperationStatusDeserializer::deserialize(
+                        "Status", stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct StackSetOperationActionDeserializer;
@@ -8287,21 +6226,11 @@ impl StackSetOperationPreferencesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<StackSetOperationPreferences, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = StackSetOperationPreferences::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, StackSetOperationPreferences, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "FailureToleranceCount" => {
                         obj.failure_tolerance_count =
                             Some(FailureToleranceCountDeserializer::deserialize(
@@ -8331,31 +6260,15 @@ impl StackSetOperationPreferencesDeserializer {
                             )?);
                     }
                     "RegionOrder" => {
-                        obj.region_order = match obj.region_order {
-                            Some(ref mut existing) => {
-                                existing.extend(RegionListDeserializer::deserialize(
-                                    "RegionOrder",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => {
-                                Some(RegionListDeserializer::deserialize("RegionOrder", stack)?)
-                            }
-                        };
+                        obj.region_order
+                            .get_or_insert(vec![])
+                            .extend(RegionListDeserializer::deserialize("RegionOrder", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -8423,39 +6336,16 @@ impl StackSetOperationResultSummariesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<StackSetOperationResultSummary>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(StackSetOperationResultSummaryDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(StackSetOperationResultSummaryDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>The structure that contains information about a specified operation's results for a given account in a given region.</p>
@@ -8480,21 +6370,11 @@ impl StackSetOperationResultSummaryDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<StackSetOperationResultSummary, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = StackSetOperationResultSummary::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, StackSetOperationResultSummary, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Account" => {
                         obj.account = Some(AccountDeserializer::deserialize("Account", stack)?);
                     }
@@ -8517,17 +6397,10 @@ impl StackSetOperationResultSummaryDeserializer {
                             Some(ReasonDeserializer::deserialize("StatusReason", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct StackSetOperationStatusDeserializer;
@@ -8551,39 +6424,16 @@ impl StackSetOperationSummariesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<StackSetOperationSummary>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(StackSetOperationSummaryDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(StackSetOperationSummaryDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>The structures that contain summary information about the specified operation.</p>
@@ -8608,21 +6458,11 @@ impl StackSetOperationSummaryDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<StackSetOperationSummary, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = StackSetOperationSummary::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, StackSetOperationSummary, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Action" => {
                         obj.action = Some(StackSetOperationActionDeserializer::deserialize(
                             "Action", stack,
@@ -8650,17 +6490,10 @@ impl StackSetOperationSummaryDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct StackSetStatusDeserializer;
@@ -8684,37 +6517,14 @@ impl StackSetSummariesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<StackSetSummary>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(StackSetSummaryDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(StackSetSummaryDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>The structures that contain summary information about the specified stack set.</p>
@@ -8737,51 +6547,29 @@ impl StackSetSummaryDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<StackSetSummary, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = StackSetSummary::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, StackSetSummary, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Description" => {
+                    obj.description =
+                        Some(DescriptionDeserializer::deserialize("Description", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Description" => {
-                        obj.description =
-                            Some(DescriptionDeserializer::deserialize("Description", stack)?);
-                    }
-                    "StackSetId" => {
-                        obj.stack_set_id =
-                            Some(StackSetIdDeserializer::deserialize("StackSetId", stack)?);
-                    }
-                    "StackSetName" => {
-                        obj.stack_set_name = Some(StackSetNameDeserializer::deserialize(
-                            "StackSetName",
-                            stack,
-                        )?);
-                    }
-                    "Status" => {
-                        obj.status =
-                            Some(StackSetStatusDeserializer::deserialize("Status", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "StackSetId" => {
+                    obj.stack_set_id =
+                        Some(StackSetIdDeserializer::deserialize("StackSetId", stack)?);
                 }
+                "StackSetName" => {
+                    obj.stack_set_name = Some(StackSetNameDeserializer::deserialize(
+                        "StackSetName",
+                        stack,
+                    )?);
+                }
+                "Status" => {
+                    obj.status = Some(StackSetStatusDeserializer::deserialize("Status", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct StackStatusDeserializer;
@@ -8831,37 +6619,14 @@ impl StackSummariesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<StackSummary>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(StackSummaryDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(StackSummaryDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>The StackSummary Data Type</p>
@@ -8898,85 +6663,62 @@ impl StackSummaryDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<StackSummary, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = StackSummary::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, StackSummary, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CreationTime" => {
+                    obj.creation_time =
+                        CreationTimeDeserializer::deserialize("CreationTime", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CreationTime" => {
-                        obj.creation_time =
-                            CreationTimeDeserializer::deserialize("CreationTime", stack)?;
-                    }
-                    "DeletionTime" => {
-                        obj.deletion_time = Some(DeletionTimeDeserializer::deserialize(
-                            "DeletionTime",
-                            stack,
-                        )?);
-                    }
-                    "DriftInformation" => {
-                        obj.drift_information =
-                            Some(StackDriftInformationSummaryDeserializer::deserialize(
-                                "DriftInformation",
-                                stack,
-                            )?);
-                    }
-                    "LastUpdatedTime" => {
-                        obj.last_updated_time = Some(LastUpdatedTimeDeserializer::deserialize(
-                            "LastUpdatedTime",
-                            stack,
-                        )?);
-                    }
-                    "ParentId" => {
-                        obj.parent_id = Some(StackIdDeserializer::deserialize("ParentId", stack)?);
-                    }
-                    "RootId" => {
-                        obj.root_id = Some(StackIdDeserializer::deserialize("RootId", stack)?);
-                    }
-                    "StackId" => {
-                        obj.stack_id = Some(StackIdDeserializer::deserialize("StackId", stack)?);
-                    }
-                    "StackName" => {
-                        obj.stack_name = StackNameDeserializer::deserialize("StackName", stack)?;
-                    }
-                    "StackStatus" => {
-                        obj.stack_status =
-                            StackStatusDeserializer::deserialize("StackStatus", stack)?;
-                    }
-                    "StackStatusReason" => {
-                        obj.stack_status_reason = Some(StackStatusReasonDeserializer::deserialize(
-                            "StackStatusReason",
-                            stack,
-                        )?);
-                    }
-                    "TemplateDescription" => {
-                        obj.template_description =
-                            Some(TemplateDescriptionDeserializer::deserialize(
-                                "TemplateDescription",
-                                stack,
-                            )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "DeletionTime" => {
+                    obj.deletion_time = Some(DeletionTimeDeserializer::deserialize(
+                        "DeletionTime",
+                        stack,
+                    )?);
                 }
+                "DriftInformation" => {
+                    obj.drift_information =
+                        Some(StackDriftInformationSummaryDeserializer::deserialize(
+                            "DriftInformation",
+                            stack,
+                        )?);
+                }
+                "LastUpdatedTime" => {
+                    obj.last_updated_time = Some(LastUpdatedTimeDeserializer::deserialize(
+                        "LastUpdatedTime",
+                        stack,
+                    )?);
+                }
+                "ParentId" => {
+                    obj.parent_id = Some(StackIdDeserializer::deserialize("ParentId", stack)?);
+                }
+                "RootId" => {
+                    obj.root_id = Some(StackIdDeserializer::deserialize("RootId", stack)?);
+                }
+                "StackId" => {
+                    obj.stack_id = Some(StackIdDeserializer::deserialize("StackId", stack)?);
+                }
+                "StackName" => {
+                    obj.stack_name = StackNameDeserializer::deserialize("StackName", stack)?;
+                }
+                "StackStatus" => {
+                    obj.stack_status = StackStatusDeserializer::deserialize("StackStatus", stack)?;
+                }
+                "StackStatusReason" => {
+                    obj.stack_status_reason = Some(StackStatusReasonDeserializer::deserialize(
+                        "StackStatusReason",
+                        stack,
+                    )?);
+                }
+                "TemplateDescription" => {
+                    obj.template_description = Some(TemplateDescriptionDeserializer::deserialize(
+                        "TemplateDescription",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct StacksDeserializer;
@@ -8986,37 +6728,14 @@ impl StacksDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Stack>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(StackDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(StackDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct StageListDeserializer;
@@ -9026,37 +6745,14 @@ impl StageListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(TemplateStageDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(TemplateStageDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -9119,39 +6815,18 @@ impl TagDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Tag, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Tag::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Tag, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Key" => {
+                    obj.key = TagKeyDeserializer::deserialize("Key", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Key" => {
-                        obj.key = TagKeyDeserializer::deserialize("Key", stack)?;
-                    }
-                    "Value" => {
-                        obj.value = TagValueDeserializer::deserialize("Value", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Value" => {
+                    obj.value = TagValueDeserializer::deserialize("Value", stack)?;
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -9204,37 +6879,14 @@ impl TagsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Tag>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(TagDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(TagDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -9297,52 +6949,31 @@ impl TemplateParameterDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<TemplateParameter, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = TemplateParameter::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, TemplateParameter, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DefaultValue" => {
+                    obj.default_value = Some(ParameterValueDeserializer::deserialize(
+                        "DefaultValue",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DefaultValue" => {
-                        obj.default_value = Some(ParameterValueDeserializer::deserialize(
-                            "DefaultValue",
-                            stack,
-                        )?);
-                    }
-                    "Description" => {
-                        obj.description =
-                            Some(DescriptionDeserializer::deserialize("Description", stack)?);
-                    }
-                    "NoEcho" => {
-                        obj.no_echo = Some(NoEchoDeserializer::deserialize("NoEcho", stack)?);
-                    }
-                    "ParameterKey" => {
-                        obj.parameter_key = Some(ParameterKeyDeserializer::deserialize(
-                            "ParameterKey",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Description" => {
+                    obj.description =
+                        Some(DescriptionDeserializer::deserialize("Description", stack)?);
                 }
+                "NoEcho" => {
+                    obj.no_echo = Some(NoEchoDeserializer::deserialize("NoEcho", stack)?);
+                }
+                "ParameterKey" => {
+                    obj.parameter_key = Some(ParameterKeyDeserializer::deserialize(
+                        "ParameterKey",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct TemplateParametersDeserializer;
@@ -9352,37 +6983,14 @@ impl TemplateParametersDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<TemplateParameter>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(TemplateParameterDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(TemplateParameterDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct TemplateStageDeserializer;
@@ -9448,37 +7056,14 @@ impl TransformsListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(TransformNameDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(TransformNameDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct TypeDeserializer;
@@ -9687,21 +7272,11 @@ impl UpdateStackInstancesOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UpdateStackInstancesOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = UpdateStackInstancesOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, UpdateStackInstancesOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "OperationId" => {
                         obj.operation_id = Some(ClientRequestTokenDeserializer::deserialize(
                             "OperationId",
@@ -9709,17 +7284,10 @@ impl UpdateStackInstancesOutputDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>The output for an <a>UpdateStack</a> action.</p>
@@ -9736,36 +7304,15 @@ impl UpdateStackOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UpdateStackOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = UpdateStackOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, UpdateStackOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "StackId" => {
+                    obj.stack_id = Some(StackIdDeserializer::deserialize("StackId", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "StackId" => {
-                        obj.stack_id = Some(StackIdDeserializer::deserialize("StackId", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -9894,39 +7441,18 @@ impl UpdateStackSetOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UpdateStackSetOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = UpdateStackSetOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, UpdateStackSetOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "OperationId" => {
+                    obj.operation_id = Some(ClientRequestTokenDeserializer::deserialize(
+                        "OperationId",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "OperationId" => {
-                        obj.operation_id = Some(ClientRequestTokenDeserializer::deserialize(
-                            "OperationId",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -9967,36 +7493,19 @@ impl UpdateTerminationProtectionOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UpdateTerminationProtectionOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = UpdateTerminationProtectionOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, UpdateTerminationProtectionOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "StackId" => {
                         obj.stack_id = Some(StackIdDeserializer::deserialize("StackId", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct UrlDeserializer;
@@ -10076,89 +7585,37 @@ impl ValidateTemplateOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ValidateTemplateOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ValidateTemplateOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ValidateTemplateOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Capabilities" => {
+                    obj.capabilities.get_or_insert(vec![]).extend(
+                        CapabilitiesDeserializer::deserialize("Capabilities", stack)?,
+                    );
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Capabilities" => {
-                        obj.capabilities = match obj.capabilities {
-                            Some(ref mut existing) => {
-                                existing.extend(CapabilitiesDeserializer::deserialize(
-                                    "Capabilities",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(CapabilitiesDeserializer::deserialize(
-                                "Capabilities",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "CapabilitiesReason" => {
-                        obj.capabilities_reason =
-                            Some(CapabilitiesReasonDeserializer::deserialize(
-                                "CapabilitiesReason",
-                                stack,
-                            )?);
-                    }
-                    "DeclaredTransforms" => {
-                        obj.declared_transforms = match obj.declared_transforms {
-                            Some(ref mut existing) => {
-                                existing.extend(TransformsListDeserializer::deserialize(
-                                    "DeclaredTransforms",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(TransformsListDeserializer::deserialize(
-                                "DeclaredTransforms",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "Description" => {
-                        obj.description =
-                            Some(DescriptionDeserializer::deserialize("Description", stack)?);
-                    }
-                    "Parameters" => {
-                        obj.parameters = match obj.parameters {
-                            Some(ref mut existing) => {
-                                existing.extend(TemplateParametersDeserializer::deserialize(
-                                    "Parameters",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(TemplateParametersDeserializer::deserialize(
-                                "Parameters",
-                                stack,
-                            )?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "CapabilitiesReason" => {
+                    obj.capabilities_reason = Some(CapabilitiesReasonDeserializer::deserialize(
+                        "CapabilitiesReason",
+                        stack,
+                    )?);
                 }
+                "DeclaredTransforms" => {
+                    obj.declared_transforms.get_or_insert(vec![]).extend(
+                        TransformsListDeserializer::deserialize("DeclaredTransforms", stack)?,
+                    );
+                }
+                "Description" => {
+                    obj.description =
+                        Some(DescriptionDeserializer::deserialize("Description", stack)?);
+                }
+                "Parameters" => {
+                    obj.parameters.get_or_insert(vec![]).extend(
+                        TemplateParametersDeserializer::deserialize("Parameters", stack)?,
+                    );
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ValueDeserializer;

--- a/rusoto/services/cloudsearch/src/generated.rs
+++ b/rusoto/services/cloudsearch/src/generated.rs
@@ -25,20 +25,15 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
 use rusoto_core::xmlutil::{
-    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+    characters, deserialize_elements, end_element, find_start_element, peek_at_name, skip_tree,
+    start_element,
 };
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;
-use xml::reader::XmlEvent;
 use xml::EventReader;
 
-enum DeserializerNext {
-    Close,
-    Skip,
-    Element(String),
-}
 struct APIVersionDeserializer;
 impl APIVersionDeserializer {
     #[allow(unused_variables)]
@@ -81,39 +76,18 @@ impl AccessPoliciesStatusDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AccessPoliciesStatus, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AccessPoliciesStatus::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, AccessPoliciesStatus, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Options" => {
+                    obj.options = PolicyDocumentDeserializer::deserialize("Options", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Options" => {
-                        obj.options = PolicyDocumentDeserializer::deserialize("Options", stack)?;
-                    }
-                    "Status" => {
-                        obj.status = OptionStatusDeserializer::deserialize("Status", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Status" => {
+                    obj.status = OptionStatusDeserializer::deserialize("Status", stack)?;
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct AlgorithmicStemmingDeserializer;
@@ -152,59 +126,36 @@ impl AnalysisOptionsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AnalysisOptions, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AnalysisOptions::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, AnalysisOptions, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AlgorithmicStemming" => {
+                    obj.algorithmic_stemming = Some(AlgorithmicStemmingDeserializer::deserialize(
+                        "AlgorithmicStemming",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AlgorithmicStemming" => {
-                        obj.algorithmic_stemming =
-                            Some(AlgorithmicStemmingDeserializer::deserialize(
-                                "AlgorithmicStemming",
-                                stack,
-                            )?);
-                    }
-                    "JapaneseTokenizationDictionary" => {
-                        obj.japanese_tokenization_dictionary =
-                            Some(StringDeserializer::deserialize(
-                                "JapaneseTokenizationDictionary",
-                                stack,
-                            )?);
-                    }
-                    "StemmingDictionary" => {
-                        obj.stemming_dictionary = Some(StringDeserializer::deserialize(
-                            "StemmingDictionary",
-                            stack,
-                        )?);
-                    }
-                    "Stopwords" => {
-                        obj.stopwords = Some(StringDeserializer::deserialize("Stopwords", stack)?);
-                    }
-                    "Synonyms" => {
-                        obj.synonyms = Some(StringDeserializer::deserialize("Synonyms", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "JapaneseTokenizationDictionary" => {
+                    obj.japanese_tokenization_dictionary = Some(StringDeserializer::deserialize(
+                        "JapaneseTokenizationDictionary",
+                        stack,
+                    )?);
                 }
+                "StemmingDictionary" => {
+                    obj.stemming_dictionary = Some(StringDeserializer::deserialize(
+                        "StemmingDictionary",
+                        stack,
+                    )?);
+                }
+                "Stopwords" => {
+                    obj.stopwords = Some(StringDeserializer::deserialize("Stopwords", stack)?);
+                }
+                "Synonyms" => {
+                    obj.synonyms = Some(StringDeserializer::deserialize("Synonyms", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -256,50 +207,28 @@ impl AnalysisSchemeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AnalysisScheme, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AnalysisScheme::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, AnalysisScheme, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AnalysisOptions" => {
+                    obj.analysis_options = Some(AnalysisOptionsDeserializer::deserialize(
+                        "AnalysisOptions",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AnalysisOptions" => {
-                        obj.analysis_options = Some(AnalysisOptionsDeserializer::deserialize(
-                            "AnalysisOptions",
-                            stack,
-                        )?);
-                    }
-                    "AnalysisSchemeLanguage" => {
-                        obj.analysis_scheme_language =
-                            AnalysisSchemeLanguageDeserializer::deserialize(
-                                "AnalysisSchemeLanguage",
-                                stack,
-                            )?;
-                    }
-                    "AnalysisSchemeName" => {
-                        obj.analysis_scheme_name =
-                            StandardNameDeserializer::deserialize("AnalysisSchemeName", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "AnalysisSchemeLanguage" => {
+                    obj.analysis_scheme_language = AnalysisSchemeLanguageDeserializer::deserialize(
+                        "AnalysisSchemeLanguage",
+                        stack,
+                    )?;
                 }
+                "AnalysisSchemeName" => {
+                    obj.analysis_scheme_name =
+                        StandardNameDeserializer::deserialize("AnalysisSchemeName", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -358,39 +287,18 @@ impl AnalysisSchemeStatusDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AnalysisSchemeStatus, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AnalysisSchemeStatus::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, AnalysisSchemeStatus, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Options" => {
+                    obj.options = AnalysisSchemeDeserializer::deserialize("Options", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Options" => {
-                        obj.options = AnalysisSchemeDeserializer::deserialize("Options", stack)?;
-                    }
-                    "Status" => {
-                        obj.status = OptionStatusDeserializer::deserialize("Status", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Status" => {
+                    obj.status = OptionStatusDeserializer::deserialize("Status", stack)?;
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct AnalysisSchemeStatusListDeserializer;
@@ -400,39 +308,16 @@ impl AnalysisSchemeStatusListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<AnalysisSchemeStatus>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(AnalysisSchemeStatusDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(AnalysisSchemeStatusDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>The status and configuration of the domain's availability options.</p>
@@ -450,21 +335,11 @@ impl AvailabilityOptionsStatusDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AvailabilityOptionsStatus, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AvailabilityOptionsStatus::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, AvailabilityOptionsStatus, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Options" => {
                         obj.options = MultiAZDeserializer::deserialize("Options", stack)?;
                     }
@@ -472,17 +347,10 @@ impl AvailabilityOptionsStatusDeserializer {
                         obj.status = OptionStatusDeserializer::deserialize("Status", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct BooleanDeserializer;
@@ -531,47 +399,21 @@ impl BuildSuggestersResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<BuildSuggestersResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = BuildSuggestersResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, BuildSuggestersResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "FieldNames" => {
-                        obj.field_names = match obj.field_names {
-                            Some(ref mut existing) => {
-                                existing.extend(FieldNameListDeserializer::deserialize(
-                                    "FieldNames",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => {
-                                Some(FieldNameListDeserializer::deserialize("FieldNames", stack)?)
-                            }
-                        };
+                        obj.field_names
+                            .get_or_insert(vec![])
+                            .extend(FieldNameListDeserializer::deserialize("FieldNames", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Container for the parameters to the <code><a>CreateDomain</a></code> operation. Specifies a name for the new search domain.</p>
@@ -607,39 +449,18 @@ impl CreateDomainResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateDomainResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateDomainResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CreateDomainResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DomainStatus" => {
+                    obj.domain_status = Some(DomainStatusDeserializer::deserialize(
+                        "DomainStatus",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DomainStatus" => {
-                        obj.domain_status = Some(DomainStatusDeserializer::deserialize(
-                            "DomainStatus",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Options for a field that contains an array of dates. Present if <code>IndexFieldType</code> specifies the field is of type <code>date-array</code>. All options are enabled by default.</p>
@@ -664,55 +485,34 @@ impl DateArrayOptionsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DateArrayOptions, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DateArrayOptions::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DateArrayOptions, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DefaultValue" => {
+                    obj.default_value =
+                        Some(FieldValueDeserializer::deserialize("DefaultValue", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DefaultValue" => {
-                        obj.default_value =
-                            Some(FieldValueDeserializer::deserialize("DefaultValue", stack)?);
-                    }
-                    "FacetEnabled" => {
-                        obj.facet_enabled =
-                            Some(BooleanDeserializer::deserialize("FacetEnabled", stack)?);
-                    }
-                    "ReturnEnabled" => {
-                        obj.return_enabled =
-                            Some(BooleanDeserializer::deserialize("ReturnEnabled", stack)?);
-                    }
-                    "SearchEnabled" => {
-                        obj.search_enabled =
-                            Some(BooleanDeserializer::deserialize("SearchEnabled", stack)?);
-                    }
-                    "SourceFields" => {
-                        obj.source_fields = Some(FieldNameCommaListDeserializer::deserialize(
-                            "SourceFields",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "FacetEnabled" => {
+                    obj.facet_enabled =
+                        Some(BooleanDeserializer::deserialize("FacetEnabled", stack)?);
                 }
+                "ReturnEnabled" => {
+                    obj.return_enabled =
+                        Some(BooleanDeserializer::deserialize("ReturnEnabled", stack)?);
+                }
+                "SearchEnabled" => {
+                    obj.search_enabled =
+                        Some(BooleanDeserializer::deserialize("SearchEnabled", stack)?);
+                }
+                "SourceFields" => {
+                    obj.source_fields = Some(FieldNameCommaListDeserializer::deserialize(
+                        "SourceFields",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -775,57 +575,36 @@ impl DateOptionsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DateOptions, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DateOptions::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DateOptions, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DefaultValue" => {
+                    obj.default_value =
+                        Some(FieldValueDeserializer::deserialize("DefaultValue", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DefaultValue" => {
-                        obj.default_value =
-                            Some(FieldValueDeserializer::deserialize("DefaultValue", stack)?);
-                    }
-                    "FacetEnabled" => {
-                        obj.facet_enabled =
-                            Some(BooleanDeserializer::deserialize("FacetEnabled", stack)?);
-                    }
-                    "ReturnEnabled" => {
-                        obj.return_enabled =
-                            Some(BooleanDeserializer::deserialize("ReturnEnabled", stack)?);
-                    }
-                    "SearchEnabled" => {
-                        obj.search_enabled =
-                            Some(BooleanDeserializer::deserialize("SearchEnabled", stack)?);
-                    }
-                    "SortEnabled" => {
-                        obj.sort_enabled =
-                            Some(BooleanDeserializer::deserialize("SortEnabled", stack)?);
-                    }
-                    "SourceField" => {
-                        obj.source_field =
-                            Some(FieldNameDeserializer::deserialize("SourceField", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "FacetEnabled" => {
+                    obj.facet_enabled =
+                        Some(BooleanDeserializer::deserialize("FacetEnabled", stack)?);
                 }
+                "ReturnEnabled" => {
+                    obj.return_enabled =
+                        Some(BooleanDeserializer::deserialize("ReturnEnabled", stack)?);
+                }
+                "SearchEnabled" => {
+                    obj.search_enabled =
+                        Some(BooleanDeserializer::deserialize("SearchEnabled", stack)?);
+                }
+                "SortEnabled" => {
+                    obj.sort_enabled =
+                        Some(BooleanDeserializer::deserialize("SortEnabled", stack)?);
+                }
+                "SourceField" => {
+                    obj.source_field =
+                        Some(FieldNameDeserializer::deserialize("SourceField", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -909,37 +688,20 @@ impl DefineAnalysisSchemeResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DefineAnalysisSchemeResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DefineAnalysisSchemeResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DefineAnalysisSchemeResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AnalysisScheme" => {
                         obj.analysis_scheme =
                             AnalysisSchemeStatusDeserializer::deserialize("AnalysisScheme", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Container for the parameters to the <code><a>DefineExpression</a></code> operation. Specifies the name of the domain you want to update and the expression you want to configure.</p>
@@ -980,37 +742,20 @@ impl DefineExpressionResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DefineExpressionResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DefineExpressionResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DefineExpressionResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Expression" => {
                         obj.expression =
                             ExpressionStatusDeserializer::deserialize("Expression", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Container for the parameters to the <code><a>DefineIndexField</a></code> operation. Specifies the name of the domain you want to update and the index field configuration.</p>
@@ -1052,37 +797,20 @@ impl DefineIndexFieldResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DefineIndexFieldResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DefineIndexFieldResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DefineIndexFieldResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "IndexField" => {
                         obj.index_field =
                             IndexFieldStatusDeserializer::deserialize("IndexField", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Container for the parameters to the <code><a>DefineSuggester</a></code> operation. Specifies the name of the domain you want to update and the suggester configuration.</p>
@@ -1123,37 +851,20 @@ impl DefineSuggesterResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DefineSuggesterResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DefineSuggesterResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DefineSuggesterResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Suggester" => {
                         obj.suggester =
                             SuggesterStatusDeserializer::deserialize("Suggester", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Container for the parameters to the <code><a>DeleteAnalysisScheme</a></code> operation. Specifies the name of the domain you want to update and the analysis scheme you want to delete. </p>
@@ -1195,37 +906,20 @@ impl DeleteAnalysisSchemeResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DeleteAnalysisSchemeResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DeleteAnalysisSchemeResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DeleteAnalysisSchemeResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AnalysisScheme" => {
                         obj.analysis_scheme =
                             AnalysisSchemeStatusDeserializer::deserialize("AnalysisScheme", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Container for the parameters to the <code><a>DeleteDomain</a></code> operation. Specifies the name of the domain you want to delete.</p>
@@ -1261,39 +955,18 @@ impl DeleteDomainResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DeleteDomainResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DeleteDomainResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DeleteDomainResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DomainStatus" => {
+                    obj.domain_status = Some(DomainStatusDeserializer::deserialize(
+                        "DomainStatus",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DomainStatus" => {
-                        obj.domain_status = Some(DomainStatusDeserializer::deserialize(
-                            "DomainStatus",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Container for the parameters to the <code><a>DeleteExpression</a></code> operation. Specifies the name of the domain you want to update and the name of the expression you want to delete.</p>
@@ -1335,37 +1008,20 @@ impl DeleteExpressionResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DeleteExpressionResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DeleteExpressionResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DeleteExpressionResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Expression" => {
                         obj.expression =
                             ExpressionStatusDeserializer::deserialize("Expression", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Container for the parameters to the <code><a>DeleteIndexField</a></code> operation. Specifies the name of the domain you want to update and the name of the index field you want to delete.</p>
@@ -1407,37 +1063,20 @@ impl DeleteIndexFieldResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DeleteIndexFieldResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DeleteIndexFieldResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DeleteIndexFieldResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "IndexField" => {
                         obj.index_field =
                             IndexFieldStatusDeserializer::deserialize("IndexField", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Container for the parameters to the <code><a>DeleteSuggester</a></code> operation. Specifies the name of the domain you want to update and name of the suggester you want to delete.</p>
@@ -1479,37 +1118,20 @@ impl DeleteSuggesterResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DeleteSuggesterResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DeleteSuggesterResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DeleteSuggesterResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Suggester" => {
                         obj.suggester =
                             SuggesterStatusDeserializer::deserialize("Suggester", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Container for the parameters to the <code><a>DescribeAnalysisSchemes</a></code> operation. Specifies the name of the domain you want to describe. To limit the response to particular analysis schemes, specify the names of the analysis schemes you want to describe. To show the active configuration and exclude any pending changes, set the <code>Deployed</code> option to <code>true</code>. </p>
@@ -1563,21 +1185,11 @@ impl DescribeAnalysisSchemesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeAnalysisSchemesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeAnalysisSchemesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeAnalysisSchemesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AnalysisSchemes" => {
                         obj.analysis_schemes.extend(
                             AnalysisSchemeStatusListDeserializer::deserialize(
@@ -1587,17 +1199,10 @@ impl DescribeAnalysisSchemesResponseDeserializer {
                         );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Container for the parameters to the <code><a>DescribeAvailabilityOptions</a></code> operation. Specifies the name of the domain you want to describe. To show the active configuration and exclude any pending changes, set the Deployed option to <code>true</code>.</p>
@@ -1642,21 +1247,11 @@ impl DescribeAvailabilityOptionsResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeAvailabilityOptionsResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeAvailabilityOptionsResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeAvailabilityOptionsResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AvailabilityOptions" => {
                         obj.availability_options =
                             Some(AvailabilityOptionsStatusDeserializer::deserialize(
@@ -1665,17 +1260,10 @@ impl DescribeAvailabilityOptionsResponseDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Container for the parameters to the <code><a>DescribeDomains</a></code> operation. By default shows the status of all domains. To restrict the response to particular domains, specify the names of the domains you want to describe.</p>
@@ -1717,21 +1305,11 @@ impl DescribeDomainsResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeDomainsResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeDomainsResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeDomainsResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DomainStatusList" => {
                         obj.domain_status_list
                             .extend(DomainStatusListDeserializer::deserialize(
@@ -1740,17 +1318,10 @@ impl DescribeDomainsResponseDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Container for the parameters to the <code><a>DescribeDomains</a></code> operation. Specifies the name of the domain you want to describe. To restrict the response to particular expressions, specify the names of the expressions you want to describe. To show the active configuration and exclude any pending changes, set the <code>Deployed</code> option to <code>true</code>.</p>
@@ -1804,21 +1375,11 @@ impl DescribeExpressionsResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeExpressionsResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeExpressionsResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeExpressionsResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Expressions" => {
                         obj.expressions
                             .extend(ExpressionStatusListDeserializer::deserialize(
@@ -1827,17 +1388,10 @@ impl DescribeExpressionsResponseDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Container for the parameters to the <code><a>DescribeIndexFields</a></code> operation. Specifies the name of the domain you want to describe. To restrict the response to particular index fields, specify the names of the index fields you want to describe. To show the active configuration and exclude any pending changes, set the <code>Deployed</code> option to <code>true</code>.</p>
@@ -1891,21 +1445,11 @@ impl DescribeIndexFieldsResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeIndexFieldsResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeIndexFieldsResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeIndexFieldsResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "IndexFields" => {
                         obj.index_fields
                             .extend(IndexFieldStatusListDeserializer::deserialize(
@@ -1914,17 +1458,10 @@ impl DescribeIndexFieldsResponseDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Container for the parameters to the <code><a>DescribeScalingParameters</a></code> operation. Specifies the name of the domain you want to describe. </p>
@@ -1959,21 +1496,11 @@ impl DescribeScalingParametersResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeScalingParametersResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeScalingParametersResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeScalingParametersResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ScalingParameters" => {
                         obj.scaling_parameters = ScalingParametersStatusDeserializer::deserialize(
                             "ScalingParameters",
@@ -1981,17 +1508,10 @@ impl DescribeScalingParametersResponseDeserializer {
                         )?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Container for the parameters to the <code><a>DescribeServiceAccessPolicies</a></code> operation. Specifies the name of the domain you want to describe. To show the active configuration and exclude any pending changes, set the <code>Deployed</code> option to <code>true</code>.</p>
@@ -2036,37 +1556,20 @@ impl DescribeServiceAccessPoliciesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeServiceAccessPoliciesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeServiceAccessPoliciesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeServiceAccessPoliciesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AccessPolicies" => {
                         obj.access_policies =
                             AccessPoliciesStatusDeserializer::deserialize("AccessPolicies", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Container for the parameters to the <code><a>DescribeSuggester</a></code> operation. Specifies the name of the domain you want to describe. To restrict the response to particular suggesters, specify the names of the suggesters you want to describe. To show the active configuration and exclude any pending changes, set the <code>Deployed</code> option to <code>true</code>.</p>
@@ -2120,21 +1623,11 @@ impl DescribeSuggestersResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeSuggestersResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeSuggestersResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeSuggestersResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Suggesters" => {
                         obj.suggesters
                             .extend(SuggesterStatusListDeserializer::deserialize(
@@ -2143,17 +1636,10 @@ impl DescribeSuggestersResponseDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Options for a search suggester.</p>
@@ -2174,21 +1660,11 @@ impl DocumentSuggesterOptionsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DocumentSuggesterOptions, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DocumentSuggesterOptions::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DocumentSuggesterOptions, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "FuzzyMatching" => {
                         obj.fuzzy_matching = Some(SuggesterFuzzyMatchingDeserializer::deserialize(
                             "FuzzyMatching",
@@ -2204,17 +1680,10 @@ impl DocumentSuggesterOptionsDeserializer {
                             FieldNameDeserializer::deserialize("SourceField", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -2334,90 +1803,67 @@ impl DomainStatusDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DomainStatus, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DomainStatus::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DomainStatus, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "ARN" => {
+                    obj.arn = Some(ARNDeserializer::deserialize("ARN", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "ARN" => {
-                        obj.arn = Some(ARNDeserializer::deserialize("ARN", stack)?);
-                    }
-                    "Created" => {
-                        obj.created = Some(BooleanDeserializer::deserialize("Created", stack)?);
-                    }
-                    "Deleted" => {
-                        obj.deleted = Some(BooleanDeserializer::deserialize("Deleted", stack)?);
-                    }
-                    "DocService" => {
-                        obj.doc_service = Some(ServiceEndpointDeserializer::deserialize(
-                            "DocService",
-                            stack,
-                        )?);
-                    }
-                    "DomainId" => {
-                        obj.domain_id = DomainIdDeserializer::deserialize("DomainId", stack)?;
-                    }
-                    "DomainName" => {
-                        obj.domain_name = DomainNameDeserializer::deserialize("DomainName", stack)?;
-                    }
-                    "Limits" => {
-                        obj.limits = Some(LimitsDeserializer::deserialize("Limits", stack)?);
-                    }
-                    "Processing" => {
-                        obj.processing =
-                            Some(BooleanDeserializer::deserialize("Processing", stack)?);
-                    }
-                    "RequiresIndexDocuments" => {
-                        obj.requires_index_documents =
-                            BooleanDeserializer::deserialize("RequiresIndexDocuments", stack)?;
-                    }
-                    "SearchInstanceCount" => {
-                        obj.search_instance_count = Some(InstanceCountDeserializer::deserialize(
-                            "SearchInstanceCount",
-                            stack,
-                        )?);
-                    }
-                    "SearchInstanceType" => {
-                        obj.search_instance_type =
-                            Some(SearchInstanceTypeDeserializer::deserialize(
-                                "SearchInstanceType",
-                                stack,
-                            )?);
-                    }
-                    "SearchPartitionCount" => {
-                        obj.search_partition_count = Some(PartitionCountDeserializer::deserialize(
-                            "SearchPartitionCount",
-                            stack,
-                        )?);
-                    }
-                    "SearchService" => {
-                        obj.search_service = Some(ServiceEndpointDeserializer::deserialize(
-                            "SearchService",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Created" => {
+                    obj.created = Some(BooleanDeserializer::deserialize("Created", stack)?);
                 }
+                "Deleted" => {
+                    obj.deleted = Some(BooleanDeserializer::deserialize("Deleted", stack)?);
+                }
+                "DocService" => {
+                    obj.doc_service = Some(ServiceEndpointDeserializer::deserialize(
+                        "DocService",
+                        stack,
+                    )?);
+                }
+                "DomainId" => {
+                    obj.domain_id = DomainIdDeserializer::deserialize("DomainId", stack)?;
+                }
+                "DomainName" => {
+                    obj.domain_name = DomainNameDeserializer::deserialize("DomainName", stack)?;
+                }
+                "Limits" => {
+                    obj.limits = Some(LimitsDeserializer::deserialize("Limits", stack)?);
+                }
+                "Processing" => {
+                    obj.processing = Some(BooleanDeserializer::deserialize("Processing", stack)?);
+                }
+                "RequiresIndexDocuments" => {
+                    obj.requires_index_documents =
+                        BooleanDeserializer::deserialize("RequiresIndexDocuments", stack)?;
+                }
+                "SearchInstanceCount" => {
+                    obj.search_instance_count = Some(InstanceCountDeserializer::deserialize(
+                        "SearchInstanceCount",
+                        stack,
+                    )?);
+                }
+                "SearchInstanceType" => {
+                    obj.search_instance_type = Some(SearchInstanceTypeDeserializer::deserialize(
+                        "SearchInstanceType",
+                        stack,
+                    )?);
+                }
+                "SearchPartitionCount" => {
+                    obj.search_partition_count = Some(PartitionCountDeserializer::deserialize(
+                        "SearchPartitionCount",
+                        stack,
+                    )?);
+                }
+                "SearchService" => {
+                    obj.search_service = Some(ServiceEndpointDeserializer::deserialize(
+                        "SearchService",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct DomainStatusListDeserializer;
@@ -2427,37 +1873,14 @@ impl DomainStatusListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<DomainStatus>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(DomainStatusDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(DomainStatusDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct DoubleDeserializer;
@@ -2496,55 +1919,34 @@ impl DoubleArrayOptionsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DoubleArrayOptions, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DoubleArrayOptions::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DoubleArrayOptions, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DefaultValue" => {
+                    obj.default_value =
+                        Some(DoubleDeserializer::deserialize("DefaultValue", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DefaultValue" => {
-                        obj.default_value =
-                            Some(DoubleDeserializer::deserialize("DefaultValue", stack)?);
-                    }
-                    "FacetEnabled" => {
-                        obj.facet_enabled =
-                            Some(BooleanDeserializer::deserialize("FacetEnabled", stack)?);
-                    }
-                    "ReturnEnabled" => {
-                        obj.return_enabled =
-                            Some(BooleanDeserializer::deserialize("ReturnEnabled", stack)?);
-                    }
-                    "SearchEnabled" => {
-                        obj.search_enabled =
-                            Some(BooleanDeserializer::deserialize("SearchEnabled", stack)?);
-                    }
-                    "SourceFields" => {
-                        obj.source_fields = Some(FieldNameCommaListDeserializer::deserialize(
-                            "SourceFields",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "FacetEnabled" => {
+                    obj.facet_enabled =
+                        Some(BooleanDeserializer::deserialize("FacetEnabled", stack)?);
                 }
+                "ReturnEnabled" => {
+                    obj.return_enabled =
+                        Some(BooleanDeserializer::deserialize("ReturnEnabled", stack)?);
+                }
+                "SearchEnabled" => {
+                    obj.search_enabled =
+                        Some(BooleanDeserializer::deserialize("SearchEnabled", stack)?);
+                }
+                "SourceFields" => {
+                    obj.source_fields = Some(FieldNameCommaListDeserializer::deserialize(
+                        "SourceFields",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -2611,57 +2013,36 @@ impl DoubleOptionsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DoubleOptions, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DoubleOptions::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DoubleOptions, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DefaultValue" => {
+                    obj.default_value =
+                        Some(DoubleDeserializer::deserialize("DefaultValue", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DefaultValue" => {
-                        obj.default_value =
-                            Some(DoubleDeserializer::deserialize("DefaultValue", stack)?);
-                    }
-                    "FacetEnabled" => {
-                        obj.facet_enabled =
-                            Some(BooleanDeserializer::deserialize("FacetEnabled", stack)?);
-                    }
-                    "ReturnEnabled" => {
-                        obj.return_enabled =
-                            Some(BooleanDeserializer::deserialize("ReturnEnabled", stack)?);
-                    }
-                    "SearchEnabled" => {
-                        obj.search_enabled =
-                            Some(BooleanDeserializer::deserialize("SearchEnabled", stack)?);
-                    }
-                    "SortEnabled" => {
-                        obj.sort_enabled =
-                            Some(BooleanDeserializer::deserialize("SortEnabled", stack)?);
-                    }
-                    "SourceField" => {
-                        obj.source_field =
-                            Some(FieldNameDeserializer::deserialize("SourceField", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "FacetEnabled" => {
+                    obj.facet_enabled =
+                        Some(BooleanDeserializer::deserialize("FacetEnabled", stack)?);
                 }
+                "ReturnEnabled" => {
+                    obj.return_enabled =
+                        Some(BooleanDeserializer::deserialize("ReturnEnabled", stack)?);
+                }
+                "SearchEnabled" => {
+                    obj.search_enabled =
+                        Some(BooleanDeserializer::deserialize("SearchEnabled", stack)?);
+                }
+                "SortEnabled" => {
+                    obj.sort_enabled =
+                        Some(BooleanDeserializer::deserialize("SortEnabled", stack)?);
+                }
+                "SourceField" => {
+                    obj.source_field =
+                        Some(FieldNameDeserializer::deserialize("SourceField", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -2750,41 +2131,20 @@ impl ExpressionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Expression, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Expression::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Expression, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "ExpressionName" => {
+                    obj.expression_name =
+                        StandardNameDeserializer::deserialize("ExpressionName", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "ExpressionName" => {
-                        obj.expression_name =
-                            StandardNameDeserializer::deserialize("ExpressionName", stack)?;
-                    }
-                    "ExpressionValue" => {
-                        obj.expression_value =
-                            ExpressionValueDeserializer::deserialize("ExpressionValue", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "ExpressionValue" => {
+                    obj.expression_value =
+                        ExpressionValueDeserializer::deserialize("ExpressionValue", stack)?;
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -2823,39 +2183,18 @@ impl ExpressionStatusDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ExpressionStatus, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ExpressionStatus::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ExpressionStatus, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Options" => {
+                    obj.options = ExpressionDeserializer::deserialize("Options", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Options" => {
-                        obj.options = ExpressionDeserializer::deserialize("Options", stack)?;
-                    }
-                    "Status" => {
-                        obj.status = OptionStatusDeserializer::deserialize("Status", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Status" => {
+                    obj.status = OptionStatusDeserializer::deserialize("Status", stack)?;
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ExpressionStatusListDeserializer;
@@ -2865,37 +2204,14 @@ impl ExpressionStatusListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<ExpressionStatus>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(ExpressionStatusDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(ExpressionStatusDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ExpressionValueDeserializer;
@@ -2947,37 +2263,14 @@ impl FieldNameListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(FieldNameDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(FieldNameDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct FieldValueDeserializer;
@@ -3027,47 +2320,17 @@ impl IndexDocumentsResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<IndexDocumentsResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = IndexDocumentsResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, IndexDocumentsResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "FieldNames" => {
+                    obj.field_names
+                        .get_or_insert(vec![])
+                        .extend(FieldNameListDeserializer::deserialize("FieldNames", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "FieldNames" => {
-                        obj.field_names = match obj.field_names {
-                            Some(ref mut existing) => {
-                                existing.extend(FieldNameListDeserializer::deserialize(
-                                    "FieldNames",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => {
-                                Some(FieldNameListDeserializer::deserialize("FieldNames", stack)?)
-                            }
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Configuration information for a field in the index, including its name, type, and options. The supported options depend on the <code><a>IndexFieldType</a></code>.</p>
@@ -3096,103 +2359,80 @@ impl IndexFieldDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<IndexField, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = IndexField::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, IndexField, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DateArrayOptions" => {
+                    obj.date_array_options = Some(DateArrayOptionsDeserializer::deserialize(
+                        "DateArrayOptions",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DateArrayOptions" => {
-                        obj.date_array_options = Some(DateArrayOptionsDeserializer::deserialize(
-                            "DateArrayOptions",
-                            stack,
-                        )?);
-                    }
-                    "DateOptions" => {
-                        obj.date_options =
-                            Some(DateOptionsDeserializer::deserialize("DateOptions", stack)?);
-                    }
-                    "DoubleArrayOptions" => {
-                        obj.double_array_options =
-                            Some(DoubleArrayOptionsDeserializer::deserialize(
-                                "DoubleArrayOptions",
-                                stack,
-                            )?);
-                    }
-                    "DoubleOptions" => {
-                        obj.double_options = Some(DoubleOptionsDeserializer::deserialize(
-                            "DoubleOptions",
-                            stack,
-                        )?);
-                    }
-                    "IndexFieldName" => {
-                        obj.index_field_name =
-                            DynamicFieldNameDeserializer::deserialize("IndexFieldName", stack)?;
-                    }
-                    "IndexFieldType" => {
-                        obj.index_field_type =
-                            IndexFieldTypeDeserializer::deserialize("IndexFieldType", stack)?;
-                    }
-                    "IntArrayOptions" => {
-                        obj.int_array_options = Some(IntArrayOptionsDeserializer::deserialize(
-                            "IntArrayOptions",
-                            stack,
-                        )?);
-                    }
-                    "IntOptions" => {
-                        obj.int_options =
-                            Some(IntOptionsDeserializer::deserialize("IntOptions", stack)?);
-                    }
-                    "LatLonOptions" => {
-                        obj.lat_lon_options = Some(LatLonOptionsDeserializer::deserialize(
-                            "LatLonOptions",
-                            stack,
-                        )?);
-                    }
-                    "LiteralArrayOptions" => {
-                        obj.literal_array_options =
-                            Some(LiteralArrayOptionsDeserializer::deserialize(
-                                "LiteralArrayOptions",
-                                stack,
-                            )?);
-                    }
-                    "LiteralOptions" => {
-                        obj.literal_options = Some(LiteralOptionsDeserializer::deserialize(
-                            "LiteralOptions",
-                            stack,
-                        )?);
-                    }
-                    "TextArrayOptions" => {
-                        obj.text_array_options = Some(TextArrayOptionsDeserializer::deserialize(
-                            "TextArrayOptions",
-                            stack,
-                        )?);
-                    }
-                    "TextOptions" => {
-                        obj.text_options =
-                            Some(TextOptionsDeserializer::deserialize("TextOptions", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "DateOptions" => {
+                    obj.date_options =
+                        Some(DateOptionsDeserializer::deserialize("DateOptions", stack)?);
                 }
+                "DoubleArrayOptions" => {
+                    obj.double_array_options = Some(DoubleArrayOptionsDeserializer::deserialize(
+                        "DoubleArrayOptions",
+                        stack,
+                    )?);
+                }
+                "DoubleOptions" => {
+                    obj.double_options = Some(DoubleOptionsDeserializer::deserialize(
+                        "DoubleOptions",
+                        stack,
+                    )?);
+                }
+                "IndexFieldName" => {
+                    obj.index_field_name =
+                        DynamicFieldNameDeserializer::deserialize("IndexFieldName", stack)?;
+                }
+                "IndexFieldType" => {
+                    obj.index_field_type =
+                        IndexFieldTypeDeserializer::deserialize("IndexFieldType", stack)?;
+                }
+                "IntArrayOptions" => {
+                    obj.int_array_options = Some(IntArrayOptionsDeserializer::deserialize(
+                        "IntArrayOptions",
+                        stack,
+                    )?);
+                }
+                "IntOptions" => {
+                    obj.int_options =
+                        Some(IntOptionsDeserializer::deserialize("IntOptions", stack)?);
+                }
+                "LatLonOptions" => {
+                    obj.lat_lon_options = Some(LatLonOptionsDeserializer::deserialize(
+                        "LatLonOptions",
+                        stack,
+                    )?);
+                }
+                "LiteralArrayOptions" => {
+                    obj.literal_array_options = Some(LiteralArrayOptionsDeserializer::deserialize(
+                        "LiteralArrayOptions",
+                        stack,
+                    )?);
+                }
+                "LiteralOptions" => {
+                    obj.literal_options = Some(LiteralOptionsDeserializer::deserialize(
+                        "LiteralOptions",
+                        stack,
+                    )?);
+                }
+                "TextArrayOptions" => {
+                    obj.text_array_options = Some(TextArrayOptionsDeserializer::deserialize(
+                        "TextArrayOptions",
+                        stack,
+                    )?);
+                }
+                "TextOptions" => {
+                    obj.text_options =
+                        Some(TextOptionsDeserializer::deserialize("TextOptions", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -3307,39 +2547,18 @@ impl IndexFieldStatusDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<IndexFieldStatus, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = IndexFieldStatus::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, IndexFieldStatus, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Options" => {
+                    obj.options = IndexFieldDeserializer::deserialize("Options", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Options" => {
-                        obj.options = IndexFieldDeserializer::deserialize("Options", stack)?;
-                    }
-                    "Status" => {
-                        obj.status = OptionStatusDeserializer::deserialize("Status", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Status" => {
+                    obj.status = OptionStatusDeserializer::deserialize("Status", stack)?;
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct IndexFieldStatusListDeserializer;
@@ -3349,37 +2568,14 @@ impl IndexFieldStatusListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<IndexFieldStatus>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(IndexFieldStatusDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(IndexFieldStatusDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct IndexFieldTypeDeserializer;
@@ -3432,55 +2628,33 @@ impl IntArrayOptionsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<IntArrayOptions, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = IntArrayOptions::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, IntArrayOptions, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DefaultValue" => {
+                    obj.default_value = Some(LongDeserializer::deserialize("DefaultValue", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DefaultValue" => {
-                        obj.default_value =
-                            Some(LongDeserializer::deserialize("DefaultValue", stack)?);
-                    }
-                    "FacetEnabled" => {
-                        obj.facet_enabled =
-                            Some(BooleanDeserializer::deserialize("FacetEnabled", stack)?);
-                    }
-                    "ReturnEnabled" => {
-                        obj.return_enabled =
-                            Some(BooleanDeserializer::deserialize("ReturnEnabled", stack)?);
-                    }
-                    "SearchEnabled" => {
-                        obj.search_enabled =
-                            Some(BooleanDeserializer::deserialize("SearchEnabled", stack)?);
-                    }
-                    "SourceFields" => {
-                        obj.source_fields = Some(FieldNameCommaListDeserializer::deserialize(
-                            "SourceFields",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "FacetEnabled" => {
+                    obj.facet_enabled =
+                        Some(BooleanDeserializer::deserialize("FacetEnabled", stack)?);
                 }
+                "ReturnEnabled" => {
+                    obj.return_enabled =
+                        Some(BooleanDeserializer::deserialize("ReturnEnabled", stack)?);
+                }
+                "SearchEnabled" => {
+                    obj.search_enabled =
+                        Some(BooleanDeserializer::deserialize("SearchEnabled", stack)?);
+                }
+                "SourceFields" => {
+                    obj.source_fields = Some(FieldNameCommaListDeserializer::deserialize(
+                        "SourceFields",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -3547,57 +2721,35 @@ impl IntOptionsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<IntOptions, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = IntOptions::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, IntOptions, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DefaultValue" => {
+                    obj.default_value = Some(LongDeserializer::deserialize("DefaultValue", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DefaultValue" => {
-                        obj.default_value =
-                            Some(LongDeserializer::deserialize("DefaultValue", stack)?);
-                    }
-                    "FacetEnabled" => {
-                        obj.facet_enabled =
-                            Some(BooleanDeserializer::deserialize("FacetEnabled", stack)?);
-                    }
-                    "ReturnEnabled" => {
-                        obj.return_enabled =
-                            Some(BooleanDeserializer::deserialize("ReturnEnabled", stack)?);
-                    }
-                    "SearchEnabled" => {
-                        obj.search_enabled =
-                            Some(BooleanDeserializer::deserialize("SearchEnabled", stack)?);
-                    }
-                    "SortEnabled" => {
-                        obj.sort_enabled =
-                            Some(BooleanDeserializer::deserialize("SortEnabled", stack)?);
-                    }
-                    "SourceField" => {
-                        obj.source_field =
-                            Some(FieldNameDeserializer::deserialize("SourceField", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "FacetEnabled" => {
+                    obj.facet_enabled =
+                        Some(BooleanDeserializer::deserialize("FacetEnabled", stack)?);
                 }
+                "ReturnEnabled" => {
+                    obj.return_enabled =
+                        Some(BooleanDeserializer::deserialize("ReturnEnabled", stack)?);
+                }
+                "SearchEnabled" => {
+                    obj.search_enabled =
+                        Some(BooleanDeserializer::deserialize("SearchEnabled", stack)?);
+                }
+                "SortEnabled" => {
+                    obj.sort_enabled =
+                        Some(BooleanDeserializer::deserialize("SortEnabled", stack)?);
+                }
+                "SourceField" => {
+                    obj.source_field =
+                        Some(FieldNameDeserializer::deserialize("SourceField", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -3669,57 +2821,36 @@ impl LatLonOptionsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<LatLonOptions, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = LatLonOptions::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, LatLonOptions, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DefaultValue" => {
+                    obj.default_value =
+                        Some(FieldValueDeserializer::deserialize("DefaultValue", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DefaultValue" => {
-                        obj.default_value =
-                            Some(FieldValueDeserializer::deserialize("DefaultValue", stack)?);
-                    }
-                    "FacetEnabled" => {
-                        obj.facet_enabled =
-                            Some(BooleanDeserializer::deserialize("FacetEnabled", stack)?);
-                    }
-                    "ReturnEnabled" => {
-                        obj.return_enabled =
-                            Some(BooleanDeserializer::deserialize("ReturnEnabled", stack)?);
-                    }
-                    "SearchEnabled" => {
-                        obj.search_enabled =
-                            Some(BooleanDeserializer::deserialize("SearchEnabled", stack)?);
-                    }
-                    "SortEnabled" => {
-                        obj.sort_enabled =
-                            Some(BooleanDeserializer::deserialize("SortEnabled", stack)?);
-                    }
-                    "SourceField" => {
-                        obj.source_field =
-                            Some(FieldNameDeserializer::deserialize("SourceField", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "FacetEnabled" => {
+                    obj.facet_enabled =
+                        Some(BooleanDeserializer::deserialize("FacetEnabled", stack)?);
                 }
+                "ReturnEnabled" => {
+                    obj.return_enabled =
+                        Some(BooleanDeserializer::deserialize("ReturnEnabled", stack)?);
+                }
+                "SearchEnabled" => {
+                    obj.search_enabled =
+                        Some(BooleanDeserializer::deserialize("SearchEnabled", stack)?);
+                }
+                "SortEnabled" => {
+                    obj.sort_enabled =
+                        Some(BooleanDeserializer::deserialize("SortEnabled", stack)?);
+                }
+                "SourceField" => {
+                    obj.source_field =
+                        Some(FieldNameDeserializer::deserialize("SourceField", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -3778,47 +2909,25 @@ impl LimitsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Limits, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Limits::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Limits, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "MaximumPartitionCount" => {
+                    obj.maximum_partition_count = MaximumPartitionCountDeserializer::deserialize(
+                        "MaximumPartitionCount",
+                        stack,
+                    )?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "MaximumPartitionCount" => {
-                        obj.maximum_partition_count =
-                            MaximumPartitionCountDeserializer::deserialize(
-                                "MaximumPartitionCount",
-                                stack,
-                            )?;
-                    }
-                    "MaximumReplicationCount" => {
-                        obj.maximum_replication_count =
-                            MaximumReplicationCountDeserializer::deserialize(
-                                "MaximumReplicationCount",
-                                stack,
-                            )?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "MaximumReplicationCount" => {
+                    obj.maximum_replication_count =
+                        MaximumReplicationCountDeserializer::deserialize(
+                            "MaximumReplicationCount",
+                            stack,
+                        )?;
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>The result of a <code>ListDomainNames</code> request. Contains a list of the domains owned by an account.</p>
@@ -3835,21 +2944,11 @@ impl ListDomainNamesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListDomainNamesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListDomainNamesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListDomainNamesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DomainNames" => {
                         obj.domain_names = Some(DomainNameMapDeserializer::deserialize(
                             "DomainNames",
@@ -3857,17 +2956,10 @@ impl ListDomainNamesResponseDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Options for a field that contains an array of literal strings. Present if <code>IndexFieldType</code> specifies the field is of type <code>literal-array</code>. All options are enabled by default.</p>
@@ -3892,55 +2984,34 @@ impl LiteralArrayOptionsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<LiteralArrayOptions, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = LiteralArrayOptions::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, LiteralArrayOptions, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DefaultValue" => {
+                    obj.default_value =
+                        Some(FieldValueDeserializer::deserialize("DefaultValue", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DefaultValue" => {
-                        obj.default_value =
-                            Some(FieldValueDeserializer::deserialize("DefaultValue", stack)?);
-                    }
-                    "FacetEnabled" => {
-                        obj.facet_enabled =
-                            Some(BooleanDeserializer::deserialize("FacetEnabled", stack)?);
-                    }
-                    "ReturnEnabled" => {
-                        obj.return_enabled =
-                            Some(BooleanDeserializer::deserialize("ReturnEnabled", stack)?);
-                    }
-                    "SearchEnabled" => {
-                        obj.search_enabled =
-                            Some(BooleanDeserializer::deserialize("SearchEnabled", stack)?);
-                    }
-                    "SourceFields" => {
-                        obj.source_fields = Some(FieldNameCommaListDeserializer::deserialize(
-                            "SourceFields",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "FacetEnabled" => {
+                    obj.facet_enabled =
+                        Some(BooleanDeserializer::deserialize("FacetEnabled", stack)?);
                 }
+                "ReturnEnabled" => {
+                    obj.return_enabled =
+                        Some(BooleanDeserializer::deserialize("ReturnEnabled", stack)?);
+                }
+                "SearchEnabled" => {
+                    obj.search_enabled =
+                        Some(BooleanDeserializer::deserialize("SearchEnabled", stack)?);
+                }
+                "SourceFields" => {
+                    obj.source_fields = Some(FieldNameCommaListDeserializer::deserialize(
+                        "SourceFields",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -4003,57 +3074,36 @@ impl LiteralOptionsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<LiteralOptions, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = LiteralOptions::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, LiteralOptions, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DefaultValue" => {
+                    obj.default_value =
+                        Some(FieldValueDeserializer::deserialize("DefaultValue", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DefaultValue" => {
-                        obj.default_value =
-                            Some(FieldValueDeserializer::deserialize("DefaultValue", stack)?);
-                    }
-                    "FacetEnabled" => {
-                        obj.facet_enabled =
-                            Some(BooleanDeserializer::deserialize("FacetEnabled", stack)?);
-                    }
-                    "ReturnEnabled" => {
-                        obj.return_enabled =
-                            Some(BooleanDeserializer::deserialize("ReturnEnabled", stack)?);
-                    }
-                    "SearchEnabled" => {
-                        obj.search_enabled =
-                            Some(BooleanDeserializer::deserialize("SearchEnabled", stack)?);
-                    }
-                    "SortEnabled" => {
-                        obj.sort_enabled =
-                            Some(BooleanDeserializer::deserialize("SortEnabled", stack)?);
-                    }
-                    "SourceField" => {
-                        obj.source_field =
-                            Some(FieldNameDeserializer::deserialize("SourceField", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "FacetEnabled" => {
+                    obj.facet_enabled =
+                        Some(BooleanDeserializer::deserialize("FacetEnabled", stack)?);
                 }
+                "ReturnEnabled" => {
+                    obj.return_enabled =
+                        Some(BooleanDeserializer::deserialize("ReturnEnabled", stack)?);
+                }
+                "SearchEnabled" => {
+                    obj.search_enabled =
+                        Some(BooleanDeserializer::deserialize("SearchEnabled", stack)?);
+                }
+                "SortEnabled" => {
+                    obj.sort_enabled =
+                        Some(BooleanDeserializer::deserialize("SortEnabled", stack)?);
+                }
+                "SourceField" => {
+                    obj.source_field =
+                        Some(FieldNameDeserializer::deserialize("SourceField", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -4191,52 +3241,31 @@ impl OptionStatusDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<OptionStatus, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = OptionStatus::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, OptionStatus, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CreationDate" => {
+                    obj.creation_date =
+                        UpdateTimestampDeserializer::deserialize("CreationDate", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CreationDate" => {
-                        obj.creation_date =
-                            UpdateTimestampDeserializer::deserialize("CreationDate", stack)?;
-                    }
-                    "PendingDeletion" => {
-                        obj.pending_deletion =
-                            Some(BooleanDeserializer::deserialize("PendingDeletion", stack)?);
-                    }
-                    "State" => {
-                        obj.state = OptionStateDeserializer::deserialize("State", stack)?;
-                    }
-                    "UpdateDate" => {
-                        obj.update_date =
-                            UpdateTimestampDeserializer::deserialize("UpdateDate", stack)?;
-                    }
-                    "UpdateVersion" => {
-                        obj.update_version =
-                            Some(UIntValueDeserializer::deserialize("UpdateVersion", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "PendingDeletion" => {
+                    obj.pending_deletion =
+                        Some(BooleanDeserializer::deserialize("PendingDeletion", stack)?);
                 }
+                "State" => {
+                    obj.state = OptionStateDeserializer::deserialize("State", stack)?;
+                }
+                "UpdateDate" => {
+                    obj.update_date =
+                        UpdateTimestampDeserializer::deserialize("UpdateDate", stack)?;
+                }
+                "UpdateVersion" => {
+                    obj.update_version =
+                        Some(UIntValueDeserializer::deserialize("UpdateVersion", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PartitionCountDeserializer;
@@ -4299,52 +3328,31 @@ impl ScalingParametersDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ScalingParameters, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ScalingParameters::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DesiredInstanceType" => {
-                        obj.desired_instance_type =
-                            Some(PartitionInstanceTypeDeserializer::deserialize(
-                                "DesiredInstanceType",
-                                stack,
-                            )?);
-                    }
-                    "DesiredPartitionCount" => {
-                        obj.desired_partition_count = Some(UIntValueDeserializer::deserialize(
-                            "DesiredPartitionCount",
+        deserialize_elements::<_, ScalingParameters, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DesiredInstanceType" => {
+                    obj.desired_instance_type =
+                        Some(PartitionInstanceTypeDeserializer::deserialize(
+                            "DesiredInstanceType",
                             stack,
                         )?);
-                    }
-                    "DesiredReplicationCount" => {
-                        obj.desired_replication_count = Some(UIntValueDeserializer::deserialize(
-                            "DesiredReplicationCount",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                "DesiredPartitionCount" => {
+                    obj.desired_partition_count = Some(UIntValueDeserializer::deserialize(
+                        "DesiredPartitionCount",
+                        stack,
+                    )?);
+                }
+                "DesiredReplicationCount" => {
+                    obj.desired_replication_count = Some(UIntValueDeserializer::deserialize(
+                        "DesiredReplicationCount",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -4392,21 +3400,11 @@ impl ScalingParametersStatusDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ScalingParametersStatus, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ScalingParametersStatus::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ScalingParametersStatus, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Options" => {
                         obj.options = ScalingParametersDeserializer::deserialize("Options", stack)?;
                     }
@@ -4414,17 +3412,10 @@ impl ScalingParametersStatusDeserializer {
                         obj.status = OptionStatusDeserializer::deserialize("Status", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct SearchInstanceTypeDeserializer;
@@ -4454,37 +3445,15 @@ impl ServiceEndpointDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ServiceEndpoint, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ServiceEndpoint::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ServiceEndpoint, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Endpoint" => {
+                    obj.endpoint = Some(ServiceUrlDeserializer::deserialize("Endpoint", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Endpoint" => {
-                        obj.endpoint =
-                            Some(ServiceUrlDeserializer::deserialize("Endpoint", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ServiceUrlDeserializer;
@@ -4555,44 +3524,23 @@ impl SuggesterDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Suggester, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Suggester::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Suggester, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DocumentSuggesterOptions" => {
+                    obj.document_suggester_options =
+                        DocumentSuggesterOptionsDeserializer::deserialize(
+                            "DocumentSuggesterOptions",
+                            stack,
+                        )?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DocumentSuggesterOptions" => {
-                        obj.document_suggester_options =
-                            DocumentSuggesterOptionsDeserializer::deserialize(
-                                "DocumentSuggesterOptions",
-                                stack,
-                            )?;
-                    }
-                    "SuggesterName" => {
-                        obj.suggester_name =
-                            StandardNameDeserializer::deserialize("SuggesterName", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "SuggesterName" => {
+                    obj.suggester_name =
+                        StandardNameDeserializer::deserialize("SuggesterName", stack)?;
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -4645,39 +3593,18 @@ impl SuggesterStatusDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<SuggesterStatus, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = SuggesterStatus::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, SuggesterStatus, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Options" => {
+                    obj.options = SuggesterDeserializer::deserialize("Options", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Options" => {
-                        obj.options = SuggesterDeserializer::deserialize("Options", stack)?;
-                    }
-                    "Status" => {
-                        obj.status = OptionStatusDeserializer::deserialize("Status", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Status" => {
+                    obj.status = OptionStatusDeserializer::deserialize("Status", stack)?;
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct SuggesterStatusListDeserializer;
@@ -4687,37 +3614,14 @@ impl SuggesterStatusListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<SuggesterStatus>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(SuggesterStatusDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(SuggesterStatusDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Options for a field that contains an array of text strings. Present if <code>IndexFieldType</code> specifies the field is of type <code>text-array</code>. A <code>text-array</code> field is always searchable. All options are enabled by default.</p>
@@ -4742,55 +3646,34 @@ impl TextArrayOptionsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<TextArrayOptions, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = TextArrayOptions::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, TextArrayOptions, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AnalysisScheme" => {
+                    obj.analysis_scheme =
+                        Some(WordDeserializer::deserialize("AnalysisScheme", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AnalysisScheme" => {
-                        obj.analysis_scheme =
-                            Some(WordDeserializer::deserialize("AnalysisScheme", stack)?);
-                    }
-                    "DefaultValue" => {
-                        obj.default_value =
-                            Some(FieldValueDeserializer::deserialize("DefaultValue", stack)?);
-                    }
-                    "HighlightEnabled" => {
-                        obj.highlight_enabled =
-                            Some(BooleanDeserializer::deserialize("HighlightEnabled", stack)?);
-                    }
-                    "ReturnEnabled" => {
-                        obj.return_enabled =
-                            Some(BooleanDeserializer::deserialize("ReturnEnabled", stack)?);
-                    }
-                    "SourceFields" => {
-                        obj.source_fields = Some(FieldNameCommaListDeserializer::deserialize(
-                            "SourceFields",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "DefaultValue" => {
+                    obj.default_value =
+                        Some(FieldValueDeserializer::deserialize("DefaultValue", stack)?);
                 }
+                "HighlightEnabled" => {
+                    obj.highlight_enabled =
+                        Some(BooleanDeserializer::deserialize("HighlightEnabled", stack)?);
+                }
+                "ReturnEnabled" => {
+                    obj.return_enabled =
+                        Some(BooleanDeserializer::deserialize("ReturnEnabled", stack)?);
+                }
+                "SourceFields" => {
+                    obj.source_fields = Some(FieldNameCommaListDeserializer::deserialize(
+                        "SourceFields",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -4850,57 +3733,36 @@ impl TextOptionsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<TextOptions, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = TextOptions::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, TextOptions, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AnalysisScheme" => {
+                    obj.analysis_scheme =
+                        Some(WordDeserializer::deserialize("AnalysisScheme", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AnalysisScheme" => {
-                        obj.analysis_scheme =
-                            Some(WordDeserializer::deserialize("AnalysisScheme", stack)?);
-                    }
-                    "DefaultValue" => {
-                        obj.default_value =
-                            Some(FieldValueDeserializer::deserialize("DefaultValue", stack)?);
-                    }
-                    "HighlightEnabled" => {
-                        obj.highlight_enabled =
-                            Some(BooleanDeserializer::deserialize("HighlightEnabled", stack)?);
-                    }
-                    "ReturnEnabled" => {
-                        obj.return_enabled =
-                            Some(BooleanDeserializer::deserialize("ReturnEnabled", stack)?);
-                    }
-                    "SortEnabled" => {
-                        obj.sort_enabled =
-                            Some(BooleanDeserializer::deserialize("SortEnabled", stack)?);
-                    }
-                    "SourceField" => {
-                        obj.source_field =
-                            Some(FieldNameDeserializer::deserialize("SourceField", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "DefaultValue" => {
+                    obj.default_value =
+                        Some(FieldValueDeserializer::deserialize("DefaultValue", stack)?);
                 }
+                "HighlightEnabled" => {
+                    obj.highlight_enabled =
+                        Some(BooleanDeserializer::deserialize("HighlightEnabled", stack)?);
+                }
+                "ReturnEnabled" => {
+                    obj.return_enabled =
+                        Some(BooleanDeserializer::deserialize("ReturnEnabled", stack)?);
+                }
+                "SortEnabled" => {
+                    obj.sort_enabled =
+                        Some(BooleanDeserializer::deserialize("SortEnabled", stack)?);
+                }
+                "SourceField" => {
+                    obj.source_field =
+                        Some(FieldNameDeserializer::deserialize("SourceField", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -4996,21 +3858,11 @@ impl UpdateAvailabilityOptionsResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UpdateAvailabilityOptionsResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = UpdateAvailabilityOptionsResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, UpdateAvailabilityOptionsResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AvailabilityOptions" => {
                         obj.availability_options =
                             Some(AvailabilityOptionsStatusDeserializer::deserialize(
@@ -5019,17 +3871,10 @@ impl UpdateAvailabilityOptionsResponseDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Container for the parameters to the <code><a>UpdateScalingParameters</a></code> operation. Specifies the name of the domain you want to update and the scaling parameters you want to configure.</p>
@@ -5070,21 +3915,11 @@ impl UpdateScalingParametersResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UpdateScalingParametersResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = UpdateScalingParametersResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, UpdateScalingParametersResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ScalingParameters" => {
                         obj.scaling_parameters = ScalingParametersStatusDeserializer::deserialize(
                             "ScalingParameters",
@@ -5092,17 +3927,10 @@ impl UpdateScalingParametersResponseDeserializer {
                         )?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Container for the parameters to the <code><a>UpdateServiceAccessPolicies</a></code> operation. Specifies the name of the domain you want to update and the access rules you want to configure.</p>
@@ -5144,37 +3972,20 @@ impl UpdateServiceAccessPoliciesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UpdateServiceAccessPoliciesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = UpdateServiceAccessPoliciesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, UpdateServiceAccessPoliciesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AccessPolicies" => {
                         obj.access_policies =
                             AccessPoliciesStatusDeserializer::deserialize("AccessPolicies", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct UpdateTimestampDeserializer;

--- a/rusoto/services/elasticache/src/generated.rs
+++ b/rusoto/services/elasticache/src/generated.rs
@@ -25,20 +25,15 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
 use rusoto_core::xmlutil::{
-    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+    characters, deserialize_elements, end_element, find_start_element, peek_at_name, skip_tree,
+    start_element,
 };
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;
-use xml::reader::XmlEvent;
 use xml::EventReader;
 
-enum DeserializerNext {
-    Close,
-    Skip,
-    Element(String),
-}
 /// <p>Represents the input of an AddTagsToResource operation.</p>
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct AddTagsToResourceMessage {
@@ -90,48 +85,21 @@ impl AllowedNodeTypeModificationsMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AllowedNodeTypeModificationsMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AllowedNodeTypeModificationsMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, AllowedNodeTypeModificationsMessage, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ScaleUpModifications" => {
-                        obj.scale_up_modifications = match obj.scale_up_modifications {
-                            Some(ref mut existing) => {
-                                existing.extend(NodeTypeListDeserializer::deserialize(
-                                    "ScaleUpModifications",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(NodeTypeListDeserializer::deserialize(
-                                "ScaleUpModifications",
-                                stack,
-                            )?),
-                        };
+                        obj.scale_up_modifications.get_or_insert(vec![]).extend(
+                            NodeTypeListDeserializer::deserialize("ScaleUpModifications", stack)?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Represents the input of an AuthorizeCacheSecurityGroupIngress operation.</p>
@@ -181,21 +149,11 @@ impl AuthorizeCacheSecurityGroupIngressResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AuthorizeCacheSecurityGroupIngressResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AuthorizeCacheSecurityGroupIngressResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, AuthorizeCacheSecurityGroupIngressResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CacheSecurityGroup" => {
                         obj.cache_security_group =
                             Some(CacheSecurityGroupDeserializer::deserialize(
@@ -204,17 +162,10 @@ impl AuthorizeCacheSecurityGroupIngressResultDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct AutomaticFailoverStatusDeserializer;
@@ -245,36 +196,15 @@ impl AvailabilityZoneDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AvailabilityZone, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AvailabilityZone::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, AvailabilityZone, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Name" => {
+                    obj.name = Some(StringDeserializer::deserialize("Name", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Name" => {
-                        obj.name = Some(StringDeserializer::deserialize("Name", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct AvailabilityZonesListDeserializer;
@@ -284,37 +214,14 @@ impl AvailabilityZonesListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "AvailabilityZone" {
-                        obj.push(StringDeserializer::deserialize("AvailabilityZone", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "AvailabilityZone" {
+                obj.push(StringDeserializer::deserialize("AvailabilityZone", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -418,210 +325,157 @@ impl CacheClusterDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CacheCluster, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CacheCluster::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CacheCluster, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AtRestEncryptionEnabled" => {
+                    obj.at_rest_encryption_enabled = Some(
+                        BooleanOptionalDeserializer::deserialize("AtRestEncryptionEnabled", stack)?,
+                    );
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AtRestEncryptionEnabled" => {
-                        obj.at_rest_encryption_enabled =
-                            Some(BooleanOptionalDeserializer::deserialize(
-                                "AtRestEncryptionEnabled",
-                                stack,
-                            )?);
-                    }
-                    "AuthTokenEnabled" => {
-                        obj.auth_token_enabled = Some(BooleanOptionalDeserializer::deserialize(
-                            "AuthTokenEnabled",
-                            stack,
-                        )?);
-                    }
-                    "AutoMinorVersionUpgrade" => {
-                        obj.auto_minor_version_upgrade = Some(BooleanDeserializer::deserialize(
-                            "AutoMinorVersionUpgrade",
-                            stack,
-                        )?);
-                    }
-                    "CacheClusterCreateTime" => {
-                        obj.cache_cluster_create_time = Some(TStampDeserializer::deserialize(
-                            "CacheClusterCreateTime",
-                            stack,
-                        )?);
-                    }
-                    "CacheClusterId" => {
-                        obj.cache_cluster_id =
-                            Some(StringDeserializer::deserialize("CacheClusterId", stack)?);
-                    }
-                    "CacheClusterStatus" => {
-                        obj.cache_cluster_status = Some(StringDeserializer::deserialize(
-                            "CacheClusterStatus",
-                            stack,
-                        )?);
-                    }
-                    "CacheNodeType" => {
-                        obj.cache_node_type =
-                            Some(StringDeserializer::deserialize("CacheNodeType", stack)?);
-                    }
-                    "CacheNodes" => {
-                        obj.cache_nodes = match obj.cache_nodes {
-                            Some(ref mut existing) => {
-                                existing.extend(CacheNodeListDeserializer::deserialize(
-                                    "CacheNodes",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => {
-                                Some(CacheNodeListDeserializer::deserialize("CacheNodes", stack)?)
-                            }
-                        };
-                    }
-                    "CacheParameterGroup" => {
-                        obj.cache_parameter_group =
-                            Some(CacheParameterGroupStatusDeserializer::deserialize(
-                                "CacheParameterGroup",
-                                stack,
-                            )?);
-                    }
-                    "CacheSecurityGroups" => {
-                        obj.cache_security_groups = match obj.cache_security_groups {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    CacheSecurityGroupMembershipListDeserializer::deserialize(
-                                        "CacheSecurityGroups",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => {
-                                Some(CacheSecurityGroupMembershipListDeserializer::deserialize(
-                                    "CacheSecurityGroups",
-                                    stack,
-                                )?)
-                            }
-                        };
-                    }
-                    "CacheSubnetGroupName" => {
-                        obj.cache_subnet_group_name = Some(StringDeserializer::deserialize(
-                            "CacheSubnetGroupName",
-                            stack,
-                        )?);
-                    }
-                    "ClientDownloadLandingPage" => {
-                        obj.client_download_landing_page = Some(StringDeserializer::deserialize(
-                            "ClientDownloadLandingPage",
-                            stack,
-                        )?);
-                    }
-                    "ConfigurationEndpoint" => {
-                        obj.configuration_endpoint = Some(EndpointDeserializer::deserialize(
-                            "ConfigurationEndpoint",
-                            stack,
-                        )?);
-                    }
-                    "Engine" => {
-                        obj.engine = Some(StringDeserializer::deserialize("Engine", stack)?);
-                    }
-                    "EngineVersion" => {
-                        obj.engine_version =
-                            Some(StringDeserializer::deserialize("EngineVersion", stack)?);
-                    }
-                    "NotificationConfiguration" => {
-                        obj.notification_configuration =
-                            Some(NotificationConfigurationDeserializer::deserialize(
-                                "NotificationConfiguration",
-                                stack,
-                            )?);
-                    }
-                    "NumCacheNodes" => {
-                        obj.num_cache_nodes = Some(IntegerOptionalDeserializer::deserialize(
-                            "NumCacheNodes",
-                            stack,
-                        )?);
-                    }
-                    "PendingModifiedValues" => {
-                        obj.pending_modified_values =
-                            Some(PendingModifiedValuesDeserializer::deserialize(
-                                "PendingModifiedValues",
-                                stack,
-                            )?);
-                    }
-                    "PreferredAvailabilityZone" => {
-                        obj.preferred_availability_zone = Some(StringDeserializer::deserialize(
-                            "PreferredAvailabilityZone",
-                            stack,
-                        )?);
-                    }
-                    "PreferredMaintenanceWindow" => {
-                        obj.preferred_maintenance_window = Some(StringDeserializer::deserialize(
-                            "PreferredMaintenanceWindow",
-                            stack,
-                        )?);
-                    }
-                    "ReplicationGroupId" => {
-                        obj.replication_group_id = Some(StringDeserializer::deserialize(
-                            "ReplicationGroupId",
-                            stack,
-                        )?);
-                    }
-                    "SecurityGroups" => {
-                        obj.security_groups = match obj.security_groups {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    SecurityGroupMembershipListDeserializer::deserialize(
-                                        "SecurityGroups",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(SecurityGroupMembershipListDeserializer::deserialize(
-                                "SecurityGroups",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "SnapshotRetentionLimit" => {
-                        obj.snapshot_retention_limit =
-                            Some(IntegerOptionalDeserializer::deserialize(
-                                "SnapshotRetentionLimit",
-                                stack,
-                            )?);
-                    }
-                    "SnapshotWindow" => {
-                        obj.snapshot_window =
-                            Some(StringDeserializer::deserialize("SnapshotWindow", stack)?);
-                    }
-                    "TransitEncryptionEnabled" => {
-                        obj.transit_encryption_enabled =
-                            Some(BooleanOptionalDeserializer::deserialize(
-                                "TransitEncryptionEnabled",
-                                stack,
-                            )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "AuthTokenEnabled" => {
+                    obj.auth_token_enabled = Some(BooleanOptionalDeserializer::deserialize(
+                        "AuthTokenEnabled",
+                        stack,
+                    )?);
                 }
+                "AutoMinorVersionUpgrade" => {
+                    obj.auto_minor_version_upgrade = Some(BooleanDeserializer::deserialize(
+                        "AutoMinorVersionUpgrade",
+                        stack,
+                    )?);
+                }
+                "CacheClusterCreateTime" => {
+                    obj.cache_cluster_create_time = Some(TStampDeserializer::deserialize(
+                        "CacheClusterCreateTime",
+                        stack,
+                    )?);
+                }
+                "CacheClusterId" => {
+                    obj.cache_cluster_id =
+                        Some(StringDeserializer::deserialize("CacheClusterId", stack)?);
+                }
+                "CacheClusterStatus" => {
+                    obj.cache_cluster_status = Some(StringDeserializer::deserialize(
+                        "CacheClusterStatus",
+                        stack,
+                    )?);
+                }
+                "CacheNodeType" => {
+                    obj.cache_node_type =
+                        Some(StringDeserializer::deserialize("CacheNodeType", stack)?);
+                }
+                "CacheNodes" => {
+                    obj.cache_nodes
+                        .get_or_insert(vec![])
+                        .extend(CacheNodeListDeserializer::deserialize("CacheNodes", stack)?);
+                }
+                "CacheParameterGroup" => {
+                    obj.cache_parameter_group =
+                        Some(CacheParameterGroupStatusDeserializer::deserialize(
+                            "CacheParameterGroup",
+                            stack,
+                        )?);
+                }
+                "CacheSecurityGroups" => {
+                    obj.cache_security_groups.get_or_insert(vec![]).extend(
+                        CacheSecurityGroupMembershipListDeserializer::deserialize(
+                            "CacheSecurityGroups",
+                            stack,
+                        )?,
+                    );
+                }
+                "CacheSubnetGroupName" => {
+                    obj.cache_subnet_group_name = Some(StringDeserializer::deserialize(
+                        "CacheSubnetGroupName",
+                        stack,
+                    )?);
+                }
+                "ClientDownloadLandingPage" => {
+                    obj.client_download_landing_page = Some(StringDeserializer::deserialize(
+                        "ClientDownloadLandingPage",
+                        stack,
+                    )?);
+                }
+                "ConfigurationEndpoint" => {
+                    obj.configuration_endpoint = Some(EndpointDeserializer::deserialize(
+                        "ConfigurationEndpoint",
+                        stack,
+                    )?);
+                }
+                "Engine" => {
+                    obj.engine = Some(StringDeserializer::deserialize("Engine", stack)?);
+                }
+                "EngineVersion" => {
+                    obj.engine_version =
+                        Some(StringDeserializer::deserialize("EngineVersion", stack)?);
+                }
+                "NotificationConfiguration" => {
+                    obj.notification_configuration =
+                        Some(NotificationConfigurationDeserializer::deserialize(
+                            "NotificationConfiguration",
+                            stack,
+                        )?);
+                }
+                "NumCacheNodes" => {
+                    obj.num_cache_nodes = Some(IntegerOptionalDeserializer::deserialize(
+                        "NumCacheNodes",
+                        stack,
+                    )?);
+                }
+                "PendingModifiedValues" => {
+                    obj.pending_modified_values =
+                        Some(PendingModifiedValuesDeserializer::deserialize(
+                            "PendingModifiedValues",
+                            stack,
+                        )?);
+                }
+                "PreferredAvailabilityZone" => {
+                    obj.preferred_availability_zone = Some(StringDeserializer::deserialize(
+                        "PreferredAvailabilityZone",
+                        stack,
+                    )?);
+                }
+                "PreferredMaintenanceWindow" => {
+                    obj.preferred_maintenance_window = Some(StringDeserializer::deserialize(
+                        "PreferredMaintenanceWindow",
+                        stack,
+                    )?);
+                }
+                "ReplicationGroupId" => {
+                    obj.replication_group_id = Some(StringDeserializer::deserialize(
+                        "ReplicationGroupId",
+                        stack,
+                    )?);
+                }
+                "SecurityGroups" => {
+                    obj.security_groups.get_or_insert(vec![]).extend(
+                        SecurityGroupMembershipListDeserializer::deserialize(
+                            "SecurityGroups",
+                            stack,
+                        )?,
+                    );
+                }
+                "SnapshotRetentionLimit" => {
+                    obj.snapshot_retention_limit = Some(IntegerOptionalDeserializer::deserialize(
+                        "SnapshotRetentionLimit",
+                        stack,
+                    )?);
+                }
+                "SnapshotWindow" => {
+                    obj.snapshot_window =
+                        Some(StringDeserializer::deserialize("SnapshotWindow", stack)?);
+                }
+                "TransitEncryptionEnabled" => {
+                    obj.transit_encryption_enabled =
+                        Some(BooleanOptionalDeserializer::deserialize(
+                            "TransitEncryptionEnabled",
+                            stack,
+                        )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct CacheClusterListDeserializer;
@@ -631,40 +485,17 @@ impl CacheClusterListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<CacheCluster>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "CacheCluster" {
-                        obj.push(CacheClusterDeserializer::deserialize(
-                            "CacheCluster",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "CacheCluster" {
+                obj.push(CacheClusterDeserializer::deserialize(
+                    "CacheCluster",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Represents the output of a <code>DescribeCacheClusters</code> operation.</p>
@@ -683,51 +514,20 @@ impl CacheClusterMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CacheClusterMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CacheClusterMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CacheClusterMessage, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CacheClusters" => {
+                    obj.cache_clusters.get_or_insert(vec![]).extend(
+                        CacheClusterListDeserializer::deserialize("CacheClusters", stack)?,
+                    );
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CacheClusters" => {
-                        obj.cache_clusters = match obj.cache_clusters {
-                            Some(ref mut existing) => {
-                                existing.extend(CacheClusterListDeserializer::deserialize(
-                                    "CacheClusters",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(CacheClusterListDeserializer::deserialize(
-                                "CacheClusters",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "Marker" => {
-                        obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Marker" => {
+                    obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Provides all of the details about a particular cache engine version.</p>
@@ -752,59 +552,37 @@ impl CacheEngineVersionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CacheEngineVersion, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CacheEngineVersion::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CacheEngineVersion, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CacheEngineDescription" => {
+                    obj.cache_engine_description = Some(StringDeserializer::deserialize(
+                        "CacheEngineDescription",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CacheEngineDescription" => {
-                        obj.cache_engine_description = Some(StringDeserializer::deserialize(
-                            "CacheEngineDescription",
-                            stack,
-                        )?);
-                    }
-                    "CacheEngineVersionDescription" => {
-                        obj.cache_engine_version_description =
-                            Some(StringDeserializer::deserialize(
-                                "CacheEngineVersionDescription",
-                                stack,
-                            )?);
-                    }
-                    "CacheParameterGroupFamily" => {
-                        obj.cache_parameter_group_family = Some(StringDeserializer::deserialize(
-                            "CacheParameterGroupFamily",
-                            stack,
-                        )?);
-                    }
-                    "Engine" => {
-                        obj.engine = Some(StringDeserializer::deserialize("Engine", stack)?);
-                    }
-                    "EngineVersion" => {
-                        obj.engine_version =
-                            Some(StringDeserializer::deserialize("EngineVersion", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "CacheEngineVersionDescription" => {
+                    obj.cache_engine_version_description = Some(StringDeserializer::deserialize(
+                        "CacheEngineVersionDescription",
+                        stack,
+                    )?);
                 }
+                "CacheParameterGroupFamily" => {
+                    obj.cache_parameter_group_family = Some(StringDeserializer::deserialize(
+                        "CacheParameterGroupFamily",
+                        stack,
+                    )?);
+                }
+                "Engine" => {
+                    obj.engine = Some(StringDeserializer::deserialize("Engine", stack)?);
+                }
+                "EngineVersion" => {
+                    obj.engine_version =
+                        Some(StringDeserializer::deserialize("EngineVersion", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct CacheEngineVersionListDeserializer;
@@ -814,40 +592,17 @@ impl CacheEngineVersionListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<CacheEngineVersion>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "CacheEngineVersion" {
-                        obj.push(CacheEngineVersionDeserializer::deserialize(
-                            "CacheEngineVersion",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "CacheEngineVersion" {
+                obj.push(CacheEngineVersionDeserializer::deserialize(
+                    "CacheEngineVersion",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Represents the output of a <a>DescribeCacheEngineVersions</a> operation.</p>
@@ -866,51 +621,27 @@ impl CacheEngineVersionMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CacheEngineVersionMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CacheEngineVersionMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CacheEngineVersionMessage, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CacheEngineVersions" => {
-                        obj.cache_engine_versions = match obj.cache_engine_versions {
-                            Some(ref mut existing) => {
-                                existing.extend(CacheEngineVersionListDeserializer::deserialize(
-                                    "CacheEngineVersions",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(CacheEngineVersionListDeserializer::deserialize(
+                        obj.cache_engine_versions.get_or_insert(vec![]).extend(
+                            CacheEngineVersionListDeserializer::deserialize(
                                 "CacheEngineVersions",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     "Marker" => {
                         obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p><p>Represents an individual cache node within a cluster. Each cache node runs its own instance of the cluster&#39;s protocol-compliant caching software - either Memcached or Redis.</p> <p>The following node types are supported by ElastiCache. Generally speaking, the current generation types provide more memory and computational power at lower cost when compared to their equivalent previous generation counterparts.</p> <ul> <li> <p>General purpose:</p> <ul> <li> <p>Current generation: </p> <p> <b>T2 node types:</b> <code>cache.t2.micro</code>, <code>cache.t2.small</code>, <code>cache.t2.medium</code> </p> <p> <b>M3 node types:</b> <code>cache.m3.medium</code>, <code>cache.m3.large</code>, <code>cache.m3.xlarge</code>, <code>cache.m3.2xlarge</code> </p> <p> <b>M4 node types:</b> <code>cache.m4.large</code>, <code>cache.m4.xlarge</code>, <code>cache.m4.2xlarge</code>, <code>cache.m4.4xlarge</code>, <code>cache.m4.10xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>T1 node types:</b> <code>cache.t1.micro</code> </p> <p> <b>M1 node types:</b> <code>cache.m1.small</code>, <code>cache.m1.medium</code>, <code>cache.m1.large</code>, <code>cache.m1.xlarge</code> </p> </li> </ul> </li> <li> <p>Compute optimized:</p> <ul> <li> <p>Previous generation: (not recommended)</p> <p> <b>C1 node types:</b> <code>cache.c1.xlarge</code> </p> </li> </ul> </li> <li> <p>Memory optimized:</p> <ul> <li> <p>Current generation: </p> <p> <b>R3 node types:</b> <code>cache.r3.large</code>, <code>cache.r3.xlarge</code>, <code>cache.r3.2xlarge</code>, <code>cache.r3.4xlarge</code>, <code>cache.r3.8xlarge</code> </p> <p> <b>R4 node types;</b> <code>cache.r4.large</code>, <code>cache.r4.xlarge</code>, <code>cache.r4.2xlarge</code>, <code>cache.r4.4xlarge</code>, <code>cache.r4.8xlarge</code>, <code>cache.r4.16xlarge</code> </p> </li> <li> <p>Previous generation: (not recommended)</p> <p> <b>M2 node types:</b> <code>cache.m2.xlarge</code>, <code>cache.m2.2xlarge</code>, <code>cache.m2.4xlarge</code> </p> </li> </ul> </li> </ul> <p> <b>Notes:</b> </p> <ul> <li> <p>All T2 instances are created in an Amazon Virtual Private Cloud (Amazon VPC).</p> </li> <li> <p>Redis (cluster mode disabled): Redis backup/restore is not supported on T1 and T2 instances. </p> </li> <li> <p>Redis (cluster mode enabled): Backup/restore is not supported on T1 instances.</p> </li> <li> <p>Redis Append-only files (AOF) functionality is not supported for T1 or T2 instances.</p> </li> </ul> <p>For a complete listing of node types and specifications, see:</p> <ul> <li> <p> <a href="http://aws.amazon.com/elasticache/details">Amazon ElastiCache Product Features and Details</a> </p> </li> <li> <p> <a href="http://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/ParameterGroups.Memcached.html#ParameterGroups.Memcached.NodeSpecific">Cache Node Type-Specific Parameters for Memcached</a> </p> </li> <li> <p> <a href="http://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/ParameterGroups.Redis.html#ParameterGroups.Redis.NodeSpecific">Cache Node Type-Specific Parameters for Redis</a> </p> </li> </ul></p>
@@ -939,66 +670,45 @@ impl CacheNodeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CacheNode, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CacheNode::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CacheNode, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CacheNodeCreateTime" => {
+                    obj.cache_node_create_time = Some(TStampDeserializer::deserialize(
+                        "CacheNodeCreateTime",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CacheNodeCreateTime" => {
-                        obj.cache_node_create_time = Some(TStampDeserializer::deserialize(
-                            "CacheNodeCreateTime",
-                            stack,
-                        )?);
-                    }
-                    "CacheNodeId" => {
-                        obj.cache_node_id =
-                            Some(StringDeserializer::deserialize("CacheNodeId", stack)?);
-                    }
-                    "CacheNodeStatus" => {
-                        obj.cache_node_status =
-                            Some(StringDeserializer::deserialize("CacheNodeStatus", stack)?);
-                    }
-                    "CustomerAvailabilityZone" => {
-                        obj.customer_availability_zone = Some(StringDeserializer::deserialize(
-                            "CustomerAvailabilityZone",
-                            stack,
-                        )?);
-                    }
-                    "Endpoint" => {
-                        obj.endpoint = Some(EndpointDeserializer::deserialize("Endpoint", stack)?);
-                    }
-                    "ParameterGroupStatus" => {
-                        obj.parameter_group_status = Some(StringDeserializer::deserialize(
-                            "ParameterGroupStatus",
-                            stack,
-                        )?);
-                    }
-                    "SourceCacheNodeId" => {
-                        obj.source_cache_node_id =
-                            Some(StringDeserializer::deserialize("SourceCacheNodeId", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "CacheNodeId" => {
+                    obj.cache_node_id =
+                        Some(StringDeserializer::deserialize("CacheNodeId", stack)?);
                 }
+                "CacheNodeStatus" => {
+                    obj.cache_node_status =
+                        Some(StringDeserializer::deserialize("CacheNodeStatus", stack)?);
+                }
+                "CustomerAvailabilityZone" => {
+                    obj.customer_availability_zone = Some(StringDeserializer::deserialize(
+                        "CustomerAvailabilityZone",
+                        stack,
+                    )?);
+                }
+                "Endpoint" => {
+                    obj.endpoint = Some(EndpointDeserializer::deserialize("Endpoint", stack)?);
+                }
+                "ParameterGroupStatus" => {
+                    obj.parameter_group_status = Some(StringDeserializer::deserialize(
+                        "ParameterGroupStatus",
+                        stack,
+                    )?);
+                }
+                "SourceCacheNodeId" => {
+                    obj.source_cache_node_id =
+                        Some(StringDeserializer::deserialize("SourceCacheNodeId", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct CacheNodeIdsListDeserializer;
@@ -1008,37 +718,14 @@ impl CacheNodeIdsListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "CacheNodeId" {
-                        obj.push(StringDeserializer::deserialize("CacheNodeId", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "CacheNodeId" {
+                obj.push(StringDeserializer::deserialize("CacheNodeId", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -1060,37 +747,14 @@ impl CacheNodeListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<CacheNode>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "CacheNode" {
-                        obj.push(CacheNodeDeserializer::deserialize("CacheNode", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "CacheNode" {
+                obj.push(CacheNodeDeserializer::deserialize("CacheNode", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>A parameter that has a different value for each cache node type it is applied to. For example, in a Redis cluster, a <code>cache.m1.large</code> cache node type would have a larger <code>maxmemory</code> value than a <code>cache.m1.small</code> type.</p>
@@ -1123,43 +787,22 @@ impl CacheNodeTypeSpecificParameterDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CacheNodeTypeSpecificParameter, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CacheNodeTypeSpecificParameter::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CacheNodeTypeSpecificParameter, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AllowedValues" => {
                         obj.allowed_values =
                             Some(StringDeserializer::deserialize("AllowedValues", stack)?);
                     }
                     "CacheNodeTypeSpecificValues" => {
-                        obj.cache_node_type_specific_values = match obj
-                            .cache_node_type_specific_values
-                        {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    CacheNodeTypeSpecificValueListDeserializer::deserialize(
-                                        "CacheNodeTypeSpecificValues",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(CacheNodeTypeSpecificValueListDeserializer::deserialize(
+                        obj.cache_node_type_specific_values
+                            .get_or_insert(vec![])
+                            .extend(CacheNodeTypeSpecificValueListDeserializer::deserialize(
                                 "CacheNodeTypeSpecificValues",
                                 stack,
-                            )?),
-                        };
+                            )?);
                     }
                     "ChangeType" => {
                         obj.change_type =
@@ -1190,17 +833,10 @@ impl CacheNodeTypeSpecificParameterDeserializer {
                         obj.source = Some(StringDeserializer::deserialize("Source", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct CacheNodeTypeSpecificParametersListDeserializer;
@@ -1210,40 +846,17 @@ impl CacheNodeTypeSpecificParametersListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<CacheNodeTypeSpecificParameter>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "CacheNodeTypeSpecificParameter" {
-                        obj.push(CacheNodeTypeSpecificParameterDeserializer::deserialize(
-                            "CacheNodeTypeSpecificParameter",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "CacheNodeTypeSpecificParameter" {
+                obj.push(CacheNodeTypeSpecificParameterDeserializer::deserialize(
+                    "CacheNodeTypeSpecificParameter",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>A value that applies only to a certain cache node type.</p>
@@ -1262,21 +875,11 @@ impl CacheNodeTypeSpecificValueDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CacheNodeTypeSpecificValue, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CacheNodeTypeSpecificValue::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CacheNodeTypeSpecificValue, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CacheNodeType" => {
                         obj.cache_node_type =
                             Some(StringDeserializer::deserialize("CacheNodeType", stack)?);
@@ -1285,17 +888,10 @@ impl CacheNodeTypeSpecificValueDeserializer {
                         obj.value = Some(StringDeserializer::deserialize("Value", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct CacheNodeTypeSpecificValueListDeserializer;
@@ -1305,40 +901,17 @@ impl CacheNodeTypeSpecificValueListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<CacheNodeTypeSpecificValue>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "CacheNodeTypeSpecificValue" {
-                        obj.push(CacheNodeTypeSpecificValueDeserializer::deserialize(
-                            "CacheNodeTypeSpecificValue",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "CacheNodeTypeSpecificValue" {
+                obj.push(CacheNodeTypeSpecificValueDeserializer::deserialize(
+                    "CacheNodeTypeSpecificValue",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Represents the output of a <code>CreateCacheParameterGroup</code> operation.</p>
@@ -1359,49 +932,27 @@ impl CacheParameterGroupDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CacheParameterGroup, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CacheParameterGroup::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CacheParameterGroup, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CacheParameterGroupFamily" => {
+                    obj.cache_parameter_group_family = Some(StringDeserializer::deserialize(
+                        "CacheParameterGroupFamily",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CacheParameterGroupFamily" => {
-                        obj.cache_parameter_group_family = Some(StringDeserializer::deserialize(
-                            "CacheParameterGroupFamily",
-                            stack,
-                        )?);
-                    }
-                    "CacheParameterGroupName" => {
-                        obj.cache_parameter_group_name = Some(StringDeserializer::deserialize(
-                            "CacheParameterGroupName",
-                            stack,
-                        )?);
-                    }
-                    "Description" => {
-                        obj.description =
-                            Some(StringDeserializer::deserialize("Description", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "CacheParameterGroupName" => {
+                    obj.cache_parameter_group_name = Some(StringDeserializer::deserialize(
+                        "CacheParameterGroupName",
+                        stack,
+                    )?);
                 }
+                "Description" => {
+                    obj.description = Some(StringDeserializer::deserialize("Description", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Represents the output of a <code>DescribeCacheParameters</code> operation.</p>
@@ -1422,69 +973,34 @@ impl CacheParameterGroupDetailsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CacheParameterGroupDetails, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CacheParameterGroupDetails::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    match &name[..] {
-                        "CacheNodeTypeSpecificParameters" => {
-                            obj.cache_node_type_specific_parameters = match obj
-                                .cache_node_type_specific_parameters
-                            {
-                                Some(ref mut existing) => {
-                                    existing.extend(CacheNodeTypeSpecificParametersListDeserializer::deserialize("CacheNodeTypeSpecificParameters", stack)?);
-                                    Some(existing.to_vec())
-                                }
-                                None => Some(
-                                    CacheNodeTypeSpecificParametersListDeserializer::deserialize(
-                                        "CacheNodeTypeSpecificParameters",
-                                        stack,
-                                    )?,
-                                ),
-                            };
-                        }
-                        "Marker" => {
-                            obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
-                        }
-                        "Parameters" => {
-                            obj.parameters = match obj.parameters {
-                                Some(ref mut existing) => {
-                                    existing.extend(ParametersListDeserializer::deserialize(
-                                        "Parameters",
-                                        stack,
-                                    )?);
-                                    Some(existing.to_vec())
-                                }
-                                None => Some(ParametersListDeserializer::deserialize(
-                                    "Parameters",
+        deserialize_elements::<_, CacheParameterGroupDetails, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
+                    "CacheNodeTypeSpecificParameters" => {
+                        obj.cache_node_type_specific_parameters
+                            .get_or_insert(vec![])
+                            .extend(
+                                CacheNodeTypeSpecificParametersListDeserializer::deserialize(
+                                    "CacheNodeTypeSpecificParameters",
                                     stack,
-                                )?),
-                            };
-                        }
-                        _ => skip_tree(stack),
+                                )?,
+                            );
                     }
+                    "Marker" => {
+                        obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
+                    }
+                    "Parameters" => {
+                        obj.parameters.get_or_insert(vec![]).extend(
+                            ParametersListDeserializer::deserialize("Parameters", stack)?,
+                        );
+                    }
+                    _ => skip_tree(stack),
                 }
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct CacheParameterGroupListDeserializer;
@@ -1494,40 +1010,17 @@ impl CacheParameterGroupListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<CacheParameterGroup>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "CacheParameterGroup" {
-                        obj.push(CacheParameterGroupDeserializer::deserialize(
-                            "CacheParameterGroup",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "CacheParameterGroup" {
+                obj.push(CacheParameterGroupDeserializer::deserialize(
+                    "CacheParameterGroup",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p><p>Represents the output of one of the following operations:</p> <ul> <li> <p> <code>ModifyCacheParameterGroup</code> </p> </li> <li> <p> <code>ResetCacheParameterGroup</code> </p> </li> </ul></p>
@@ -1544,21 +1037,11 @@ impl CacheParameterGroupNameMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CacheParameterGroupNameMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CacheParameterGroupNameMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CacheParameterGroupNameMessage, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CacheParameterGroupName" => {
                         obj.cache_parameter_group_name = Some(StringDeserializer::deserialize(
                             "CacheParameterGroupName",
@@ -1566,17 +1049,10 @@ impl CacheParameterGroupNameMessageDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Status of the cache parameter group.</p>
@@ -1597,35 +1073,18 @@ impl CacheParameterGroupStatusDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CacheParameterGroupStatus, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CacheParameterGroupStatus::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CacheParameterGroupStatus, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CacheNodeIdsToReboot" => {
-                        obj.cache_node_ids_to_reboot = match obj.cache_node_ids_to_reboot {
-                            Some(ref mut existing) => {
-                                existing.extend(CacheNodeIdsListDeserializer::deserialize(
-                                    "CacheNodeIdsToReboot",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(CacheNodeIdsListDeserializer::deserialize(
+                        obj.cache_node_ids_to_reboot.get_or_insert(vec![]).extend(
+                            CacheNodeIdsListDeserializer::deserialize(
                                 "CacheNodeIdsToReboot",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     "CacheParameterGroupName" => {
                         obj.cache_parameter_group_name = Some(StringDeserializer::deserialize(
@@ -1640,17 +1099,10 @@ impl CacheParameterGroupStatusDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Represents the output of a <code>DescribeCacheParameterGroups</code> operation.</p>
@@ -1669,51 +1121,27 @@ impl CacheParameterGroupsMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CacheParameterGroupsMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CacheParameterGroupsMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CacheParameterGroupsMessage, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CacheParameterGroups" => {
-                        obj.cache_parameter_groups = match obj.cache_parameter_groups {
-                            Some(ref mut existing) => {
-                                existing.extend(CacheParameterGroupListDeserializer::deserialize(
-                                    "CacheParameterGroups",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(CacheParameterGroupListDeserializer::deserialize(
+                        obj.cache_parameter_groups.get_or_insert(vec![]).extend(
+                            CacheParameterGroupListDeserializer::deserialize(
                                 "CacheParameterGroups",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     "Marker" => {
                         obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p><p>Represents the output of one of the following operations:</p> <ul> <li> <p> <code>AuthorizeCacheSecurityGroupIngress</code> </p> </li> <li> <p> <code>CreateCacheSecurityGroup</code> </p> </li> <li> <p> <code>RevokeCacheSecurityGroupIngress</code> </p> </li> </ul></p>
@@ -1736,61 +1164,29 @@ impl CacheSecurityGroupDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CacheSecurityGroup, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CacheSecurityGroup::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CacheSecurityGroup, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CacheSecurityGroupName" => {
+                    obj.cache_security_group_name = Some(StringDeserializer::deserialize(
+                        "CacheSecurityGroupName",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CacheSecurityGroupName" => {
-                        obj.cache_security_group_name = Some(StringDeserializer::deserialize(
-                            "CacheSecurityGroupName",
-                            stack,
-                        )?);
-                    }
-                    "Description" => {
-                        obj.description =
-                            Some(StringDeserializer::deserialize("Description", stack)?);
-                    }
-                    "EC2SecurityGroups" => {
-                        obj.ec2_security_groups = match obj.ec2_security_groups {
-                            Some(ref mut existing) => {
-                                existing.extend(EC2SecurityGroupListDeserializer::deserialize(
-                                    "EC2SecurityGroups",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(EC2SecurityGroupListDeserializer::deserialize(
-                                "EC2SecurityGroups",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "OwnerId" => {
-                        obj.owner_id = Some(StringDeserializer::deserialize("OwnerId", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Description" => {
+                    obj.description = Some(StringDeserializer::deserialize("Description", stack)?);
                 }
+                "EC2SecurityGroups" => {
+                    obj.ec2_security_groups.get_or_insert(vec![]).extend(
+                        EC2SecurityGroupListDeserializer::deserialize("EC2SecurityGroups", stack)?,
+                    );
+                }
+                "OwnerId" => {
+                    obj.owner_id = Some(StringDeserializer::deserialize("OwnerId", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Represents a cluster's status within a particular cache security group.</p>
@@ -1809,21 +1205,11 @@ impl CacheSecurityGroupMembershipDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CacheSecurityGroupMembership, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CacheSecurityGroupMembership::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CacheSecurityGroupMembership, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CacheSecurityGroupName" => {
                         obj.cache_security_group_name = Some(StringDeserializer::deserialize(
                             "CacheSecurityGroupName",
@@ -1834,17 +1220,10 @@ impl CacheSecurityGroupMembershipDeserializer {
                         obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct CacheSecurityGroupMembershipListDeserializer;
@@ -1854,40 +1233,17 @@ impl CacheSecurityGroupMembershipListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<CacheSecurityGroupMembership>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "CacheSecurityGroup" {
-                        obj.push(CacheSecurityGroupMembershipDeserializer::deserialize(
-                            "CacheSecurityGroup",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "CacheSecurityGroup" {
+                obj.push(CacheSecurityGroupMembershipDeserializer::deserialize(
+                    "CacheSecurityGroup",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Represents the output of a <code>DescribeCacheSecurityGroups</code> operation.</p>
@@ -1906,51 +1262,27 @@ impl CacheSecurityGroupMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CacheSecurityGroupMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CacheSecurityGroupMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CacheSecurityGroupMessage, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CacheSecurityGroups" => {
-                        obj.cache_security_groups = match obj.cache_security_groups {
-                            Some(ref mut existing) => {
-                                existing.extend(CacheSecurityGroupsDeserializer::deserialize(
-                                    "CacheSecurityGroups",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(CacheSecurityGroupsDeserializer::deserialize(
+                        obj.cache_security_groups.get_or_insert(vec![]).extend(
+                            CacheSecurityGroupsDeserializer::deserialize(
                                 "CacheSecurityGroups",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     "Marker" => {
                         obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -1972,40 +1304,17 @@ impl CacheSecurityGroupsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<CacheSecurityGroup>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "CacheSecurityGroup" {
-                        obj.push(CacheSecurityGroupDeserializer::deserialize(
-                            "CacheSecurityGroup",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "CacheSecurityGroup" {
+                obj.push(CacheSecurityGroupDeserializer::deserialize(
+                    "CacheSecurityGroup",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p><p>Represents the output of one of the following operations:</p> <ul> <li> <p> <code>CreateCacheSubnetGroup</code> </p> </li> <li> <p> <code>ModifyCacheSubnetGroup</code> </p> </li> </ul></p>
@@ -2028,58 +1337,32 @@ impl CacheSubnetGroupDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CacheSubnetGroup, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CacheSubnetGroup::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CacheSubnetGroup, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CacheSubnetGroupDescription" => {
+                    obj.cache_subnet_group_description = Some(StringDeserializer::deserialize(
+                        "CacheSubnetGroupDescription",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CacheSubnetGroupDescription" => {
-                        obj.cache_subnet_group_description = Some(StringDeserializer::deserialize(
-                            "CacheSubnetGroupDescription",
-                            stack,
-                        )?);
-                    }
-                    "CacheSubnetGroupName" => {
-                        obj.cache_subnet_group_name = Some(StringDeserializer::deserialize(
-                            "CacheSubnetGroupName",
-                            stack,
-                        )?);
-                    }
-                    "Subnets" => {
-                        obj.subnets = match obj.subnets {
-                            Some(ref mut existing) => {
-                                existing
-                                    .extend(SubnetListDeserializer::deserialize("Subnets", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(SubnetListDeserializer::deserialize("Subnets", stack)?),
-                        };
-                    }
-                    "VpcId" => {
-                        obj.vpc_id = Some(StringDeserializer::deserialize("VpcId", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "CacheSubnetGroupName" => {
+                    obj.cache_subnet_group_name = Some(StringDeserializer::deserialize(
+                        "CacheSubnetGroupName",
+                        stack,
+                    )?);
                 }
+                "Subnets" => {
+                    obj.subnets
+                        .get_or_insert(vec![])
+                        .extend(SubnetListDeserializer::deserialize("Subnets", stack)?);
+                }
+                "VpcId" => {
+                    obj.vpc_id = Some(StringDeserializer::deserialize("VpcId", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Represents the output of a <code>DescribeCacheSubnetGroups</code> operation.</p>
@@ -2098,51 +1381,24 @@ impl CacheSubnetGroupMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CacheSubnetGroupMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CacheSubnetGroupMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CacheSubnetGroupMessage, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CacheSubnetGroups" => {
-                        obj.cache_subnet_groups = match obj.cache_subnet_groups {
-                            Some(ref mut existing) => {
-                                existing.extend(CacheSubnetGroupsDeserializer::deserialize(
-                                    "CacheSubnetGroups",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(CacheSubnetGroupsDeserializer::deserialize(
-                                "CacheSubnetGroups",
-                                stack,
-                            )?),
-                        };
+                        obj.cache_subnet_groups.get_or_insert(vec![]).extend(
+                            CacheSubnetGroupsDeserializer::deserialize("CacheSubnetGroups", stack)?,
+                        );
                     }
                     "Marker" => {
                         obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct CacheSubnetGroupsDeserializer;
@@ -2152,40 +1408,17 @@ impl CacheSubnetGroupsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<CacheSubnetGroup>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "CacheSubnetGroup" {
-                        obj.push(CacheSubnetGroupDeserializer::deserialize(
-                            "CacheSubnetGroup",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "CacheSubnetGroup" {
+                obj.push(CacheSubnetGroupDeserializer::deserialize(
+                    "CacheSubnetGroup",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ChangeTypeDeserializer;
@@ -2209,37 +1442,14 @@ impl ClusterIdListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "ClusterId" {
-                        obj.push(StringDeserializer::deserialize("ClusterId", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "ClusterId" {
+                obj.push(StringDeserializer::deserialize("ClusterId", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Node group (shard) configuration options when adding or removing replicas. Each node group (shard) configuration has the following members: NodeGroupId, NewReplicaCount, and PreferredAvailabilityZones. </p>
@@ -2323,36 +1533,15 @@ impl CopySnapshotResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CopySnapshotResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CopySnapshotResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CopySnapshotResult, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Snapshot" => {
+                    obj.snapshot = Some(SnapshotDeserializer::deserialize("Snapshot", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Snapshot" => {
-                        obj.snapshot = Some(SnapshotDeserializer::deserialize("Snapshot", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Represents the input of a CreateCacheCluster operation.</p>
@@ -2540,21 +1729,11 @@ impl CreateCacheClusterResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateCacheClusterResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateCacheClusterResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateCacheClusterResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CacheCluster" => {
                         obj.cache_cluster = Some(CacheClusterDeserializer::deserialize(
                             "CacheCluster",
@@ -2562,17 +1741,10 @@ impl CreateCacheClusterResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Represents the input of a <code>CreateCacheParameterGroup</code> operation.</p>
@@ -2619,21 +1791,11 @@ impl CreateCacheParameterGroupResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateCacheParameterGroupResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateCacheParameterGroupResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateCacheParameterGroupResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CacheParameterGroup" => {
                         obj.cache_parameter_group =
                             Some(CacheParameterGroupDeserializer::deserialize(
@@ -2642,17 +1804,10 @@ impl CreateCacheParameterGroupResultDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Represents the input of a <code>CreateCacheSecurityGroup</code> operation.</p>
@@ -2693,21 +1848,11 @@ impl CreateCacheSecurityGroupResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateCacheSecurityGroupResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateCacheSecurityGroupResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateCacheSecurityGroupResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CacheSecurityGroup" => {
                         obj.cache_security_group =
                             Some(CacheSecurityGroupDeserializer::deserialize(
@@ -2716,17 +1861,10 @@ impl CreateCacheSecurityGroupResultDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Represents the input of a <code>CreateCacheSubnetGroup</code> operation.</p>
@@ -2777,21 +1915,11 @@ impl CreateCacheSubnetGroupResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateCacheSubnetGroupResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateCacheSubnetGroupResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateCacheSubnetGroupResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CacheSubnetGroup" => {
                         obj.cache_subnet_group = Some(CacheSubnetGroupDeserializer::deserialize(
                             "CacheSubnetGroup",
@@ -2799,17 +1927,10 @@ impl CreateCacheSubnetGroupResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Represents the input of a <code>CreateReplicationGroup</code> operation.</p>
@@ -3039,21 +2160,11 @@ impl CreateReplicationGroupResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateReplicationGroupResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateReplicationGroupResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateReplicationGroupResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ReplicationGroup" => {
                         obj.replication_group = Some(ReplicationGroupDeserializer::deserialize(
                             "ReplicationGroup",
@@ -3061,17 +2172,10 @@ impl CreateReplicationGroupResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Represents the input of a <code>CreateSnapshot</code> operation.</p>
@@ -3116,36 +2220,15 @@ impl CreateSnapshotResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateSnapshotResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateSnapshotResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CreateSnapshotResult, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Snapshot" => {
+                    obj.snapshot = Some(SnapshotDeserializer::deserialize("Snapshot", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Snapshot" => {
-                        obj.snapshot = Some(SnapshotDeserializer::deserialize("Snapshot", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -3214,21 +2297,11 @@ impl DecreaseReplicaCountResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DecreaseReplicaCountResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DecreaseReplicaCountResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DecreaseReplicaCountResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ReplicationGroup" => {
                         obj.replication_group = Some(ReplicationGroupDeserializer::deserialize(
                             "ReplicationGroup",
@@ -3236,17 +2309,10 @@ impl DecreaseReplicaCountResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Represents the input of a <code>DeleteCacheCluster</code> operation.</p>
@@ -3292,21 +2358,11 @@ impl DeleteCacheClusterResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DeleteCacheClusterResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DeleteCacheClusterResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DeleteCacheClusterResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CacheCluster" => {
                         obj.cache_cluster = Some(CacheClusterDeserializer::deserialize(
                             "CacheCluster",
@@ -3314,17 +2370,10 @@ impl DeleteCacheClusterResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Represents the input of a <code>DeleteCacheParameterGroup</code> operation.</p>
@@ -3447,21 +2496,11 @@ impl DeleteReplicationGroupResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DeleteReplicationGroupResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DeleteReplicationGroupResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DeleteReplicationGroupResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ReplicationGroup" => {
                         obj.replication_group = Some(ReplicationGroupDeserializer::deserialize(
                             "ReplicationGroup",
@@ -3469,17 +2508,10 @@ impl DeleteReplicationGroupResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Represents the input of a <code>DeleteSnapshot</code> operation.</p>
@@ -3514,36 +2546,15 @@ impl DeleteSnapshotResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DeleteSnapshotResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DeleteSnapshotResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DeleteSnapshotResult, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Snapshot" => {
+                    obj.snapshot = Some(SnapshotDeserializer::deserialize("Snapshot", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Snapshot" => {
-                        obj.snapshot = Some(SnapshotDeserializer::deserialize("Snapshot", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Represents the input of a <code>DescribeCacheClusters</code> operation.</p>
@@ -3856,21 +2867,11 @@ impl DescribeEngineDefaultParametersResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeEngineDefaultParametersResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeEngineDefaultParametersResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeEngineDefaultParametersResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "EngineDefaults" => {
                         obj.engine_defaults = Some(EngineDefaultsDeserializer::deserialize(
                             "EngineDefaults",
@@ -3878,17 +2879,10 @@ impl DescribeEngineDefaultParametersResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Represents the input of a <code>DescribeEvents</code> operation.</p>
@@ -4128,50 +3122,24 @@ impl DescribeSnapshotsListMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeSnapshotsListMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeSnapshotsListMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeSnapshotsListMessage, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Marker" => {
                         obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                     }
                     "Snapshots" => {
-                        obj.snapshots = match obj.snapshots {
-                            Some(ref mut existing) => {
-                                existing.extend(SnapshotListDeserializer::deserialize(
-                                    "Snapshots",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => {
-                                Some(SnapshotListDeserializer::deserialize("Snapshots", stack)?)
-                            }
-                        };
+                        obj.snapshots
+                            .get_or_insert(vec![])
+                            .extend(SnapshotListDeserializer::deserialize("Snapshots", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Represents the input of a <code>DescribeSnapshotsMessage</code> operation.</p>
@@ -4264,48 +3232,27 @@ impl EC2SecurityGroupDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<EC2SecurityGroup, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = EC2SecurityGroup::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, EC2SecurityGroup, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "EC2SecurityGroupName" => {
+                    obj.ec2_security_group_name = Some(StringDeserializer::deserialize(
+                        "EC2SecurityGroupName",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "EC2SecurityGroupName" => {
-                        obj.ec2_security_group_name = Some(StringDeserializer::deserialize(
-                            "EC2SecurityGroupName",
-                            stack,
-                        )?);
-                    }
-                    "EC2SecurityGroupOwnerId" => {
-                        obj.ec2_security_group_owner_id = Some(StringDeserializer::deserialize(
-                            "EC2SecurityGroupOwnerId",
-                            stack,
-                        )?);
-                    }
-                    "Status" => {
-                        obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "EC2SecurityGroupOwnerId" => {
+                    obj.ec2_security_group_owner_id = Some(StringDeserializer::deserialize(
+                        "EC2SecurityGroupOwnerId",
+                        stack,
+                    )?);
                 }
+                "Status" => {
+                    obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct EC2SecurityGroupListDeserializer;
@@ -4315,40 +3262,17 @@ impl EC2SecurityGroupListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<EC2SecurityGroup>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "EC2SecurityGroup" {
-                        obj.push(EC2SecurityGroupDeserializer::deserialize(
-                            "EC2SecurityGroup",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "EC2SecurityGroup" {
+                obj.push(EC2SecurityGroupDeserializer::deserialize(
+                    "EC2SecurityGroup",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Represents the information required for client programs to connect to a cache node.</p>
@@ -4367,39 +3291,18 @@ impl EndpointDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Endpoint, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Endpoint::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Endpoint, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Address" => {
+                    obj.address = Some(StringDeserializer::deserialize("Address", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Address" => {
-                        obj.address = Some(StringDeserializer::deserialize("Address", stack)?);
-                    }
-                    "Port" => {
-                        obj.port = Some(IntegerDeserializer::deserialize("Port", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Port" => {
+                    obj.port = Some(IntegerDeserializer::deserialize("Port", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Represents the output of a <code>DescribeEngineDefaultParameters</code> operation.</p>
@@ -4422,76 +3325,36 @@ impl EngineDefaultsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<EngineDefaults, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = EngineDefaults::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, EngineDefaults, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CacheNodeTypeSpecificParameters" => {
+                    obj.cache_node_type_specific_parameters
+                        .get_or_insert(vec![])
+                        .extend(
+                            CacheNodeTypeSpecificParametersListDeserializer::deserialize(
+                                "CacheNodeTypeSpecificParameters",
+                                stack,
+                            )?,
+                        );
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    match &name[..] {
-                        "CacheNodeTypeSpecificParameters" => {
-                            obj.cache_node_type_specific_parameters = match obj
-                                .cache_node_type_specific_parameters
-                            {
-                                Some(ref mut existing) => {
-                                    existing.extend(CacheNodeTypeSpecificParametersListDeserializer::deserialize("CacheNodeTypeSpecificParameters", stack)?);
-                                    Some(existing.to_vec())
-                                }
-                                None => Some(
-                                    CacheNodeTypeSpecificParametersListDeserializer::deserialize(
-                                        "CacheNodeTypeSpecificParameters",
-                                        stack,
-                                    )?,
-                                ),
-                            };
-                        }
-                        "CacheParameterGroupFamily" => {
-                            obj.cache_parameter_group_family =
-                                Some(StringDeserializer::deserialize(
-                                    "CacheParameterGroupFamily",
-                                    stack,
-                                )?);
-                        }
-                        "Marker" => {
-                            obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
-                        }
-                        "Parameters" => {
-                            obj.parameters = match obj.parameters {
-                                Some(ref mut existing) => {
-                                    existing.extend(ParametersListDeserializer::deserialize(
-                                        "Parameters",
-                                        stack,
-                                    )?);
-                                    Some(existing.to_vec())
-                                }
-                                None => Some(ParametersListDeserializer::deserialize(
-                                    "Parameters",
-                                    stack,
-                                )?),
-                            };
-                        }
-                        _ => skip_tree(stack),
-                    }
+                "CacheParameterGroupFamily" => {
+                    obj.cache_parameter_group_family = Some(StringDeserializer::deserialize(
+                        "CacheParameterGroupFamily",
+                        stack,
+                    )?);
                 }
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Marker" => {
+                    obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                 }
+                "Parameters" => {
+                    obj.parameters.get_or_insert(vec![]).extend(
+                        ParametersListDeserializer::deserialize("Parameters", stack)?,
+                    );
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Represents a single occurrence of something interesting within the system. Some examples of events are creating a cluster, adding or removing a cache node, or rebooting a node.</p>
@@ -4514,47 +3377,26 @@ impl EventDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Event, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Event::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Event, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Date" => {
+                    obj.date = Some(TStampDeserializer::deserialize("Date", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Date" => {
-                        obj.date = Some(TStampDeserializer::deserialize("Date", stack)?);
-                    }
-                    "Message" => {
-                        obj.message = Some(StringDeserializer::deserialize("Message", stack)?);
-                    }
-                    "SourceIdentifier" => {
-                        obj.source_identifier =
-                            Some(StringDeserializer::deserialize("SourceIdentifier", stack)?);
-                    }
-                    "SourceType" => {
-                        obj.source_type =
-                            Some(SourceTypeDeserializer::deserialize("SourceType", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Message" => {
+                    obj.message = Some(StringDeserializer::deserialize("Message", stack)?);
                 }
+                "SourceIdentifier" => {
+                    obj.source_identifier =
+                        Some(StringDeserializer::deserialize("SourceIdentifier", stack)?);
+                }
+                "SourceType" => {
+                    obj.source_type =
+                        Some(SourceTypeDeserializer::deserialize("SourceType", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct EventListDeserializer;
@@ -4564,37 +3406,14 @@ impl EventListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Event>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "Event" {
-                        obj.push(EventDeserializer::deserialize("Event", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "Event" {
+                obj.push(EventDeserializer::deserialize("Event", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Represents the output of a <code>DescribeEvents</code> operation.</p>
@@ -4613,46 +3432,20 @@ impl EventsMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<EventsMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = EventsMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, EventsMessage, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Events" => {
+                    obj.events
+                        .get_or_insert(vec![])
+                        .extend(EventListDeserializer::deserialize("Events", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Events" => {
-                        obj.events = match obj.events {
-                            Some(ref mut existing) => {
-                                existing
-                                    .extend(EventListDeserializer::deserialize("Events", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(EventListDeserializer::deserialize("Events", stack)?),
-                        };
-                    }
-                    "Marker" => {
-                        obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Marker" => {
+                    obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -4712,21 +3505,11 @@ impl IncreaseReplicaCountResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<IncreaseReplicaCountResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = IncreaseReplicaCountResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, IncreaseReplicaCountResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ReplicationGroup" => {
                         obj.replication_group = Some(ReplicationGroupDeserializer::deserialize(
                             "ReplicationGroup",
@@ -4734,17 +3517,10 @@ impl IncreaseReplicaCountResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct IntegerDeserializer;
@@ -4989,21 +3765,11 @@ impl ModifyCacheClusterResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ModifyCacheClusterResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ModifyCacheClusterResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ModifyCacheClusterResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CacheCluster" => {
                         obj.cache_cluster = Some(CacheClusterDeserializer::deserialize(
                             "CacheCluster",
@@ -5011,17 +3777,10 @@ impl ModifyCacheClusterResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Represents the input of a <code>ModifyCacheParameterGroup</code> operation.</p>
@@ -5106,21 +3865,11 @@ impl ModifyCacheSubnetGroupResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ModifyCacheSubnetGroupResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ModifyCacheSubnetGroupResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ModifyCacheSubnetGroupResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CacheSubnetGroup" => {
                         obj.cache_subnet_group = Some(CacheSubnetGroupDeserializer::deserialize(
                             "CacheSubnetGroup",
@@ -5128,17 +3877,10 @@ impl ModifyCacheSubnetGroupResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Represents the input of a <code>ModifyReplicationGroups</code> operation.</p>
@@ -5295,21 +4037,11 @@ impl ModifyReplicationGroupResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ModifyReplicationGroupResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ModifyReplicationGroupResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ModifyReplicationGroupResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ReplicationGroup" => {
                         obj.replication_group = Some(ReplicationGroupDeserializer::deserialize(
                             "ReplicationGroup",
@@ -5317,17 +4049,10 @@ impl ModifyReplicationGroupResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Represents the input for a <code>ModifyReplicationGroupShardConfiguration</code> operation.</p>
@@ -5408,21 +4133,11 @@ impl ModifyReplicationGroupShardConfigurationResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ModifyReplicationGroupShardConfigurationResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ModifyReplicationGroupShardConfigurationResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ModifyReplicationGroupShardConfigurationResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ReplicationGroup" => {
                         obj.replication_group = Some(ReplicationGroupDeserializer::deserialize(
                             "ReplicationGroup",
@@ -5430,17 +4145,10 @@ impl ModifyReplicationGroupShardConfigurationResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Represents a collection of cache nodes in a replication group. One node in the node group is the read/write primary node. All the other nodes are read-only Replica nodes.</p>
@@ -5465,62 +4173,31 @@ impl NodeGroupDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<NodeGroup, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = NodeGroup::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, NodeGroup, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "NodeGroupId" => {
+                    obj.node_group_id =
+                        Some(StringDeserializer::deserialize("NodeGroupId", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "NodeGroupId" => {
-                        obj.node_group_id =
-                            Some(StringDeserializer::deserialize("NodeGroupId", stack)?);
-                    }
-                    "NodeGroupMembers" => {
-                        obj.node_group_members = match obj.node_group_members {
-                            Some(ref mut existing) => {
-                                existing.extend(NodeGroupMemberListDeserializer::deserialize(
-                                    "NodeGroupMembers",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(NodeGroupMemberListDeserializer::deserialize(
-                                "NodeGroupMembers",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "PrimaryEndpoint" => {
-                        obj.primary_endpoint =
-                            Some(EndpointDeserializer::deserialize("PrimaryEndpoint", stack)?);
-                    }
-                    "Slots" => {
-                        obj.slots = Some(StringDeserializer::deserialize("Slots", stack)?);
-                    }
-                    "Status" => {
-                        obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "NodeGroupMembers" => {
+                    obj.node_group_members.get_or_insert(vec![]).extend(
+                        NodeGroupMemberListDeserializer::deserialize("NodeGroupMembers", stack)?,
+                    );
                 }
+                "PrimaryEndpoint" => {
+                    obj.primary_endpoint =
+                        Some(EndpointDeserializer::deserialize("PrimaryEndpoint", stack)?);
+                }
+                "Slots" => {
+                    obj.slots = Some(StringDeserializer::deserialize("Slots", stack)?);
+                }
+                "Status" => {
+                    obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Node group (shard) configuration options. Each node group (shard) configuration has the following: <code>Slots</code>, <code>PrimaryAvailabilityZone</code>, <code>ReplicaAvailabilityZones</code>, <code>ReplicaCount</code>.</p>
@@ -5545,69 +4222,41 @@ impl NodeGroupConfigurationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<NodeGroupConfiguration, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = NodeGroupConfiguration::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, NodeGroupConfiguration, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "NodeGroupId" => {
+                    obj.node_group_id = Some(AllowedNodeGroupIdDeserializer::deserialize(
+                        "NodeGroupId",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "NodeGroupId" => {
-                        obj.node_group_id = Some(AllowedNodeGroupIdDeserializer::deserialize(
-                            "NodeGroupId",
-                            stack,
-                        )?);
-                    }
-                    "PrimaryAvailabilityZone" => {
-                        obj.primary_availability_zone = Some(StringDeserializer::deserialize(
-                            "PrimaryAvailabilityZone",
-                            stack,
-                        )?);
-                    }
-                    "ReplicaAvailabilityZones" => {
-                        obj.replica_availability_zones = match obj.replica_availability_zones {
-                            Some(ref mut existing) => {
-                                existing.extend(AvailabilityZonesListDeserializer::deserialize(
-                                    "ReplicaAvailabilityZones",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(AvailabilityZonesListDeserializer::deserialize(
-                                "ReplicaAvailabilityZones",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "ReplicaCount" => {
-                        obj.replica_count = Some(IntegerOptionalDeserializer::deserialize(
-                            "ReplicaCount",
-                            stack,
-                        )?);
-                    }
-                    "Slots" => {
-                        obj.slots = Some(StringDeserializer::deserialize("Slots", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "PrimaryAvailabilityZone" => {
+                    obj.primary_availability_zone = Some(StringDeserializer::deserialize(
+                        "PrimaryAvailabilityZone",
+                        stack,
+                    )?);
                 }
+                "ReplicaAvailabilityZones" => {
+                    obj.replica_availability_zones.get_or_insert(vec![]).extend(
+                        AvailabilityZonesListDeserializer::deserialize(
+                            "ReplicaAvailabilityZones",
+                            stack,
+                        )?,
+                    );
+                }
+                "ReplicaCount" => {
+                    obj.replica_count = Some(IntegerOptionalDeserializer::deserialize(
+                        "ReplicaCount",
+                        stack,
+                    )?);
+                }
+                "Slots" => {
+                    obj.slots = Some(StringDeserializer::deserialize("Slots", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -5666,37 +4315,14 @@ impl NodeGroupListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<NodeGroup>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "NodeGroup" {
-                        obj.push(NodeGroupDeserializer::deserialize("NodeGroup", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "NodeGroup" {
+                obj.push(NodeGroupDeserializer::deserialize("NodeGroup", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Represents a single node within a node group (shard).</p>
@@ -5721,55 +4347,33 @@ impl NodeGroupMemberDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<NodeGroupMember, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = NodeGroupMember::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, NodeGroupMember, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CacheClusterId" => {
+                    obj.cache_cluster_id =
+                        Some(StringDeserializer::deserialize("CacheClusterId", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CacheClusterId" => {
-                        obj.cache_cluster_id =
-                            Some(StringDeserializer::deserialize("CacheClusterId", stack)?);
-                    }
-                    "CacheNodeId" => {
-                        obj.cache_node_id =
-                            Some(StringDeserializer::deserialize("CacheNodeId", stack)?);
-                    }
-                    "CurrentRole" => {
-                        obj.current_role =
-                            Some(StringDeserializer::deserialize("CurrentRole", stack)?);
-                    }
-                    "PreferredAvailabilityZone" => {
-                        obj.preferred_availability_zone = Some(StringDeserializer::deserialize(
-                            "PreferredAvailabilityZone",
-                            stack,
-                        )?);
-                    }
-                    "ReadEndpoint" => {
-                        obj.read_endpoint =
-                            Some(EndpointDeserializer::deserialize("ReadEndpoint", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "CacheNodeId" => {
+                    obj.cache_node_id =
+                        Some(StringDeserializer::deserialize("CacheNodeId", stack)?);
                 }
+                "CurrentRole" => {
+                    obj.current_role = Some(StringDeserializer::deserialize("CurrentRole", stack)?);
+                }
+                "PreferredAvailabilityZone" => {
+                    obj.preferred_availability_zone = Some(StringDeserializer::deserialize(
+                        "PreferredAvailabilityZone",
+                        stack,
+                    )?);
+                }
+                "ReadEndpoint" => {
+                    obj.read_endpoint =
+                        Some(EndpointDeserializer::deserialize("ReadEndpoint", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct NodeGroupMemberListDeserializer;
@@ -5779,40 +4383,17 @@ impl NodeGroupMemberListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<NodeGroupMember>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "NodeGroupMember" {
-                        obj.push(NodeGroupMemberDeserializer::deserialize(
-                            "NodeGroupMember",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "NodeGroupMember" {
+                obj.push(NodeGroupMemberDeserializer::deserialize(
+                    "NodeGroupMember",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -5864,67 +4445,46 @@ impl NodeSnapshotDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<NodeSnapshot, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = NodeSnapshot::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, NodeSnapshot, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CacheClusterId" => {
+                    obj.cache_cluster_id =
+                        Some(StringDeserializer::deserialize("CacheClusterId", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CacheClusterId" => {
-                        obj.cache_cluster_id =
-                            Some(StringDeserializer::deserialize("CacheClusterId", stack)?);
-                    }
-                    "CacheNodeCreateTime" => {
-                        obj.cache_node_create_time = Some(TStampDeserializer::deserialize(
-                            "CacheNodeCreateTime",
+                "CacheNodeCreateTime" => {
+                    obj.cache_node_create_time = Some(TStampDeserializer::deserialize(
+                        "CacheNodeCreateTime",
+                        stack,
+                    )?);
+                }
+                "CacheNodeId" => {
+                    obj.cache_node_id =
+                        Some(StringDeserializer::deserialize("CacheNodeId", stack)?);
+                }
+                "CacheSize" => {
+                    obj.cache_size = Some(StringDeserializer::deserialize("CacheSize", stack)?);
+                }
+                "NodeGroupConfiguration" => {
+                    obj.node_group_configuration =
+                        Some(NodeGroupConfigurationDeserializer::deserialize(
+                            "NodeGroupConfiguration",
                             stack,
                         )?);
-                    }
-                    "CacheNodeId" => {
-                        obj.cache_node_id =
-                            Some(StringDeserializer::deserialize("CacheNodeId", stack)?);
-                    }
-                    "CacheSize" => {
-                        obj.cache_size = Some(StringDeserializer::deserialize("CacheSize", stack)?);
-                    }
-                    "NodeGroupConfiguration" => {
-                        obj.node_group_configuration =
-                            Some(NodeGroupConfigurationDeserializer::deserialize(
-                                "NodeGroupConfiguration",
-                                stack,
-                            )?);
-                    }
-                    "NodeGroupId" => {
-                        obj.node_group_id =
-                            Some(StringDeserializer::deserialize("NodeGroupId", stack)?);
-                    }
-                    "SnapshotCreateTime" => {
-                        obj.snapshot_create_time = Some(TStampDeserializer::deserialize(
-                            "SnapshotCreateTime",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                "NodeGroupId" => {
+                    obj.node_group_id =
+                        Some(StringDeserializer::deserialize("NodeGroupId", stack)?);
+                }
+                "SnapshotCreateTime" => {
+                    obj.snapshot_create_time = Some(TStampDeserializer::deserialize(
+                        "SnapshotCreateTime",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct NodeSnapshotListDeserializer;
@@ -5934,40 +4494,17 @@ impl NodeSnapshotListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<NodeSnapshot>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "NodeSnapshot" {
-                        obj.push(NodeSnapshotDeserializer::deserialize(
-                            "NodeSnapshot",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "NodeSnapshot" {
+                obj.push(NodeSnapshotDeserializer::deserialize(
+                    "NodeSnapshot",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct NodeTypeListDeserializer;
@@ -5977,37 +4514,14 @@ impl NodeTypeListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(StringDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(StringDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Describes a notification topic and its status. Notification topics are used for publishing ElastiCache events to subscribers using Amazon Simple Notification Service (SNS).</p>
@@ -6026,21 +4540,11 @@ impl NotificationConfigurationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<NotificationConfiguration, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = NotificationConfiguration::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, NotificationConfiguration, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "TopicArn" => {
                         obj.topic_arn = Some(StringDeserializer::deserialize("TopicArn", stack)?);
                     }
@@ -6049,17 +4553,10 @@ impl NotificationConfigurationDeserializer {
                             Some(StringDeserializer::deserialize("TopicStatus", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Describes an individual setting that controls some aspect of ElastiCache behavior.</p>
@@ -6092,69 +4589,47 @@ impl ParameterDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Parameter, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Parameter::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Parameter, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AllowedValues" => {
+                    obj.allowed_values =
+                        Some(StringDeserializer::deserialize("AllowedValues", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AllowedValues" => {
-                        obj.allowed_values =
-                            Some(StringDeserializer::deserialize("AllowedValues", stack)?);
-                    }
-                    "ChangeType" => {
-                        obj.change_type =
-                            Some(ChangeTypeDeserializer::deserialize("ChangeType", stack)?);
-                    }
-                    "DataType" => {
-                        obj.data_type = Some(StringDeserializer::deserialize("DataType", stack)?);
-                    }
-                    "Description" => {
-                        obj.description =
-                            Some(StringDeserializer::deserialize("Description", stack)?);
-                    }
-                    "IsModifiable" => {
-                        obj.is_modifiable =
-                            Some(BooleanDeserializer::deserialize("IsModifiable", stack)?);
-                    }
-                    "MinimumEngineVersion" => {
-                        obj.minimum_engine_version = Some(StringDeserializer::deserialize(
-                            "MinimumEngineVersion",
-                            stack,
-                        )?);
-                    }
-                    "ParameterName" => {
-                        obj.parameter_name =
-                            Some(StringDeserializer::deserialize("ParameterName", stack)?);
-                    }
-                    "ParameterValue" => {
-                        obj.parameter_value =
-                            Some(StringDeserializer::deserialize("ParameterValue", stack)?);
-                    }
-                    "Source" => {
-                        obj.source = Some(StringDeserializer::deserialize("Source", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "ChangeType" => {
+                    obj.change_type =
+                        Some(ChangeTypeDeserializer::deserialize("ChangeType", stack)?);
                 }
+                "DataType" => {
+                    obj.data_type = Some(StringDeserializer::deserialize("DataType", stack)?);
+                }
+                "Description" => {
+                    obj.description = Some(StringDeserializer::deserialize("Description", stack)?);
+                }
+                "IsModifiable" => {
+                    obj.is_modifiable =
+                        Some(BooleanDeserializer::deserialize("IsModifiable", stack)?);
+                }
+                "MinimumEngineVersion" => {
+                    obj.minimum_engine_version = Some(StringDeserializer::deserialize(
+                        "MinimumEngineVersion",
+                        stack,
+                    )?);
+                }
+                "ParameterName" => {
+                    obj.parameter_name =
+                        Some(StringDeserializer::deserialize("ParameterName", stack)?);
+                }
+                "ParameterValue" => {
+                    obj.parameter_value =
+                        Some(StringDeserializer::deserialize("ParameterValue", stack)?);
+                }
+                "Source" => {
+                    obj.source = Some(StringDeserializer::deserialize("Source", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Describes a name-value pair that is used to update the value of a parameter.</p>
@@ -6202,37 +4677,14 @@ impl ParametersListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Parameter>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "Parameter" {
-                        obj.push(ParameterDeserializer::deserialize("Parameter", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "Parameter" {
+                obj.push(ParameterDeserializer::deserialize("Parameter", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PendingAutomaticFailoverStatusDeserializer;
@@ -6269,62 +4721,31 @@ impl PendingModifiedValuesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<PendingModifiedValues, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = PendingModifiedValues::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, PendingModifiedValues, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CacheNodeIdsToRemove" => {
+                    obj.cache_node_ids_to_remove.get_or_insert(vec![]).extend(
+                        CacheNodeIdsListDeserializer::deserialize("CacheNodeIdsToRemove", stack)?,
+                    );
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CacheNodeIdsToRemove" => {
-                        obj.cache_node_ids_to_remove = match obj.cache_node_ids_to_remove {
-                            Some(ref mut existing) => {
-                                existing.extend(CacheNodeIdsListDeserializer::deserialize(
-                                    "CacheNodeIdsToRemove",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(CacheNodeIdsListDeserializer::deserialize(
-                                "CacheNodeIdsToRemove",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "CacheNodeType" => {
-                        obj.cache_node_type =
-                            Some(StringDeserializer::deserialize("CacheNodeType", stack)?);
-                    }
-                    "EngineVersion" => {
-                        obj.engine_version =
-                            Some(StringDeserializer::deserialize("EngineVersion", stack)?);
-                    }
-                    "NumCacheNodes" => {
-                        obj.num_cache_nodes = Some(IntegerOptionalDeserializer::deserialize(
-                            "NumCacheNodes",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "CacheNodeType" => {
+                    obj.cache_node_type =
+                        Some(StringDeserializer::deserialize("CacheNodeType", stack)?);
                 }
+                "EngineVersion" => {
+                    obj.engine_version =
+                        Some(StringDeserializer::deserialize("EngineVersion", stack)?);
+                }
+                "NumCacheNodes" => {
+                    obj.num_cache_nodes = Some(IntegerOptionalDeserializer::deserialize(
+                        "NumCacheNodes",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -6390,21 +4811,11 @@ impl PurchaseReservedCacheNodesOfferingResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<PurchaseReservedCacheNodesOfferingResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = PurchaseReservedCacheNodesOfferingResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, PurchaseReservedCacheNodesOfferingResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ReservedCacheNode" => {
                         obj.reserved_cache_node = Some(ReservedCacheNodeDeserializer::deserialize(
                             "ReservedCacheNode",
@@ -6412,17 +4823,10 @@ impl PurchaseReservedCacheNodesOfferingResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Represents the input of a <code>RebootCacheCluster</code> operation.</p>
@@ -6467,21 +4871,11 @@ impl RebootCacheClusterResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<RebootCacheClusterResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = RebootCacheClusterResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, RebootCacheClusterResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CacheCluster" => {
                         obj.cache_cluster = Some(CacheClusterDeserializer::deserialize(
                             "CacheCluster",
@@ -6489,17 +4883,10 @@ impl RebootCacheClusterResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Contains the specific price and frequency of a recurring charges for a reserved cache node, or for a reserved cache node offering.</p>
@@ -6518,45 +4905,24 @@ impl RecurringChargeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<RecurringCharge, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = RecurringCharge::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, RecurringCharge, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "RecurringChargeAmount" => {
+                    obj.recurring_charge_amount = Some(DoubleDeserializer::deserialize(
+                        "RecurringChargeAmount",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "RecurringChargeAmount" => {
-                        obj.recurring_charge_amount = Some(DoubleDeserializer::deserialize(
-                            "RecurringChargeAmount",
-                            stack,
-                        )?);
-                    }
-                    "RecurringChargeFrequency" => {
-                        obj.recurring_charge_frequency = Some(StringDeserializer::deserialize(
-                            "RecurringChargeFrequency",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "RecurringChargeFrequency" => {
+                    obj.recurring_charge_frequency = Some(StringDeserializer::deserialize(
+                        "RecurringChargeFrequency",
+                        stack,
+                    )?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct RecurringChargeListDeserializer;
@@ -6566,40 +4932,17 @@ impl RecurringChargeListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<RecurringCharge>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "RecurringCharge" {
-                        obj.push(RecurringChargeDeserializer::deserialize(
-                            "RecurringCharge",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "RecurringCharge" {
+                obj.push(RecurringChargeDeserializer::deserialize(
+                    "RecurringCharge",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -6692,143 +5035,99 @@ impl ReplicationGroupDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ReplicationGroup, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ReplicationGroup::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ReplicationGroup, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AtRestEncryptionEnabled" => {
+                    obj.at_rest_encryption_enabled = Some(
+                        BooleanOptionalDeserializer::deserialize("AtRestEncryptionEnabled", stack)?,
+                    );
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AtRestEncryptionEnabled" => {
-                        obj.at_rest_encryption_enabled =
-                            Some(BooleanOptionalDeserializer::deserialize(
-                                "AtRestEncryptionEnabled",
-                                stack,
-                            )?);
-                    }
-                    "AuthTokenEnabled" => {
-                        obj.auth_token_enabled = Some(BooleanOptionalDeserializer::deserialize(
-                            "AuthTokenEnabled",
-                            stack,
-                        )?);
-                    }
-                    "AutomaticFailover" => {
-                        obj.automatic_failover =
-                            Some(AutomaticFailoverStatusDeserializer::deserialize(
-                                "AutomaticFailover",
-                                stack,
-                            )?);
-                    }
-                    "CacheNodeType" => {
-                        obj.cache_node_type =
-                            Some(StringDeserializer::deserialize("CacheNodeType", stack)?);
-                    }
-                    "ClusterEnabled" => {
-                        obj.cluster_enabled = Some(BooleanOptionalDeserializer::deserialize(
-                            "ClusterEnabled",
-                            stack,
-                        )?);
-                    }
-                    "ConfigurationEndpoint" => {
-                        obj.configuration_endpoint = Some(EndpointDeserializer::deserialize(
-                            "ConfigurationEndpoint",
-                            stack,
-                        )?);
-                    }
-                    "Description" => {
-                        obj.description =
-                            Some(StringDeserializer::deserialize("Description", stack)?);
-                    }
-                    "MemberClusters" => {
-                        obj.member_clusters = match obj.member_clusters {
-                            Some(ref mut existing) => {
-                                existing.extend(ClusterIdListDeserializer::deserialize(
-                                    "MemberClusters",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ClusterIdListDeserializer::deserialize(
-                                "MemberClusters",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "NodeGroups" => {
-                        obj.node_groups = match obj.node_groups {
-                            Some(ref mut existing) => {
-                                existing.extend(NodeGroupListDeserializer::deserialize(
-                                    "NodeGroups",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => {
-                                Some(NodeGroupListDeserializer::deserialize("NodeGroups", stack)?)
-                            }
-                        };
-                    }
-                    "PendingModifiedValues" => {
-                        obj.pending_modified_values = Some(
-                            ReplicationGroupPendingModifiedValuesDeserializer::deserialize(
-                                "PendingModifiedValues",
-                                stack,
-                            )?,
-                        );
-                    }
-                    "ReplicationGroupId" => {
-                        obj.replication_group_id = Some(StringDeserializer::deserialize(
-                            "ReplicationGroupId",
-                            stack,
-                        )?);
-                    }
-                    "SnapshotRetentionLimit" => {
-                        obj.snapshot_retention_limit =
-                            Some(IntegerOptionalDeserializer::deserialize(
-                                "SnapshotRetentionLimit",
-                                stack,
-                            )?);
-                    }
-                    "SnapshotWindow" => {
-                        obj.snapshot_window =
-                            Some(StringDeserializer::deserialize("SnapshotWindow", stack)?);
-                    }
-                    "SnapshottingClusterId" => {
-                        obj.snapshotting_cluster_id = Some(StringDeserializer::deserialize(
-                            "SnapshottingClusterId",
-                            stack,
-                        )?);
-                    }
-                    "Status" => {
-                        obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
-                    }
-                    "TransitEncryptionEnabled" => {
-                        obj.transit_encryption_enabled =
-                            Some(BooleanOptionalDeserializer::deserialize(
-                                "TransitEncryptionEnabled",
-                                stack,
-                            )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "AuthTokenEnabled" => {
+                    obj.auth_token_enabled = Some(BooleanOptionalDeserializer::deserialize(
+                        "AuthTokenEnabled",
+                        stack,
+                    )?);
                 }
+                "AutomaticFailover" => {
+                    obj.automatic_failover =
+                        Some(AutomaticFailoverStatusDeserializer::deserialize(
+                            "AutomaticFailover",
+                            stack,
+                        )?);
+                }
+                "CacheNodeType" => {
+                    obj.cache_node_type =
+                        Some(StringDeserializer::deserialize("CacheNodeType", stack)?);
+                }
+                "ClusterEnabled" => {
+                    obj.cluster_enabled = Some(BooleanOptionalDeserializer::deserialize(
+                        "ClusterEnabled",
+                        stack,
+                    )?);
+                }
+                "ConfigurationEndpoint" => {
+                    obj.configuration_endpoint = Some(EndpointDeserializer::deserialize(
+                        "ConfigurationEndpoint",
+                        stack,
+                    )?);
+                }
+                "Description" => {
+                    obj.description = Some(StringDeserializer::deserialize("Description", stack)?);
+                }
+                "MemberClusters" => {
+                    obj.member_clusters.get_or_insert(vec![]).extend(
+                        ClusterIdListDeserializer::deserialize("MemberClusters", stack)?,
+                    );
+                }
+                "NodeGroups" => {
+                    obj.node_groups
+                        .get_or_insert(vec![])
+                        .extend(NodeGroupListDeserializer::deserialize("NodeGroups", stack)?);
+                }
+                "PendingModifiedValues" => {
+                    obj.pending_modified_values = Some(
+                        ReplicationGroupPendingModifiedValuesDeserializer::deserialize(
+                            "PendingModifiedValues",
+                            stack,
+                        )?,
+                    );
+                }
+                "ReplicationGroupId" => {
+                    obj.replication_group_id = Some(StringDeserializer::deserialize(
+                        "ReplicationGroupId",
+                        stack,
+                    )?);
+                }
+                "SnapshotRetentionLimit" => {
+                    obj.snapshot_retention_limit = Some(IntegerOptionalDeserializer::deserialize(
+                        "SnapshotRetentionLimit",
+                        stack,
+                    )?);
+                }
+                "SnapshotWindow" => {
+                    obj.snapshot_window =
+                        Some(StringDeserializer::deserialize("SnapshotWindow", stack)?);
+                }
+                "SnapshottingClusterId" => {
+                    obj.snapshotting_cluster_id = Some(StringDeserializer::deserialize(
+                        "SnapshottingClusterId",
+                        stack,
+                    )?);
+                }
+                "Status" => {
+                    obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
+                }
+                "TransitEncryptionEnabled" => {
+                    obj.transit_encryption_enabled =
+                        Some(BooleanOptionalDeserializer::deserialize(
+                            "TransitEncryptionEnabled",
+                            stack,
+                        )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ReplicationGroupListDeserializer;
@@ -6838,40 +5137,17 @@ impl ReplicationGroupListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<ReplicationGroup>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "ReplicationGroup" {
-                        obj.push(ReplicationGroupDeserializer::deserialize(
-                            "ReplicationGroup",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "ReplicationGroup" {
+                obj.push(ReplicationGroupDeserializer::deserialize(
+                    "ReplicationGroup",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Represents the output of a <code>DescribeReplicationGroups</code> operation.</p>
@@ -6890,51 +5166,27 @@ impl ReplicationGroupMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ReplicationGroupMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ReplicationGroupMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ReplicationGroupMessage, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Marker" => {
                         obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                     }
                     "ReplicationGroups" => {
-                        obj.replication_groups = match obj.replication_groups {
-                            Some(ref mut existing) => {
-                                existing.extend(ReplicationGroupListDeserializer::deserialize(
-                                    "ReplicationGroups",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ReplicationGroupListDeserializer::deserialize(
+                        obj.replication_groups.get_or_insert(vec![]).extend(
+                            ReplicationGroupListDeserializer::deserialize(
                                 "ReplicationGroups",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>The settings to be applied to the Redis replication group, either immediately or during the next maintenance window.</p>
@@ -6955,21 +5207,11 @@ impl ReplicationGroupPendingModifiedValuesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ReplicationGroupPendingModifiedValues, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ReplicationGroupPendingModifiedValues::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ReplicationGroupPendingModifiedValues, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AutomaticFailoverStatus" => {
                         obj.automatic_failover_status =
                             Some(PendingAutomaticFailoverStatusDeserializer::deserialize(
@@ -6988,17 +5230,10 @@ impl ReplicationGroupPendingModifiedValuesDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Represents the output of a <code>PurchaseReservedCacheNodesOffering</code> operation.</p>
@@ -7039,98 +5274,66 @@ impl ReservedCacheNodeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ReservedCacheNode, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ReservedCacheNode::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ReservedCacheNode, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CacheNodeCount" => {
+                    obj.cache_node_count =
+                        Some(IntegerDeserializer::deserialize("CacheNodeCount", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CacheNodeCount" => {
-                        obj.cache_node_count =
-                            Some(IntegerDeserializer::deserialize("CacheNodeCount", stack)?);
-                    }
-                    "CacheNodeType" => {
-                        obj.cache_node_type =
-                            Some(StringDeserializer::deserialize("CacheNodeType", stack)?);
-                    }
-                    "Duration" => {
-                        obj.duration = Some(IntegerDeserializer::deserialize("Duration", stack)?);
-                    }
-                    "FixedPrice" => {
-                        obj.fixed_price =
-                            Some(DoubleDeserializer::deserialize("FixedPrice", stack)?);
-                    }
-                    "OfferingType" => {
-                        obj.offering_type =
-                            Some(StringDeserializer::deserialize("OfferingType", stack)?);
-                    }
-                    "ProductDescription" => {
-                        obj.product_description = Some(StringDeserializer::deserialize(
-                            "ProductDescription",
-                            stack,
-                        )?);
-                    }
-                    "RecurringCharges" => {
-                        obj.recurring_charges = match obj.recurring_charges {
-                            Some(ref mut existing) => {
-                                existing.extend(RecurringChargeListDeserializer::deserialize(
-                                    "RecurringCharges",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(RecurringChargeListDeserializer::deserialize(
-                                "RecurringCharges",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "ReservationARN" => {
-                        obj.reservation_arn =
-                            Some(StringDeserializer::deserialize("ReservationARN", stack)?);
-                    }
-                    "ReservedCacheNodeId" => {
-                        obj.reserved_cache_node_id = Some(StringDeserializer::deserialize(
-                            "ReservedCacheNodeId",
-                            stack,
-                        )?);
-                    }
-                    "ReservedCacheNodesOfferingId" => {
-                        obj.reserved_cache_nodes_offering_id = Some(
-                            StringDeserializer::deserialize("ReservedCacheNodesOfferingId", stack)?,
-                        );
-                    }
-                    "StartTime" => {
-                        obj.start_time = Some(TStampDeserializer::deserialize("StartTime", stack)?);
-                    }
-                    "State" => {
-                        obj.state = Some(StringDeserializer::deserialize("State", stack)?);
-                    }
-                    "UsagePrice" => {
-                        obj.usage_price =
-                            Some(DoubleDeserializer::deserialize("UsagePrice", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "CacheNodeType" => {
+                    obj.cache_node_type =
+                        Some(StringDeserializer::deserialize("CacheNodeType", stack)?);
                 }
+                "Duration" => {
+                    obj.duration = Some(IntegerDeserializer::deserialize("Duration", stack)?);
+                }
+                "FixedPrice" => {
+                    obj.fixed_price = Some(DoubleDeserializer::deserialize("FixedPrice", stack)?);
+                }
+                "OfferingType" => {
+                    obj.offering_type =
+                        Some(StringDeserializer::deserialize("OfferingType", stack)?);
+                }
+                "ProductDescription" => {
+                    obj.product_description = Some(StringDeserializer::deserialize(
+                        "ProductDescription",
+                        stack,
+                    )?);
+                }
+                "RecurringCharges" => {
+                    obj.recurring_charges.get_or_insert(vec![]).extend(
+                        RecurringChargeListDeserializer::deserialize("RecurringCharges", stack)?,
+                    );
+                }
+                "ReservationARN" => {
+                    obj.reservation_arn =
+                        Some(StringDeserializer::deserialize("ReservationARN", stack)?);
+                }
+                "ReservedCacheNodeId" => {
+                    obj.reserved_cache_node_id = Some(StringDeserializer::deserialize(
+                        "ReservedCacheNodeId",
+                        stack,
+                    )?);
+                }
+                "ReservedCacheNodesOfferingId" => {
+                    obj.reserved_cache_nodes_offering_id = Some(StringDeserializer::deserialize(
+                        "ReservedCacheNodesOfferingId",
+                        stack,
+                    )?);
+                }
+                "StartTime" => {
+                    obj.start_time = Some(TStampDeserializer::deserialize("StartTime", stack)?);
+                }
+                "State" => {
+                    obj.state = Some(StringDeserializer::deserialize("State", stack)?);
+                }
+                "UsagePrice" => {
+                    obj.usage_price = Some(DoubleDeserializer::deserialize("UsagePrice", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ReservedCacheNodeListDeserializer;
@@ -7140,40 +5343,17 @@ impl ReservedCacheNodeListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<ReservedCacheNode>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "ReservedCacheNode" {
-                        obj.push(ReservedCacheNodeDeserializer::deserialize(
-                            "ReservedCacheNode",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "ReservedCacheNode" {
+                obj.push(ReservedCacheNodeDeserializer::deserialize(
+                    "ReservedCacheNode",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Represents the output of a <code>DescribeReservedCacheNodes</code> operation.</p>
@@ -7192,51 +5372,27 @@ impl ReservedCacheNodeMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ReservedCacheNodeMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ReservedCacheNodeMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ReservedCacheNodeMessage, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Marker" => {
                         obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                     }
                     "ReservedCacheNodes" => {
-                        obj.reserved_cache_nodes = match obj.reserved_cache_nodes {
-                            Some(ref mut existing) => {
-                                existing.extend(ReservedCacheNodeListDeserializer::deserialize(
-                                    "ReservedCacheNodes",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ReservedCacheNodeListDeserializer::deserialize(
+                        obj.reserved_cache_nodes.get_or_insert(vec![]).extend(
+                            ReservedCacheNodeListDeserializer::deserialize(
                                 "ReservedCacheNodes",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Describes all of the attributes of a reserved cache node offering.</p>
@@ -7267,21 +5423,11 @@ impl ReservedCacheNodesOfferingDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ReservedCacheNodesOffering, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ReservedCacheNodesOffering::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ReservedCacheNodesOffering, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CacheNodeType" => {
                         obj.cache_node_type =
                             Some(StringDeserializer::deserialize("CacheNodeType", stack)?);
@@ -7304,19 +5450,12 @@ impl ReservedCacheNodesOfferingDeserializer {
                         )?);
                     }
                     "RecurringCharges" => {
-                        obj.recurring_charges = match obj.recurring_charges {
-                            Some(ref mut existing) => {
-                                existing.extend(RecurringChargeListDeserializer::deserialize(
-                                    "RecurringCharges",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(RecurringChargeListDeserializer::deserialize(
+                        obj.recurring_charges.get_or_insert(vec![]).extend(
+                            RecurringChargeListDeserializer::deserialize(
                                 "RecurringCharges",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     "ReservedCacheNodesOfferingId" => {
                         obj.reserved_cache_nodes_offering_id = Some(
@@ -7328,17 +5467,10 @@ impl ReservedCacheNodesOfferingDeserializer {
                             Some(DoubleDeserializer::deserialize("UsagePrice", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct ReservedCacheNodesOfferingListDeserializer;
@@ -7348,40 +5480,17 @@ impl ReservedCacheNodesOfferingListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<ReservedCacheNodesOffering>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "ReservedCacheNodesOffering" {
-                        obj.push(ReservedCacheNodesOfferingDeserializer::deserialize(
-                            "ReservedCacheNodesOffering",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "ReservedCacheNodesOffering" {
+                obj.push(ReservedCacheNodesOfferingDeserializer::deserialize(
+                    "ReservedCacheNodesOffering",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Represents the output of a <code>DescribeReservedCacheNodesOfferings</code> operation.</p>
@@ -7400,55 +5509,27 @@ impl ReservedCacheNodesOfferingMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ReservedCacheNodesOfferingMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ReservedCacheNodesOfferingMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ReservedCacheNodesOfferingMessage, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Marker" => {
                         obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                     }
                     "ReservedCacheNodesOfferings" => {
-                        obj.reserved_cache_nodes_offerings = match obj
-                            .reserved_cache_nodes_offerings
-                        {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    ReservedCacheNodesOfferingListDeserializer::deserialize(
-                                        "ReservedCacheNodesOfferings",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ReservedCacheNodesOfferingListDeserializer::deserialize(
+                        obj.reserved_cache_nodes_offerings
+                            .get_or_insert(vec![])
+                            .extend(ReservedCacheNodesOfferingListDeserializer::deserialize(
                                 "ReservedCacheNodesOfferings",
                                 stack,
-                            )?),
-                        };
+                            )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Represents the input of a <code>ResetCacheParameterGroup</code> operation.</p>
@@ -7547,39 +5628,18 @@ impl ReshardingStatusDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ReshardingStatus, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ReshardingStatus::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ReshardingStatus, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "SlotMigration" => {
+                    obj.slot_migration = Some(SlotMigrationDeserializer::deserialize(
+                        "SlotMigration",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "SlotMigration" => {
-                        obj.slot_migration = Some(SlotMigrationDeserializer::deserialize(
-                            "SlotMigration",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Represents the input of a <code>RevokeCacheSecurityGroupIngress</code> operation.</p>
@@ -7629,21 +5689,11 @@ impl RevokeCacheSecurityGroupIngressResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<RevokeCacheSecurityGroupIngressResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = RevokeCacheSecurityGroupIngressResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, RevokeCacheSecurityGroupIngressResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CacheSecurityGroup" => {
                         obj.cache_security_group =
                             Some(CacheSecurityGroupDeserializer::deserialize(
@@ -7652,17 +5702,10 @@ impl RevokeCacheSecurityGroupIngressResultDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -7693,21 +5736,11 @@ impl SecurityGroupMembershipDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<SecurityGroupMembership, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = SecurityGroupMembership::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, SecurityGroupMembership, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "SecurityGroupId" => {
                         obj.security_group_id =
                             Some(StringDeserializer::deserialize("SecurityGroupId", stack)?);
@@ -7716,17 +5749,10 @@ impl SecurityGroupMembershipDeserializer {
                         obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct SecurityGroupMembershipListDeserializer;
@@ -7736,39 +5762,16 @@ impl SecurityGroupMembershipListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<SecurityGroupMembership>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(SecurityGroupMembershipDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(SecurityGroupMembershipDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Represents the progress of an online resharding operation.</p>
@@ -7785,39 +5788,18 @@ impl SlotMigrationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<SlotMigration, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = SlotMigration::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, SlotMigration, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "ProgressPercentage" => {
+                    obj.progress_percentage = Some(DoubleDeserializer::deserialize(
+                        "ProgressPercentage",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "ProgressPercentage" => {
-                        obj.progress_percentage = Some(DoubleDeserializer::deserialize(
-                            "ProgressPercentage",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Represents a copy of an entire Redis cluster as of the time when the snapshot was taken.</p>
@@ -7880,162 +5862,130 @@ impl SnapshotDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Snapshot, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Snapshot::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Snapshot, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AutoMinorVersionUpgrade" => {
+                    obj.auto_minor_version_upgrade = Some(BooleanDeserializer::deserialize(
+                        "AutoMinorVersionUpgrade",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AutoMinorVersionUpgrade" => {
-                        obj.auto_minor_version_upgrade = Some(BooleanDeserializer::deserialize(
-                            "AutoMinorVersionUpgrade",
+                "AutomaticFailover" => {
+                    obj.automatic_failover =
+                        Some(AutomaticFailoverStatusDeserializer::deserialize(
+                            "AutomaticFailover",
                             stack,
                         )?);
-                    }
-                    "AutomaticFailover" => {
-                        obj.automatic_failover =
-                            Some(AutomaticFailoverStatusDeserializer::deserialize(
-                                "AutomaticFailover",
-                                stack,
-                            )?);
-                    }
-                    "CacheClusterCreateTime" => {
-                        obj.cache_cluster_create_time = Some(TStampDeserializer::deserialize(
-                            "CacheClusterCreateTime",
-                            stack,
-                        )?);
-                    }
-                    "CacheClusterId" => {
-                        obj.cache_cluster_id =
-                            Some(StringDeserializer::deserialize("CacheClusterId", stack)?);
-                    }
-                    "CacheNodeType" => {
-                        obj.cache_node_type =
-                            Some(StringDeserializer::deserialize("CacheNodeType", stack)?);
-                    }
-                    "CacheParameterGroupName" => {
-                        obj.cache_parameter_group_name = Some(StringDeserializer::deserialize(
-                            "CacheParameterGroupName",
-                            stack,
-                        )?);
-                    }
-                    "CacheSubnetGroupName" => {
-                        obj.cache_subnet_group_name = Some(StringDeserializer::deserialize(
-                            "CacheSubnetGroupName",
-                            stack,
-                        )?);
-                    }
-                    "Engine" => {
-                        obj.engine = Some(StringDeserializer::deserialize("Engine", stack)?);
-                    }
-                    "EngineVersion" => {
-                        obj.engine_version =
-                            Some(StringDeserializer::deserialize("EngineVersion", stack)?);
-                    }
-                    "NodeSnapshots" => {
-                        obj.node_snapshots = match obj.node_snapshots {
-                            Some(ref mut existing) => {
-                                existing.extend(NodeSnapshotListDeserializer::deserialize(
-                                    "NodeSnapshots",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(NodeSnapshotListDeserializer::deserialize(
-                                "NodeSnapshots",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "NumCacheNodes" => {
-                        obj.num_cache_nodes = Some(IntegerOptionalDeserializer::deserialize(
-                            "NumCacheNodes",
-                            stack,
-                        )?);
-                    }
-                    "NumNodeGroups" => {
-                        obj.num_node_groups = Some(IntegerOptionalDeserializer::deserialize(
-                            "NumNodeGroups",
-                            stack,
-                        )?);
-                    }
-                    "Port" => {
-                        obj.port = Some(IntegerOptionalDeserializer::deserialize("Port", stack)?);
-                    }
-                    "PreferredAvailabilityZone" => {
-                        obj.preferred_availability_zone = Some(StringDeserializer::deserialize(
-                            "PreferredAvailabilityZone",
-                            stack,
-                        )?);
-                    }
-                    "PreferredMaintenanceWindow" => {
-                        obj.preferred_maintenance_window = Some(StringDeserializer::deserialize(
-                            "PreferredMaintenanceWindow",
-                            stack,
-                        )?);
-                    }
-                    "ReplicationGroupDescription" => {
-                        obj.replication_group_description = Some(StringDeserializer::deserialize(
-                            "ReplicationGroupDescription",
-                            stack,
-                        )?);
-                    }
-                    "ReplicationGroupId" => {
-                        obj.replication_group_id = Some(StringDeserializer::deserialize(
-                            "ReplicationGroupId",
-                            stack,
-                        )?);
-                    }
-                    "SnapshotName" => {
-                        obj.snapshot_name =
-                            Some(StringDeserializer::deserialize("SnapshotName", stack)?);
-                    }
-                    "SnapshotRetentionLimit" => {
-                        obj.snapshot_retention_limit =
-                            Some(IntegerOptionalDeserializer::deserialize(
-                                "SnapshotRetentionLimit",
-                                stack,
-                            )?);
-                    }
-                    "SnapshotSource" => {
-                        obj.snapshot_source =
-                            Some(StringDeserializer::deserialize("SnapshotSource", stack)?);
-                    }
-                    "SnapshotStatus" => {
-                        obj.snapshot_status =
-                            Some(StringDeserializer::deserialize("SnapshotStatus", stack)?);
-                    }
-                    "SnapshotWindow" => {
-                        obj.snapshot_window =
-                            Some(StringDeserializer::deserialize("SnapshotWindow", stack)?);
-                    }
-                    "TopicArn" => {
-                        obj.topic_arn = Some(StringDeserializer::deserialize("TopicArn", stack)?);
-                    }
-                    "VpcId" => {
-                        obj.vpc_id = Some(StringDeserializer::deserialize("VpcId", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                "CacheClusterCreateTime" => {
+                    obj.cache_cluster_create_time = Some(TStampDeserializer::deserialize(
+                        "CacheClusterCreateTime",
+                        stack,
+                    )?);
+                }
+                "CacheClusterId" => {
+                    obj.cache_cluster_id =
+                        Some(StringDeserializer::deserialize("CacheClusterId", stack)?);
+                }
+                "CacheNodeType" => {
+                    obj.cache_node_type =
+                        Some(StringDeserializer::deserialize("CacheNodeType", stack)?);
+                }
+                "CacheParameterGroupName" => {
+                    obj.cache_parameter_group_name = Some(StringDeserializer::deserialize(
+                        "CacheParameterGroupName",
+                        stack,
+                    )?);
+                }
+                "CacheSubnetGroupName" => {
+                    obj.cache_subnet_group_name = Some(StringDeserializer::deserialize(
+                        "CacheSubnetGroupName",
+                        stack,
+                    )?);
+                }
+                "Engine" => {
+                    obj.engine = Some(StringDeserializer::deserialize("Engine", stack)?);
+                }
+                "EngineVersion" => {
+                    obj.engine_version =
+                        Some(StringDeserializer::deserialize("EngineVersion", stack)?);
+                }
+                "NodeSnapshots" => {
+                    obj.node_snapshots.get_or_insert(vec![]).extend(
+                        NodeSnapshotListDeserializer::deserialize("NodeSnapshots", stack)?,
+                    );
+                }
+                "NumCacheNodes" => {
+                    obj.num_cache_nodes = Some(IntegerOptionalDeserializer::deserialize(
+                        "NumCacheNodes",
+                        stack,
+                    )?);
+                }
+                "NumNodeGroups" => {
+                    obj.num_node_groups = Some(IntegerOptionalDeserializer::deserialize(
+                        "NumNodeGroups",
+                        stack,
+                    )?);
+                }
+                "Port" => {
+                    obj.port = Some(IntegerOptionalDeserializer::deserialize("Port", stack)?);
+                }
+                "PreferredAvailabilityZone" => {
+                    obj.preferred_availability_zone = Some(StringDeserializer::deserialize(
+                        "PreferredAvailabilityZone",
+                        stack,
+                    )?);
+                }
+                "PreferredMaintenanceWindow" => {
+                    obj.preferred_maintenance_window = Some(StringDeserializer::deserialize(
+                        "PreferredMaintenanceWindow",
+                        stack,
+                    )?);
+                }
+                "ReplicationGroupDescription" => {
+                    obj.replication_group_description = Some(StringDeserializer::deserialize(
+                        "ReplicationGroupDescription",
+                        stack,
+                    )?);
+                }
+                "ReplicationGroupId" => {
+                    obj.replication_group_id = Some(StringDeserializer::deserialize(
+                        "ReplicationGroupId",
+                        stack,
+                    )?);
+                }
+                "SnapshotName" => {
+                    obj.snapshot_name =
+                        Some(StringDeserializer::deserialize("SnapshotName", stack)?);
+                }
+                "SnapshotRetentionLimit" => {
+                    obj.snapshot_retention_limit = Some(IntegerOptionalDeserializer::deserialize(
+                        "SnapshotRetentionLimit",
+                        stack,
+                    )?);
+                }
+                "SnapshotSource" => {
+                    obj.snapshot_source =
+                        Some(StringDeserializer::deserialize("SnapshotSource", stack)?);
+                }
+                "SnapshotStatus" => {
+                    obj.snapshot_status =
+                        Some(StringDeserializer::deserialize("SnapshotStatus", stack)?);
+                }
+                "SnapshotWindow" => {
+                    obj.snapshot_window =
+                        Some(StringDeserializer::deserialize("SnapshotWindow", stack)?);
+                }
+                "TopicArn" => {
+                    obj.topic_arn = Some(StringDeserializer::deserialize("TopicArn", stack)?);
+                }
+                "VpcId" => {
+                    obj.vpc_id = Some(StringDeserializer::deserialize("VpcId", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -8057,37 +6007,14 @@ impl SnapshotListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Snapshot>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "Snapshot" {
-                        obj.push(SnapshotDeserializer::deserialize("Snapshot", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "Snapshot" {
+                obj.push(SnapshotDeserializer::deserialize("Snapshot", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct SourceTypeDeserializer;
@@ -8134,44 +6061,22 @@ impl SubnetDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Subnet, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Subnet::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Subnet, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "SubnetAvailabilityZone" => {
+                    obj.subnet_availability_zone = Some(AvailabilityZoneDeserializer::deserialize(
+                        "SubnetAvailabilityZone",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "SubnetAvailabilityZone" => {
-                        obj.subnet_availability_zone =
-                            Some(AvailabilityZoneDeserializer::deserialize(
-                                "SubnetAvailabilityZone",
-                                stack,
-                            )?);
-                    }
-                    "SubnetIdentifier" => {
-                        obj.subnet_identifier =
-                            Some(StringDeserializer::deserialize("SubnetIdentifier", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "SubnetIdentifier" => {
+                    obj.subnet_identifier =
+                        Some(StringDeserializer::deserialize("SubnetIdentifier", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -8193,37 +6098,14 @@ impl SubnetListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Subnet>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "Subnet" {
-                        obj.push(SubnetDeserializer::deserialize("Subnet", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "Subnet" {
+                obj.push(SubnetDeserializer::deserialize("Subnet", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct TStampDeserializer;
@@ -8256,39 +6138,18 @@ impl TagDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Tag, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Tag::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Tag, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Key" => {
+                    obj.key = Some(StringDeserializer::deserialize("Key", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Key" => {
-                        obj.key = Some(StringDeserializer::deserialize("Key", stack)?);
-                    }
-                    "Value" => {
-                        obj.value = Some(StringDeserializer::deserialize("Value", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Value" => {
+                    obj.value = Some(StringDeserializer::deserialize("Value", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -8317,37 +6178,14 @@ impl TagListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Tag>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "Tag" {
-                        obj.push(TagDeserializer::deserialize("Tag", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "Tag" {
+                obj.push(TagDeserializer::deserialize("Tag", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -8376,43 +6214,17 @@ impl TagListMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<TagListMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = TagListMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, TagListMessage, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "TagList" => {
+                    obj.tag_list
+                        .get_or_insert(vec![])
+                        .extend(TagListDeserializer::deserialize("TagList", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "TagList" => {
-                        obj.tag_list = match obj.tag_list {
-                            Some(ref mut existing) => {
-                                existing
-                                    .extend(TagListDeserializer::deserialize("TagList", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(TagListDeserializer::deserialize("TagList", stack)?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -8452,39 +6264,18 @@ impl TestFailoverResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<TestFailoverResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = TestFailoverResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, TestFailoverResult, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "ReplicationGroup" => {
+                    obj.replication_group = Some(ReplicationGroupDeserializer::deserialize(
+                        "ReplicationGroup",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "ReplicationGroup" => {
-                        obj.replication_group = Some(ReplicationGroupDeserializer::deserialize(
-                            "ReplicationGroup",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// Errors returned by AddTagsToResource

--- a/rusoto/services/elb/src/generated.rs
+++ b/rusoto/services/elb/src/generated.rs
@@ -25,20 +25,15 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
 use rusoto_core::xmlutil::{
-    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+    characters, deserialize_elements, end_element, find_start_element, peek_at_name, skip_tree,
+    start_element,
 };
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;
-use xml::reader::XmlEvent;
 use xml::EventReader;
 
-enum DeserializerNext {
-    Close,
-    Skip,
-    Element(String),
-}
 /// <p>Information about the <code>AccessLog</code> attribute.</p>
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct AccessLog {
@@ -59,54 +54,33 @@ impl AccessLogDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AccessLog, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AccessLog::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, AccessLog, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "EmitInterval" => {
+                    obj.emit_interval = Some(AccessLogIntervalDeserializer::deserialize(
+                        "EmitInterval",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "EmitInterval" => {
-                        obj.emit_interval = Some(AccessLogIntervalDeserializer::deserialize(
-                            "EmitInterval",
-                            stack,
-                        )?);
-                    }
-                    "Enabled" => {
-                        obj.enabled = AccessLogEnabledDeserializer::deserialize("Enabled", stack)?;
-                    }
-                    "S3BucketName" => {
-                        obj.s3_bucket_name = Some(S3BucketNameDeserializer::deserialize(
-                            "S3BucketName",
-                            stack,
-                        )?);
-                    }
-                    "S3BucketPrefix" => {
-                        obj.s3_bucket_prefix = Some(AccessLogPrefixDeserializer::deserialize(
-                            "S3BucketPrefix",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Enabled" => {
+                    obj.enabled = AccessLogEnabledDeserializer::deserialize("Enabled", stack)?;
                 }
+                "S3BucketName" => {
+                    obj.s3_bucket_name = Some(S3BucketNameDeserializer::deserialize(
+                        "S3BucketName",
+                        stack,
+                    )?);
+                }
+                "S3BucketPrefix" => {
+                    obj.s3_bucket_prefix = Some(AccessLogPrefixDeserializer::deserialize(
+                        "S3BucketPrefix",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -252,48 +226,21 @@ impl AddAvailabilityZonesOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AddAvailabilityZonesOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AddAvailabilityZonesOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, AddAvailabilityZonesOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AvailabilityZones" => {
-                        obj.availability_zones = match obj.availability_zones {
-                            Some(ref mut existing) => {
-                                existing.extend(AvailabilityZonesDeserializer::deserialize(
-                                    "AvailabilityZones",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(AvailabilityZonesDeserializer::deserialize(
-                                "AvailabilityZones",
-                                stack,
-                            )?),
-                        };
+                        obj.availability_zones.get_or_insert(vec![]).extend(
+                            AvailabilityZonesDeserializer::deserialize("AvailabilityZones", stack)?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Contains the parameters for AddTags.</p>
@@ -359,43 +306,22 @@ impl AdditionalAttributeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AdditionalAttribute, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AdditionalAttribute::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, AdditionalAttribute, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Key" => {
+                    obj.key = Some(AdditionalAttributeKeyDeserializer::deserialize(
+                        "Key", stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Key" => {
-                        obj.key = Some(AdditionalAttributeKeyDeserializer::deserialize(
-                            "Key", stack,
-                        )?);
-                    }
-                    "Value" => {
-                        obj.value = Some(AdditionalAttributeValueDeserializer::deserialize(
-                            "Value", stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Value" => {
+                    obj.value = Some(AdditionalAttributeValueDeserializer::deserialize(
+                        "Value", stack,
+                    )?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -452,39 +378,16 @@ impl AdditionalAttributesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<AdditionalAttribute>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(AdditionalAttributeDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(AdditionalAttributeDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -506,39 +409,16 @@ impl AppCookieStickinessPoliciesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<AppCookieStickinessPolicy>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(AppCookieStickinessPolicyDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(AppCookieStickinessPolicyDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Information about a policy for application-controlled session stickiness.</p>
@@ -557,21 +437,11 @@ impl AppCookieStickinessPolicyDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AppCookieStickinessPolicy, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AppCookieStickinessPolicy::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, AppCookieStickinessPolicy, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CookieName" => {
                         obj.cookie_name =
                             Some(CookieNameDeserializer::deserialize("CookieName", stack)?);
@@ -581,17 +451,10 @@ impl AppCookieStickinessPolicyDeserializer {
                             Some(PolicyNameDeserializer::deserialize("PolicyName", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Contains the parameters for ApplySecurityGroupsToLoadBalancer.</p>
@@ -638,48 +501,21 @@ impl ApplySecurityGroupsToLoadBalancerOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ApplySecurityGroupsToLoadBalancerOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ApplySecurityGroupsToLoadBalancerOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ApplySecurityGroupsToLoadBalancerOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "SecurityGroups" => {
-                        obj.security_groups = match obj.security_groups {
-                            Some(ref mut existing) => {
-                                existing.extend(SecurityGroupsDeserializer::deserialize(
-                                    "SecurityGroups",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(SecurityGroupsDeserializer::deserialize(
-                                "SecurityGroups",
-                                stack,
-                            )?),
-                        };
+                        obj.security_groups.get_or_insert(vec![]).extend(
+                            SecurityGroupsDeserializer::deserialize("SecurityGroups", stack)?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Contains the parameters for AttachLoaBalancerToSubnets.</p>
@@ -722,43 +558,21 @@ impl AttachLoadBalancerToSubnetsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AttachLoadBalancerToSubnetsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AttachLoadBalancerToSubnetsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, AttachLoadBalancerToSubnetsOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Subnets" => {
-                        obj.subnets = match obj.subnets {
-                            Some(ref mut existing) => {
-                                existing
-                                    .extend(SubnetsDeserializer::deserialize("Subnets", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(SubnetsDeserializer::deserialize("Subnets", stack)?),
-                        };
+                        obj.subnets
+                            .get_or_insert(vec![])
+                            .extend(SubnetsDeserializer::deserialize("Subnets", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct AttributeNameDeserializer;
@@ -824,37 +638,14 @@ impl AvailabilityZonesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(AvailabilityZoneDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(AvailabilityZoneDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -885,21 +676,11 @@ impl BackendServerDescriptionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<BackendServerDescription, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = BackendServerDescription::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, BackendServerDescription, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "InstancePort" => {
                         obj.instance_port = Some(InstancePortDeserializer::deserialize(
                             "InstancePort",
@@ -907,31 +688,15 @@ impl BackendServerDescriptionDeserializer {
                         )?);
                     }
                     "PolicyNames" => {
-                        obj.policy_names = match obj.policy_names {
-                            Some(ref mut existing) => {
-                                existing.extend(PolicyNamesDeserializer::deserialize(
-                                    "PolicyNames",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => {
-                                Some(PolicyNamesDeserializer::deserialize("PolicyNames", stack)?)
-                            }
-                        };
+                        obj.policy_names
+                            .get_or_insert(vec![])
+                            .extend(PolicyNamesDeserializer::deserialize("PolicyNames", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct BackendServerDescriptionsDeserializer;
@@ -941,39 +706,16 @@ impl BackendServerDescriptionsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<BackendServerDescription>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(BackendServerDescriptionDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(BackendServerDescriptionDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct CardinalityDeserializer;
@@ -1034,37 +776,20 @@ impl ConfigureHealthCheckOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ConfigureHealthCheckOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ConfigureHealthCheckOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ConfigureHealthCheckOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "HealthCheck" => {
                         obj.health_check =
                             Some(HealthCheckDeserializer::deserialize("HealthCheck", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Information about the <code>ConnectionDraining</code> attribute.</p>
@@ -1083,42 +808,21 @@ impl ConnectionDrainingDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ConnectionDraining, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ConnectionDraining::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ConnectionDraining, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Enabled" => {
+                    obj.enabled =
+                        ConnectionDrainingEnabledDeserializer::deserialize("Enabled", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Enabled" => {
-                        obj.enabled =
-                            ConnectionDrainingEnabledDeserializer::deserialize("Enabled", stack)?;
-                    }
-                    "Timeout" => {
-                        obj.timeout = Some(ConnectionDrainingTimeoutDeserializer::deserialize(
-                            "Timeout", stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Timeout" => {
+                    obj.timeout = Some(ConnectionDrainingTimeoutDeserializer::deserialize(
+                        "Timeout", stack,
+                    )?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -1186,37 +890,15 @@ impl ConnectionSettingsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ConnectionSettings, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ConnectionSettings::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ConnectionSettings, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "IdleTimeout" => {
+                    obj.idle_timeout = IdleTimeoutDeserializer::deserialize("IdleTimeout", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "IdleTimeout" => {
-                        obj.idle_timeout =
-                            IdleTimeoutDeserializer::deserialize("IdleTimeout", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -1341,36 +1023,19 @@ impl CreateAccessPointOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateAccessPointOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateAccessPointOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateAccessPointOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DNSName" => {
                         obj.dns_name = Some(DNSNameDeserializer::deserialize("DNSName", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Contains the parameters for CreateAppCookieStickinessPolicy.</p>
@@ -1615,38 +1280,16 @@ impl CrossZoneLoadBalancingDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CrossZoneLoadBalancing, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CrossZoneLoadBalancing::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CrossZoneLoadBalancing, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Enabled" => {
+                    obj.enabled =
+                        CrossZoneLoadBalancingEnabledDeserializer::deserialize("Enabled", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Enabled" => {
-                        obj.enabled = CrossZoneLoadBalancingEnabledDeserializer::deserialize(
-                            "Enabled", stack,
-                        )?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -1891,45 +1534,21 @@ impl DeregisterEndPointsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DeregisterEndPointsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DeregisterEndPointsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DeregisterEndPointsOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Instances" => {
-                        obj.instances = match obj.instances {
-                            Some(ref mut existing) => {
-                                existing.extend(InstancesDeserializer::deserialize(
-                                    "Instances",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(InstancesDeserializer::deserialize("Instances", stack)?),
-                        };
+                        obj.instances
+                            .get_or_insert(vec![])
+                            .extend(InstancesDeserializer::deserialize("Instances", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Contains the parameters for DescribeLoadBalancers.</p>
@@ -1987,52 +1606,28 @@ impl DescribeAccessPointsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeAccessPointsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeAccessPointsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeAccessPointsOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "LoadBalancerDescriptions" => {
-                        obj.load_balancer_descriptions = match obj.load_balancer_descriptions {
-                            Some(ref mut existing) => {
-                                existing.extend(LoadBalancerDescriptionsDeserializer::deserialize(
-                                    "LoadBalancerDescriptions",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(LoadBalancerDescriptionsDeserializer::deserialize(
+                        obj.load_balancer_descriptions.get_or_insert(vec![]).extend(
+                            LoadBalancerDescriptionsDeserializer::deserialize(
                                 "LoadBalancerDescriptions",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     "NextMarker" => {
                         obj.next_marker =
                             Some(MarkerDeserializer::deserialize("NextMarker", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -2079,46 +1674,25 @@ impl DescribeAccountLimitsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeAccountLimitsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeAccountLimitsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeAccountLimitsOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Limits" => {
-                        obj.limits = match obj.limits {
-                            Some(ref mut existing) => {
-                                existing.extend(LimitsDeserializer::deserialize("Limits", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(LimitsDeserializer::deserialize("Limits", stack)?),
-                        };
+                        obj.limits
+                            .get_or_insert(vec![])
+                            .extend(LimitsDeserializer::deserialize("Limits", stack)?);
                     }
                     "NextMarker" => {
                         obj.next_marker =
                             Some(MarkerDeserializer::deserialize("NextMarker", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Contains the parameters for DescribeInstanceHealth.</p>
@@ -2167,48 +1741,21 @@ impl DescribeEndPointStateOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeEndPointStateOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeEndPointStateOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeEndPointStateOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "InstanceStates" => {
-                        obj.instance_states = match obj.instance_states {
-                            Some(ref mut existing) => {
-                                existing.extend(InstanceStatesDeserializer::deserialize(
-                                    "InstanceStates",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(InstanceStatesDeserializer::deserialize(
-                                "InstanceStates",
-                                stack,
-                            )?),
-                        };
+                        obj.instance_states.get_or_insert(vec![]).extend(
+                            InstanceStatesDeserializer::deserialize("InstanceStates", stack)?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Contains the parameters for DescribeLoadBalancerAttributes.</p>
@@ -2248,21 +1795,11 @@ impl DescribeLoadBalancerAttributesOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeLoadBalancerAttributesOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeLoadBalancerAttributesOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeLoadBalancerAttributesOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "LoadBalancerAttributes" => {
                         obj.load_balancer_attributes =
                             Some(LoadBalancerAttributesDeserializer::deserialize(
@@ -2271,17 +1808,10 @@ impl DescribeLoadBalancerAttributesOutputDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Contains the parameters for DescribeLoadBalancerPolicies.</p>
@@ -2329,48 +1859,24 @@ impl DescribeLoadBalancerPoliciesOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeLoadBalancerPoliciesOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeLoadBalancerPoliciesOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeLoadBalancerPoliciesOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "PolicyDescriptions" => {
-                        obj.policy_descriptions = match obj.policy_descriptions {
-                            Some(ref mut existing) => {
-                                existing.extend(PolicyDescriptionsDeserializer::deserialize(
-                                    "PolicyDescriptions",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(PolicyDescriptionsDeserializer::deserialize(
+                        obj.policy_descriptions.get_or_insert(vec![]).extend(
+                            PolicyDescriptionsDeserializer::deserialize(
                                 "PolicyDescriptions",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Contains the parameters for DescribeLoadBalancerPolicyTypes.</p>
@@ -2413,48 +1919,24 @@ impl DescribeLoadBalancerPolicyTypesOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeLoadBalancerPolicyTypesOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeLoadBalancerPolicyTypesOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeLoadBalancerPolicyTypesOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "PolicyTypeDescriptions" => {
-                        obj.policy_type_descriptions = match obj.policy_type_descriptions {
-                            Some(ref mut existing) => {
-                                existing.extend(PolicyTypeDescriptionsDeserializer::deserialize(
-                                    "PolicyTypeDescriptions",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(PolicyTypeDescriptionsDeserializer::deserialize(
+                        obj.policy_type_descriptions.get_or_insert(vec![]).extend(
+                            PolicyTypeDescriptionsDeserializer::deserialize(
                                 "PolicyTypeDescriptions",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Contains the parameters for DescribeTags.</p>
@@ -2495,48 +1977,17 @@ impl DescribeTagsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeTagsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeTagsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DescribeTagsOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "TagDescriptions" => {
+                    obj.tag_descriptions.get_or_insert(vec![]).extend(
+                        TagDescriptionsDeserializer::deserialize("TagDescriptions", stack)?,
+                    );
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "TagDescriptions" => {
-                        obj.tag_descriptions = match obj.tag_descriptions {
-                            Some(ref mut existing) => {
-                                existing.extend(TagDescriptionsDeserializer::deserialize(
-                                    "TagDescriptions",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(TagDescriptionsDeserializer::deserialize(
-                                "TagDescriptions",
-                                stack,
-                            )?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct DescriptionDeserializer;
@@ -2593,43 +2044,21 @@ impl DetachLoadBalancerFromSubnetsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DetachLoadBalancerFromSubnetsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DetachLoadBalancerFromSubnetsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DetachLoadBalancerFromSubnetsOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Subnets" => {
-                        obj.subnets = match obj.subnets {
-                            Some(ref mut existing) => {
-                                existing
-                                    .extend(SubnetsDeserializer::deserialize("Subnets", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(SubnetsDeserializer::deserialize("Subnets", stack)?),
-                        };
+                        obj.subnets
+                            .get_or_insert(vec![])
+                            .extend(SubnetsDeserializer::deserialize("Subnets", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Information about a health check.</p>
@@ -2654,54 +2083,29 @@ impl HealthCheckDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<HealthCheck, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = HealthCheck::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, HealthCheck, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "HealthyThreshold" => {
+                    obj.healthy_threshold =
+                        HealthyThresholdDeserializer::deserialize("HealthyThreshold", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "HealthyThreshold" => {
-                        obj.healthy_threshold =
-                            HealthyThresholdDeserializer::deserialize("HealthyThreshold", stack)?;
-                    }
-                    "Interval" => {
-                        obj.interval =
-                            HealthCheckIntervalDeserializer::deserialize("Interval", stack)?;
-                    }
-                    "Target" => {
-                        obj.target = HealthCheckTargetDeserializer::deserialize("Target", stack)?;
-                    }
-                    "Timeout" => {
-                        obj.timeout =
-                            HealthCheckTimeoutDeserializer::deserialize("Timeout", stack)?;
-                    }
-                    "UnhealthyThreshold" => {
-                        obj.unhealthy_threshold = UnhealthyThresholdDeserializer::deserialize(
-                            "UnhealthyThreshold",
-                            stack,
-                        )?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Interval" => {
+                    obj.interval = HealthCheckIntervalDeserializer::deserialize("Interval", stack)?;
                 }
+                "Target" => {
+                    obj.target = HealthCheckTargetDeserializer::deserialize("Target", stack)?;
+                }
+                "Timeout" => {
+                    obj.timeout = HealthCheckTimeoutDeserializer::deserialize("Timeout", stack)?;
+                }
+                "UnhealthyThreshold" => {
+                    obj.unhealthy_threshold =
+                        UnhealthyThresholdDeserializer::deserialize("UnhealthyThreshold", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -2818,37 +2222,16 @@ impl InstanceDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Instance, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Instance::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Instance, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "InstanceId" => {
+                    obj.instance_id =
+                        Some(InstanceIdDeserializer::deserialize("InstanceId", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "InstanceId" => {
-                        obj.instance_id =
-                            Some(InstanceIdDeserializer::deserialize("InstanceId", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -2915,48 +2298,27 @@ impl InstanceStateDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<InstanceState, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = InstanceState::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, InstanceState, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Description" => {
+                    obj.description =
+                        Some(DescriptionDeserializer::deserialize("Description", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Description" => {
-                        obj.description =
-                            Some(DescriptionDeserializer::deserialize("Description", stack)?);
-                    }
-                    "InstanceId" => {
-                        obj.instance_id =
-                            Some(InstanceIdDeserializer::deserialize("InstanceId", stack)?);
-                    }
-                    "ReasonCode" => {
-                        obj.reason_code =
-                            Some(ReasonCodeDeserializer::deserialize("ReasonCode", stack)?);
-                    }
-                    "State" => {
-                        obj.state = Some(StateDeserializer::deserialize("State", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "InstanceId" => {
+                    obj.instance_id =
+                        Some(InstanceIdDeserializer::deserialize("InstanceId", stack)?);
                 }
+                "ReasonCode" => {
+                    obj.reason_code =
+                        Some(ReasonCodeDeserializer::deserialize("ReasonCode", stack)?);
+                }
+                "State" => {
+                    obj.state = Some(StateDeserializer::deserialize("State", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct InstanceStatesDeserializer;
@@ -2966,37 +2328,14 @@ impl InstanceStatesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<InstanceState>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(InstanceStateDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(InstanceStateDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct InstancesDeserializer;
@@ -3006,37 +2345,14 @@ impl InstancesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Instance>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(InstanceDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(InstanceDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -3058,39 +2374,16 @@ impl LBCookieStickinessPoliciesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<LBCookieStickinessPolicy>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(LBCookieStickinessPolicyDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(LBCookieStickinessPolicyDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Information about a policy for duration-based session stickiness.</p>
@@ -3109,21 +2402,11 @@ impl LBCookieStickinessPolicyDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<LBCookieStickinessPolicy, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = LBCookieStickinessPolicy::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, LBCookieStickinessPolicy, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CookieExpirationPeriod" => {
                         obj.cookie_expiration_period =
                             Some(CookieExpirationPeriodDeserializer::deserialize(
@@ -3136,17 +2419,10 @@ impl LBCookieStickinessPolicyDeserializer {
                             Some(PolicyNameDeserializer::deserialize("PolicyName", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Information about an Elastic Load Balancing resource limit for your AWS account.</p>
@@ -3165,39 +2441,18 @@ impl LimitDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Limit, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Limit::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Limit, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Max" => {
+                    obj.max = Some(MaxDeserializer::deserialize("Max", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Max" => {
-                        obj.max = Some(MaxDeserializer::deserialize("Max", stack)?);
-                    }
-                    "Name" => {
-                        obj.name = Some(NameDeserializer::deserialize("Name", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Name" => {
+                    obj.name = Some(NameDeserializer::deserialize("Name", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct LimitsDeserializer;
@@ -3207,37 +2462,14 @@ impl LimitsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Limit>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(LimitDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(LimitDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Information about a listener.</p> <p>For information about the protocols and the ports supported by Elastic Load Balancing, see <a href="http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-listener-config.html">Listeners for Your Classic Load Balancer</a> in the <i>Classic Load Balancers Guide</i>.</p>
@@ -3262,56 +2494,35 @@ impl ListenerDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Listener, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Listener::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Listener, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "InstancePort" => {
+                    obj.instance_port =
+                        InstancePortDeserializer::deserialize("InstancePort", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "InstancePort" => {
-                        obj.instance_port =
-                            InstancePortDeserializer::deserialize("InstancePort", stack)?;
-                    }
-                    "InstanceProtocol" => {
-                        obj.instance_protocol = Some(ProtocolDeserializer::deserialize(
-                            "InstanceProtocol",
-                            stack,
-                        )?);
-                    }
-                    "LoadBalancerPort" => {
-                        obj.load_balancer_port =
-                            AccessPointPortDeserializer::deserialize("LoadBalancerPort", stack)?;
-                    }
-                    "Protocol" => {
-                        obj.protocol = ProtocolDeserializer::deserialize("Protocol", stack)?;
-                    }
-                    "SSLCertificateId" => {
-                        obj.ssl_certificate_id = Some(SSLCertificateIdDeserializer::deserialize(
-                            "SSLCertificateId",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "InstanceProtocol" => {
+                    obj.instance_protocol = Some(ProtocolDeserializer::deserialize(
+                        "InstanceProtocol",
+                        stack,
+                    )?);
                 }
+                "LoadBalancerPort" => {
+                    obj.load_balancer_port =
+                        AccessPointPortDeserializer::deserialize("LoadBalancerPort", stack)?;
+                }
+                "Protocol" => {
+                    obj.protocol = ProtocolDeserializer::deserialize("Protocol", stack)?;
+                }
+                "SSLCertificateId" => {
+                    obj.ssl_certificate_id = Some(SSLCertificateIdDeserializer::deserialize(
+                        "SSLCertificateId",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -3358,50 +2569,20 @@ impl ListenerDescriptionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListenerDescription, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListenerDescription::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ListenerDescription, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Listener" => {
+                    obj.listener = Some(ListenerDeserializer::deserialize("Listener", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Listener" => {
-                        obj.listener = Some(ListenerDeserializer::deserialize("Listener", stack)?);
-                    }
-                    "PolicyNames" => {
-                        obj.policy_names = match obj.policy_names {
-                            Some(ref mut existing) => {
-                                existing.extend(PolicyNamesDeserializer::deserialize(
-                                    "PolicyNames",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => {
-                                Some(PolicyNamesDeserializer::deserialize("PolicyNames", stack)?)
-                            }
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "PolicyNames" => {
+                    obj.policy_names
+                        .get_or_insert(vec![])
+                        .extend(PolicyNamesDeserializer::deserialize("PolicyNames", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ListenerDescriptionsDeserializer;
@@ -3411,39 +2592,16 @@ impl ListenerDescriptionsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<ListenerDescription>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(ListenerDescriptionDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(ListenerDescriptionDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -3480,73 +2638,42 @@ impl LoadBalancerAttributesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<LoadBalancerAttributes, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = LoadBalancerAttributes::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, LoadBalancerAttributes, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AccessLog" => {
+                    obj.access_log = Some(AccessLogDeserializer::deserialize("AccessLog", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AccessLog" => {
-                        obj.access_log =
-                            Some(AccessLogDeserializer::deserialize("AccessLog", stack)?);
-                    }
-                    "AdditionalAttributes" => {
-                        obj.additional_attributes = match obj.additional_attributes {
-                            Some(ref mut existing) => {
-                                existing.extend(AdditionalAttributesDeserializer::deserialize(
-                                    "AdditionalAttributes",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(AdditionalAttributesDeserializer::deserialize(
-                                "AdditionalAttributes",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "ConnectionDraining" => {
-                        obj.connection_draining =
-                            Some(ConnectionDrainingDeserializer::deserialize(
-                                "ConnectionDraining",
-                                stack,
-                            )?);
-                    }
-                    "ConnectionSettings" => {
-                        obj.connection_settings =
-                            Some(ConnectionSettingsDeserializer::deserialize(
-                                "ConnectionSettings",
-                                stack,
-                            )?);
-                    }
-                    "CrossZoneLoadBalancing" => {
-                        obj.cross_zone_load_balancing =
-                            Some(CrossZoneLoadBalancingDeserializer::deserialize(
-                                "CrossZoneLoadBalancing",
-                                stack,
-                            )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "AdditionalAttributes" => {
+                    obj.additional_attributes.get_or_insert(vec![]).extend(
+                        AdditionalAttributesDeserializer::deserialize(
+                            "AdditionalAttributes",
+                            stack,
+                        )?,
+                    );
                 }
+                "ConnectionDraining" => {
+                    obj.connection_draining = Some(ConnectionDrainingDeserializer::deserialize(
+                        "ConnectionDraining",
+                        stack,
+                    )?);
+                }
+                "ConnectionSettings" => {
+                    obj.connection_settings = Some(ConnectionSettingsDeserializer::deserialize(
+                        "ConnectionSettings",
+                        stack,
+                    )?);
+                }
+                "CrossZoneLoadBalancing" => {
+                    obj.cross_zone_load_balancing =
+                        Some(CrossZoneLoadBalancingDeserializer::deserialize(
+                            "CrossZoneLoadBalancing",
+                            stack,
+                        )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -3641,52 +2768,23 @@ impl LoadBalancerDescriptionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<LoadBalancerDescription, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = LoadBalancerDescription::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, LoadBalancerDescription, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AvailabilityZones" => {
-                        obj.availability_zones = match obj.availability_zones {
-                            Some(ref mut existing) => {
-                                existing.extend(AvailabilityZonesDeserializer::deserialize(
-                                    "AvailabilityZones",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(AvailabilityZonesDeserializer::deserialize(
-                                "AvailabilityZones",
-                                stack,
-                            )?),
-                        };
+                        obj.availability_zones.get_or_insert(vec![]).extend(
+                            AvailabilityZonesDeserializer::deserialize("AvailabilityZones", stack)?,
+                        );
                     }
                     "BackendServerDescriptions" => {
-                        obj.backend_server_descriptions = match obj.backend_server_descriptions {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    BackendServerDescriptionsDeserializer::deserialize(
-                                        "BackendServerDescriptions",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(BackendServerDescriptionsDeserializer::deserialize(
+                        obj.backend_server_descriptions
+                            .get_or_insert(vec![])
+                            .extend(BackendServerDescriptionsDeserializer::deserialize(
                                 "BackendServerDescriptions",
                                 stack,
-                            )?),
-                        };
+                            )?);
                     }
                     "CanonicalHostedZoneName" => {
                         obj.canonical_hosted_zone_name = Some(DNSNameDeserializer::deserialize(
@@ -3712,31 +2810,17 @@ impl LoadBalancerDescriptionDeserializer {
                             Some(HealthCheckDeserializer::deserialize("HealthCheck", stack)?);
                     }
                     "Instances" => {
-                        obj.instances = match obj.instances {
-                            Some(ref mut existing) => {
-                                existing.extend(InstancesDeserializer::deserialize(
-                                    "Instances",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(InstancesDeserializer::deserialize("Instances", stack)?),
-                        };
+                        obj.instances
+                            .get_or_insert(vec![])
+                            .extend(InstancesDeserializer::deserialize("Instances", stack)?);
                     }
                     "ListenerDescriptions" => {
-                        obj.listener_descriptions = match obj.listener_descriptions {
-                            Some(ref mut existing) => {
-                                existing.extend(ListenerDescriptionsDeserializer::deserialize(
-                                    "ListenerDescriptions",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ListenerDescriptionsDeserializer::deserialize(
+                        obj.listener_descriptions.get_or_insert(vec![]).extend(
+                            ListenerDescriptionsDeserializer::deserialize(
                                 "ListenerDescriptions",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     "LoadBalancerName" => {
                         obj.load_balancer_name = Some(AccessPointNameDeserializer::deserialize(
@@ -3753,19 +2837,9 @@ impl LoadBalancerDescriptionDeserializer {
                         )?);
                     }
                     "SecurityGroups" => {
-                        obj.security_groups = match obj.security_groups {
-                            Some(ref mut existing) => {
-                                existing.extend(SecurityGroupsDeserializer::deserialize(
-                                    "SecurityGroups",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(SecurityGroupsDeserializer::deserialize(
-                                "SecurityGroups",
-                                stack,
-                            )?),
-                        };
+                        obj.security_groups.get_or_insert(vec![]).extend(
+                            SecurityGroupsDeserializer::deserialize("SecurityGroups", stack)?,
+                        );
                     }
                     "SourceSecurityGroup" => {
                         obj.source_security_group =
@@ -3775,30 +2849,18 @@ impl LoadBalancerDescriptionDeserializer {
                             )?);
                     }
                     "Subnets" => {
-                        obj.subnets = match obj.subnets {
-                            Some(ref mut existing) => {
-                                existing
-                                    .extend(SubnetsDeserializer::deserialize("Subnets", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(SubnetsDeserializer::deserialize("Subnets", stack)?),
-                        };
+                        obj.subnets
+                            .get_or_insert(vec![])
+                            .extend(SubnetsDeserializer::deserialize("Subnets", stack)?);
                     }
                     "VPCId" => {
                         obj.vpc_id = Some(VPCIdDeserializer::deserialize("VPCId", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct LoadBalancerDescriptionsDeserializer;
@@ -3808,39 +2870,16 @@ impl LoadBalancerDescriptionsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<LoadBalancerDescription>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(LoadBalancerDescriptionDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(LoadBalancerDescriptionDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -3954,21 +2993,11 @@ impl ModifyLoadBalancerAttributesOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ModifyLoadBalancerAttributesOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ModifyLoadBalancerAttributesOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ModifyLoadBalancerAttributesOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "LoadBalancerAttributes" => {
                         obj.load_balancer_attributes =
                             Some(LoadBalancerAttributesDeserializer::deserialize(
@@ -3983,17 +3012,10 @@ impl ModifyLoadBalancerAttributesOutputDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct NameDeserializer;
@@ -4028,84 +3050,33 @@ impl PoliciesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Policies, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Policies::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Policies, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AppCookieStickinessPolicies" => {
+                    obj.app_cookie_stickiness_policies
+                        .get_or_insert(vec![])
+                        .extend(AppCookieStickinessPoliciesDeserializer::deserialize(
+                            "AppCookieStickinessPolicies",
+                            stack,
+                        )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AppCookieStickinessPolicies" => {
-                        obj.app_cookie_stickiness_policies =
-                            match obj.app_cookie_stickiness_policies {
-                                Some(ref mut existing) => {
-                                    existing.extend(
-                                        AppCookieStickinessPoliciesDeserializer::deserialize(
-                                            "AppCookieStickinessPolicies",
-                                            stack,
-                                        )?,
-                                    );
-                                    Some(existing.to_vec())
-                                }
-                                None => Some(AppCookieStickinessPoliciesDeserializer::deserialize(
-                                    "AppCookieStickinessPolicies",
-                                    stack,
-                                )?),
-                            };
-                    }
-                    "LBCookieStickinessPolicies" => {
-                        obj.lb_cookie_stickiness_policies = match obj.lb_cookie_stickiness_policies
-                        {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    LBCookieStickinessPoliciesDeserializer::deserialize(
-                                        "LBCookieStickinessPolicies",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(LBCookieStickinessPoliciesDeserializer::deserialize(
-                                "LBCookieStickinessPolicies",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "OtherPolicies" => {
-                        obj.other_policies = match obj.other_policies {
-                            Some(ref mut existing) => {
-                                existing.extend(PolicyNamesDeserializer::deserialize(
-                                    "OtherPolicies",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(PolicyNamesDeserializer::deserialize(
-                                "OtherPolicies",
-                                stack,
-                            )?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "LBCookieStickinessPolicies" => {
+                    obj.lb_cookie_stickiness_policies
+                        .get_or_insert(vec![])
+                        .extend(LBCookieStickinessPoliciesDeserializer::deserialize(
+                            "LBCookieStickinessPolicies",
+                            stack,
+                        )?);
                 }
+                "OtherPolicies" => {
+                    obj.other_policies.get_or_insert(vec![]).extend(
+                        PolicyNamesDeserializer::deserialize("OtherPolicies", stack)?,
+                    );
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Information about a policy attribute.</p>
@@ -4151,21 +3122,11 @@ impl PolicyAttributeDescriptionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<PolicyAttributeDescription, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = PolicyAttributeDescription::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, PolicyAttributeDescription, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AttributeName" => {
                         obj.attribute_name = Some(AttributeNameDeserializer::deserialize(
                             "AttributeName",
@@ -4179,17 +3140,10 @@ impl PolicyAttributeDescriptionDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct PolicyAttributeDescriptionsDeserializer;
@@ -4199,39 +3153,16 @@ impl PolicyAttributeDescriptionsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<PolicyAttributeDescription>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(PolicyAttributeDescriptionDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(PolicyAttributeDescriptionDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Information about a policy attribute type.</p>
@@ -4256,21 +3187,11 @@ impl PolicyAttributeTypeDescriptionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<PolicyAttributeTypeDescription, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = PolicyAttributeTypeDescription::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, PolicyAttributeTypeDescription, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AttributeName" => {
                         obj.attribute_name = Some(AttributeNameDeserializer::deserialize(
                             "AttributeName",
@@ -4298,17 +3219,10 @@ impl PolicyAttributeTypeDescriptionDeserializer {
                             Some(DescriptionDeserializer::deserialize("Description", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct PolicyAttributeTypeDescriptionsDeserializer;
@@ -4318,39 +3232,16 @@ impl PolicyAttributeTypeDescriptionsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<PolicyAttributeTypeDescription>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(PolicyAttributeTypeDescriptionDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(PolicyAttributeTypeDescriptionDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -4383,61 +3274,30 @@ impl PolicyDescriptionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<PolicyDescription, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = PolicyDescription::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "PolicyAttributeDescriptions" => {
-                        obj.policy_attribute_descriptions = match obj.policy_attribute_descriptions
-                        {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    PolicyAttributeDescriptionsDeserializer::deserialize(
-                                        "PolicyAttributeDescriptions",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(PolicyAttributeDescriptionsDeserializer::deserialize(
-                                "PolicyAttributeDescriptions",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "PolicyName" => {
-                        obj.policy_name =
-                            Some(PolicyNameDeserializer::deserialize("PolicyName", stack)?);
-                    }
-                    "PolicyTypeName" => {
-                        obj.policy_type_name = Some(PolicyTypeNameDeserializer::deserialize(
-                            "PolicyTypeName",
+        deserialize_elements::<_, PolicyDescription, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "PolicyAttributeDescriptions" => {
+                    obj.policy_attribute_descriptions
+                        .get_or_insert(vec![])
+                        .extend(PolicyAttributeDescriptionsDeserializer::deserialize(
+                            "PolicyAttributeDescriptions",
                             stack,
                         )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                "PolicyName" => {
+                    obj.policy_name =
+                        Some(PolicyNameDeserializer::deserialize("PolicyName", stack)?);
+                }
+                "PolicyTypeName" => {
+                    obj.policy_type_name = Some(PolicyTypeNameDeserializer::deserialize(
+                        "PolicyTypeName",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PolicyDescriptionsDeserializer;
@@ -4447,37 +3307,14 @@ impl PolicyDescriptionsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<PolicyDescription>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(PolicyDescriptionDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(PolicyDescriptionDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PolicyNameDeserializer;
@@ -4501,37 +3338,14 @@ impl PolicyNamesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(PolicyNameDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(PolicyNameDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -4564,62 +3378,30 @@ impl PolicyTypeDescriptionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<PolicyTypeDescription, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = PolicyTypeDescription::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, PolicyTypeDescription, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Description" => {
+                    obj.description =
+                        Some(DescriptionDeserializer::deserialize("Description", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Description" => {
-                        obj.description =
-                            Some(DescriptionDeserializer::deserialize("Description", stack)?);
-                    }
-                    "PolicyAttributeTypeDescriptions" => {
-                        obj.policy_attribute_type_descriptions = match obj
-                            .policy_attribute_type_descriptions
-                        {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    PolicyAttributeTypeDescriptionsDeserializer::deserialize(
-                                        "PolicyAttributeTypeDescriptions",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(PolicyAttributeTypeDescriptionsDeserializer::deserialize(
-                                "PolicyAttributeTypeDescriptions",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "PolicyTypeName" => {
-                        obj.policy_type_name = Some(PolicyTypeNameDeserializer::deserialize(
-                            "PolicyTypeName",
+                "PolicyAttributeTypeDescriptions" => {
+                    obj.policy_attribute_type_descriptions
+                        .get_or_insert(vec![])
+                        .extend(PolicyAttributeTypeDescriptionsDeserializer::deserialize(
+                            "PolicyAttributeTypeDescriptions",
                             stack,
                         )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                "PolicyTypeName" => {
+                    obj.policy_type_name = Some(PolicyTypeNameDeserializer::deserialize(
+                        "PolicyTypeName",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PolicyTypeDescriptionsDeserializer;
@@ -4629,39 +3411,16 @@ impl PolicyTypeDescriptionsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<PolicyTypeDescription>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(PolicyTypeDescriptionDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(PolicyTypeDescriptionDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PolicyTypeNameDeserializer;
@@ -4773,45 +3532,21 @@ impl RegisterEndPointsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<RegisterEndPointsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = RegisterEndPointsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, RegisterEndPointsOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Instances" => {
-                        obj.instances = match obj.instances {
-                            Some(ref mut existing) => {
-                                existing.extend(InstancesDeserializer::deserialize(
-                                    "Instances",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(InstancesDeserializer::deserialize("Instances", stack)?),
-                        };
+                        obj.instances
+                            .get_or_insert(vec![])
+                            .extend(InstancesDeserializer::deserialize("Instances", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Contains the parameters for DisableAvailabilityZonesForLoadBalancer.</p>
@@ -4858,48 +3593,21 @@ impl RemoveAvailabilityZonesOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<RemoveAvailabilityZonesOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = RemoveAvailabilityZonesOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, RemoveAvailabilityZonesOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AvailabilityZones" => {
-                        obj.availability_zones = match obj.availability_zones {
-                            Some(ref mut existing) => {
-                                existing.extend(AvailabilityZonesDeserializer::deserialize(
-                                    "AvailabilityZones",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(AvailabilityZonesDeserializer::deserialize(
-                                "AvailabilityZones",
-                                stack,
-                            )?),
-                        };
+                        obj.availability_zones.get_or_insert(vec![]).extend(
+                            AvailabilityZonesDeserializer::deserialize("AvailabilityZones", stack)?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Contains the parameters for RemoveTags.</p>
@@ -5026,37 +3734,14 @@ impl SecurityGroupsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(SecurityGroupIdDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(SecurityGroupIdDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -5262,45 +3947,24 @@ impl SourceSecurityGroupDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<SourceSecurityGroup, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = SourceSecurityGroup::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, SourceSecurityGroup, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "GroupName" => {
+                    obj.group_name = Some(SecurityGroupNameDeserializer::deserialize(
+                        "GroupName",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "GroupName" => {
-                        obj.group_name = Some(SecurityGroupNameDeserializer::deserialize(
-                            "GroupName",
-                            stack,
-                        )?);
-                    }
-                    "OwnerAlias" => {
-                        obj.owner_alias = Some(SecurityGroupOwnerAliasDeserializer::deserialize(
-                            "OwnerAlias",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "OwnerAlias" => {
+                    obj.owner_alias = Some(SecurityGroupOwnerAliasDeserializer::deserialize(
+                        "OwnerAlias",
+                        stack,
+                    )?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct StateDeserializer;
@@ -5338,37 +4002,14 @@ impl SubnetsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(SubnetIdDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(SubnetIdDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -5399,39 +4040,18 @@ impl TagDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Tag, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Tag::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Tag, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Key" => {
+                    obj.key = TagKeyDeserializer::deserialize("Key", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Key" => {
-                        obj.key = TagKeyDeserializer::deserialize("Key", stack)?;
-                    }
-                    "Value" => {
-                        obj.value = Some(TagValueDeserializer::deserialize("Value", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Value" => {
+                    obj.value = Some(TagValueDeserializer::deserialize("Value", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -5467,48 +4087,23 @@ impl TagDescriptionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<TagDescription, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = TagDescription::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, TagDescription, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "LoadBalancerName" => {
+                    obj.load_balancer_name = Some(AccessPointNameDeserializer::deserialize(
+                        "LoadBalancerName",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "LoadBalancerName" => {
-                        obj.load_balancer_name = Some(AccessPointNameDeserializer::deserialize(
-                            "LoadBalancerName",
-                            stack,
-                        )?);
-                    }
-                    "Tags" => {
-                        obj.tags = match obj.tags {
-                            Some(ref mut existing) => {
-                                existing.extend(TagListDeserializer::deserialize("Tags", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(TagListDeserializer::deserialize("Tags", stack)?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Tags" => {
+                    obj.tags
+                        .get_or_insert(vec![])
+                        .extend(TagListDeserializer::deserialize("Tags", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct TagDescriptionsDeserializer;
@@ -5518,37 +4113,14 @@ impl TagDescriptionsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<TagDescription>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(TagDescriptionDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(TagDescriptionDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct TagKeyDeserializer;
@@ -5606,37 +4178,14 @@ impl TagListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Tag>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(TagDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(TagDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 

--- a/rusoto/services/iam/src/generated.rs
+++ b/rusoto/services/iam/src/generated.rs
@@ -25,20 +25,15 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
 use rusoto_core::xmlutil::{
-    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+    characters, deserialize_elements, end_element, find_start_element, peek_at_name, skip_tree,
+    start_element,
 };
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;
-use xml::reader::XmlEvent;
 use xml::EventReader;
 
-enum DeserializerNext {
-    Close,
-    Skip,
-    Element(String),
-}
 /// <p><p>Contains information about an AWS access key.</p> <p> This data type is used as a response element in the <a>CreateAccessKey</a> and <a>ListAccessKeys</a> operations. </p> <note> <p>The <code>SecretAccessKey</code> value is returned only in response to <a>CreateAccessKey</a>. You can get a secret access key only when you first create an access key; you cannot recover the secret access key later. If you lose a secret access key, you must create a new access key.</p> </note></p>
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct AccessKey {
@@ -61,51 +56,29 @@ impl AccessKeyDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AccessKey, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AccessKey::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, AccessKey, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AccessKeyId" => {
+                    obj.access_key_id =
+                        AccessKeyIdTypeDeserializer::deserialize("AccessKeyId", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AccessKeyId" => {
-                        obj.access_key_id =
-                            AccessKeyIdTypeDeserializer::deserialize("AccessKeyId", stack)?;
-                    }
-                    "CreateDate" => {
-                        obj.create_date =
-                            Some(DateTypeDeserializer::deserialize("CreateDate", stack)?);
-                    }
-                    "SecretAccessKey" => {
-                        obj.secret_access_key =
-                            AccessKeySecretTypeDeserializer::deserialize("SecretAccessKey", stack)?;
-                    }
-                    "Status" => {
-                        obj.status = StatusTypeDeserializer::deserialize("Status", stack)?;
-                    }
-                    "UserName" => {
-                        obj.user_name = UserNameTypeDeserializer::deserialize("UserName", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "CreateDate" => {
+                    obj.create_date = Some(DateTypeDeserializer::deserialize("CreateDate", stack)?);
                 }
+                "SecretAccessKey" => {
+                    obj.secret_access_key =
+                        AccessKeySecretTypeDeserializer::deserialize("SecretAccessKey", stack)?;
+                }
+                "Status" => {
+                    obj.status = StatusTypeDeserializer::deserialize("Status", stack)?;
+                }
+                "UserName" => {
+                    obj.user_name = UserNameTypeDeserializer::deserialize("UserName", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct AccessKeyIdTypeDeserializer;
@@ -140,44 +113,21 @@ impl AccessKeyLastUsedDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AccessKeyLastUsed, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AccessKeyLastUsed::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, AccessKeyLastUsed, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "LastUsedDate" => {
+                    obj.last_used_date = DateTypeDeserializer::deserialize("LastUsedDate", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "LastUsedDate" => {
-                        obj.last_used_date =
-                            DateTypeDeserializer::deserialize("LastUsedDate", stack)?;
-                    }
-                    "Region" => {
-                        obj.region = StringTypeDeserializer::deserialize("Region", stack)?;
-                    }
-                    "ServiceName" => {
-                        obj.service_name =
-                            StringTypeDeserializer::deserialize("ServiceName", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Region" => {
+                    obj.region = StringTypeDeserializer::deserialize("Region", stack)?;
                 }
+                "ServiceName" => {
+                    obj.service_name = StringTypeDeserializer::deserialize("ServiceName", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains information about an AWS access key, without its secret key.</p> <p>This data type is used as a response element in the <a>ListAccessKeys</a> operation.</p>
@@ -200,50 +150,27 @@ impl AccessKeyMetadataDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AccessKeyMetadata, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AccessKeyMetadata::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, AccessKeyMetadata, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AccessKeyId" => {
+                    obj.access_key_id = Some(AccessKeyIdTypeDeserializer::deserialize(
+                        "AccessKeyId",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AccessKeyId" => {
-                        obj.access_key_id = Some(AccessKeyIdTypeDeserializer::deserialize(
-                            "AccessKeyId",
-                            stack,
-                        )?);
-                    }
-                    "CreateDate" => {
-                        obj.create_date =
-                            Some(DateTypeDeserializer::deserialize("CreateDate", stack)?);
-                    }
-                    "Status" => {
-                        obj.status = Some(StatusTypeDeserializer::deserialize("Status", stack)?);
-                    }
-                    "UserName" => {
-                        obj.user_name =
-                            Some(UserNameTypeDeserializer::deserialize("UserName", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "CreateDate" => {
+                    obj.create_date = Some(DateTypeDeserializer::deserialize("CreateDate", stack)?);
                 }
+                "Status" => {
+                    obj.status = Some(StatusTypeDeserializer::deserialize("Status", stack)?);
+                }
+                "UserName" => {
+                    obj.user_name = Some(UserNameTypeDeserializer::deserialize("UserName", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct AccessKeyMetadataListTypeDeserializer;
@@ -253,37 +180,14 @@ impl AccessKeyMetadataListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<AccessKeyMetadata>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(AccessKeyMetadataDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(AccessKeyMetadataDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct AccessKeySecretTypeDeserializer;
@@ -307,37 +211,14 @@ impl AccountAliasListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(AccountAliasTypeDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(AccountAliasTypeDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct AccountAliasTypeDeserializer;
@@ -459,37 +340,14 @@ impl ArnListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(ArnTypeDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(ArnTypeDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ArnTypeDeserializer;
@@ -588,21 +446,11 @@ impl AttachedPermissionsBoundaryDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AttachedPermissionsBoundary, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AttachedPermissionsBoundary::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, AttachedPermissionsBoundary, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "PermissionsBoundaryArn" => {
                         obj.permissions_boundary_arn = Some(ArnTypeDeserializer::deserialize(
                             "PermissionsBoundaryArn",
@@ -617,17 +465,10 @@ impl AttachedPermissionsBoundaryDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct AttachedPoliciesListTypeDeserializer;
@@ -637,37 +478,14 @@ impl AttachedPoliciesListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<AttachedPolicy>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(AttachedPolicyDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(AttachedPolicyDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains information about an attached policy.</p> <p>An attached policy is a managed policy that has been attached to a user, group, or role. This data type is used as a response element in the <a>ListAttachedGroupPolicies</a>, <a>ListAttachedRolePolicies</a>, <a>ListAttachedUserPolicies</a>, and <a>GetAccountAuthorizationDetails</a> operations. </p> <p>For more information about managed policies, refer to <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>
@@ -685,43 +503,21 @@ impl AttachedPolicyDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AttachedPolicy, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AttachedPolicy::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, AttachedPolicy, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "PolicyArn" => {
+                    obj.policy_arn = Some(ArnTypeDeserializer::deserialize("PolicyArn", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "PolicyArn" => {
-                        obj.policy_arn =
-                            Some(ArnTypeDeserializer::deserialize("PolicyArn", stack)?);
-                    }
-                    "PolicyName" => {
-                        obj.policy_name = Some(PolicyNameTypeDeserializer::deserialize(
-                            "PolicyName",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "PolicyName" => {
+                    obj.policy_name = Some(PolicyNameTypeDeserializer::deserialize(
+                        "PolicyName",
+                        stack,
+                    )?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct AttachmentCountTypeDeserializer;
@@ -829,39 +625,16 @@ impl CertificateListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<SigningCertificate>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(SigningCertificateDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(SigningCertificateDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -893,37 +666,14 @@ impl ClientIDListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(ClientIDTypeDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(ClientIDTypeDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -1034,39 +784,16 @@ impl ContextKeyNamesResultListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(ContextKeyNameTypeDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(ContextKeyNameTypeDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -1116,36 +843,19 @@ impl CreateAccessKeyResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateAccessKeyResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateAccessKeyResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateAccessKeyResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AccessKey" => {
                         obj.access_key = AccessKeyDeserializer::deserialize("AccessKey", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -1205,36 +915,15 @@ impl CreateGroupResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateGroupResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateGroupResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CreateGroupResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Group" => {
+                    obj.group = GroupDeserializer::deserialize("Group", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Group" => {
-                        obj.group = GroupDeserializer::deserialize("Group", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -1278,37 +967,20 @@ impl CreateInstanceProfileResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateInstanceProfileResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateInstanceProfileResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateInstanceProfileResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "InstanceProfile" => {
                         obj.instance_profile =
                             InstanceProfileDeserializer::deserialize("InstanceProfile", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -1355,37 +1027,20 @@ impl CreateLoginProfileResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateLoginProfileResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateLoginProfileResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateLoginProfileResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "LoginProfile" => {
                         obj.login_profile =
                             LoginProfileDeserializer::deserialize("LoginProfile", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -1437,21 +1092,11 @@ impl CreateOpenIDConnectProviderResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateOpenIDConnectProviderResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateOpenIDConnectProviderResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateOpenIDConnectProviderResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "OpenIDConnectProviderArn" => {
                         obj.open_id_connect_provider_arn = Some(ArnTypeDeserializer::deserialize(
                             "OpenIDConnectProviderArn",
@@ -1459,17 +1104,10 @@ impl CreateOpenIDConnectProviderResponseDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -1521,36 +1159,15 @@ impl CreatePolicyResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreatePolicyResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreatePolicyResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CreatePolicyResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Policy" => {
+                    obj.policy = Some(PolicyDeserializer::deserialize("Policy", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Policy" => {
-                        obj.policy = Some(PolicyDeserializer::deserialize("Policy", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -1600,21 +1217,11 @@ impl CreatePolicyVersionResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreatePolicyVersionResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreatePolicyVersionResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreatePolicyVersionResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "PolicyVersion" => {
                         obj.policy_version = Some(PolicyVersionDeserializer::deserialize(
                             "PolicyVersion",
@@ -1622,17 +1229,10 @@ impl CreatePolicyVersionResponseDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -1705,36 +1305,15 @@ impl CreateRoleResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateRoleResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateRoleResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CreateRoleResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Role" => {
+                    obj.role = RoleDeserializer::deserialize("Role", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Role" => {
-                        obj.role = RoleDeserializer::deserialize("Role", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -1776,37 +1355,20 @@ impl CreateSAMLProviderResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateSAMLProviderResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateSAMLProviderResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateSAMLProviderResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "SAMLProviderArn" => {
                         obj.saml_provider_arn =
                             Some(ArnTypeDeserializer::deserialize("SAMLProviderArn", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -1854,36 +1416,19 @@ impl CreateServiceLinkedRoleResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateServiceLinkedRoleResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateServiceLinkedRoleResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateServiceLinkedRoleResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Role" => {
                         obj.role = Some(RoleDeserializer::deserialize("Role", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -1921,21 +1466,11 @@ impl CreateServiceSpecificCredentialResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateServiceSpecificCredentialResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateServiceSpecificCredentialResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateServiceSpecificCredentialResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ServiceSpecificCredential" => {
                         obj.service_specific_credential =
                             Some(ServiceSpecificCredentialDeserializer::deserialize(
@@ -1944,17 +1479,10 @@ impl CreateServiceSpecificCredentialResponseDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -2008,36 +1536,15 @@ impl CreateUserResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateUserResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateUserResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CreateUserResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "User" => {
+                    obj.user = Some(UserDeserializer::deserialize("User", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "User" => {
-                        obj.user = Some(UserDeserializer::deserialize("User", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -2081,37 +1588,20 @@ impl CreateVirtualMFADeviceResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateVirtualMFADeviceResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateVirtualMFADeviceResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateVirtualMFADeviceResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "VirtualMFADevice" => {
                         obj.virtual_mfa_device =
                             VirtualMFADeviceDeserializer::deserialize("VirtualMFADevice", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct DateTypeDeserializer;
@@ -2499,37 +1989,20 @@ impl DeleteServiceLinkedRoleResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DeleteServiceLinkedRoleResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DeleteServiceLinkedRoleResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DeleteServiceLinkedRoleResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DeletionTaskId" => {
                         obj.deletion_task_id =
                             DeletionTaskIdTypeDeserializer::deserialize("DeletionTaskId", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -2681,51 +2154,24 @@ impl DeletionTaskFailureReasonTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DeletionTaskFailureReasonType, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DeletionTaskFailureReasonType::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DeletionTaskFailureReasonType, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Reason" => {
                         obj.reason = Some(ReasonTypeDeserializer::deserialize("Reason", stack)?);
                     }
                     "RoleUsageList" => {
-                        obj.role_usage_list = match obj.role_usage_list {
-                            Some(ref mut existing) => {
-                                existing.extend(RoleUsageListTypeDeserializer::deserialize(
-                                    "RoleUsageList",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(RoleUsageListTypeDeserializer::deserialize(
-                                "RoleUsageList",
-                                stack,
-                            )?),
-                        };
+                        obj.role_usage_list.get_or_insert(vec![]).extend(
+                            RoleUsageListTypeDeserializer::deserialize("RoleUsageList", stack)?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct DeletionTaskIdTypeDeserializer;
@@ -2872,42 +2318,21 @@ impl EntityDetailsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<EntityDetails, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = EntityDetails::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, EntityDetails, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "EntityInfo" => {
+                    obj.entity_info = EntityInfoDeserializer::deserialize("EntityInfo", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "EntityInfo" => {
-                        obj.entity_info = EntityInfoDeserializer::deserialize("EntityInfo", stack)?;
-                    }
-                    "LastAuthenticated" => {
-                        obj.last_authenticated = Some(DateTypeDeserializer::deserialize(
-                            "LastAuthenticated",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "LastAuthenticated" => {
+                    obj.last_authenticated = Some(DateTypeDeserializer::deserialize(
+                        "LastAuthenticated",
+                        stack,
+                    )?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct EntityDetailsListTypeDeserializer;
@@ -2917,37 +2342,14 @@ impl EntityDetailsListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<EntityDetails>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(EntityDetailsDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(EntityDetailsDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains details about the specified entity (user or role).</p> <p>This data type is an element of the <a>EntityDetails</a> object.</p>
@@ -2971,48 +2373,27 @@ impl EntityInfoDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<EntityInfo, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = EntityInfo::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, EntityInfo, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Arn" => {
+                    obj.arn = ArnTypeDeserializer::deserialize("Arn", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Arn" => {
-                        obj.arn = ArnTypeDeserializer::deserialize("Arn", stack)?;
-                    }
-                    "Id" => {
-                        obj.id = IdTypeDeserializer::deserialize("Id", stack)?;
-                    }
-                    "Name" => {
-                        obj.name = UserNameTypeDeserializer::deserialize("Name", stack)?;
-                    }
-                    "Path" => {
-                        obj.path = Some(PathTypeDeserializer::deserialize("Path", stack)?);
-                    }
-                    "Type" => {
-                        obj.type_ = PolicyOwnerEntityTypeDeserializer::deserialize("Type", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Id" => {
+                    obj.id = IdTypeDeserializer::deserialize("Id", stack)?;
                 }
+                "Name" => {
+                    obj.name = UserNameTypeDeserializer::deserialize("Name", stack)?;
+                }
+                "Path" => {
+                    obj.path = Some(PathTypeDeserializer::deserialize("Path", stack)?);
+                }
+                "Type" => {
+                    obj.type_ = PolicyOwnerEntityTypeDeserializer::deserialize("Type", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -3057,39 +2438,18 @@ impl ErrorDetailsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ErrorDetails, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ErrorDetails::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ErrorDetails, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Code" => {
+                    obj.code = StringTypeDeserializer::deserialize("Code", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Code" => {
-                        obj.code = StringTypeDeserializer::deserialize("Code", stack)?;
-                    }
-                    "Message" => {
-                        obj.message = StringTypeDeserializer::deserialize("Message", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Message" => {
+                    obj.message = StringTypeDeserializer::deserialize("Message", stack)?;
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct EvalDecisionDetailsTypeDeserializer;
@@ -3157,112 +2517,63 @@ impl EvaluationResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<EvaluationResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = EvaluationResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, EvaluationResult, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "EvalActionName" => {
+                    obj.eval_action_name =
+                        ActionNameTypeDeserializer::deserialize("EvalActionName", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "EvalActionName" => {
-                        obj.eval_action_name =
-                            ActionNameTypeDeserializer::deserialize("EvalActionName", stack)?;
-                    }
-                    "EvalDecision" => {
-                        obj.eval_decision = PolicyEvaluationDecisionTypeDeserializer::deserialize(
-                            "EvalDecision",
-                            stack,
-                        )?;
-                    }
-                    "EvalDecisionDetails" => {
-                        obj.eval_decision_details =
-                            Some(EvalDecisionDetailsTypeDeserializer::deserialize(
-                                "EvalDecisionDetails",
-                                stack,
-                            )?);
-                    }
-                    "EvalResourceName" => {
-                        obj.eval_resource_name = Some(ResourceNameTypeDeserializer::deserialize(
-                            "EvalResourceName",
+                "EvalDecision" => {
+                    obj.eval_decision = PolicyEvaluationDecisionTypeDeserializer::deserialize(
+                        "EvalDecision",
+                        stack,
+                    )?;
+                }
+                "EvalDecisionDetails" => {
+                    obj.eval_decision_details =
+                        Some(EvalDecisionDetailsTypeDeserializer::deserialize(
+                            "EvalDecisionDetails",
                             stack,
                         )?);
-                    }
-                    "MatchedStatements" => {
-                        obj.matched_statements = match obj.matched_statements {
-                            Some(ref mut existing) => {
-                                existing.extend(StatementListTypeDeserializer::deserialize(
-                                    "MatchedStatements",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(StatementListTypeDeserializer::deserialize(
-                                "MatchedStatements",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "MissingContextValues" => {
-                        obj.missing_context_values = match obj.missing_context_values {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    ContextKeyNamesResultListTypeDeserializer::deserialize(
-                                        "MissingContextValues",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ContextKeyNamesResultListTypeDeserializer::deserialize(
-                                "MissingContextValues",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "OrganizationsDecisionDetail" => {
-                        obj.organizations_decision_detail =
-                            Some(OrganizationsDecisionDetailDeserializer::deserialize(
-                                "OrganizationsDecisionDetail",
-                                stack,
-                            )?);
-                    }
-                    "ResourceSpecificResults" => {
-                        obj.resource_specific_results = match obj.resource_specific_results {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    ResourceSpecificResultListTypeDeserializer::deserialize(
-                                        "ResourceSpecificResults",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ResourceSpecificResultListTypeDeserializer::deserialize(
-                                "ResourceSpecificResults",
-                                stack,
-                            )?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                "EvalResourceName" => {
+                    obj.eval_resource_name = Some(ResourceNameTypeDeserializer::deserialize(
+                        "EvalResourceName",
+                        stack,
+                    )?);
+                }
+                "MatchedStatements" => {
+                    obj.matched_statements.get_or_insert(vec![]).extend(
+                        StatementListTypeDeserializer::deserialize("MatchedStatements", stack)?,
+                    );
+                }
+                "MissingContextValues" => {
+                    obj.missing_context_values.get_or_insert(vec![]).extend(
+                        ContextKeyNamesResultListTypeDeserializer::deserialize(
+                            "MissingContextValues",
+                            stack,
+                        )?,
+                    );
+                }
+                "OrganizationsDecisionDetail" => {
+                    obj.organizations_decision_detail =
+                        Some(OrganizationsDecisionDetailDeserializer::deserialize(
+                            "OrganizationsDecisionDetail",
+                            stack,
+                        )?);
+                }
+                "ResourceSpecificResults" => {
+                    obj.resource_specific_results.get_or_insert(vec![]).extend(
+                        ResourceSpecificResultListTypeDeserializer::deserialize(
+                            "ResourceSpecificResults",
+                            stack,
+                        )?,
+                    );
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct EvaluationResultsListTypeDeserializer;
@@ -3272,37 +2583,14 @@ impl EvaluationResultsListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<EvaluationResult>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(EvaluationResultDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(EvaluationResultDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ExistingUserNameTypeDeserializer;
@@ -3335,21 +2623,11 @@ impl GenerateCredentialReportResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GenerateCredentialReportResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GenerateCredentialReportResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GenerateCredentialReportResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Description" => {
                         obj.description =
                             Some(ReportStateDescriptionTypeDeserializer::deserialize(
@@ -3361,17 +2639,10 @@ impl GenerateCredentialReportResponseDeserializer {
                         obj.state = Some(ReportStateTypeDeserializer::deserialize("State", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -3406,36 +2677,19 @@ impl GenerateServiceLastAccessedDetailsResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GenerateServiceLastAccessedDetailsResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GenerateServiceLastAccessedDetailsResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GenerateServiceLastAccessedDetailsResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "JobId" => {
                         obj.job_id = Some(JobIDTypeDeserializer::deserialize("JobId", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -3473,21 +2727,11 @@ impl GetAccessKeyLastUsedResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetAccessKeyLastUsedResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetAccessKeyLastUsedResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetAccessKeyLastUsedResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AccessKeyLastUsed" => {
                         obj.access_key_last_used = Some(
                             AccessKeyLastUsedDeserializer::deserialize("AccessKeyLastUsed", stack)?,
@@ -3499,17 +2743,10 @@ impl GetAccessKeyLastUsedResponseDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -3574,35 +2811,15 @@ impl GetAccountAuthorizationDetailsResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetAccountAuthorizationDetailsResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetAccountAuthorizationDetailsResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetAccountAuthorizationDetailsResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "GroupDetailList" => {
-                        obj.group_detail_list = match obj.group_detail_list {
-                            Some(ref mut existing) => {
-                                existing.extend(GroupDetailListTypeDeserializer::deserialize(
-                                    "GroupDetailList",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(GroupDetailListTypeDeserializer::deserialize(
-                                "GroupDetailList",
-                                stack,
-                            )?),
-                        };
+                        obj.group_detail_list.get_or_insert(vec![]).extend(
+                            GroupDetailListTypeDeserializer::deserialize("GroupDetailList", stack)?,
+                        );
                     }
                     "IsTruncated" => {
                         obj.is_truncated =
@@ -3612,62 +2829,27 @@ impl GetAccountAuthorizationDetailsResponseDeserializer {
                         obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
                     }
                     "Policies" => {
-                        obj.policies = match obj.policies {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    ManagedPolicyDetailListTypeDeserializer::deserialize(
-                                        "Policies", stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ManagedPolicyDetailListTypeDeserializer::deserialize(
+                        obj.policies.get_or_insert(vec![]).extend(
+                            ManagedPolicyDetailListTypeDeserializer::deserialize(
                                 "Policies", stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     "RoleDetailList" => {
-                        obj.role_detail_list = match obj.role_detail_list {
-                            Some(ref mut existing) => {
-                                existing.extend(RoleDetailListTypeDeserializer::deserialize(
-                                    "RoleDetailList",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(RoleDetailListTypeDeserializer::deserialize(
-                                "RoleDetailList",
-                                stack,
-                            )?),
-                        };
+                        obj.role_detail_list.get_or_insert(vec![]).extend(
+                            RoleDetailListTypeDeserializer::deserialize("RoleDetailList", stack)?,
+                        );
                     }
                     "UserDetailList" => {
-                        obj.user_detail_list = match obj.user_detail_list {
-                            Some(ref mut existing) => {
-                                existing.extend(UserDetailListTypeDeserializer::deserialize(
-                                    "UserDetailList",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(UserDetailListTypeDeserializer::deserialize(
-                                "UserDetailList",
-                                stack,
-                            )?),
-                        };
+                        obj.user_detail_list.get_or_insert(vec![]).extend(
+                            UserDetailListTypeDeserializer::deserialize("UserDetailList", stack)?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Contains the response to a successful <a>GetAccountPasswordPolicy</a> request. </p>
@@ -3684,37 +2866,20 @@ impl GetAccountPasswordPolicyResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetAccountPasswordPolicyResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetAccountPasswordPolicyResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetAccountPasswordPolicyResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "PasswordPolicy" => {
                         obj.password_policy =
                             PasswordPolicyDeserializer::deserialize("PasswordPolicy", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Contains the response to a successful <a>GetAccountSummary</a> request. </p>
@@ -3731,21 +2896,11 @@ impl GetAccountSummaryResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetAccountSummaryResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetAccountSummaryResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetAccountSummaryResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "SummaryMap" => {
                         obj.summary_map = Some(SummaryMapTypeDeserializer::deserialize(
                             "SummaryMap",
@@ -3753,17 +2908,10 @@ impl GetAccountSummaryResponseDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -3803,50 +2951,24 @@ impl GetContextKeysForPolicyResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetContextKeysForPolicyResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetContextKeysForPolicyResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetContextKeysForPolicyResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ContextKeyNames" => {
-                        obj.context_key_names = match obj.context_key_names {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    ContextKeyNamesResultListTypeDeserializer::deserialize(
-                                        "ContextKeyNames",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ContextKeyNamesResultListTypeDeserializer::deserialize(
+                        obj.context_key_names.get_or_insert(vec![]).extend(
+                            ContextKeyNamesResultListTypeDeserializer::deserialize(
                                 "ContextKeyNames",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -3898,21 +3020,11 @@ impl GetCredentialReportResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetCredentialReportResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetCredentialReportResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetCredentialReportResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Content" => {
                         obj.content = Some(ReportContentTypeDeserializer::deserialize(
                             "Content", stack,
@@ -3929,17 +3041,10 @@ impl GetCredentialReportResponseDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -3982,45 +3087,22 @@ impl GetGroupPolicyResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetGroupPolicyResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetGroupPolicyResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, GetGroupPolicyResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "GroupName" => {
+                    obj.group_name = GroupNameTypeDeserializer::deserialize("GroupName", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "GroupName" => {
-                        obj.group_name =
-                            GroupNameTypeDeserializer::deserialize("GroupName", stack)?;
-                    }
-                    "PolicyDocument" => {
-                        obj.policy_document =
-                            PolicyDocumentTypeDeserializer::deserialize("PolicyDocument", stack)?;
-                    }
-                    "PolicyName" => {
-                        obj.policy_name =
-                            PolicyNameTypeDeserializer::deserialize("PolicyName", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "PolicyDocument" => {
+                    obj.policy_document =
+                        PolicyDocumentTypeDeserializer::deserialize("PolicyDocument", stack)?;
                 }
+                "PolicyName" => {
+                    obj.policy_name = PolicyNameTypeDeserializer::deserialize("PolicyName", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -4075,47 +3157,26 @@ impl GetGroupResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetGroupResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetGroupResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, GetGroupResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Group" => {
+                    obj.group = GroupDeserializer::deserialize("Group", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Group" => {
-                        obj.group = GroupDeserializer::deserialize("Group", stack)?;
-                    }
-                    "IsTruncated" => {
-                        obj.is_truncated =
-                            Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
-                    }
-                    "Marker" => {
-                        obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
-                    }
-                    "Users" => {
-                        obj.users
-                            .extend(UserListTypeDeserializer::deserialize("Users", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "IsTruncated" => {
+                    obj.is_truncated =
+                        Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
                 }
+                "Marker" => {
+                    obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
+                }
+                "Users" => {
+                    obj.users
+                        .extend(UserListTypeDeserializer::deserialize("Users", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -4154,37 +3215,20 @@ impl GetInstanceProfileResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetInstanceProfileResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetInstanceProfileResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetInstanceProfileResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "InstanceProfile" => {
                         obj.instance_profile =
                             InstanceProfileDeserializer::deserialize("InstanceProfile", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -4220,37 +3264,20 @@ impl GetLoginProfileResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetLoginProfileResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetLoginProfileResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetLoginProfileResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "LoginProfile" => {
                         obj.login_profile =
                             LoginProfileDeserializer::deserialize("LoginProfile", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -4295,54 +3322,24 @@ impl GetOpenIDConnectProviderResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetOpenIDConnectProviderResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetOpenIDConnectProviderResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetOpenIDConnectProviderResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ClientIDList" => {
-                        obj.client_id_list = match obj.client_id_list {
-                            Some(ref mut existing) => {
-                                existing.extend(ClientIDListTypeDeserializer::deserialize(
-                                    "ClientIDList",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ClientIDListTypeDeserializer::deserialize(
-                                "ClientIDList",
-                                stack,
-                            )?),
-                        };
+                        obj.client_id_list.get_or_insert(vec![]).extend(
+                            ClientIDListTypeDeserializer::deserialize("ClientIDList", stack)?,
+                        );
                     }
                     "CreateDate" => {
                         obj.create_date =
                             Some(DateTypeDeserializer::deserialize("CreateDate", stack)?);
                     }
                     "ThumbprintList" => {
-                        obj.thumbprint_list = match obj.thumbprint_list {
-                            Some(ref mut existing) => {
-                                existing.extend(ThumbprintListTypeDeserializer::deserialize(
-                                    "ThumbprintList",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ThumbprintListTypeDeserializer::deserialize(
-                                "ThumbprintList",
-                                stack,
-                            )?),
-                        };
+                        obj.thumbprint_list.get_or_insert(vec![]).extend(
+                            ThumbprintListTypeDeserializer::deserialize("ThumbprintList", stack)?,
+                        );
                     }
                     "Url" => {
                         obj.url = Some(OpenIDConnectProviderUrlTypeDeserializer::deserialize(
@@ -4350,17 +3347,10 @@ impl GetOpenIDConnectProviderResponseDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -4396,36 +3386,15 @@ impl GetPolicyResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetPolicyResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetPolicyResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, GetPolicyResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Policy" => {
+                    obj.policy = Some(PolicyDeserializer::deserialize("Policy", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Policy" => {
-                        obj.policy = Some(PolicyDeserializer::deserialize("Policy", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -4464,21 +3433,11 @@ impl GetPolicyVersionResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetPolicyVersionResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetPolicyVersionResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetPolicyVersionResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "PolicyVersion" => {
                         obj.policy_version = Some(PolicyVersionDeserializer::deserialize(
                             "PolicyVersion",
@@ -4486,17 +3445,10 @@ impl GetPolicyVersionResponseDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -4539,44 +3491,22 @@ impl GetRolePolicyResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetRolePolicyResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetRolePolicyResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, GetRolePolicyResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "PolicyDocument" => {
+                    obj.policy_document =
+                        PolicyDocumentTypeDeserializer::deserialize("PolicyDocument", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "PolicyDocument" => {
-                        obj.policy_document =
-                            PolicyDocumentTypeDeserializer::deserialize("PolicyDocument", stack)?;
-                    }
-                    "PolicyName" => {
-                        obj.policy_name =
-                            PolicyNameTypeDeserializer::deserialize("PolicyName", stack)?;
-                    }
-                    "RoleName" => {
-                        obj.role_name = RoleNameTypeDeserializer::deserialize("RoleName", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "PolicyName" => {
+                    obj.policy_name = PolicyNameTypeDeserializer::deserialize("PolicyName", stack)?;
                 }
+                "RoleName" => {
+                    obj.role_name = RoleNameTypeDeserializer::deserialize("RoleName", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -4612,36 +3542,15 @@ impl GetRoleResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetRoleResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetRoleResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, GetRoleResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Role" => {
+                    obj.role = RoleDeserializer::deserialize("Role", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Role" => {
-                        obj.role = RoleDeserializer::deserialize("Role", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -4684,21 +3593,11 @@ impl GetSAMLProviderResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetSAMLProviderResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetSAMLProviderResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetSAMLProviderResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CreateDate" => {
                         obj.create_date =
                             Some(DateTypeDeserializer::deserialize("CreateDate", stack)?);
@@ -4715,17 +3614,10 @@ impl GetSAMLProviderResponseDeserializer {
                             Some(DateTypeDeserializer::deserialize("ValidUntil", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -4770,21 +3662,11 @@ impl GetSSHPublicKeyResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetSSHPublicKeyResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetSSHPublicKeyResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetSSHPublicKeyResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "SSHPublicKey" => {
                         obj.ssh_public_key = Some(SSHPublicKeyDeserializer::deserialize(
                             "SSHPublicKey",
@@ -4792,17 +3674,10 @@ impl GetSSHPublicKeyResponseDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -4841,37 +3716,20 @@ impl GetServerCertificateResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetServerCertificateResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetServerCertificateResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetServerCertificateResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ServerCertificate" => {
                         obj.server_certificate =
                             ServerCertificateDeserializer::deserialize("ServerCertificate", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -4931,21 +3789,11 @@ impl GetServiceLastAccessedDetailsResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetServiceLastAccessedDetailsResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetServiceLastAccessedDetailsResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetServiceLastAccessedDetailsResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Error" => {
                         obj.error = Some(ErrorDetailsDeserializer::deserialize("Error", stack)?);
                     }
@@ -4977,17 +3825,10 @@ impl GetServiceLastAccessedDetailsResponseDeserializer {
                         );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -5057,21 +3898,11 @@ impl GetServiceLastAccessedDetailsWithEntitiesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetServiceLastAccessedDetailsWithEntitiesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetServiceLastAccessedDetailsWithEntitiesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetServiceLastAccessedDetailsWithEntitiesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "EntityDetailsList" => {
                         obj.entity_details_list.extend(
                             EntityDetailsListTypeDeserializer::deserialize(
@@ -5103,17 +3934,10 @@ impl GetServiceLastAccessedDetailsWithEntitiesResponseDeserializer {
                         obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -5153,21 +3977,11 @@ impl GetServiceLinkedRoleDeletionStatusResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetServiceLinkedRoleDeletionStatusResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetServiceLinkedRoleDeletionStatusResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetServiceLinkedRoleDeletionStatusResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Reason" => {
                         obj.reason = Some(DeletionTaskFailureReasonTypeDeserializer::deserialize(
                             "Reason", stack,
@@ -5178,17 +3992,10 @@ impl GetServiceLinkedRoleDeletionStatusResponseDeserializer {
                             DeletionTaskStatusTypeDeserializer::deserialize("Status", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -5231,45 +4038,23 @@ impl GetUserPolicyResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetUserPolicyResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetUserPolicyResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, GetUserPolicyResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "PolicyDocument" => {
+                    obj.policy_document =
+                        PolicyDocumentTypeDeserializer::deserialize("PolicyDocument", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "PolicyDocument" => {
-                        obj.policy_document =
-                            PolicyDocumentTypeDeserializer::deserialize("PolicyDocument", stack)?;
-                    }
-                    "PolicyName" => {
-                        obj.policy_name =
-                            PolicyNameTypeDeserializer::deserialize("PolicyName", stack)?;
-                    }
-                    "UserName" => {
-                        obj.user_name =
-                            ExistingUserNameTypeDeserializer::deserialize("UserName", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "PolicyName" => {
+                    obj.policy_name = PolicyNameTypeDeserializer::deserialize("PolicyName", stack)?;
                 }
+                "UserName" => {
+                    obj.user_name =
+                        ExistingUserNameTypeDeserializer::deserialize("UserName", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -5307,36 +4092,15 @@ impl GetUserResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetUserResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetUserResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, GetUserResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "User" => {
+                    obj.user = UserDeserializer::deserialize("User", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "User" => {
-                        obj.user = UserDeserializer::deserialize("User", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p><p>Contains information about an IAM group entity.</p> <p>This data type is used as a response element in the following operations:</p> <ul> <li> <p> <a>CreateGroup</a> </p> </li> <li> <p> <a>GetGroup</a> </p> </li> <li> <p> <a>ListGroups</a> </p> </li> </ul></p>
@@ -5361,49 +4125,27 @@ impl GroupDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Group, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Group::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Group, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Arn" => {
+                    obj.arn = ArnTypeDeserializer::deserialize("Arn", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Arn" => {
-                        obj.arn = ArnTypeDeserializer::deserialize("Arn", stack)?;
-                    }
-                    "CreateDate" => {
-                        obj.create_date = DateTypeDeserializer::deserialize("CreateDate", stack)?;
-                    }
-                    "GroupId" => {
-                        obj.group_id = IdTypeDeserializer::deserialize("GroupId", stack)?;
-                    }
-                    "GroupName" => {
-                        obj.group_name =
-                            GroupNameTypeDeserializer::deserialize("GroupName", stack)?;
-                    }
-                    "Path" => {
-                        obj.path = PathTypeDeserializer::deserialize("Path", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "CreateDate" => {
+                    obj.create_date = DateTypeDeserializer::deserialize("CreateDate", stack)?;
                 }
+                "GroupId" => {
+                    obj.group_id = IdTypeDeserializer::deserialize("GroupId", stack)?;
+                }
+                "GroupName" => {
+                    obj.group_name = GroupNameTypeDeserializer::deserialize("GroupName", stack)?;
+                }
+                "Path" => {
+                    obj.path = PathTypeDeserializer::deserialize("Path", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains information about an IAM group, including all of the group's policies.</p> <p>This data type is used as a response element in the <a>GetAccountAuthorizationDetails</a> operation.</p>
@@ -5431,80 +4173,41 @@ impl GroupDetailDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GroupDetail, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GroupDetail::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, GroupDetail, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Arn" => {
+                    obj.arn = Some(ArnTypeDeserializer::deserialize("Arn", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Arn" => {
-                        obj.arn = Some(ArnTypeDeserializer::deserialize("Arn", stack)?);
-                    }
-                    "AttachedManagedPolicies" => {
-                        obj.attached_managed_policies = match obj.attached_managed_policies {
-                            Some(ref mut existing) => {
-                                existing.extend(AttachedPoliciesListTypeDeserializer::deserialize(
-                                    "AttachedManagedPolicies",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(AttachedPoliciesListTypeDeserializer::deserialize(
-                                "AttachedManagedPolicies",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "CreateDate" => {
-                        obj.create_date =
-                            Some(DateTypeDeserializer::deserialize("CreateDate", stack)?);
-                    }
-                    "GroupId" => {
-                        obj.group_id = Some(IdTypeDeserializer::deserialize("GroupId", stack)?);
-                    }
-                    "GroupName" => {
-                        obj.group_name =
-                            Some(GroupNameTypeDeserializer::deserialize("GroupName", stack)?);
-                    }
-                    "GroupPolicyList" => {
-                        obj.group_policy_list = match obj.group_policy_list {
-                            Some(ref mut existing) => {
-                                existing.extend(PolicyDetailListTypeDeserializer::deserialize(
-                                    "GroupPolicyList",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(PolicyDetailListTypeDeserializer::deserialize(
-                                "GroupPolicyList",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "Path" => {
-                        obj.path = Some(PathTypeDeserializer::deserialize("Path", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "AttachedManagedPolicies" => {
+                    obj.attached_managed_policies.get_or_insert(vec![]).extend(
+                        AttachedPoliciesListTypeDeserializer::deserialize(
+                            "AttachedManagedPolicies",
+                            stack,
+                        )?,
+                    );
                 }
+                "CreateDate" => {
+                    obj.create_date = Some(DateTypeDeserializer::deserialize("CreateDate", stack)?);
+                }
+                "GroupId" => {
+                    obj.group_id = Some(IdTypeDeserializer::deserialize("GroupId", stack)?);
+                }
+                "GroupName" => {
+                    obj.group_name =
+                        Some(GroupNameTypeDeserializer::deserialize("GroupName", stack)?);
+                }
+                "GroupPolicyList" => {
+                    obj.group_policy_list.get_or_insert(vec![]).extend(
+                        PolicyDetailListTypeDeserializer::deserialize("GroupPolicyList", stack)?,
+                    );
+                }
+                "Path" => {
+                    obj.path = Some(PathTypeDeserializer::deserialize("Path", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct GroupDetailListTypeDeserializer;
@@ -5514,37 +4217,14 @@ impl GroupDetailListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<GroupDetail>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(GroupDetailDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(GroupDetailDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct GroupListTypeDeserializer;
@@ -5554,37 +4234,14 @@ impl GroupListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Group>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(GroupDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(GroupDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct GroupNameListTypeDeserializer;
@@ -5594,37 +4251,14 @@ impl GroupNameListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(GroupNameTypeDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(GroupNameTypeDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct GroupNameTypeDeserializer;
@@ -5679,57 +4313,35 @@ impl InstanceProfileDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<InstanceProfile, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = InstanceProfile::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, InstanceProfile, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Arn" => {
+                    obj.arn = ArnTypeDeserializer::deserialize("Arn", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Arn" => {
-                        obj.arn = ArnTypeDeserializer::deserialize("Arn", stack)?;
-                    }
-                    "CreateDate" => {
-                        obj.create_date = DateTypeDeserializer::deserialize("CreateDate", stack)?;
-                    }
-                    "InstanceProfileId" => {
-                        obj.instance_profile_id =
-                            IdTypeDeserializer::deserialize("InstanceProfileId", stack)?;
-                    }
-                    "InstanceProfileName" => {
-                        obj.instance_profile_name =
-                            InstanceProfileNameTypeDeserializer::deserialize(
-                                "InstanceProfileName",
-                                stack,
-                            )?;
-                    }
-                    "Path" => {
-                        obj.path = PathTypeDeserializer::deserialize("Path", stack)?;
-                    }
-                    "Roles" => {
-                        obj.roles
-                            .extend(RoleListTypeDeserializer::deserialize("Roles", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "CreateDate" => {
+                    obj.create_date = DateTypeDeserializer::deserialize("CreateDate", stack)?;
                 }
+                "InstanceProfileId" => {
+                    obj.instance_profile_id =
+                        IdTypeDeserializer::deserialize("InstanceProfileId", stack)?;
+                }
+                "InstanceProfileName" => {
+                    obj.instance_profile_name = InstanceProfileNameTypeDeserializer::deserialize(
+                        "InstanceProfileName",
+                        stack,
+                    )?;
+                }
+                "Path" => {
+                    obj.path = PathTypeDeserializer::deserialize("Path", stack)?;
+                }
+                "Roles" => {
+                    obj.roles
+                        .extend(RoleListTypeDeserializer::deserialize("Roles", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct InstanceProfileListTypeDeserializer;
@@ -5739,37 +4351,14 @@ impl InstanceProfileListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<InstanceProfile>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(InstanceProfileDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(InstanceProfileDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct InstanceProfileNameTypeDeserializer;
@@ -5894,48 +4483,27 @@ impl ListAccessKeysResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListAccessKeysResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListAccessKeysResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ListAccessKeysResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AccessKeyMetadata" => {
+                    obj.access_key_metadata.extend(
+                        AccessKeyMetadataListTypeDeserializer::deserialize(
+                            "AccessKeyMetadata",
+                            stack,
+                        )?,
+                    );
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AccessKeyMetadata" => {
-                        obj.access_key_metadata.extend(
-                            AccessKeyMetadataListTypeDeserializer::deserialize(
-                                "AccessKeyMetadata",
-                                stack,
-                            )?,
-                        );
-                    }
-                    "IsTruncated" => {
-                        obj.is_truncated =
-                            Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
-                    }
-                    "Marker" => {
-                        obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "IsTruncated" => {
+                    obj.is_truncated =
+                        Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
                 }
+                "Marker" => {
+                    obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -5985,21 +4553,11 @@ impl ListAccountAliasesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListAccountAliasesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListAccountAliasesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListAccountAliasesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AccountAliases" => {
                         obj.account_aliases
                             .extend(AccountAliasListTypeDeserializer::deserialize(
@@ -6015,17 +4573,10 @@ impl ListAccountAliasesResponseDeserializer {
                         obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -6083,35 +4634,18 @@ impl ListAttachedGroupPoliciesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListAttachedGroupPoliciesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListAttachedGroupPoliciesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListAttachedGroupPoliciesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AttachedPolicies" => {
-                        obj.attached_policies = match obj.attached_policies {
-                            Some(ref mut existing) => {
-                                existing.extend(AttachedPoliciesListTypeDeserializer::deserialize(
-                                    "AttachedPolicies",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(AttachedPoliciesListTypeDeserializer::deserialize(
+                        obj.attached_policies.get_or_insert(vec![]).extend(
+                            AttachedPoliciesListTypeDeserializer::deserialize(
                                 "AttachedPolicies",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     "IsTruncated" => {
                         obj.is_truncated =
@@ -6121,17 +4655,10 @@ impl ListAttachedGroupPoliciesResponseDeserializer {
                         obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -6189,35 +4716,18 @@ impl ListAttachedRolePoliciesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListAttachedRolePoliciesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListAttachedRolePoliciesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListAttachedRolePoliciesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AttachedPolicies" => {
-                        obj.attached_policies = match obj.attached_policies {
-                            Some(ref mut existing) => {
-                                existing.extend(AttachedPoliciesListTypeDeserializer::deserialize(
-                                    "AttachedPolicies",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(AttachedPoliciesListTypeDeserializer::deserialize(
+                        obj.attached_policies.get_or_insert(vec![]).extend(
+                            AttachedPoliciesListTypeDeserializer::deserialize(
                                 "AttachedPolicies",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     "IsTruncated" => {
                         obj.is_truncated =
@@ -6227,17 +4737,10 @@ impl ListAttachedRolePoliciesResponseDeserializer {
                         obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -6295,35 +4798,18 @@ impl ListAttachedUserPoliciesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListAttachedUserPoliciesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListAttachedUserPoliciesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListAttachedUserPoliciesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AttachedPolicies" => {
-                        obj.attached_policies = match obj.attached_policies {
-                            Some(ref mut existing) => {
-                                existing.extend(AttachedPoliciesListTypeDeserializer::deserialize(
-                                    "AttachedPolicies",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(AttachedPoliciesListTypeDeserializer::deserialize(
+                        obj.attached_policies.get_or_insert(vec![]).extend(
+                            AttachedPoliciesListTypeDeserializer::deserialize(
                                 "AttachedPolicies",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     "IsTruncated" => {
                         obj.is_truncated =
@@ -6333,17 +4819,10 @@ impl ListAttachedUserPoliciesResponseDeserializer {
                         obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -6415,21 +4894,11 @@ impl ListEntitiesForPolicyResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListEntitiesForPolicyResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListEntitiesForPolicyResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListEntitiesForPolicyResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "IsTruncated" => {
                         obj.is_truncated =
                             Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
@@ -6438,62 +4907,25 @@ impl ListEntitiesForPolicyResponseDeserializer {
                         obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
                     }
                     "PolicyGroups" => {
-                        obj.policy_groups = match obj.policy_groups {
-                            Some(ref mut existing) => {
-                                existing.extend(PolicyGroupListTypeDeserializer::deserialize(
-                                    "PolicyGroups",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(PolicyGroupListTypeDeserializer::deserialize(
-                                "PolicyGroups",
-                                stack,
-                            )?),
-                        };
+                        obj.policy_groups.get_or_insert(vec![]).extend(
+                            PolicyGroupListTypeDeserializer::deserialize("PolicyGroups", stack)?,
+                        );
                     }
                     "PolicyRoles" => {
-                        obj.policy_roles = match obj.policy_roles {
-                            Some(ref mut existing) => {
-                                existing.extend(PolicyRoleListTypeDeserializer::deserialize(
-                                    "PolicyRoles",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(PolicyRoleListTypeDeserializer::deserialize(
-                                "PolicyRoles",
-                                stack,
-                            )?),
-                        };
+                        obj.policy_roles.get_or_insert(vec![]).extend(
+                            PolicyRoleListTypeDeserializer::deserialize("PolicyRoles", stack)?,
+                        );
                     }
                     "PolicyUsers" => {
-                        obj.policy_users = match obj.policy_users {
-                            Some(ref mut existing) => {
-                                existing.extend(PolicyUserListTypeDeserializer::deserialize(
-                                    "PolicyUsers",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(PolicyUserListTypeDeserializer::deserialize(
-                                "PolicyUsers",
-                                stack,
-                            )?),
-                        };
+                        obj.policy_users.get_or_insert(vec![]).extend(
+                            PolicyUserListTypeDeserializer::deserialize("PolicyUsers", stack)?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -6546,21 +4978,11 @@ impl ListGroupPoliciesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListGroupPoliciesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListGroupPoliciesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListGroupPoliciesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "IsTruncated" => {
                         obj.is_truncated =
                             Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
@@ -6576,17 +4998,10 @@ impl ListGroupPoliciesResponseDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -6639,21 +5054,11 @@ impl ListGroupsForUserResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListGroupsForUserResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListGroupsForUserResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListGroupsForUserResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Groups" => {
                         obj.groups
                             .extend(GroupListTypeDeserializer::deserialize("Groups", stack)?);
@@ -6666,17 +5071,10 @@ impl ListGroupsForUserResponseDeserializer {
                         obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -6731,44 +5129,23 @@ impl ListGroupsResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListGroupsResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListGroupsResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ListGroupsResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Groups" => {
+                    obj.groups
+                        .extend(GroupListTypeDeserializer::deserialize("Groups", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Groups" => {
-                        obj.groups
-                            .extend(GroupListTypeDeserializer::deserialize("Groups", stack)?);
-                    }
-                    "IsTruncated" => {
-                        obj.is_truncated =
-                            Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
-                    }
-                    "Marker" => {
-                        obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "IsTruncated" => {
+                    obj.is_truncated =
+                        Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
                 }
+                "Marker" => {
+                    obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -6821,21 +5198,11 @@ impl ListInstanceProfilesForRoleResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListInstanceProfilesForRoleResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListInstanceProfilesForRoleResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListInstanceProfilesForRoleResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "InstanceProfiles" => {
                         obj.instance_profiles.extend(
                             InstanceProfileListTypeDeserializer::deserialize(
@@ -6852,17 +5219,10 @@ impl ListInstanceProfilesForRoleResponseDeserializer {
                         obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -6917,21 +5277,11 @@ impl ListInstanceProfilesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListInstanceProfilesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListInstanceProfilesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListInstanceProfilesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "InstanceProfiles" => {
                         obj.instance_profiles.extend(
                             InstanceProfileListTypeDeserializer::deserialize(
@@ -6948,17 +5298,10 @@ impl ListInstanceProfilesResponseDeserializer {
                         obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -7013,47 +5356,26 @@ impl ListMFADevicesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListMFADevicesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListMFADevicesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ListMFADevicesResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "IsTruncated" => {
+                    obj.is_truncated =
+                        Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "IsTruncated" => {
-                        obj.is_truncated =
-                            Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
-                    }
-                    "MFADevices" => {
-                        obj.mfa_devices
-                            .extend(MfaDeviceListTypeDeserializer::deserialize(
-                                "MFADevices",
-                                stack,
-                            )?);
-                    }
-                    "Marker" => {
-                        obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "MFADevices" => {
+                    obj.mfa_devices
+                        .extend(MfaDeviceListTypeDeserializer::deserialize(
+                            "MFADevices",
+                            stack,
+                        )?);
                 }
+                "Marker" => {
+                    obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -7084,51 +5406,24 @@ impl ListOpenIDConnectProvidersResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListOpenIDConnectProvidersResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListOpenIDConnectProvidersResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListOpenIDConnectProvidersResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "OpenIDConnectProviderList" => {
-                        obj.open_id_connect_provider_list = match obj.open_id_connect_provider_list
-                        {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    OpenIDConnectProviderListTypeDeserializer::deserialize(
-                                        "OpenIDConnectProviderList",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(OpenIDConnectProviderListTypeDeserializer::deserialize(
+                        obj.open_id_connect_provider_list
+                            .get_or_insert(vec![])
+                            .extend(OpenIDConnectProviderListTypeDeserializer::deserialize(
                                 "OpenIDConnectProviderList",
                                 stack,
-                            )?),
-                        };
+                            )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Contains details about the permissions policies that are attached to the specified identity (user, group, or role).</p> <p>This data type is used as a response element in the <a>ListPoliciesGrantingServiceAccess</a> operation.</p>
@@ -7147,55 +5442,30 @@ impl ListPoliciesGrantingServiceAccessEntryDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListPoliciesGrantingServiceAccessEntry, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListPoliciesGrantingServiceAccessEntry::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    match &name[..] {
-                        "Policies" => {
-                            obj.policies = match obj.policies {
-                                Some(ref mut existing) => {
-                                    existing.extend(PolicyGrantingServiceAccessListTypeDeserializer::deserialize("Policies", stack)?);
-                                    Some(existing.to_vec())
-                                }
-                                None => Some(
-                                    PolicyGrantingServiceAccessListTypeDeserializer::deserialize(
-                                        "Policies", stack,
-                                    )?,
-                                ),
-                            };
-                        }
-                        "ServiceNamespace" => {
-                            obj.service_namespace =
-                                Some(ServiceNamespaceTypeDeserializer::deserialize(
-                                    "ServiceNamespace",
-                                    stack,
-                                )?);
-                        }
-                        _ => skip_tree(stack),
+        deserialize_elements::<_, ListPoliciesGrantingServiceAccessEntry, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
+                    "Policies" => {
+                        obj.policies.get_or_insert(vec![]).extend(
+                            PolicyGrantingServiceAccessListTypeDeserializer::deserialize(
+                                "Policies", stack,
+                            )?,
+                        );
                     }
+                    "ServiceNamespace" => {
+                        obj.service_namespace =
+                            Some(ServiceNamespaceTypeDeserializer::deserialize(
+                                "ServiceNamespace",
+                                stack,
+                            )?);
+                    }
+                    _ => skip_tree(stack),
                 }
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -7246,21 +5516,11 @@ impl ListPoliciesGrantingServiceAccessResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListPoliciesGrantingServiceAccessResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListPoliciesGrantingServiceAccessResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListPoliciesGrantingServiceAccessResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "IsTruncated" => {
                         obj.is_truncated =
                             Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
@@ -7272,17 +5532,10 @@ impl ListPoliciesGrantingServiceAccessResponseDeserializer {
                         obj.policies_granting_service_access.extend(ListPolicyGrantingServiceAccessResponseListTypeDeserializer::deserialize("PoliciesGrantingServiceAccess", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -7355,53 +5608,24 @@ impl ListPoliciesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListPoliciesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListPoliciesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ListPoliciesResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "IsTruncated" => {
+                    obj.is_truncated =
+                        Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "IsTruncated" => {
-                        obj.is_truncated =
-                            Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
-                    }
-                    "Marker" => {
-                        obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
-                    }
-                    "Policies" => {
-                        obj.policies = match obj.policies {
-                            Some(ref mut existing) => {
-                                existing.extend(PolicyListTypeDeserializer::deserialize(
-                                    "Policies", stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => {
-                                Some(PolicyListTypeDeserializer::deserialize("Policies", stack)?)
-                            }
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Marker" => {
+                    obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
                 }
+                "Policies" => {
+                    obj.policies
+                        .get_or_insert(vec![])
+                        .extend(PolicyListTypeDeserializer::deserialize("Policies", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ListPolicyGrantingServiceAccessResponseListTypeDeserializer;
@@ -7411,41 +5635,18 @@ impl ListPolicyGrantingServiceAccessResponseListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<ListPoliciesGrantingServiceAccessEntry>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(
-                            ListPoliciesGrantingServiceAccessEntryDeserializer::deserialize(
-                                "member", stack,
-                            )?,
-                        );
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(
+                    ListPoliciesGrantingServiceAccessEntryDeserializer::deserialize(
+                        "member", stack,
+                    )?,
+                );
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -7498,21 +5699,11 @@ impl ListPolicyVersionsResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListPolicyVersionsResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListPolicyVersionsResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListPolicyVersionsResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "IsTruncated" => {
                         obj.is_truncated =
                             Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
@@ -7521,32 +5712,17 @@ impl ListPolicyVersionsResponseDeserializer {
                         obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
                     }
                     "Versions" => {
-                        obj.versions = match obj.versions {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    PolicyDocumentVersionListTypeDeserializer::deserialize(
-                                        "Versions", stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(PolicyDocumentVersionListTypeDeserializer::deserialize(
+                        obj.versions.get_or_insert(vec![]).extend(
+                            PolicyDocumentVersionListTypeDeserializer::deserialize(
                                 "Versions", stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -7599,21 +5775,11 @@ impl ListRolePoliciesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListRolePoliciesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListRolePoliciesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListRolePoliciesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "IsTruncated" => {
                         obj.is_truncated =
                             Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
@@ -7629,17 +5795,10 @@ impl ListRolePoliciesResponseDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -7691,44 +5850,23 @@ impl ListRoleTagsResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListRoleTagsResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListRoleTagsResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ListRoleTagsResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "IsTruncated" => {
+                    obj.is_truncated =
+                        Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "IsTruncated" => {
-                        obj.is_truncated =
-                            Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
-                    }
-                    "Marker" => {
-                        obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
-                    }
-                    "Tags" => {
-                        obj.tags
-                            .extend(TagListTypeDeserializer::deserialize("Tags", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Marker" => {
+                    obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
                 }
+                "Tags" => {
+                    obj.tags
+                        .extend(TagListTypeDeserializer::deserialize("Tags", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -7783,44 +5921,23 @@ impl ListRolesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListRolesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListRolesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ListRolesResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "IsTruncated" => {
+                    obj.is_truncated =
+                        Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "IsTruncated" => {
-                        obj.is_truncated =
-                            Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
-                    }
-                    "Marker" => {
-                        obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
-                    }
-                    "Roles" => {
-                        obj.roles
-                            .extend(RoleListTypeDeserializer::deserialize("Roles", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Marker" => {
+                    obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
                 }
+                "Roles" => {
+                    obj.roles
+                        .extend(RoleListTypeDeserializer::deserialize("Roles", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -7851,48 +5968,24 @@ impl ListSAMLProvidersResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListSAMLProvidersResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListSAMLProvidersResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListSAMLProvidersResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "SAMLProviderList" => {
-                        obj.saml_provider_list = match obj.saml_provider_list {
-                            Some(ref mut existing) => {
-                                existing.extend(SAMLProviderListTypeDeserializer::deserialize(
-                                    "SAMLProviderList",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(SAMLProviderListTypeDeserializer::deserialize(
+                        obj.saml_provider_list.get_or_insert(vec![]).extend(
+                            SAMLProviderListTypeDeserializer::deserialize(
                                 "SAMLProviderList",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -7947,21 +6040,11 @@ impl ListSSHPublicKeysResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListSSHPublicKeysResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListSSHPublicKeysResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListSSHPublicKeysResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "IsTruncated" => {
                         obj.is_truncated =
                             Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
@@ -7970,32 +6053,15 @@ impl ListSSHPublicKeysResponseDeserializer {
                         obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
                     }
                     "SSHPublicKeys" => {
-                        obj.ssh_public_keys = match obj.ssh_public_keys {
-                            Some(ref mut existing) => {
-                                existing.extend(SSHPublicKeyListTypeDeserializer::deserialize(
-                                    "SSHPublicKeys",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(SSHPublicKeyListTypeDeserializer::deserialize(
-                                "SSHPublicKeys",
-                                stack,
-                            )?),
-                        };
+                        obj.ssh_public_keys.get_or_insert(vec![]).extend(
+                            SSHPublicKeyListTypeDeserializer::deserialize("SSHPublicKeys", stack)?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -8050,21 +6116,11 @@ impl ListServerCertificatesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListServerCertificatesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListServerCertificatesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListServerCertificatesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "IsTruncated" => {
                         obj.is_truncated =
                             Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
@@ -8081,17 +6137,10 @@ impl ListServerCertificatesResponseDeserializer {
                         );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -8133,51 +6182,24 @@ impl ListServiceSpecificCredentialsResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListServiceSpecificCredentialsResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListServiceSpecificCredentialsResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    match &name[..] {
-                        "ServiceSpecificCredentials" => {
-                            obj.service_specific_credentials = match obj
-                                .service_specific_credentials
-                            {
-                                Some(ref mut existing) => {
-                                    existing.extend(ServiceSpecificCredentialsListTypeDeserializer::deserialize("ServiceSpecificCredentials", stack)?);
-                                    Some(existing.to_vec())
-                                }
-                                None => Some(
-                                    ServiceSpecificCredentialsListTypeDeserializer::deserialize(
-                                        "ServiceSpecificCredentials",
-                                        stack,
-                                    )?,
-                                ),
-                            };
-                        }
-                        _ => skip_tree(stack),
+        deserialize_elements::<_, ListServiceSpecificCredentialsResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
+                    "ServiceSpecificCredentials" => {
+                        obj.service_specific_credentials
+                            .get_or_insert(vec![])
+                            .extend(ServiceSpecificCredentialsListTypeDeserializer::deserialize(
+                                "ServiceSpecificCredentials",
+                                stack,
+                            )?);
                     }
+                    _ => skip_tree(stack),
                 }
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -8232,21 +6254,11 @@ impl ListSigningCertificatesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListSigningCertificatesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListSigningCertificatesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListSigningCertificatesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Certificates" => {
                         obj.certificates
                             .extend(CertificateListTypeDeserializer::deserialize(
@@ -8262,17 +6274,10 @@ impl ListSigningCertificatesResponseDeserializer {
                         obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -8325,21 +6330,11 @@ impl ListUserPoliciesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListUserPoliciesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListUserPoliciesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListUserPoliciesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "IsTruncated" => {
                         obj.is_truncated =
                             Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
@@ -8355,17 +6350,10 @@ impl ListUserPoliciesResponseDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -8417,44 +6405,23 @@ impl ListUserTagsResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListUserTagsResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListUserTagsResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ListUserTagsResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "IsTruncated" => {
+                    obj.is_truncated =
+                        Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "IsTruncated" => {
-                        obj.is_truncated =
-                            Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
-                    }
-                    "Marker" => {
-                        obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
-                    }
-                    "Tags" => {
-                        obj.tags
-                            .extend(TagListTypeDeserializer::deserialize("Tags", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Marker" => {
+                    obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
                 }
+                "Tags" => {
+                    obj.tags
+                        .extend(TagListTypeDeserializer::deserialize("Tags", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -8509,44 +6476,23 @@ impl ListUsersResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListUsersResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListUsersResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ListUsersResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "IsTruncated" => {
+                    obj.is_truncated =
+                        Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "IsTruncated" => {
-                        obj.is_truncated =
-                            Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
-                    }
-                    "Marker" => {
-                        obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
-                    }
-                    "Users" => {
-                        obj.users
-                            .extend(UserListTypeDeserializer::deserialize("Users", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Marker" => {
+                    obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
                 }
+                "Users" => {
+                    obj.users
+                        .extend(UserListTypeDeserializer::deserialize("Users", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -8601,21 +6547,11 @@ impl ListVirtualMFADevicesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListVirtualMFADevicesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListVirtualMFADevicesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListVirtualMFADevicesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "IsTruncated" => {
                         obj.is_truncated =
                             Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
@@ -8632,17 +6568,10 @@ impl ListVirtualMFADevicesResponseDeserializer {
                         );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Contains the user name and password create date for a user.</p> <p> This data type is used as a response element in the <a>CreateLoginProfile</a> and <a>GetLoginProfile</a> operations. </p>
@@ -8663,45 +6592,24 @@ impl LoginProfileDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<LoginProfile, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = LoginProfile::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, LoginProfile, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CreateDate" => {
+                    obj.create_date = DateTypeDeserializer::deserialize("CreateDate", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CreateDate" => {
-                        obj.create_date = DateTypeDeserializer::deserialize("CreateDate", stack)?;
-                    }
-                    "PasswordResetRequired" => {
-                        obj.password_reset_required = Some(BooleanTypeDeserializer::deserialize(
-                            "PasswordResetRequired",
-                            stack,
-                        )?);
-                    }
-                    "UserName" => {
-                        obj.user_name = UserNameTypeDeserializer::deserialize("UserName", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "PasswordResetRequired" => {
+                    obj.password_reset_required = Some(BooleanTypeDeserializer::deserialize(
+                        "PasswordResetRequired",
+                        stack,
+                    )?);
                 }
+                "UserName" => {
+                    obj.user_name = UserNameTypeDeserializer::deserialize("UserName", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains information about an MFA device.</p> <p>This data type is used as a response element in the <a>ListMFADevices</a> operation.</p>
@@ -8722,43 +6630,22 @@ impl MFADeviceDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<MFADevice, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = MFADevice::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, MFADevice, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "EnableDate" => {
+                    obj.enable_date = DateTypeDeserializer::deserialize("EnableDate", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "EnableDate" => {
-                        obj.enable_date = DateTypeDeserializer::deserialize("EnableDate", stack)?;
-                    }
-                    "SerialNumber" => {
-                        obj.serial_number =
-                            SerialNumberTypeDeserializer::deserialize("SerialNumber", stack)?;
-                    }
-                    "UserName" => {
-                        obj.user_name = UserNameTypeDeserializer::deserialize("UserName", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "SerialNumber" => {
+                    obj.serial_number =
+                        SerialNumberTypeDeserializer::deserialize("SerialNumber", stack)?;
                 }
+                "UserName" => {
+                    obj.user_name = UserNameTypeDeserializer::deserialize("UserName", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains information about a managed policy, including the policy's ARN, versions, and the number of principal entities (users, groups, and roles) that the policy is attached to.</p> <p>This data type is used as a response element in the <a>GetAccountAuthorizationDetails</a> operation.</p> <p>For more information about managed policies, see <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>
@@ -8796,103 +6683,70 @@ impl ManagedPolicyDetailDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ManagedPolicyDetail, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ManagedPolicyDetail::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ManagedPolicyDetail, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Arn" => {
+                    obj.arn = Some(ArnTypeDeserializer::deserialize("Arn", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Arn" => {
-                        obj.arn = Some(ArnTypeDeserializer::deserialize("Arn", stack)?);
-                    }
-                    "AttachmentCount" => {
-                        obj.attachment_count = Some(AttachmentCountTypeDeserializer::deserialize(
-                            "AttachmentCount",
-                            stack,
-                        )?);
-                    }
-                    "CreateDate" => {
-                        obj.create_date =
-                            Some(DateTypeDeserializer::deserialize("CreateDate", stack)?);
-                    }
-                    "DefaultVersionId" => {
-                        obj.default_version_id =
-                            Some(PolicyVersionIdTypeDeserializer::deserialize(
-                                "DefaultVersionId",
-                                stack,
-                            )?);
-                    }
-                    "Description" => {
-                        obj.description = Some(PolicyDescriptionTypeDeserializer::deserialize(
-                            "Description",
-                            stack,
-                        )?);
-                    }
-                    "IsAttachable" => {
-                        obj.is_attachable =
-                            Some(BooleanTypeDeserializer::deserialize("IsAttachable", stack)?);
-                    }
-                    "Path" => {
-                        obj.path = Some(PolicyPathTypeDeserializer::deserialize("Path", stack)?);
-                    }
-                    "PermissionsBoundaryUsageCount" => {
-                        obj.permissions_boundary_usage_count =
-                            Some(AttachmentCountTypeDeserializer::deserialize(
-                                "PermissionsBoundaryUsageCount",
-                                stack,
-                            )?);
-                    }
-                    "PolicyId" => {
-                        obj.policy_id = Some(IdTypeDeserializer::deserialize("PolicyId", stack)?);
-                    }
-                    "PolicyName" => {
-                        obj.policy_name = Some(PolicyNameTypeDeserializer::deserialize(
-                            "PolicyName",
-                            stack,
-                        )?);
-                    }
-                    "PolicyVersionList" => {
-                        obj.policy_version_list = match obj.policy_version_list {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    PolicyDocumentVersionListTypeDeserializer::deserialize(
-                                        "PolicyVersionList",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(PolicyDocumentVersionListTypeDeserializer::deserialize(
-                                "PolicyVersionList",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "UpdateDate" => {
-                        obj.update_date =
-                            Some(DateTypeDeserializer::deserialize("UpdateDate", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "AttachmentCount" => {
+                    obj.attachment_count = Some(AttachmentCountTypeDeserializer::deserialize(
+                        "AttachmentCount",
+                        stack,
+                    )?);
                 }
+                "CreateDate" => {
+                    obj.create_date = Some(DateTypeDeserializer::deserialize("CreateDate", stack)?);
+                }
+                "DefaultVersionId" => {
+                    obj.default_version_id = Some(PolicyVersionIdTypeDeserializer::deserialize(
+                        "DefaultVersionId",
+                        stack,
+                    )?);
+                }
+                "Description" => {
+                    obj.description = Some(PolicyDescriptionTypeDeserializer::deserialize(
+                        "Description",
+                        stack,
+                    )?);
+                }
+                "IsAttachable" => {
+                    obj.is_attachable =
+                        Some(BooleanTypeDeserializer::deserialize("IsAttachable", stack)?);
+                }
+                "Path" => {
+                    obj.path = Some(PolicyPathTypeDeserializer::deserialize("Path", stack)?);
+                }
+                "PermissionsBoundaryUsageCount" => {
+                    obj.permissions_boundary_usage_count =
+                        Some(AttachmentCountTypeDeserializer::deserialize(
+                            "PermissionsBoundaryUsageCount",
+                            stack,
+                        )?);
+                }
+                "PolicyId" => {
+                    obj.policy_id = Some(IdTypeDeserializer::deserialize("PolicyId", stack)?);
+                }
+                "PolicyName" => {
+                    obj.policy_name = Some(PolicyNameTypeDeserializer::deserialize(
+                        "PolicyName",
+                        stack,
+                    )?);
+                }
+                "PolicyVersionList" => {
+                    obj.policy_version_list.get_or_insert(vec![]).extend(
+                        PolicyDocumentVersionListTypeDeserializer::deserialize(
+                            "PolicyVersionList",
+                            stack,
+                        )?,
+                    );
+                }
+                "UpdateDate" => {
+                    obj.update_date = Some(DateTypeDeserializer::deserialize("UpdateDate", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ManagedPolicyDetailListTypeDeserializer;
@@ -8902,39 +6756,16 @@ impl ManagedPolicyDetailListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<ManagedPolicyDetail>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(ManagedPolicyDetailDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(ManagedPolicyDetailDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct MarkerTypeDeserializer;
@@ -8972,37 +6803,14 @@ impl MfaDeviceListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<MFADevice>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(MFADeviceDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(MFADeviceDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct MinimumPasswordLengthTypeDeserializer;
@@ -9032,36 +6840,19 @@ impl OpenIDConnectProviderListEntryDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<OpenIDConnectProviderListEntry, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = OpenIDConnectProviderListEntry::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, OpenIDConnectProviderListEntry, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Arn" => {
                         obj.arn = Some(ArnTypeDeserializer::deserialize("Arn", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct OpenIDConnectProviderListTypeDeserializer;
@@ -9071,39 +6862,16 @@ impl OpenIDConnectProviderListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<OpenIDConnectProviderListEntry>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(OpenIDConnectProviderListEntryDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(OpenIDConnectProviderListEntryDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct OpenIDConnectProviderUrlTypeDeserializer;
@@ -9134,21 +6902,11 @@ impl OrganizationsDecisionDetailDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<OrganizationsDecisionDetail, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = OrganizationsDecisionDetail::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, OrganizationsDecisionDetail, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AllowedByOrganizations" => {
                         obj.allowed_by_organizations = Some(BooleanTypeDeserializer::deserialize(
                             "AllowedByOrganizations",
@@ -9156,17 +6914,10 @@ impl OrganizationsDecisionDetailDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Contains information about the account password policy.</p> <p> This data type is used as a response element in the <a>GetAccountPasswordPolicy</a> operation. </p>
@@ -9201,98 +6952,73 @@ impl PasswordPolicyDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<PasswordPolicy, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = PasswordPolicy::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, PasswordPolicy, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AllowUsersToChangePassword" => {
+                    obj.allow_users_to_change_password = Some(
+                        BooleanTypeDeserializer::deserialize("AllowUsersToChangePassword", stack)?,
+                    );
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AllowUsersToChangePassword" => {
-                        obj.allow_users_to_change_password =
-                            Some(BooleanTypeDeserializer::deserialize(
-                                "AllowUsersToChangePassword",
-                                stack,
-                            )?);
-                    }
-                    "ExpirePasswords" => {
-                        obj.expire_passwords = Some(BooleanTypeDeserializer::deserialize(
-                            "ExpirePasswords",
-                            stack,
-                        )?);
-                    }
-                    "HardExpiry" => {
-                        obj.hard_expiry = Some(BooleanObjectTypeDeserializer::deserialize(
-                            "HardExpiry",
-                            stack,
-                        )?);
-                    }
-                    "MaxPasswordAge" => {
-                        obj.max_password_age = Some(MaxPasswordAgeTypeDeserializer::deserialize(
-                            "MaxPasswordAge",
-                            stack,
-                        )?);
-                    }
-                    "MinimumPasswordLength" => {
-                        obj.minimum_password_length =
-                            Some(MinimumPasswordLengthTypeDeserializer::deserialize(
-                                "MinimumPasswordLength",
-                                stack,
-                            )?);
-                    }
-                    "PasswordReusePrevention" => {
-                        obj.password_reuse_prevention =
-                            Some(PasswordReusePreventionTypeDeserializer::deserialize(
-                                "PasswordReusePrevention",
-                                stack,
-                            )?);
-                    }
-                    "RequireLowercaseCharacters" => {
-                        obj.require_lowercase_characters =
-                            Some(BooleanTypeDeserializer::deserialize(
-                                "RequireLowercaseCharacters",
-                                stack,
-                            )?);
-                    }
-                    "RequireNumbers" => {
-                        obj.require_numbers = Some(BooleanTypeDeserializer::deserialize(
-                            "RequireNumbers",
-                            stack,
-                        )?);
-                    }
-                    "RequireSymbols" => {
-                        obj.require_symbols = Some(BooleanTypeDeserializer::deserialize(
-                            "RequireSymbols",
-                            stack,
-                        )?);
-                    }
-                    "RequireUppercaseCharacters" => {
-                        obj.require_uppercase_characters =
-                            Some(BooleanTypeDeserializer::deserialize(
-                                "RequireUppercaseCharacters",
-                                stack,
-                            )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "ExpirePasswords" => {
+                    obj.expire_passwords = Some(BooleanTypeDeserializer::deserialize(
+                        "ExpirePasswords",
+                        stack,
+                    )?);
                 }
+                "HardExpiry" => {
+                    obj.hard_expiry = Some(BooleanObjectTypeDeserializer::deserialize(
+                        "HardExpiry",
+                        stack,
+                    )?);
+                }
+                "MaxPasswordAge" => {
+                    obj.max_password_age = Some(MaxPasswordAgeTypeDeserializer::deserialize(
+                        "MaxPasswordAge",
+                        stack,
+                    )?);
+                }
+                "MinimumPasswordLength" => {
+                    obj.minimum_password_length =
+                        Some(MinimumPasswordLengthTypeDeserializer::deserialize(
+                            "MinimumPasswordLength",
+                            stack,
+                        )?);
+                }
+                "PasswordReusePrevention" => {
+                    obj.password_reuse_prevention =
+                        Some(PasswordReusePreventionTypeDeserializer::deserialize(
+                            "PasswordReusePrevention",
+                            stack,
+                        )?);
+                }
+                "RequireLowercaseCharacters" => {
+                    obj.require_lowercase_characters = Some(BooleanTypeDeserializer::deserialize(
+                        "RequireLowercaseCharacters",
+                        stack,
+                    )?);
+                }
+                "RequireNumbers" => {
+                    obj.require_numbers = Some(BooleanTypeDeserializer::deserialize(
+                        "RequireNumbers",
+                        stack,
+                    )?);
+                }
+                "RequireSymbols" => {
+                    obj.require_symbols = Some(BooleanTypeDeserializer::deserialize(
+                        "RequireSymbols",
+                        stack,
+                    )?);
+                }
+                "RequireUppercaseCharacters" => {
+                    obj.require_uppercase_characters = Some(BooleanTypeDeserializer::deserialize(
+                        "RequireUppercaseCharacters",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PasswordReusePreventionTypeDeserializer;
@@ -9370,86 +7096,62 @@ impl PolicyDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Policy, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Policy::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Policy, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Arn" => {
+                    obj.arn = Some(ArnTypeDeserializer::deserialize("Arn", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Arn" => {
-                        obj.arn = Some(ArnTypeDeserializer::deserialize("Arn", stack)?);
-                    }
-                    "AttachmentCount" => {
-                        obj.attachment_count = Some(AttachmentCountTypeDeserializer::deserialize(
-                            "AttachmentCount",
-                            stack,
-                        )?);
-                    }
-                    "CreateDate" => {
-                        obj.create_date =
-                            Some(DateTypeDeserializer::deserialize("CreateDate", stack)?);
-                    }
-                    "DefaultVersionId" => {
-                        obj.default_version_id =
-                            Some(PolicyVersionIdTypeDeserializer::deserialize(
-                                "DefaultVersionId",
-                                stack,
-                            )?);
-                    }
-                    "Description" => {
-                        obj.description = Some(PolicyDescriptionTypeDeserializer::deserialize(
-                            "Description",
-                            stack,
-                        )?);
-                    }
-                    "IsAttachable" => {
-                        obj.is_attachable =
-                            Some(BooleanTypeDeserializer::deserialize("IsAttachable", stack)?);
-                    }
-                    "Path" => {
-                        obj.path = Some(PolicyPathTypeDeserializer::deserialize("Path", stack)?);
-                    }
-                    "PermissionsBoundaryUsageCount" => {
-                        obj.permissions_boundary_usage_count =
-                            Some(AttachmentCountTypeDeserializer::deserialize(
-                                "PermissionsBoundaryUsageCount",
-                                stack,
-                            )?);
-                    }
-                    "PolicyId" => {
-                        obj.policy_id = Some(IdTypeDeserializer::deserialize("PolicyId", stack)?);
-                    }
-                    "PolicyName" => {
-                        obj.policy_name = Some(PolicyNameTypeDeserializer::deserialize(
-                            "PolicyName",
-                            stack,
-                        )?);
-                    }
-                    "UpdateDate" => {
-                        obj.update_date =
-                            Some(DateTypeDeserializer::deserialize("UpdateDate", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "AttachmentCount" => {
+                    obj.attachment_count = Some(AttachmentCountTypeDeserializer::deserialize(
+                        "AttachmentCount",
+                        stack,
+                    )?);
                 }
+                "CreateDate" => {
+                    obj.create_date = Some(DateTypeDeserializer::deserialize("CreateDate", stack)?);
+                }
+                "DefaultVersionId" => {
+                    obj.default_version_id = Some(PolicyVersionIdTypeDeserializer::deserialize(
+                        "DefaultVersionId",
+                        stack,
+                    )?);
+                }
+                "Description" => {
+                    obj.description = Some(PolicyDescriptionTypeDeserializer::deserialize(
+                        "Description",
+                        stack,
+                    )?);
+                }
+                "IsAttachable" => {
+                    obj.is_attachable =
+                        Some(BooleanTypeDeserializer::deserialize("IsAttachable", stack)?);
+                }
+                "Path" => {
+                    obj.path = Some(PolicyPathTypeDeserializer::deserialize("Path", stack)?);
+                }
+                "PermissionsBoundaryUsageCount" => {
+                    obj.permissions_boundary_usage_count =
+                        Some(AttachmentCountTypeDeserializer::deserialize(
+                            "PermissionsBoundaryUsageCount",
+                            stack,
+                        )?);
+                }
+                "PolicyId" => {
+                    obj.policy_id = Some(IdTypeDeserializer::deserialize("PolicyId", stack)?);
+                }
+                "PolicyName" => {
+                    obj.policy_name = Some(PolicyNameTypeDeserializer::deserialize(
+                        "PolicyName",
+                        stack,
+                    )?);
+                }
+                "UpdateDate" => {
+                    obj.update_date = Some(DateTypeDeserializer::deserialize("UpdateDate", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PolicyDescriptionTypeDeserializer;
@@ -9482,45 +7184,24 @@ impl PolicyDetailDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<PolicyDetail, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = PolicyDetail::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, PolicyDetail, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "PolicyDocument" => {
+                    obj.policy_document = Some(PolicyDocumentTypeDeserializer::deserialize(
+                        "PolicyDocument",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "PolicyDocument" => {
-                        obj.policy_document = Some(PolicyDocumentTypeDeserializer::deserialize(
-                            "PolicyDocument",
-                            stack,
-                        )?);
-                    }
-                    "PolicyName" => {
-                        obj.policy_name = Some(PolicyNameTypeDeserializer::deserialize(
-                            "PolicyName",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "PolicyName" => {
+                    obj.policy_name = Some(PolicyNameTypeDeserializer::deserialize(
+                        "PolicyName",
+                        stack,
+                    )?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PolicyDetailListTypeDeserializer;
@@ -9530,37 +7211,14 @@ impl PolicyDetailListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<PolicyDetail>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(PolicyDetailDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(PolicyDetailDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PolicyDocumentTypeDeserializer;
@@ -9584,37 +7242,14 @@ impl PolicyDocumentVersionListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<PolicyVersion>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(PolicyVersionDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(PolicyVersionDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PolicyEvaluationDecisionTypeDeserializer;
@@ -9652,21 +7287,11 @@ impl PolicyGrantingServiceAccessDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<PolicyGrantingServiceAccess, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = PolicyGrantingServiceAccess::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, PolicyGrantingServiceAccess, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "EntityName" => {
                         obj.entity_name = Some(EntityNameTypeDeserializer::deserialize(
                             "EntityName",
@@ -9691,17 +7316,10 @@ impl PolicyGrantingServiceAccessDeserializer {
                         obj.policy_type = PolicyTypeDeserializer::deserialize("PolicyType", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct PolicyGrantingServiceAccessListTypeDeserializer;
@@ -9711,39 +7329,16 @@ impl PolicyGrantingServiceAccessListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<PolicyGrantingServiceAccess>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(PolicyGrantingServiceAccessDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(PolicyGrantingServiceAccessDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains information about a group that a managed policy is attached to.</p> <p>This data type is used as a response element in the <a>ListEntitiesForPolicy</a> operation. </p> <p>For more information about managed policies, refer to <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>
@@ -9762,40 +7357,19 @@ impl PolicyGroupDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<PolicyGroup, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = PolicyGroup::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, PolicyGroup, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "GroupId" => {
+                    obj.group_id = Some(IdTypeDeserializer::deserialize("GroupId", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "GroupId" => {
-                        obj.group_id = Some(IdTypeDeserializer::deserialize("GroupId", stack)?);
-                    }
-                    "GroupName" => {
-                        obj.group_name =
-                            Some(GroupNameTypeDeserializer::deserialize("GroupName", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "GroupName" => {
+                    obj.group_name =
+                        Some(GroupNameTypeDeserializer::deserialize("GroupName", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PolicyGroupListTypeDeserializer;
@@ -9805,37 +7379,14 @@ impl PolicyGroupListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<PolicyGroup>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(PolicyGroupDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(PolicyGroupDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PolicyIdentifierTypeDeserializer;
@@ -9859,37 +7410,14 @@ impl PolicyListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Policy>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(PolicyDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(PolicyDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PolicyNameListTypeDeserializer;
@@ -9899,37 +7427,14 @@ impl PolicyNameListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(PolicyNameTypeDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(PolicyNameTypeDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PolicyNameTypeDeserializer;
@@ -9990,40 +7495,18 @@ impl PolicyRoleDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<PolicyRole, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = PolicyRole::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, PolicyRole, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "RoleId" => {
+                    obj.role_id = Some(IdTypeDeserializer::deserialize("RoleId", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "RoleId" => {
-                        obj.role_id = Some(IdTypeDeserializer::deserialize("RoleId", stack)?);
-                    }
-                    "RoleName" => {
-                        obj.role_name =
-                            Some(RoleNameTypeDeserializer::deserialize("RoleName", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "RoleName" => {
+                    obj.role_name = Some(RoleNameTypeDeserializer::deserialize("RoleName", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PolicyRoleListTypeDeserializer;
@@ -10033,37 +7516,14 @@ impl PolicyRoleListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<PolicyRole>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(PolicyRoleDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(PolicyRoleDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PolicySourceTypeDeserializer;
@@ -10110,40 +7570,18 @@ impl PolicyUserDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<PolicyUser, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = PolicyUser::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, PolicyUser, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "UserId" => {
+                    obj.user_id = Some(IdTypeDeserializer::deserialize("UserId", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "UserId" => {
-                        obj.user_id = Some(IdTypeDeserializer::deserialize("UserId", stack)?);
-                    }
-                    "UserName" => {
-                        obj.user_name =
-                            Some(UserNameTypeDeserializer::deserialize("UserName", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "UserName" => {
+                    obj.user_name = Some(UserNameTypeDeserializer::deserialize("UserName", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PolicyUserListTypeDeserializer;
@@ -10153,37 +7591,14 @@ impl PolicyUserListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<PolicyUser>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(PolicyUserDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(PolicyUserDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains information about a version of a managed policy.</p> <p>This data type is used as a response element in the <a>CreatePolicyVersion</a>, <a>GetPolicyVersion</a>, <a>ListPolicyVersions</a>, and <a>GetAccountAuthorizationDetails</a> operations. </p> <p>For more information about managed policies, refer to <a href="http://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html">Managed Policies and Inline Policies</a> in the <i>Using IAM</i> guide. </p>
@@ -10206,54 +7621,32 @@ impl PolicyVersionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<PolicyVersion, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = PolicyVersion::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, PolicyVersion, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CreateDate" => {
+                    obj.create_date = Some(DateTypeDeserializer::deserialize("CreateDate", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CreateDate" => {
-                        obj.create_date =
-                            Some(DateTypeDeserializer::deserialize("CreateDate", stack)?);
-                    }
-                    "Document" => {
-                        obj.document = Some(PolicyDocumentTypeDeserializer::deserialize(
-                            "Document", stack,
-                        )?);
-                    }
-                    "IsDefaultVersion" => {
-                        obj.is_default_version = Some(BooleanTypeDeserializer::deserialize(
-                            "IsDefaultVersion",
-                            stack,
-                        )?);
-                    }
-                    "VersionId" => {
-                        obj.version_id = Some(PolicyVersionIdTypeDeserializer::deserialize(
-                            "VersionId",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Document" => {
+                    obj.document = Some(PolicyDocumentTypeDeserializer::deserialize(
+                        "Document", stack,
+                    )?);
                 }
+                "IsDefaultVersion" => {
+                    obj.is_default_version = Some(BooleanTypeDeserializer::deserialize(
+                        "IsDefaultVersion",
+                        stack,
+                    )?);
+                }
+                "VersionId" => {
+                    obj.version_id = Some(PolicyVersionIdTypeDeserializer::deserialize(
+                        "VersionId",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PolicyVersionIdTypeDeserializer;
@@ -10286,39 +7679,18 @@ impl PositionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Position, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Position::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Position, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Column" => {
+                    obj.column = Some(ColumnNumberDeserializer::deserialize("Column", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Column" => {
-                        obj.column = Some(ColumnNumberDeserializer::deserialize("Column", stack)?);
-                    }
-                    "Line" => {
-                        obj.line = Some(LineNumberDeserializer::deserialize("Line", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Line" => {
+                    obj.line = Some(LineNumberDeserializer::deserialize("Line", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PublicKeyFingerprintTypeDeserializer;
@@ -10697,21 +8069,11 @@ impl ResetServiceSpecificCredentialResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ResetServiceSpecificCredentialResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ResetServiceSpecificCredentialResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ResetServiceSpecificCredentialResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ServiceSpecificCredential" => {
                         obj.service_specific_credential =
                             Some(ServiceSpecificCredentialDeserializer::deserialize(
@@ -10720,17 +8082,10 @@ impl ResetServiceSpecificCredentialResponseDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -10781,83 +8136,43 @@ impl ResourceSpecificResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ResourceSpecificResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ResourceSpecificResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ResourceSpecificResult, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "EvalDecisionDetails" => {
+                    obj.eval_decision_details =
+                        Some(EvalDecisionDetailsTypeDeserializer::deserialize(
+                            "EvalDecisionDetails",
+                            stack,
+                        )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "EvalDecisionDetails" => {
-                        obj.eval_decision_details =
-                            Some(EvalDecisionDetailsTypeDeserializer::deserialize(
-                                "EvalDecisionDetails",
-                                stack,
-                            )?);
-                    }
-                    "EvalResourceDecision" => {
-                        obj.eval_resource_decision =
-                            PolicyEvaluationDecisionTypeDeserializer::deserialize(
-                                "EvalResourceDecision",
-                                stack,
-                            )?;
-                    }
-                    "EvalResourceName" => {
-                        obj.eval_resource_name =
-                            ResourceNameTypeDeserializer::deserialize("EvalResourceName", stack)?;
-                    }
-                    "MatchedStatements" => {
-                        obj.matched_statements = match obj.matched_statements {
-                            Some(ref mut existing) => {
-                                existing.extend(StatementListTypeDeserializer::deserialize(
-                                    "MatchedStatements",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(StatementListTypeDeserializer::deserialize(
-                                "MatchedStatements",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "MissingContextValues" => {
-                        obj.missing_context_values = match obj.missing_context_values {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    ContextKeyNamesResultListTypeDeserializer::deserialize(
-                                        "MissingContextValues",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ContextKeyNamesResultListTypeDeserializer::deserialize(
-                                "MissingContextValues",
-                                stack,
-                            )?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "EvalResourceDecision" => {
+                    obj.eval_resource_decision =
+                        PolicyEvaluationDecisionTypeDeserializer::deserialize(
+                            "EvalResourceDecision",
+                            stack,
+                        )?;
                 }
+                "EvalResourceName" => {
+                    obj.eval_resource_name =
+                        ResourceNameTypeDeserializer::deserialize("EvalResourceName", stack)?;
+                }
+                "MatchedStatements" => {
+                    obj.matched_statements.get_or_insert(vec![]).extend(
+                        StatementListTypeDeserializer::deserialize("MatchedStatements", stack)?,
+                    );
+                }
+                "MissingContextValues" => {
+                    obj.missing_context_values.get_or_insert(vec![]).extend(
+                        ContextKeyNamesResultListTypeDeserializer::deserialize(
+                            "MissingContextValues",
+                            stack,
+                        )?,
+                    );
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ResourceSpecificResultListTypeDeserializer;
@@ -10867,39 +8182,16 @@ impl ResourceSpecificResultListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<ResourceSpecificResult>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(ResourceSpecificResultDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(ResourceSpecificResultDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -10968,85 +8260,59 @@ impl RoleDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Role, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Role::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Role, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Arn" => {
+                    obj.arn = ArnTypeDeserializer::deserialize("Arn", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Arn" => {
-                        obj.arn = ArnTypeDeserializer::deserialize("Arn", stack)?;
-                    }
-                    "AssumeRolePolicyDocument" => {
-                        obj.assume_role_policy_document =
-                            Some(PolicyDocumentTypeDeserializer::deserialize(
-                                "AssumeRolePolicyDocument",
-                                stack,
-                            )?);
-                    }
-                    "CreateDate" => {
-                        obj.create_date = DateTypeDeserializer::deserialize("CreateDate", stack)?;
-                    }
-                    "Description" => {
-                        obj.description = Some(RoleDescriptionTypeDeserializer::deserialize(
-                            "Description",
+                "AssumeRolePolicyDocument" => {
+                    obj.assume_role_policy_document =
+                        Some(PolicyDocumentTypeDeserializer::deserialize(
+                            "AssumeRolePolicyDocument",
                             stack,
                         )?);
-                    }
-                    "MaxSessionDuration" => {
-                        obj.max_session_duration =
-                            Some(RoleMaxSessionDurationTypeDeserializer::deserialize(
-                                "MaxSessionDuration",
-                                stack,
-                            )?);
-                    }
-                    "Path" => {
-                        obj.path = PathTypeDeserializer::deserialize("Path", stack)?;
-                    }
-                    "PermissionsBoundary" => {
-                        obj.permissions_boundary =
-                            Some(AttachedPermissionsBoundaryDeserializer::deserialize(
-                                "PermissionsBoundary",
-                                stack,
-                            )?);
-                    }
-                    "RoleId" => {
-                        obj.role_id = IdTypeDeserializer::deserialize("RoleId", stack)?;
-                    }
-                    "RoleName" => {
-                        obj.role_name = RoleNameTypeDeserializer::deserialize("RoleName", stack)?;
-                    }
-                    "Tags" => {
-                        obj.tags = match obj.tags {
-                            Some(ref mut existing) => {
-                                existing
-                                    .extend(TagListTypeDeserializer::deserialize("Tags", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(TagListTypeDeserializer::deserialize("Tags", stack)?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                "CreateDate" => {
+                    obj.create_date = DateTypeDeserializer::deserialize("CreateDate", stack)?;
+                }
+                "Description" => {
+                    obj.description = Some(RoleDescriptionTypeDeserializer::deserialize(
+                        "Description",
+                        stack,
+                    )?);
+                }
+                "MaxSessionDuration" => {
+                    obj.max_session_duration =
+                        Some(RoleMaxSessionDurationTypeDeserializer::deserialize(
+                            "MaxSessionDuration",
+                            stack,
+                        )?);
+                }
+                "Path" => {
+                    obj.path = PathTypeDeserializer::deserialize("Path", stack)?;
+                }
+                "PermissionsBoundary" => {
+                    obj.permissions_boundary =
+                        Some(AttachedPermissionsBoundaryDeserializer::deserialize(
+                            "PermissionsBoundary",
+                            stack,
+                        )?);
+                }
+                "RoleId" => {
+                    obj.role_id = IdTypeDeserializer::deserialize("RoleId", stack)?;
+                }
+                "RoleName" => {
+                    obj.role_name = RoleNameTypeDeserializer::deserialize("RoleName", stack)?;
+                }
+                "Tags" => {
+                    obj.tags
+                        .get_or_insert(vec![])
+                        .extend(TagListTypeDeserializer::deserialize("Tags", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct RoleDescriptionTypeDeserializer;
@@ -11096,119 +8362,67 @@ impl RoleDetailDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<RoleDetail, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = RoleDetail::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, RoleDetail, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Arn" => {
+                    obj.arn = Some(ArnTypeDeserializer::deserialize("Arn", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Arn" => {
-                        obj.arn = Some(ArnTypeDeserializer::deserialize("Arn", stack)?);
-                    }
-                    "AssumeRolePolicyDocument" => {
-                        obj.assume_role_policy_document =
-                            Some(PolicyDocumentTypeDeserializer::deserialize(
-                                "AssumeRolePolicyDocument",
-                                stack,
-                            )?);
-                    }
-                    "AttachedManagedPolicies" => {
-                        obj.attached_managed_policies = match obj.attached_managed_policies {
-                            Some(ref mut existing) => {
-                                existing.extend(AttachedPoliciesListTypeDeserializer::deserialize(
-                                    "AttachedManagedPolicies",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(AttachedPoliciesListTypeDeserializer::deserialize(
-                                "AttachedManagedPolicies",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "CreateDate" => {
-                        obj.create_date =
-                            Some(DateTypeDeserializer::deserialize("CreateDate", stack)?);
-                    }
-                    "InstanceProfileList" => {
-                        obj.instance_profile_list = match obj.instance_profile_list {
-                            Some(ref mut existing) => {
-                                existing.extend(InstanceProfileListTypeDeserializer::deserialize(
-                                    "InstanceProfileList",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(InstanceProfileListTypeDeserializer::deserialize(
-                                "InstanceProfileList",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "Path" => {
-                        obj.path = Some(PathTypeDeserializer::deserialize("Path", stack)?);
-                    }
-                    "PermissionsBoundary" => {
-                        obj.permissions_boundary =
-                            Some(AttachedPermissionsBoundaryDeserializer::deserialize(
-                                "PermissionsBoundary",
-                                stack,
-                            )?);
-                    }
-                    "RoleId" => {
-                        obj.role_id = Some(IdTypeDeserializer::deserialize("RoleId", stack)?);
-                    }
-                    "RoleName" => {
-                        obj.role_name =
-                            Some(RoleNameTypeDeserializer::deserialize("RoleName", stack)?);
-                    }
-                    "RolePolicyList" => {
-                        obj.role_policy_list = match obj.role_policy_list {
-                            Some(ref mut existing) => {
-                                existing.extend(PolicyDetailListTypeDeserializer::deserialize(
-                                    "RolePolicyList",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(PolicyDetailListTypeDeserializer::deserialize(
-                                "RolePolicyList",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "Tags" => {
-                        obj.tags = match obj.tags {
-                            Some(ref mut existing) => {
-                                existing
-                                    .extend(TagListTypeDeserializer::deserialize("Tags", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(TagListTypeDeserializer::deserialize("Tags", stack)?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "AssumeRolePolicyDocument" => {
+                    obj.assume_role_policy_document =
+                        Some(PolicyDocumentTypeDeserializer::deserialize(
+                            "AssumeRolePolicyDocument",
+                            stack,
+                        )?);
                 }
+                "AttachedManagedPolicies" => {
+                    obj.attached_managed_policies.get_or_insert(vec![]).extend(
+                        AttachedPoliciesListTypeDeserializer::deserialize(
+                            "AttachedManagedPolicies",
+                            stack,
+                        )?,
+                    );
+                }
+                "CreateDate" => {
+                    obj.create_date = Some(DateTypeDeserializer::deserialize("CreateDate", stack)?);
+                }
+                "InstanceProfileList" => {
+                    obj.instance_profile_list.get_or_insert(vec![]).extend(
+                        InstanceProfileListTypeDeserializer::deserialize(
+                            "InstanceProfileList",
+                            stack,
+                        )?,
+                    );
+                }
+                "Path" => {
+                    obj.path = Some(PathTypeDeserializer::deserialize("Path", stack)?);
+                }
+                "PermissionsBoundary" => {
+                    obj.permissions_boundary =
+                        Some(AttachedPermissionsBoundaryDeserializer::deserialize(
+                            "PermissionsBoundary",
+                            stack,
+                        )?);
+                }
+                "RoleId" => {
+                    obj.role_id = Some(IdTypeDeserializer::deserialize("RoleId", stack)?);
+                }
+                "RoleName" => {
+                    obj.role_name = Some(RoleNameTypeDeserializer::deserialize("RoleName", stack)?);
+                }
+                "RolePolicyList" => {
+                    obj.role_policy_list.get_or_insert(vec![]).extend(
+                        PolicyDetailListTypeDeserializer::deserialize("RolePolicyList", stack)?,
+                    );
+                }
+                "Tags" => {
+                    obj.tags
+                        .get_or_insert(vec![])
+                        .extend(TagListTypeDeserializer::deserialize("Tags", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct RoleDetailListTypeDeserializer;
@@ -11218,37 +8432,14 @@ impl RoleDetailListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<RoleDetail>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(RoleDetailDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(RoleDetailDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct RoleListTypeDeserializer;
@@ -11258,37 +8449,14 @@ impl RoleListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Role>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(RoleDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(RoleDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct RoleMaxSessionDurationTypeDeserializer;
@@ -11326,37 +8494,14 @@ impl RoleUsageListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<RoleUsageType>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(RoleUsageTypeDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(RoleUsageTypeDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>An object that contains details about how a service-linked role is used, if that information is returned by the service.</p> <p>This data type is used as a response element in the <a>GetServiceLinkedRoleDeletionStatus</a> operation.</p>
@@ -11375,49 +8520,20 @@ impl RoleUsageTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<RoleUsageType, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = RoleUsageType::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, RoleUsageType, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Region" => {
+                    obj.region = Some(RegionNameTypeDeserializer::deserialize("Region", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Region" => {
-                        obj.region =
-                            Some(RegionNameTypeDeserializer::deserialize("Region", stack)?);
-                    }
-                    "Resources" => {
-                        obj.resources = match obj.resources {
-                            Some(ref mut existing) => {
-                                existing.extend(ArnListTypeDeserializer::deserialize(
-                                    "Resources",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ArnListTypeDeserializer::deserialize("Resources", stack)?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Resources" => {
+                    obj.resources
+                        .get_or_insert(vec![])
+                        .extend(ArnListTypeDeserializer::deserialize("Resources", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct SAMLMetadataDocumentTypeDeserializer;
@@ -11452,44 +8568,21 @@ impl SAMLProviderListEntryDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<SAMLProviderListEntry, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = SAMLProviderListEntry::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, SAMLProviderListEntry, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Arn" => {
+                    obj.arn = Some(ArnTypeDeserializer::deserialize("Arn", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Arn" => {
-                        obj.arn = Some(ArnTypeDeserializer::deserialize("Arn", stack)?);
-                    }
-                    "CreateDate" => {
-                        obj.create_date =
-                            Some(DateTypeDeserializer::deserialize("CreateDate", stack)?);
-                    }
-                    "ValidUntil" => {
-                        obj.valid_until =
-                            Some(DateTypeDeserializer::deserialize("ValidUntil", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "CreateDate" => {
+                    obj.create_date = Some(DateTypeDeserializer::deserialize("CreateDate", stack)?);
                 }
+                "ValidUntil" => {
+                    obj.valid_until = Some(DateTypeDeserializer::deserialize("ValidUntil", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct SAMLProviderListTypeDeserializer;
@@ -11499,39 +8592,16 @@ impl SAMLProviderListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<SAMLProviderListEntry>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(SAMLProviderListEntryDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(SAMLProviderListEntryDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains information about an SSH public key.</p> <p>This data type is used as a response element in the <a>GetSSHPublicKey</a> and <a>UploadSSHPublicKey</a> operations. </p>
@@ -11558,59 +8628,33 @@ impl SSHPublicKeyDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<SSHPublicKey, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = SSHPublicKey::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, SSHPublicKey, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Fingerprint" => {
+                    obj.fingerprint =
+                        PublicKeyFingerprintTypeDeserializer::deserialize("Fingerprint", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Fingerprint" => {
-                        obj.fingerprint = PublicKeyFingerprintTypeDeserializer::deserialize(
-                            "Fingerprint",
-                            stack,
-                        )?;
-                    }
-                    "SSHPublicKeyBody" => {
-                        obj.ssh_public_key_body = PublicKeyMaterialTypeDeserializer::deserialize(
-                            "SSHPublicKeyBody",
-                            stack,
-                        )?;
-                    }
-                    "SSHPublicKeyId" => {
-                        obj.ssh_public_key_id =
-                            PublicKeyIdTypeDeserializer::deserialize("SSHPublicKeyId", stack)?;
-                    }
-                    "Status" => {
-                        obj.status = StatusTypeDeserializer::deserialize("Status", stack)?;
-                    }
-                    "UploadDate" => {
-                        obj.upload_date =
-                            Some(DateTypeDeserializer::deserialize("UploadDate", stack)?);
-                    }
-                    "UserName" => {
-                        obj.user_name = UserNameTypeDeserializer::deserialize("UserName", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "SSHPublicKeyBody" => {
+                    obj.ssh_public_key_body =
+                        PublicKeyMaterialTypeDeserializer::deserialize("SSHPublicKeyBody", stack)?;
                 }
+                "SSHPublicKeyId" => {
+                    obj.ssh_public_key_id =
+                        PublicKeyIdTypeDeserializer::deserialize("SSHPublicKeyId", stack)?;
+                }
+                "Status" => {
+                    obj.status = StatusTypeDeserializer::deserialize("Status", stack)?;
+                }
+                "UploadDate" => {
+                    obj.upload_date = Some(DateTypeDeserializer::deserialize("UploadDate", stack)?);
+                }
+                "UserName" => {
+                    obj.user_name = UserNameTypeDeserializer::deserialize("UserName", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct SSHPublicKeyListTypeDeserializer;
@@ -11620,39 +8664,16 @@ impl SSHPublicKeyListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<SSHPublicKeyMetadata>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(SSHPublicKeyMetadataDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(SSHPublicKeyMetadataDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains information about an SSH public key, without the key's body or fingerprint.</p> <p>This data type is used as a response element in the <a>ListSSHPublicKeys</a> operation.</p>
@@ -11675,46 +8696,25 @@ impl SSHPublicKeyMetadataDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<SSHPublicKeyMetadata, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = SSHPublicKeyMetadata::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, SSHPublicKeyMetadata, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "SSHPublicKeyId" => {
+                    obj.ssh_public_key_id =
+                        PublicKeyIdTypeDeserializer::deserialize("SSHPublicKeyId", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "SSHPublicKeyId" => {
-                        obj.ssh_public_key_id =
-                            PublicKeyIdTypeDeserializer::deserialize("SSHPublicKeyId", stack)?;
-                    }
-                    "Status" => {
-                        obj.status = StatusTypeDeserializer::deserialize("Status", stack)?;
-                    }
-                    "UploadDate" => {
-                        obj.upload_date = DateTypeDeserializer::deserialize("UploadDate", stack)?;
-                    }
-                    "UserName" => {
-                        obj.user_name = UserNameTypeDeserializer::deserialize("UserName", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Status" => {
+                    obj.status = StatusTypeDeserializer::deserialize("Status", stack)?;
                 }
+                "UploadDate" => {
+                    obj.upload_date = DateTypeDeserializer::deserialize("UploadDate", stack)?;
+                }
+                "UserName" => {
+                    obj.user_name = UserNameTypeDeserializer::deserialize("UserName", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct SerialNumberTypeDeserializer;
@@ -11749,51 +8749,29 @@ impl ServerCertificateDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ServerCertificate, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ServerCertificate::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ServerCertificate, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CertificateBody" => {
+                    obj.certificate_body =
+                        CertificateBodyTypeDeserializer::deserialize("CertificateBody", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CertificateBody" => {
-                        obj.certificate_body =
-                            CertificateBodyTypeDeserializer::deserialize("CertificateBody", stack)?;
-                    }
-                    "CertificateChain" => {
-                        obj.certificate_chain =
-                            Some(CertificateChainTypeDeserializer::deserialize(
-                                "CertificateChain",
-                                stack,
-                            )?);
-                    }
-                    "ServerCertificateMetadata" => {
-                        obj.server_certificate_metadata =
-                            ServerCertificateMetadataDeserializer::deserialize(
-                                "ServerCertificateMetadata",
-                                stack,
-                            )?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "CertificateChain" => {
+                    obj.certificate_chain = Some(CertificateChainTypeDeserializer::deserialize(
+                        "CertificateChain",
+                        stack,
+                    )?);
                 }
+                "ServerCertificateMetadata" => {
+                    obj.server_certificate_metadata =
+                        ServerCertificateMetadataDeserializer::deserialize(
+                            "ServerCertificateMetadata",
+                            stack,
+                        )?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains information about a server certificate without its certificate body, certificate chain, and private key.</p> <p> This data type is used as a response element in the <a>UploadServerCertificate</a> and <a>ListServerCertificates</a> operations. </p>
@@ -11820,21 +8798,11 @@ impl ServerCertificateMetadataDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ServerCertificateMetadata, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ServerCertificateMetadata::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ServerCertificateMetadata, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Arn" => {
                         obj.arn = ArnTypeDeserializer::deserialize("Arn", stack)?;
                     }
@@ -11861,17 +8829,10 @@ impl ServerCertificateMetadataDeserializer {
                             Some(DateTypeDeserializer::deserialize("UploadDate", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct ServerCertificateMetadataListTypeDeserializer;
@@ -11881,39 +8842,16 @@ impl ServerCertificateMetadataListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<ServerCertificateMetadata>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(ServerCertificateMetadataDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(ServerCertificateMetadataDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ServerCertificateNameTypeDeserializer;
@@ -11952,62 +8890,38 @@ impl ServiceLastAccessedDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ServiceLastAccessed, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ServiceLastAccessed::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ServiceLastAccessed, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "LastAuthenticated" => {
+                    obj.last_authenticated = Some(DateTypeDeserializer::deserialize(
+                        "LastAuthenticated",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "LastAuthenticated" => {
-                        obj.last_authenticated = Some(DateTypeDeserializer::deserialize(
-                            "LastAuthenticated",
-                            stack,
-                        )?);
-                    }
-                    "LastAuthenticatedEntity" => {
-                        obj.last_authenticated_entity = Some(ArnTypeDeserializer::deserialize(
-                            "LastAuthenticatedEntity",
-                            stack,
-                        )?);
-                    }
-                    "ServiceName" => {
-                        obj.service_name =
-                            ServiceNameTypeDeserializer::deserialize("ServiceName", stack)?;
-                    }
-                    "ServiceNamespace" => {
-                        obj.service_namespace = ServiceNamespaceTypeDeserializer::deserialize(
-                            "ServiceNamespace",
-                            stack,
-                        )?;
-                    }
-                    "TotalAuthenticatedEntities" => {
-                        obj.total_authenticated_entities =
-                            Some(IntegerTypeDeserializer::deserialize(
-                                "TotalAuthenticatedEntities",
-                                stack,
-                            )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "LastAuthenticatedEntity" => {
+                    obj.last_authenticated_entity = Some(ArnTypeDeserializer::deserialize(
+                        "LastAuthenticatedEntity",
+                        stack,
+                    )?);
                 }
+                "ServiceName" => {
+                    obj.service_name =
+                        ServiceNameTypeDeserializer::deserialize("ServiceName", stack)?;
+                }
+                "ServiceNamespace" => {
+                    obj.service_namespace =
+                        ServiceNamespaceTypeDeserializer::deserialize("ServiceNamespace", stack)?;
+                }
+                "TotalAuthenticatedEntities" => {
+                    obj.total_authenticated_entities = Some(IntegerTypeDeserializer::deserialize(
+                        "TotalAuthenticatedEntities",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ServiceNameDeserializer;
@@ -12104,21 +9018,11 @@ impl ServiceSpecificCredentialDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ServiceSpecificCredential, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ServiceSpecificCredential::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ServiceSpecificCredential, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CreateDate" => {
                         obj.create_date = DateTypeDeserializer::deserialize("CreateDate", stack)?;
                     }
@@ -12148,17 +9052,10 @@ impl ServiceSpecificCredentialDeserializer {
                         obj.user_name = UserNameTypeDeserializer::deserialize("UserName", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct ServiceSpecificCredentialIdDeserializer;
@@ -12199,21 +9096,11 @@ impl ServiceSpecificCredentialMetadataDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ServiceSpecificCredentialMetadata, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ServiceSpecificCredentialMetadata::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ServiceSpecificCredentialMetadata, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CreateDate" => {
                         obj.create_date = DateTypeDeserializer::deserialize("CreateDate", stack)?;
                     }
@@ -12239,17 +9126,10 @@ impl ServiceSpecificCredentialMetadataDeserializer {
                         obj.user_name = UserNameTypeDeserializer::deserialize("UserName", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct ServiceSpecificCredentialsListTypeDeserializer;
@@ -12259,39 +9139,16 @@ impl ServiceSpecificCredentialsListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<ServiceSpecificCredentialMetadata>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(ServiceSpecificCredentialMetadataDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(ServiceSpecificCredentialMetadataDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ServiceUserNameDeserializer;
@@ -12315,39 +9172,16 @@ impl ServicesLastAccessedDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<ServiceLastAccessed>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(ServiceLastAccessedDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(ServiceLastAccessedDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -12394,51 +9228,29 @@ impl SigningCertificateDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<SigningCertificate, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = SigningCertificate::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, SigningCertificate, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CertificateBody" => {
+                    obj.certificate_body =
+                        CertificateBodyTypeDeserializer::deserialize("CertificateBody", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CertificateBody" => {
-                        obj.certificate_body =
-                            CertificateBodyTypeDeserializer::deserialize("CertificateBody", stack)?;
-                    }
-                    "CertificateId" => {
-                        obj.certificate_id =
-                            CertificateIdTypeDeserializer::deserialize("CertificateId", stack)?;
-                    }
-                    "Status" => {
-                        obj.status = StatusTypeDeserializer::deserialize("Status", stack)?;
-                    }
-                    "UploadDate" => {
-                        obj.upload_date =
-                            Some(DateTypeDeserializer::deserialize("UploadDate", stack)?);
-                    }
-                    "UserName" => {
-                        obj.user_name = UserNameTypeDeserializer::deserialize("UserName", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "CertificateId" => {
+                    obj.certificate_id =
+                        CertificateIdTypeDeserializer::deserialize("CertificateId", stack)?;
                 }
+                "Status" => {
+                    obj.status = StatusTypeDeserializer::deserialize("Status", stack)?;
+                }
+                "UploadDate" => {
+                    obj.upload_date = Some(DateTypeDeserializer::deserialize("UploadDate", stack)?);
+                }
+                "UserName" => {
+                    obj.user_name = UserNameTypeDeserializer::deserialize("UserName", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -12543,57 +9355,27 @@ impl SimulatePolicyResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<SimulatePolicyResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = SimulatePolicyResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, SimulatePolicyResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "EvaluationResults" => {
+                    obj.evaluation_results.get_or_insert(vec![]).extend(
+                        EvaluationResultsListTypeDeserializer::deserialize(
+                            "EvaluationResults",
+                            stack,
+                        )?,
+                    );
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "EvaluationResults" => {
-                        obj.evaluation_results = match obj.evaluation_results {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    EvaluationResultsListTypeDeserializer::deserialize(
-                                        "EvaluationResults",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(EvaluationResultsListTypeDeserializer::deserialize(
-                                "EvaluationResults",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "IsTruncated" => {
-                        obj.is_truncated =
-                            Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
-                    }
-                    "Marker" => {
-                        obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "IsTruncated" => {
+                    obj.is_truncated =
+                        Some(BooleanTypeDeserializer::deserialize("IsTruncated", stack)?);
                 }
+                "Marker" => {
+                    obj.marker = Some(MarkerTypeDeserializer::deserialize("Marker", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -12719,53 +9501,32 @@ impl StatementDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Statement, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Statement::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Statement, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "EndPosition" => {
+                    obj.end_position =
+                        Some(PositionDeserializer::deserialize("EndPosition", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "EndPosition" => {
-                        obj.end_position =
-                            Some(PositionDeserializer::deserialize("EndPosition", stack)?);
-                    }
-                    "SourcePolicyId" => {
-                        obj.source_policy_id = Some(PolicyIdentifierTypeDeserializer::deserialize(
-                            "SourcePolicyId",
-                            stack,
-                        )?);
-                    }
-                    "SourcePolicyType" => {
-                        obj.source_policy_type = Some(PolicySourceTypeDeserializer::deserialize(
-                            "SourcePolicyType",
-                            stack,
-                        )?);
-                    }
-                    "StartPosition" => {
-                        obj.start_position =
-                            Some(PositionDeserializer::deserialize("StartPosition", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "SourcePolicyId" => {
+                    obj.source_policy_id = Some(PolicyIdentifierTypeDeserializer::deserialize(
+                        "SourcePolicyId",
+                        stack,
+                    )?);
                 }
+                "SourcePolicyType" => {
+                    obj.source_policy_type = Some(PolicySourceTypeDeserializer::deserialize(
+                        "SourcePolicyType",
+                        stack,
+                    )?);
+                }
+                "StartPosition" => {
+                    obj.start_position =
+                        Some(PositionDeserializer::deserialize("StartPosition", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct StatementListTypeDeserializer;
@@ -12775,37 +9536,14 @@ impl StatementListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Statement>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(StatementDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(StatementDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct StatusTypeDeserializer;
@@ -12903,39 +9641,18 @@ impl TagDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Tag, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Tag::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Tag, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Key" => {
+                    obj.key = TagKeyTypeDeserializer::deserialize("Key", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Key" => {
-                        obj.key = TagKeyTypeDeserializer::deserialize("Key", stack)?;
-                    }
-                    "Value" => {
-                        obj.value = TagValueTypeDeserializer::deserialize("Value", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Value" => {
+                    obj.value = TagValueTypeDeserializer::deserialize("Value", stack)?;
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -12985,37 +9702,14 @@ impl TagListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Tag>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(TagDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(TagDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -13095,37 +9789,14 @@ impl ThumbprintListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(ThumbprintTypeDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(ThumbprintTypeDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -13475,36 +10146,19 @@ impl UpdateRoleDescriptionResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UpdateRoleDescriptionResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = UpdateRoleDescriptionResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, UpdateRoleDescriptionResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Role" => {
                         obj.role = Some(RoleDeserializer::deserialize("Role", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -13600,37 +10254,20 @@ impl UpdateSAMLProviderResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UpdateSAMLProviderResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = UpdateSAMLProviderResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, UpdateSAMLProviderResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "SAMLProviderArn" => {
                         obj.saml_provider_arn =
                             Some(ArnTypeDeserializer::deserialize("SAMLProviderArn", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -13824,21 +10461,11 @@ impl UploadSSHPublicKeyResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UploadSSHPublicKeyResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = UploadSSHPublicKeyResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, UploadSSHPublicKeyResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "SSHPublicKey" => {
                         obj.ssh_public_key = Some(SSHPublicKeyDeserializer::deserialize(
                             "SSHPublicKey",
@@ -13846,17 +10473,10 @@ impl UploadSSHPublicKeyResponseDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -13914,21 +10534,11 @@ impl UploadServerCertificateResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UploadServerCertificateResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = UploadServerCertificateResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, UploadServerCertificateResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ServerCertificateMetadata" => {
                         obj.server_certificate_metadata =
                             Some(ServerCertificateMetadataDeserializer::deserialize(
@@ -13937,17 +10547,10 @@ impl UploadServerCertificateResponseDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -13991,37 +10594,20 @@ impl UploadSigningCertificateResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UploadSigningCertificateResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = UploadSigningCertificateResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, UploadSigningCertificateResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Certificate" => {
                         obj.certificate =
                             SigningCertificateDeserializer::deserialize("Certificate", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p><p>Contains information about an IAM user entity.</p> <p>This data type is used as a response element in the following operations:</p> <ul> <li> <p> <a>CreateUser</a> </p> </li> <li> <p> <a>GetUser</a> </p> </li> <li> <p> <a>ListUsers</a> </p> </li> </ul></p>
@@ -14052,71 +10638,45 @@ impl UserDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<User, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = User::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, User, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Arn" => {
+                    obj.arn = ArnTypeDeserializer::deserialize("Arn", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Arn" => {
-                        obj.arn = ArnTypeDeserializer::deserialize("Arn", stack)?;
-                    }
-                    "CreateDate" => {
-                        obj.create_date = DateTypeDeserializer::deserialize("CreateDate", stack)?;
-                    }
-                    "PasswordLastUsed" => {
-                        obj.password_last_used = Some(DateTypeDeserializer::deserialize(
-                            "PasswordLastUsed",
+                "CreateDate" => {
+                    obj.create_date = DateTypeDeserializer::deserialize("CreateDate", stack)?;
+                }
+                "PasswordLastUsed" => {
+                    obj.password_last_used = Some(DateTypeDeserializer::deserialize(
+                        "PasswordLastUsed",
+                        stack,
+                    )?);
+                }
+                "Path" => {
+                    obj.path = PathTypeDeserializer::deserialize("Path", stack)?;
+                }
+                "PermissionsBoundary" => {
+                    obj.permissions_boundary =
+                        Some(AttachedPermissionsBoundaryDeserializer::deserialize(
+                            "PermissionsBoundary",
                             stack,
                         )?);
-                    }
-                    "Path" => {
-                        obj.path = PathTypeDeserializer::deserialize("Path", stack)?;
-                    }
-                    "PermissionsBoundary" => {
-                        obj.permissions_boundary =
-                            Some(AttachedPermissionsBoundaryDeserializer::deserialize(
-                                "PermissionsBoundary",
-                                stack,
-                            )?);
-                    }
-                    "Tags" => {
-                        obj.tags = match obj.tags {
-                            Some(ref mut existing) => {
-                                existing
-                                    .extend(TagListTypeDeserializer::deserialize("Tags", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(TagListTypeDeserializer::deserialize("Tags", stack)?),
-                        };
-                    }
-                    "UserId" => {
-                        obj.user_id = IdTypeDeserializer::deserialize("UserId", stack)?;
-                    }
-                    "UserName" => {
-                        obj.user_name = UserNameTypeDeserializer::deserialize("UserName", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                "Tags" => {
+                    obj.tags
+                        .get_or_insert(vec![])
+                        .extend(TagListTypeDeserializer::deserialize("Tags", stack)?);
+                }
+                "UserId" => {
+                    obj.user_id = IdTypeDeserializer::deserialize("UserId", stack)?;
+                }
+                "UserName" => {
+                    obj.user_name = UserNameTypeDeserializer::deserialize("UserName", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains information about an IAM user, including all the user's policies and all the IAM groups the user is in.</p> <p>This data type is used as a response element in the <a>GetAccountAuthorizationDetails</a> operation.</p>
@@ -14150,112 +10710,57 @@ impl UserDetailDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UserDetail, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = UserDetail::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, UserDetail, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Arn" => {
+                    obj.arn = Some(ArnTypeDeserializer::deserialize("Arn", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Arn" => {
-                        obj.arn = Some(ArnTypeDeserializer::deserialize("Arn", stack)?);
-                    }
-                    "AttachedManagedPolicies" => {
-                        obj.attached_managed_policies = match obj.attached_managed_policies {
-                            Some(ref mut existing) => {
-                                existing.extend(AttachedPoliciesListTypeDeserializer::deserialize(
-                                    "AttachedManagedPolicies",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(AttachedPoliciesListTypeDeserializer::deserialize(
-                                "AttachedManagedPolicies",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "CreateDate" => {
-                        obj.create_date =
-                            Some(DateTypeDeserializer::deserialize("CreateDate", stack)?);
-                    }
-                    "GroupList" => {
-                        obj.group_list = match obj.group_list {
-                            Some(ref mut existing) => {
-                                existing.extend(GroupNameListTypeDeserializer::deserialize(
-                                    "GroupList",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(GroupNameListTypeDeserializer::deserialize(
-                                "GroupList",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "Path" => {
-                        obj.path = Some(PathTypeDeserializer::deserialize("Path", stack)?);
-                    }
-                    "PermissionsBoundary" => {
-                        obj.permissions_boundary =
-                            Some(AttachedPermissionsBoundaryDeserializer::deserialize(
-                                "PermissionsBoundary",
-                                stack,
-                            )?);
-                    }
-                    "Tags" => {
-                        obj.tags = match obj.tags {
-                            Some(ref mut existing) => {
-                                existing
-                                    .extend(TagListTypeDeserializer::deserialize("Tags", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(TagListTypeDeserializer::deserialize("Tags", stack)?),
-                        };
-                    }
-                    "UserId" => {
-                        obj.user_id = Some(IdTypeDeserializer::deserialize("UserId", stack)?);
-                    }
-                    "UserName" => {
-                        obj.user_name =
-                            Some(UserNameTypeDeserializer::deserialize("UserName", stack)?);
-                    }
-                    "UserPolicyList" => {
-                        obj.user_policy_list = match obj.user_policy_list {
-                            Some(ref mut existing) => {
-                                existing.extend(PolicyDetailListTypeDeserializer::deserialize(
-                                    "UserPolicyList",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(PolicyDetailListTypeDeserializer::deserialize(
-                                "UserPolicyList",
-                                stack,
-                            )?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "AttachedManagedPolicies" => {
+                    obj.attached_managed_policies.get_or_insert(vec![]).extend(
+                        AttachedPoliciesListTypeDeserializer::deserialize(
+                            "AttachedManagedPolicies",
+                            stack,
+                        )?,
+                    );
                 }
+                "CreateDate" => {
+                    obj.create_date = Some(DateTypeDeserializer::deserialize("CreateDate", stack)?);
+                }
+                "GroupList" => {
+                    obj.group_list.get_or_insert(vec![]).extend(
+                        GroupNameListTypeDeserializer::deserialize("GroupList", stack)?,
+                    );
+                }
+                "Path" => {
+                    obj.path = Some(PathTypeDeserializer::deserialize("Path", stack)?);
+                }
+                "PermissionsBoundary" => {
+                    obj.permissions_boundary =
+                        Some(AttachedPermissionsBoundaryDeserializer::deserialize(
+                            "PermissionsBoundary",
+                            stack,
+                        )?);
+                }
+                "Tags" => {
+                    obj.tags
+                        .get_or_insert(vec![])
+                        .extend(TagListTypeDeserializer::deserialize("Tags", stack)?);
+                }
+                "UserId" => {
+                    obj.user_id = Some(IdTypeDeserializer::deserialize("UserId", stack)?);
+                }
+                "UserName" => {
+                    obj.user_name = Some(UserNameTypeDeserializer::deserialize("UserName", stack)?);
+                }
+                "UserPolicyList" => {
+                    obj.user_policy_list.get_or_insert(vec![]).extend(
+                        PolicyDetailListTypeDeserializer::deserialize("UserPolicyList", stack)?,
+                    );
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct UserDetailListTypeDeserializer;
@@ -14265,37 +10770,14 @@ impl UserDetailListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<UserDetail>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(UserDetailDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(UserDetailDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct UserListTypeDeserializer;
@@ -14305,37 +10787,14 @@ impl UserListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<User>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(UserDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(UserDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct UserNameTypeDeserializer;
@@ -14374,54 +10833,32 @@ impl VirtualMFADeviceDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<VirtualMFADevice, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = VirtualMFADevice::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, VirtualMFADevice, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Base32StringSeed" => {
+                    obj.base_32_string_seed = Some(BootstrapDatumDeserializer::deserialize(
+                        "Base32StringSeed",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Base32StringSeed" => {
-                        obj.base_32_string_seed = Some(BootstrapDatumDeserializer::deserialize(
-                            "Base32StringSeed",
-                            stack,
-                        )?);
-                    }
-                    "EnableDate" => {
-                        obj.enable_date =
-                            Some(DateTypeDeserializer::deserialize("EnableDate", stack)?);
-                    }
-                    "QRCodePNG" => {
-                        obj.qr_code_png =
-                            Some(BootstrapDatumDeserializer::deserialize("QRCodePNG", stack)?);
-                    }
-                    "SerialNumber" => {
-                        obj.serial_number =
-                            SerialNumberTypeDeserializer::deserialize("SerialNumber", stack)?;
-                    }
-                    "User" => {
-                        obj.user = Some(UserDeserializer::deserialize("User", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "EnableDate" => {
+                    obj.enable_date = Some(DateTypeDeserializer::deserialize("EnableDate", stack)?);
                 }
+                "QRCodePNG" => {
+                    obj.qr_code_png =
+                        Some(BootstrapDatumDeserializer::deserialize("QRCodePNG", stack)?);
+                }
+                "SerialNumber" => {
+                    obj.serial_number =
+                        SerialNumberTypeDeserializer::deserialize("SerialNumber", stack)?;
+                }
+                "User" => {
+                    obj.user = Some(UserDeserializer::deserialize("User", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct VirtualMFADeviceListTypeDeserializer;
@@ -14431,37 +10868,14 @@ impl VirtualMFADeviceListTypeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<VirtualMFADevice>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(VirtualMFADeviceDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(VirtualMFADeviceDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// Errors returned by AddClientIDToOpenIDConnectProvider

--- a/rusoto/services/neptune/src/generated.rs
+++ b/rusoto/services/neptune/src/generated.rs
@@ -25,20 +25,15 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
 use rusoto_core::xmlutil::{
-    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+    characters, deserialize_elements, end_element, find_start_element, peek_at_name, skip_tree,
+    start_element,
 };
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;
-use xml::reader::XmlEvent;
 use xml::EventReader;
 
-enum DeserializerNext {
-    Close,
-    Skip,
-    Element(String),
-}
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct AddRoleToDBClusterMessage {
     /// <p>The name of the DB cluster to associate the IAM role with.</p>
@@ -105,21 +100,11 @@ impl AddSourceIdentifierToSubscriptionResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AddSourceIdentifierToSubscriptionResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AddSourceIdentifierToSubscriptionResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, AddSourceIdentifierToSubscriptionResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "EventSubscription" => {
                         obj.event_subscription = Some(EventSubscriptionDeserializer::deserialize(
                             "EventSubscription",
@@ -127,17 +112,10 @@ impl AddSourceIdentifierToSubscriptionResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p><p/></p>
@@ -218,21 +196,11 @@ impl ApplyPendingMaintenanceActionResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ApplyPendingMaintenanceActionResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ApplyPendingMaintenanceActionResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ApplyPendingMaintenanceActionResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ResourcePendingMaintenanceActions" => {
                         obj.resource_pending_maintenance_actions =
                             Some(ResourcePendingMaintenanceActionsDeserializer::deserialize(
@@ -241,17 +209,10 @@ impl ApplyPendingMaintenanceActionResultDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct AttributeValueListDeserializer;
@@ -261,37 +222,14 @@ impl AttributeValueListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "AttributeValue" {
-                        obj.push(StringDeserializer::deserialize("AttributeValue", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "AttributeValue" {
+                obj.push(StringDeserializer::deserialize("AttributeValue", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -320,36 +258,15 @@ impl AvailabilityZoneDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AvailabilityZone, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AvailabilityZone::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, AvailabilityZone, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Name" => {
+                    obj.name = Some(StringDeserializer::deserialize("Name", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Name" => {
-                        obj.name = Some(StringDeserializer::deserialize("Name", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct AvailabilityZoneListDeserializer;
@@ -359,40 +276,17 @@ impl AvailabilityZoneListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<AvailabilityZone>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "AvailabilityZone" {
-                        obj.push(AvailabilityZoneDeserializer::deserialize(
-                            "AvailabilityZone",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "AvailabilityZone" {
+                obj.push(AvailabilityZoneDeserializer::deserialize(
+                    "AvailabilityZone",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct AvailabilityZonesDeserializer;
@@ -402,37 +296,14 @@ impl AvailabilityZonesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "AvailabilityZone" {
-                        obj.push(StringDeserializer::deserialize("AvailabilityZone", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "AvailabilityZone" {
+                obj.push(StringDeserializer::deserialize("AvailabilityZone", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -491,43 +362,22 @@ impl CharacterSetDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CharacterSet, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CharacterSet::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CharacterSet, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CharacterSetDescription" => {
+                    obj.character_set_description = Some(StringDeserializer::deserialize(
+                        "CharacterSetDescription",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CharacterSetDescription" => {
-                        obj.character_set_description = Some(StringDeserializer::deserialize(
-                            "CharacterSetDescription",
-                            stack,
-                        )?);
-                    }
-                    "CharacterSetName" => {
-                        obj.character_set_name =
-                            Some(StringDeserializer::deserialize("CharacterSetName", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "CharacterSetName" => {
+                    obj.character_set_name =
+                        Some(StringDeserializer::deserialize("CharacterSetName", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>The configuration setting for the log types to be enabled for export to CloudWatch Logs for a specific DB instance or DB cluster.</p>
@@ -615,21 +465,11 @@ impl CopyDBClusterParameterGroupResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CopyDBClusterParameterGroupResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CopyDBClusterParameterGroupResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CopyDBClusterParameterGroupResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DBClusterParameterGroup" => {
                         obj.db_cluster_parameter_group =
                             Some(DBClusterParameterGroupDeserializer::deserialize(
@@ -638,17 +478,10 @@ impl CopyDBClusterParameterGroupResultDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p><p/></p>
@@ -714,21 +547,11 @@ impl CopyDBClusterSnapshotResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CopyDBClusterSnapshotResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CopyDBClusterSnapshotResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CopyDBClusterSnapshotResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DBClusterSnapshot" => {
                         obj.db_cluster_snapshot = Some(DBClusterSnapshotDeserializer::deserialize(
                             "DBClusterSnapshot",
@@ -736,17 +559,10 @@ impl CopyDBClusterSnapshotResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p><p/></p>
@@ -800,21 +616,11 @@ impl CopyDBParameterGroupResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CopyDBParameterGroupResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CopyDBParameterGroupResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CopyDBParameterGroupResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DBParameterGroup" => {
                         obj.db_parameter_group = Some(DBParameterGroupDeserializer::deserialize(
                             "DBParameterGroup",
@@ -822,17 +628,10 @@ impl CopyDBParameterGroupResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p><p/></p>
@@ -1037,21 +836,11 @@ impl CreateDBClusterParameterGroupResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateDBClusterParameterGroupResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateDBClusterParameterGroupResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateDBClusterParameterGroupResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DBClusterParameterGroup" => {
                         obj.db_cluster_parameter_group =
                             Some(DBClusterParameterGroupDeserializer::deserialize(
@@ -1060,17 +849,10 @@ impl CreateDBClusterParameterGroupResultDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -1085,37 +867,15 @@ impl CreateDBClusterResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateDBClusterResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateDBClusterResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CreateDBClusterResult, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DBCluster" => {
+                    obj.db_cluster = Some(DBClusterDeserializer::deserialize("DBCluster", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DBCluster" => {
-                        obj.db_cluster =
-                            Some(DBClusterDeserializer::deserialize("DBCluster", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p><p/></p>
@@ -1164,21 +924,11 @@ impl CreateDBClusterSnapshotResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateDBClusterSnapshotResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateDBClusterSnapshotResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateDBClusterSnapshotResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DBClusterSnapshot" => {
                         obj.db_cluster_snapshot = Some(DBClusterSnapshotDeserializer::deserialize(
                             "DBClusterSnapshot",
@@ -1186,17 +936,10 @@ impl CreateDBClusterSnapshotResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p><p/></p>
@@ -1493,37 +1236,16 @@ impl CreateDBInstanceResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateDBInstanceResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateDBInstanceResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CreateDBInstanceResult, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DBInstance" => {
+                    obj.db_instance =
+                        Some(DBInstanceDeserializer::deserialize("DBInstance", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DBInstance" => {
-                        obj.db_instance =
-                            Some(DBInstanceDeserializer::deserialize("DBInstance", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p><p/></p>
@@ -1574,21 +1296,11 @@ impl CreateDBParameterGroupResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateDBParameterGroupResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateDBParameterGroupResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateDBParameterGroupResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DBParameterGroup" => {
                         obj.db_parameter_group = Some(DBParameterGroupDeserializer::deserialize(
                             "DBParameterGroup",
@@ -1596,17 +1308,10 @@ impl CreateDBParameterGroupResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p><p/></p>
@@ -1661,21 +1366,11 @@ impl CreateDBSubnetGroupResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateDBSubnetGroupResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateDBSubnetGroupResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateDBSubnetGroupResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DBSubnetGroup" => {
                         obj.db_subnet_group = Some(DBSubnetGroupDeserializer::deserialize(
                             "DBSubnetGroup",
@@ -1683,17 +1378,10 @@ impl CreateDBSubnetGroupResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p><p/></p>
@@ -1769,21 +1457,11 @@ impl CreateEventSubscriptionResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateEventSubscriptionResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateEventSubscriptionResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateEventSubscriptionResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "EventSubscription" => {
                         obj.event_subscription = Some(EventSubscriptionDeserializer::deserialize(
                             "EventSubscription",
@@ -1791,17 +1469,10 @@ impl CreateEventSubscriptionResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Contains the details of an Amazon Neptune DB cluster. </p> <p>This data type is used as a response element in the <a>DescribeDBClusters</a> action. </p>
@@ -1886,265 +1557,184 @@ impl DBClusterDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBCluster, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBCluster::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DBCluster, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AllocatedStorage" => {
+                    obj.allocated_storage = Some(IntegerOptionalDeserializer::deserialize(
+                        "AllocatedStorage",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AllocatedStorage" => {
-                        obj.allocated_storage = Some(IntegerOptionalDeserializer::deserialize(
-                            "AllocatedStorage",
-                            stack,
-                        )?);
-                    }
-                    "AssociatedRoles" => {
-                        obj.associated_roles = match obj.associated_roles {
-                            Some(ref mut existing) => {
-                                existing.extend(DBClusterRolesDeserializer::deserialize(
-                                    "AssociatedRoles",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(DBClusterRolesDeserializer::deserialize(
-                                "AssociatedRoles",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "AvailabilityZones" => {
-                        obj.availability_zones = match obj.availability_zones {
-                            Some(ref mut existing) => {
-                                existing.extend(AvailabilityZonesDeserializer::deserialize(
-                                    "AvailabilityZones",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(AvailabilityZonesDeserializer::deserialize(
-                                "AvailabilityZones",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "BackupRetentionPeriod" => {
-                        obj.backup_retention_period =
-                            Some(IntegerOptionalDeserializer::deserialize(
-                                "BackupRetentionPeriod",
-                                stack,
-                            )?);
-                    }
-                    "CharacterSetName" => {
-                        obj.character_set_name =
-                            Some(StringDeserializer::deserialize("CharacterSetName", stack)?);
-                    }
-                    "CloneGroupId" => {
-                        obj.clone_group_id =
-                            Some(StringDeserializer::deserialize("CloneGroupId", stack)?);
-                    }
-                    "ClusterCreateTime" => {
-                        obj.cluster_create_time =
-                            Some(TStampDeserializer::deserialize("ClusterCreateTime", stack)?);
-                    }
-                    "DBClusterArn" => {
-                        obj.db_cluster_arn =
-                            Some(StringDeserializer::deserialize("DBClusterArn", stack)?);
-                    }
-                    "DBClusterIdentifier" => {
-                        obj.db_cluster_identifier = Some(StringDeserializer::deserialize(
-                            "DBClusterIdentifier",
-                            stack,
-                        )?);
-                    }
-                    "DBClusterMembers" => {
-                        obj.db_cluster_members = match obj.db_cluster_members {
-                            Some(ref mut existing) => {
-                                existing.extend(DBClusterMemberListDeserializer::deserialize(
-                                    "DBClusterMembers",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(DBClusterMemberListDeserializer::deserialize(
-                                "DBClusterMembers",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "DBClusterOptionGroupMemberships" => {
-                        obj.db_cluster_option_group_memberships = match obj
-                            .db_cluster_option_group_memberships
-                        {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    DBClusterOptionGroupMembershipsDeserializer::deserialize(
-                                        "DBClusterOptionGroupMemberships",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(DBClusterOptionGroupMembershipsDeserializer::deserialize(
-                                "DBClusterOptionGroupMemberships",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "DBClusterParameterGroup" => {
-                        obj.db_cluster_parameter_group = Some(StringDeserializer::deserialize(
-                            "DBClusterParameterGroup",
-                            stack,
-                        )?);
-                    }
-                    "DBSubnetGroup" => {
-                        obj.db_subnet_group =
-                            Some(StringDeserializer::deserialize("DBSubnetGroup", stack)?);
-                    }
-                    "DatabaseName" => {
-                        obj.database_name =
-                            Some(StringDeserializer::deserialize("DatabaseName", stack)?);
-                    }
-                    "DbClusterResourceId" => {
-                        obj.db_cluster_resource_id = Some(StringDeserializer::deserialize(
-                            "DbClusterResourceId",
-                            stack,
-                        )?);
-                    }
-                    "EarliestRestorableTime" => {
-                        obj.earliest_restorable_time = Some(TStampDeserializer::deserialize(
-                            "EarliestRestorableTime",
-                            stack,
-                        )?);
-                    }
-                    "Endpoint" => {
-                        obj.endpoint = Some(StringDeserializer::deserialize("Endpoint", stack)?);
-                    }
-                    "Engine" => {
-                        obj.engine = Some(StringDeserializer::deserialize("Engine", stack)?);
-                    }
-                    "EngineVersion" => {
-                        obj.engine_version =
-                            Some(StringDeserializer::deserialize("EngineVersion", stack)?);
-                    }
-                    "HostedZoneId" => {
-                        obj.hosted_zone_id =
-                            Some(StringDeserializer::deserialize("HostedZoneId", stack)?);
-                    }
-                    "IAMDatabaseAuthenticationEnabled" => {
-                        obj.iam_database_authentication_enabled =
-                            Some(BooleanDeserializer::deserialize(
-                                "IAMDatabaseAuthenticationEnabled",
-                                stack,
-                            )?);
-                    }
-                    "KmsKeyId" => {
-                        obj.kms_key_id = Some(StringDeserializer::deserialize("KmsKeyId", stack)?);
-                    }
-                    "LatestRestorableTime" => {
-                        obj.latest_restorable_time = Some(TStampDeserializer::deserialize(
-                            "LatestRestorableTime",
-                            stack,
-                        )?);
-                    }
-                    "MasterUsername" => {
-                        obj.master_username =
-                            Some(StringDeserializer::deserialize("MasterUsername", stack)?);
-                    }
-                    "MultiAZ" => {
-                        obj.multi_az = Some(BooleanDeserializer::deserialize("MultiAZ", stack)?);
-                    }
-                    "PercentProgress" => {
-                        obj.percent_progress =
-                            Some(StringDeserializer::deserialize("PercentProgress", stack)?);
-                    }
-                    "Port" => {
-                        obj.port = Some(IntegerOptionalDeserializer::deserialize("Port", stack)?);
-                    }
-                    "PreferredBackupWindow" => {
-                        obj.preferred_backup_window = Some(StringDeserializer::deserialize(
-                            "PreferredBackupWindow",
-                            stack,
-                        )?);
-                    }
-                    "PreferredMaintenanceWindow" => {
-                        obj.preferred_maintenance_window = Some(StringDeserializer::deserialize(
-                            "PreferredMaintenanceWindow",
-                            stack,
-                        )?);
-                    }
-                    "ReadReplicaIdentifiers" => {
-                        obj.read_replica_identifiers = match obj.read_replica_identifiers {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    ReadReplicaIdentifierListDeserializer::deserialize(
-                                        "ReadReplicaIdentifiers",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ReadReplicaIdentifierListDeserializer::deserialize(
-                                "ReadReplicaIdentifiers",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "ReaderEndpoint" => {
-                        obj.reader_endpoint =
-                            Some(StringDeserializer::deserialize("ReaderEndpoint", stack)?);
-                    }
-                    "ReplicationSourceIdentifier" => {
-                        obj.replication_source_identifier = Some(StringDeserializer::deserialize(
-                            "ReplicationSourceIdentifier",
-                            stack,
-                        )?);
-                    }
-                    "Status" => {
-                        obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
-                    }
-                    "StorageEncrypted" => {
-                        obj.storage_encrypted =
-                            Some(BooleanDeserializer::deserialize("StorageEncrypted", stack)?);
-                    }
-                    "VpcSecurityGroups" => {
-                        obj.vpc_security_groups = match obj.vpc_security_groups {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    VpcSecurityGroupMembershipListDeserializer::deserialize(
-                                        "VpcSecurityGroups",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(VpcSecurityGroupMembershipListDeserializer::deserialize(
-                                "VpcSecurityGroups",
-                                stack,
-                            )?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "AssociatedRoles" => {
+                    obj.associated_roles.get_or_insert(vec![]).extend(
+                        DBClusterRolesDeserializer::deserialize("AssociatedRoles", stack)?,
+                    );
                 }
+                "AvailabilityZones" => {
+                    obj.availability_zones.get_or_insert(vec![]).extend(
+                        AvailabilityZonesDeserializer::deserialize("AvailabilityZones", stack)?,
+                    );
+                }
+                "BackupRetentionPeriod" => {
+                    obj.backup_retention_period = Some(IntegerOptionalDeserializer::deserialize(
+                        "BackupRetentionPeriod",
+                        stack,
+                    )?);
+                }
+                "CharacterSetName" => {
+                    obj.character_set_name =
+                        Some(StringDeserializer::deserialize("CharacterSetName", stack)?);
+                }
+                "CloneGroupId" => {
+                    obj.clone_group_id =
+                        Some(StringDeserializer::deserialize("CloneGroupId", stack)?);
+                }
+                "ClusterCreateTime" => {
+                    obj.cluster_create_time =
+                        Some(TStampDeserializer::deserialize("ClusterCreateTime", stack)?);
+                }
+                "DBClusterArn" => {
+                    obj.db_cluster_arn =
+                        Some(StringDeserializer::deserialize("DBClusterArn", stack)?);
+                }
+                "DBClusterIdentifier" => {
+                    obj.db_cluster_identifier = Some(StringDeserializer::deserialize(
+                        "DBClusterIdentifier",
+                        stack,
+                    )?);
+                }
+                "DBClusterMembers" => {
+                    obj.db_cluster_members.get_or_insert(vec![]).extend(
+                        DBClusterMemberListDeserializer::deserialize("DBClusterMembers", stack)?,
+                    );
+                }
+                "DBClusterOptionGroupMemberships" => {
+                    obj.db_cluster_option_group_memberships
+                        .get_or_insert(vec![])
+                        .extend(DBClusterOptionGroupMembershipsDeserializer::deserialize(
+                            "DBClusterOptionGroupMemberships",
+                            stack,
+                        )?);
+                }
+                "DBClusterParameterGroup" => {
+                    obj.db_cluster_parameter_group = Some(StringDeserializer::deserialize(
+                        "DBClusterParameterGroup",
+                        stack,
+                    )?);
+                }
+                "DBSubnetGroup" => {
+                    obj.db_subnet_group =
+                        Some(StringDeserializer::deserialize("DBSubnetGroup", stack)?);
+                }
+                "DatabaseName" => {
+                    obj.database_name =
+                        Some(StringDeserializer::deserialize("DatabaseName", stack)?);
+                }
+                "DbClusterResourceId" => {
+                    obj.db_cluster_resource_id = Some(StringDeserializer::deserialize(
+                        "DbClusterResourceId",
+                        stack,
+                    )?);
+                }
+                "EarliestRestorableTime" => {
+                    obj.earliest_restorable_time = Some(TStampDeserializer::deserialize(
+                        "EarliestRestorableTime",
+                        stack,
+                    )?);
+                }
+                "Endpoint" => {
+                    obj.endpoint = Some(StringDeserializer::deserialize("Endpoint", stack)?);
+                }
+                "Engine" => {
+                    obj.engine = Some(StringDeserializer::deserialize("Engine", stack)?);
+                }
+                "EngineVersion" => {
+                    obj.engine_version =
+                        Some(StringDeserializer::deserialize("EngineVersion", stack)?);
+                }
+                "HostedZoneId" => {
+                    obj.hosted_zone_id =
+                        Some(StringDeserializer::deserialize("HostedZoneId", stack)?);
+                }
+                "IAMDatabaseAuthenticationEnabled" => {
+                    obj.iam_database_authentication_enabled =
+                        Some(BooleanDeserializer::deserialize(
+                            "IAMDatabaseAuthenticationEnabled",
+                            stack,
+                        )?);
+                }
+                "KmsKeyId" => {
+                    obj.kms_key_id = Some(StringDeserializer::deserialize("KmsKeyId", stack)?);
+                }
+                "LatestRestorableTime" => {
+                    obj.latest_restorable_time = Some(TStampDeserializer::deserialize(
+                        "LatestRestorableTime",
+                        stack,
+                    )?);
+                }
+                "MasterUsername" => {
+                    obj.master_username =
+                        Some(StringDeserializer::deserialize("MasterUsername", stack)?);
+                }
+                "MultiAZ" => {
+                    obj.multi_az = Some(BooleanDeserializer::deserialize("MultiAZ", stack)?);
+                }
+                "PercentProgress" => {
+                    obj.percent_progress =
+                        Some(StringDeserializer::deserialize("PercentProgress", stack)?);
+                }
+                "Port" => {
+                    obj.port = Some(IntegerOptionalDeserializer::deserialize("Port", stack)?);
+                }
+                "PreferredBackupWindow" => {
+                    obj.preferred_backup_window = Some(StringDeserializer::deserialize(
+                        "PreferredBackupWindow",
+                        stack,
+                    )?);
+                }
+                "PreferredMaintenanceWindow" => {
+                    obj.preferred_maintenance_window = Some(StringDeserializer::deserialize(
+                        "PreferredMaintenanceWindow",
+                        stack,
+                    )?);
+                }
+                "ReadReplicaIdentifiers" => {
+                    obj.read_replica_identifiers.get_or_insert(vec![]).extend(
+                        ReadReplicaIdentifierListDeserializer::deserialize(
+                            "ReadReplicaIdentifiers",
+                            stack,
+                        )?,
+                    );
+                }
+                "ReaderEndpoint" => {
+                    obj.reader_endpoint =
+                        Some(StringDeserializer::deserialize("ReaderEndpoint", stack)?);
+                }
+                "ReplicationSourceIdentifier" => {
+                    obj.replication_source_identifier = Some(StringDeserializer::deserialize(
+                        "ReplicationSourceIdentifier",
+                        stack,
+                    )?);
+                }
+                "Status" => {
+                    obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
+                }
+                "StorageEncrypted" => {
+                    obj.storage_encrypted =
+                        Some(BooleanDeserializer::deserialize("StorageEncrypted", stack)?);
+                }
+                "VpcSecurityGroups" => {
+                    obj.vpc_security_groups.get_or_insert(vec![]).extend(
+                        VpcSecurityGroupMembershipListDeserializer::deserialize(
+                            "VpcSecurityGroups",
+                            stack,
+                        )?,
+                    );
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct DBClusterListDeserializer;
@@ -2154,37 +1744,14 @@ impl DBClusterListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<DBCluster>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "DBCluster" {
-                        obj.push(DBClusterDeserializer::deserialize("DBCluster", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "DBCluster" {
+                obj.push(DBClusterDeserializer::deserialize("DBCluster", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains information about an instance that is part of a DB cluster.</p>
@@ -2207,56 +1774,34 @@ impl DBClusterMemberDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBClusterMember, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBClusterMember::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DBClusterMember, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DBClusterParameterGroupStatus" => {
+                    obj.db_cluster_parameter_group_status = Some(StringDeserializer::deserialize(
+                        "DBClusterParameterGroupStatus",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DBClusterParameterGroupStatus" => {
-                        obj.db_cluster_parameter_group_status =
-                            Some(StringDeserializer::deserialize(
-                                "DBClusterParameterGroupStatus",
-                                stack,
-                            )?);
-                    }
-                    "DBInstanceIdentifier" => {
-                        obj.db_instance_identifier = Some(StringDeserializer::deserialize(
-                            "DBInstanceIdentifier",
-                            stack,
-                        )?);
-                    }
-                    "IsClusterWriter" => {
-                        obj.is_cluster_writer =
-                            Some(BooleanDeserializer::deserialize("IsClusterWriter", stack)?);
-                    }
-                    "PromotionTier" => {
-                        obj.promotion_tier = Some(IntegerOptionalDeserializer::deserialize(
-                            "PromotionTier",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "DBInstanceIdentifier" => {
+                    obj.db_instance_identifier = Some(StringDeserializer::deserialize(
+                        "DBInstanceIdentifier",
+                        stack,
+                    )?);
                 }
+                "IsClusterWriter" => {
+                    obj.is_cluster_writer =
+                        Some(BooleanDeserializer::deserialize("IsClusterWriter", stack)?);
+                }
+                "PromotionTier" => {
+                    obj.promotion_tier = Some(IntegerOptionalDeserializer::deserialize(
+                        "PromotionTier",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct DBClusterMemberListDeserializer;
@@ -2266,40 +1811,17 @@ impl DBClusterMemberListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<DBClusterMember>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "DBClusterMember" {
-                        obj.push(DBClusterMemberDeserializer::deserialize(
-                            "DBClusterMember",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "DBClusterMember" {
+                obj.push(DBClusterMemberDeserializer::deserialize(
+                    "DBClusterMember",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains the result of a successful invocation of the <a>DescribeDBClusters</a> action.</p>
@@ -2318,50 +1840,20 @@ impl DBClusterMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBClusterMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBClusterMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DBClusterMessage, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DBClusters" => {
+                    obj.db_clusters
+                        .get_or_insert(vec![])
+                        .extend(DBClusterListDeserializer::deserialize("DBClusters", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DBClusters" => {
-                        obj.db_clusters = match obj.db_clusters {
-                            Some(ref mut existing) => {
-                                existing.extend(DBClusterListDeserializer::deserialize(
-                                    "DBClusters",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => {
-                                Some(DBClusterListDeserializer::deserialize("DBClusters", stack)?)
-                            }
-                        };
-                    }
-                    "Marker" => {
-                        obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Marker" => {
+                    obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct DBClusterOptionGroupMembershipsDeserializer;
@@ -2371,40 +1863,17 @@ impl DBClusterOptionGroupMembershipsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<DBClusterOptionGroupStatus>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "DBClusterOptionGroup" {
-                        obj.push(DBClusterOptionGroupStatusDeserializer::deserialize(
-                            "DBClusterOptionGroup",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "DBClusterOptionGroup" {
+                obj.push(DBClusterOptionGroupStatusDeserializer::deserialize(
+                    "DBClusterOptionGroup",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains status information for a DB cluster option group.</p>
@@ -2423,21 +1892,11 @@ impl DBClusterOptionGroupStatusDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBClusterOptionGroupStatus, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBClusterOptionGroupStatus::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DBClusterOptionGroupStatus, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DBClusterOptionGroupName" => {
                         obj.db_cluster_option_group_name = Some(StringDeserializer::deserialize(
                             "DBClusterOptionGroupName",
@@ -2448,17 +1907,10 @@ impl DBClusterOptionGroupStatusDeserializer {
                         obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Contains the details of an Amazon Neptune DB cluster parameter group. </p> <p>This data type is used as a response element in the <a>DescribeDBClusterParameterGroups</a> action. </p>
@@ -2481,21 +1933,11 @@ impl DBClusterParameterGroupDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBClusterParameterGroup, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBClusterParameterGroup::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DBClusterParameterGroup, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DBClusterParameterGroupArn" => {
                         obj.db_cluster_parameter_group_arn = Some(StringDeserializer::deserialize(
                             "DBClusterParameterGroupArn",
@@ -2518,17 +1960,10 @@ impl DBClusterParameterGroupDeserializer {
                             Some(StringDeserializer::deserialize("Description", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Provides details about a DB cluster parameter group including the parameters in the DB cluster parameter group.</p>
@@ -2547,51 +1982,24 @@ impl DBClusterParameterGroupDetailsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBClusterParameterGroupDetails, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBClusterParameterGroupDetails::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DBClusterParameterGroupDetails, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Marker" => {
                         obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                     }
                     "Parameters" => {
-                        obj.parameters = match obj.parameters {
-                            Some(ref mut existing) => {
-                                existing.extend(ParametersListDeserializer::deserialize(
-                                    "Parameters",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ParametersListDeserializer::deserialize(
-                                "Parameters",
-                                stack,
-                            )?),
-                        };
+                        obj.parameters.get_or_insert(vec![]).extend(
+                            ParametersListDeserializer::deserialize("Parameters", stack)?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct DBClusterParameterGroupListDeserializer;
@@ -2601,40 +2009,17 @@ impl DBClusterParameterGroupListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<DBClusterParameterGroup>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "DBClusterParameterGroup" {
-                        obj.push(DBClusterParameterGroupDeserializer::deserialize(
-                            "DBClusterParameterGroup",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "DBClusterParameterGroup" {
+                obj.push(DBClusterParameterGroupDeserializer::deserialize(
+                    "DBClusterParameterGroup",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p><p/></p>
@@ -2651,38 +2036,21 @@ impl DBClusterParameterGroupNameMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBClusterParameterGroupNameMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBClusterParameterGroupNameMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DBClusterParameterGroupNameMessage, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DBClusterParameterGroupName" => {
                         obj.db_cluster_parameter_group_name = Some(
                             StringDeserializer::deserialize("DBClusterParameterGroupName", stack)?,
                         );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p><p/></p>
@@ -2701,53 +2069,27 @@ impl DBClusterParameterGroupsMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBClusterParameterGroupsMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBClusterParameterGroupsMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DBClusterParameterGroupsMessage, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DBClusterParameterGroups" => {
-                        obj.db_cluster_parameter_groups = match obj.db_cluster_parameter_groups {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    DBClusterParameterGroupListDeserializer::deserialize(
-                                        "DBClusterParameterGroups",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(DBClusterParameterGroupListDeserializer::deserialize(
+                        obj.db_cluster_parameter_groups
+                            .get_or_insert(vec![])
+                            .extend(DBClusterParameterGroupListDeserializer::deserialize(
                                 "DBClusterParameterGroups",
                                 stack,
-                            )?),
-                        };
+                            )?);
                     }
                     "Marker" => {
                         obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Describes an AWS Identity and Access Management (IAM) role that is associated with a DB cluster.</p>
@@ -2766,39 +2108,18 @@ impl DBClusterRoleDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBClusterRole, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBClusterRole::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DBClusterRole, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "RoleArn" => {
+                    obj.role_arn = Some(StringDeserializer::deserialize("RoleArn", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "RoleArn" => {
-                        obj.role_arn = Some(StringDeserializer::deserialize("RoleArn", stack)?);
-                    }
-                    "Status" => {
-                        obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Status" => {
+                    obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct DBClusterRolesDeserializer;
@@ -2808,40 +2129,17 @@ impl DBClusterRolesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<DBClusterRole>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "DBClusterRole" {
-                        obj.push(DBClusterRoleDeserializer::deserialize(
-                            "DBClusterRole",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "DBClusterRole" {
+                obj.push(DBClusterRoleDeserializer::deserialize(
+                    "DBClusterRole",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains the details for an Amazon Neptune DB cluster snapshot </p> <p>This data type is used as a response element in the <a>DescribeDBClusterSnapshots</a> action. </p>
@@ -2896,132 +2194,101 @@ impl DBClusterSnapshotDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBClusterSnapshot, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBClusterSnapshot::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DBClusterSnapshot, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AllocatedStorage" => {
+                    obj.allocated_storage =
+                        Some(IntegerDeserializer::deserialize("AllocatedStorage", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AllocatedStorage" => {
-                        obj.allocated_storage =
-                            Some(IntegerDeserializer::deserialize("AllocatedStorage", stack)?);
-                    }
-                    "AvailabilityZones" => {
-                        obj.availability_zones = match obj.availability_zones {
-                            Some(ref mut existing) => {
-                                existing.extend(AvailabilityZonesDeserializer::deserialize(
-                                    "AvailabilityZones",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(AvailabilityZonesDeserializer::deserialize(
-                                "AvailabilityZones",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "ClusterCreateTime" => {
-                        obj.cluster_create_time =
-                            Some(TStampDeserializer::deserialize("ClusterCreateTime", stack)?);
-                    }
-                    "DBClusterIdentifier" => {
-                        obj.db_cluster_identifier = Some(StringDeserializer::deserialize(
-                            "DBClusterIdentifier",
-                            stack,
-                        )?);
-                    }
-                    "DBClusterSnapshotArn" => {
-                        obj.db_cluster_snapshot_arn = Some(StringDeserializer::deserialize(
-                            "DBClusterSnapshotArn",
-                            stack,
-                        )?);
-                    }
-                    "DBClusterSnapshotIdentifier" => {
-                        obj.db_cluster_snapshot_identifier = Some(StringDeserializer::deserialize(
-                            "DBClusterSnapshotIdentifier",
-                            stack,
-                        )?);
-                    }
-                    "Engine" => {
-                        obj.engine = Some(StringDeserializer::deserialize("Engine", stack)?);
-                    }
-                    "EngineVersion" => {
-                        obj.engine_version =
-                            Some(StringDeserializer::deserialize("EngineVersion", stack)?);
-                    }
-                    "IAMDatabaseAuthenticationEnabled" => {
-                        obj.iam_database_authentication_enabled =
-                            Some(BooleanDeserializer::deserialize(
-                                "IAMDatabaseAuthenticationEnabled",
-                                stack,
-                            )?);
-                    }
-                    "KmsKeyId" => {
-                        obj.kms_key_id = Some(StringDeserializer::deserialize("KmsKeyId", stack)?);
-                    }
-                    "LicenseModel" => {
-                        obj.license_model =
-                            Some(StringDeserializer::deserialize("LicenseModel", stack)?);
-                    }
-                    "MasterUsername" => {
-                        obj.master_username =
-                            Some(StringDeserializer::deserialize("MasterUsername", stack)?);
-                    }
-                    "PercentProgress" => {
-                        obj.percent_progress =
-                            Some(IntegerDeserializer::deserialize("PercentProgress", stack)?);
-                    }
-                    "Port" => {
-                        obj.port = Some(IntegerDeserializer::deserialize("Port", stack)?);
-                    }
-                    "SnapshotCreateTime" => {
-                        obj.snapshot_create_time = Some(TStampDeserializer::deserialize(
-                            "SnapshotCreateTime",
-                            stack,
-                        )?);
-                    }
-                    "SnapshotType" => {
-                        obj.snapshot_type =
-                            Some(StringDeserializer::deserialize("SnapshotType", stack)?);
-                    }
-                    "SourceDBClusterSnapshotArn" => {
-                        obj.source_db_cluster_snapshot_arn = Some(StringDeserializer::deserialize(
-                            "SourceDBClusterSnapshotArn",
-                            stack,
-                        )?);
-                    }
-                    "Status" => {
-                        obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
-                    }
-                    "StorageEncrypted" => {
-                        obj.storage_encrypted =
-                            Some(BooleanDeserializer::deserialize("StorageEncrypted", stack)?);
-                    }
-                    "VpcId" => {
-                        obj.vpc_id = Some(StringDeserializer::deserialize("VpcId", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "AvailabilityZones" => {
+                    obj.availability_zones.get_or_insert(vec![]).extend(
+                        AvailabilityZonesDeserializer::deserialize("AvailabilityZones", stack)?,
+                    );
                 }
+                "ClusterCreateTime" => {
+                    obj.cluster_create_time =
+                        Some(TStampDeserializer::deserialize("ClusterCreateTime", stack)?);
+                }
+                "DBClusterIdentifier" => {
+                    obj.db_cluster_identifier = Some(StringDeserializer::deserialize(
+                        "DBClusterIdentifier",
+                        stack,
+                    )?);
+                }
+                "DBClusterSnapshotArn" => {
+                    obj.db_cluster_snapshot_arn = Some(StringDeserializer::deserialize(
+                        "DBClusterSnapshotArn",
+                        stack,
+                    )?);
+                }
+                "DBClusterSnapshotIdentifier" => {
+                    obj.db_cluster_snapshot_identifier = Some(StringDeserializer::deserialize(
+                        "DBClusterSnapshotIdentifier",
+                        stack,
+                    )?);
+                }
+                "Engine" => {
+                    obj.engine = Some(StringDeserializer::deserialize("Engine", stack)?);
+                }
+                "EngineVersion" => {
+                    obj.engine_version =
+                        Some(StringDeserializer::deserialize("EngineVersion", stack)?);
+                }
+                "IAMDatabaseAuthenticationEnabled" => {
+                    obj.iam_database_authentication_enabled =
+                        Some(BooleanDeserializer::deserialize(
+                            "IAMDatabaseAuthenticationEnabled",
+                            stack,
+                        )?);
+                }
+                "KmsKeyId" => {
+                    obj.kms_key_id = Some(StringDeserializer::deserialize("KmsKeyId", stack)?);
+                }
+                "LicenseModel" => {
+                    obj.license_model =
+                        Some(StringDeserializer::deserialize("LicenseModel", stack)?);
+                }
+                "MasterUsername" => {
+                    obj.master_username =
+                        Some(StringDeserializer::deserialize("MasterUsername", stack)?);
+                }
+                "PercentProgress" => {
+                    obj.percent_progress =
+                        Some(IntegerDeserializer::deserialize("PercentProgress", stack)?);
+                }
+                "Port" => {
+                    obj.port = Some(IntegerDeserializer::deserialize("Port", stack)?);
+                }
+                "SnapshotCreateTime" => {
+                    obj.snapshot_create_time = Some(TStampDeserializer::deserialize(
+                        "SnapshotCreateTime",
+                        stack,
+                    )?);
+                }
+                "SnapshotType" => {
+                    obj.snapshot_type =
+                        Some(StringDeserializer::deserialize("SnapshotType", stack)?);
+                }
+                "SourceDBClusterSnapshotArn" => {
+                    obj.source_db_cluster_snapshot_arn = Some(StringDeserializer::deserialize(
+                        "SourceDBClusterSnapshotArn",
+                        stack,
+                    )?);
+                }
+                "Status" => {
+                    obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
+                }
+                "StorageEncrypted" => {
+                    obj.storage_encrypted =
+                        Some(BooleanDeserializer::deserialize("StorageEncrypted", stack)?);
+                }
+                "VpcId" => {
+                    obj.vpc_id = Some(StringDeserializer::deserialize("VpcId", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains the name and values of a manual DB cluster snapshot attribute.</p> <p>Manual DB cluster snapshot attributes are used to authorize other AWS accounts to restore a manual DB cluster snapshot. For more information, see the <a>ModifyDBClusterSnapshotAttribute</a> API action.</p>
@@ -3040,52 +2307,25 @@ impl DBClusterSnapshotAttributeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBClusterSnapshotAttribute, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBClusterSnapshotAttribute::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DBClusterSnapshotAttribute, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AttributeName" => {
                         obj.attribute_name =
                             Some(StringDeserializer::deserialize("AttributeName", stack)?);
                     }
                     "AttributeValues" => {
-                        obj.attribute_values = match obj.attribute_values {
-                            Some(ref mut existing) => {
-                                existing.extend(AttributeValueListDeserializer::deserialize(
-                                    "AttributeValues",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(AttributeValueListDeserializer::deserialize(
-                                "AttributeValues",
-                                stack,
-                            )?),
-                        };
+                        obj.attribute_values.get_or_insert(vec![]).extend(
+                            AttributeValueListDeserializer::deserialize("AttributeValues", stack)?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct DBClusterSnapshotAttributeListDeserializer;
@@ -3095,40 +2335,17 @@ impl DBClusterSnapshotAttributeListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<DBClusterSnapshotAttribute>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "DBClusterSnapshotAttribute" {
-                        obj.push(DBClusterSnapshotAttributeDeserializer::deserialize(
-                            "DBClusterSnapshotAttribute",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "DBClusterSnapshotAttribute" {
+                obj.push(DBClusterSnapshotAttributeDeserializer::deserialize(
+                    "DBClusterSnapshotAttribute",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains the results of a successful call to the <a>DescribeDBClusterSnapshotAttributes</a> API action.</p> <p>Manual DB cluster snapshot attributes are used to authorize other AWS accounts to copy or restore a manual DB cluster snapshot. For more information, see the <a>ModifyDBClusterSnapshotAttribute</a> API action.</p>
@@ -3147,39 +2364,18 @@ impl DBClusterSnapshotAttributesResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBClusterSnapshotAttributesResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBClusterSnapshotAttributesResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DBClusterSnapshotAttributesResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DBClusterSnapshotAttributes" => {
-                        obj.db_cluster_snapshot_attributes = match obj
-                            .db_cluster_snapshot_attributes
-                        {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    DBClusterSnapshotAttributeListDeserializer::deserialize(
-                                        "DBClusterSnapshotAttributes",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(DBClusterSnapshotAttributeListDeserializer::deserialize(
+                        obj.db_cluster_snapshot_attributes
+                            .get_or_insert(vec![])
+                            .extend(DBClusterSnapshotAttributeListDeserializer::deserialize(
                                 "DBClusterSnapshotAttributes",
                                 stack,
-                            )?),
-                        };
+                            )?);
                     }
                     "DBClusterSnapshotIdentifier" => {
                         obj.db_cluster_snapshot_identifier = Some(StringDeserializer::deserialize(
@@ -3188,17 +2384,10 @@ impl DBClusterSnapshotAttributesResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct DBClusterSnapshotListDeserializer;
@@ -3208,40 +2397,17 @@ impl DBClusterSnapshotListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<DBClusterSnapshot>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "DBClusterSnapshot" {
-                        obj.push(DBClusterSnapshotDeserializer::deserialize(
-                            "DBClusterSnapshot",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "DBClusterSnapshot" {
+                obj.push(DBClusterSnapshotDeserializer::deserialize(
+                    "DBClusterSnapshot",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p> Provides a list of DB cluster snapshots for the user as the result of a call to the <a>DescribeDBClusterSnapshots</a> action. </p>
@@ -3260,51 +2426,27 @@ impl DBClusterSnapshotMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBClusterSnapshotMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBClusterSnapshotMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DBClusterSnapshotMessage, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DBClusterSnapshots" => {
-                        obj.db_cluster_snapshots = match obj.db_cluster_snapshots {
-                            Some(ref mut existing) => {
-                                existing.extend(DBClusterSnapshotListDeserializer::deserialize(
-                                    "DBClusterSnapshots",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(DBClusterSnapshotListDeserializer::deserialize(
+                        obj.db_cluster_snapshots.get_or_insert(vec![]).extend(
+                            DBClusterSnapshotListDeserializer::deserialize(
                                 "DBClusterSnapshots",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     "Marker" => {
                         obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p> This data type is used as a response element in the action <a>DescribeDBEngineVersions</a>. </p>
@@ -3343,139 +2485,85 @@ impl DBEngineVersionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBEngineVersion, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBEngineVersion::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DBEngineVersion, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DBEngineDescription" => {
+                    obj.db_engine_description = Some(StringDeserializer::deserialize(
+                        "DBEngineDescription",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DBEngineDescription" => {
-                        obj.db_engine_description = Some(StringDeserializer::deserialize(
-                            "DBEngineDescription",
-                            stack,
-                        )?);
-                    }
-                    "DBEngineVersionDescription" => {
-                        obj.db_engine_version_description = Some(StringDeserializer::deserialize(
-                            "DBEngineVersionDescription",
-                            stack,
-                        )?);
-                    }
-                    "DBParameterGroupFamily" => {
-                        obj.db_parameter_group_family = Some(StringDeserializer::deserialize(
-                            "DBParameterGroupFamily",
-                            stack,
-                        )?);
-                    }
-                    "DefaultCharacterSet" => {
-                        obj.default_character_set = Some(CharacterSetDeserializer::deserialize(
-                            "DefaultCharacterSet",
-                            stack,
-                        )?);
-                    }
-                    "Engine" => {
-                        obj.engine = Some(StringDeserializer::deserialize("Engine", stack)?);
-                    }
-                    "EngineVersion" => {
-                        obj.engine_version =
-                            Some(StringDeserializer::deserialize("EngineVersion", stack)?);
-                    }
-                    "ExportableLogTypes" => {
-                        obj.exportable_log_types = match obj.exportable_log_types {
-                            Some(ref mut existing) => {
-                                existing.extend(LogTypeListDeserializer::deserialize(
-                                    "ExportableLogTypes",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(LogTypeListDeserializer::deserialize(
-                                "ExportableLogTypes",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "SupportedCharacterSets" => {
-                        obj.supported_character_sets = match obj.supported_character_sets {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    SupportedCharacterSetsListDeserializer::deserialize(
-                                        "SupportedCharacterSets",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(SupportedCharacterSetsListDeserializer::deserialize(
-                                "SupportedCharacterSets",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "SupportedTimezones" => {
-                        obj.supported_timezones = match obj.supported_timezones {
-                            Some(ref mut existing) => {
-                                existing.extend(SupportedTimezonesListDeserializer::deserialize(
-                                    "SupportedTimezones",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(SupportedTimezonesListDeserializer::deserialize(
-                                "SupportedTimezones",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "SupportsLogExportsToCloudwatchLogs" => {
-                        obj.supports_log_exports_to_cloudwatch_logs =
-                            Some(BooleanDeserializer::deserialize(
-                                "SupportsLogExportsToCloudwatchLogs",
-                                stack,
-                            )?);
-                    }
-                    "SupportsReadReplica" => {
-                        obj.supports_read_replica = Some(BooleanDeserializer::deserialize(
-                            "SupportsReadReplica",
-                            stack,
-                        )?);
-                    }
-                    "ValidUpgradeTarget" => {
-                        obj.valid_upgrade_target = match obj.valid_upgrade_target {
-                            Some(ref mut existing) => {
-                                existing.extend(ValidUpgradeTargetListDeserializer::deserialize(
-                                    "ValidUpgradeTarget",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ValidUpgradeTargetListDeserializer::deserialize(
-                                "ValidUpgradeTarget",
-                                stack,
-                            )?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "DBEngineVersionDescription" => {
+                    obj.db_engine_version_description = Some(StringDeserializer::deserialize(
+                        "DBEngineVersionDescription",
+                        stack,
+                    )?);
                 }
+                "DBParameterGroupFamily" => {
+                    obj.db_parameter_group_family = Some(StringDeserializer::deserialize(
+                        "DBParameterGroupFamily",
+                        stack,
+                    )?);
+                }
+                "DefaultCharacterSet" => {
+                    obj.default_character_set = Some(CharacterSetDeserializer::deserialize(
+                        "DefaultCharacterSet",
+                        stack,
+                    )?);
+                }
+                "Engine" => {
+                    obj.engine = Some(StringDeserializer::deserialize("Engine", stack)?);
+                }
+                "EngineVersion" => {
+                    obj.engine_version =
+                        Some(StringDeserializer::deserialize("EngineVersion", stack)?);
+                }
+                "ExportableLogTypes" => {
+                    obj.exportable_log_types.get_or_insert(vec![]).extend(
+                        LogTypeListDeserializer::deserialize("ExportableLogTypes", stack)?,
+                    );
+                }
+                "SupportedCharacterSets" => {
+                    obj.supported_character_sets.get_or_insert(vec![]).extend(
+                        SupportedCharacterSetsListDeserializer::deserialize(
+                            "SupportedCharacterSets",
+                            stack,
+                        )?,
+                    );
+                }
+                "SupportedTimezones" => {
+                    obj.supported_timezones.get_or_insert(vec![]).extend(
+                        SupportedTimezonesListDeserializer::deserialize(
+                            "SupportedTimezones",
+                            stack,
+                        )?,
+                    );
+                }
+                "SupportsLogExportsToCloudwatchLogs" => {
+                    obj.supports_log_exports_to_cloudwatch_logs =
+                        Some(BooleanDeserializer::deserialize(
+                            "SupportsLogExportsToCloudwatchLogs",
+                            stack,
+                        )?);
+                }
+                "SupportsReadReplica" => {
+                    obj.supports_read_replica = Some(BooleanDeserializer::deserialize(
+                        "SupportsReadReplica",
+                        stack,
+                    )?);
+                }
+                "ValidUpgradeTarget" => {
+                    obj.valid_upgrade_target.get_or_insert(vec![]).extend(
+                        ValidUpgradeTargetListDeserializer::deserialize(
+                            "ValidUpgradeTarget",
+                            stack,
+                        )?,
+                    );
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct DBEngineVersionListDeserializer;
@@ -3485,40 +2573,17 @@ impl DBEngineVersionListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<DBEngineVersion>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "DBEngineVersion" {
-                        obj.push(DBEngineVersionDeserializer::deserialize(
-                            "DBEngineVersion",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "DBEngineVersion" {
+                obj.push(DBEngineVersionDeserializer::deserialize(
+                    "DBEngineVersion",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p> Contains the result of a successful invocation of the <a>DescribeDBEngineVersions</a> action. </p>
@@ -3537,51 +2602,20 @@ impl DBEngineVersionMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBEngineVersionMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBEngineVersionMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DBEngineVersionMessage, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DBEngineVersions" => {
+                    obj.db_engine_versions.get_or_insert(vec![]).extend(
+                        DBEngineVersionListDeserializer::deserialize("DBEngineVersions", stack)?,
+                    );
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DBEngineVersions" => {
-                        obj.db_engine_versions = match obj.db_engine_versions {
-                            Some(ref mut existing) => {
-                                existing.extend(DBEngineVersionListDeserializer::deserialize(
-                                    "DBEngineVersions",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(DBEngineVersionListDeserializer::deserialize(
-                                "DBEngineVersions",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "Marker" => {
-                        obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Marker" => {
+                    obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains the details of an Amazon Neptune DB instance. </p> <p>This data type is used as a response element in the <a>DescribeDBInstances</a> action. </p>
@@ -3698,394 +2732,284 @@ impl DBInstanceDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBInstance, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBInstance::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DBInstance, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AllocatedStorage" => {
+                    obj.allocated_storage =
+                        Some(IntegerDeserializer::deserialize("AllocatedStorage", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AllocatedStorage" => {
-                        obj.allocated_storage =
-                            Some(IntegerDeserializer::deserialize("AllocatedStorage", stack)?);
-                    }
-                    "AutoMinorVersionUpgrade" => {
-                        obj.auto_minor_version_upgrade = Some(BooleanDeserializer::deserialize(
-                            "AutoMinorVersionUpgrade",
+                "AutoMinorVersionUpgrade" => {
+                    obj.auto_minor_version_upgrade = Some(BooleanDeserializer::deserialize(
+                        "AutoMinorVersionUpgrade",
+                        stack,
+                    )?);
+                }
+                "AvailabilityZone" => {
+                    obj.availability_zone =
+                        Some(StringDeserializer::deserialize("AvailabilityZone", stack)?);
+                }
+                "BackupRetentionPeriod" => {
+                    obj.backup_retention_period = Some(IntegerDeserializer::deserialize(
+                        "BackupRetentionPeriod",
+                        stack,
+                    )?);
+                }
+                "CACertificateIdentifier" => {
+                    obj.ca_certificate_identifier = Some(StringDeserializer::deserialize(
+                        "CACertificateIdentifier",
+                        stack,
+                    )?);
+                }
+                "CharacterSetName" => {
+                    obj.character_set_name =
+                        Some(StringDeserializer::deserialize("CharacterSetName", stack)?);
+                }
+                "CopyTagsToSnapshot" => {
+                    obj.copy_tags_to_snapshot = Some(BooleanDeserializer::deserialize(
+                        "CopyTagsToSnapshot",
+                        stack,
+                    )?);
+                }
+                "DBClusterIdentifier" => {
+                    obj.db_cluster_identifier = Some(StringDeserializer::deserialize(
+                        "DBClusterIdentifier",
+                        stack,
+                    )?);
+                }
+                "DBInstanceArn" => {
+                    obj.db_instance_arn =
+                        Some(StringDeserializer::deserialize("DBInstanceArn", stack)?);
+                }
+                "DBInstanceClass" => {
+                    obj.db_instance_class =
+                        Some(StringDeserializer::deserialize("DBInstanceClass", stack)?);
+                }
+                "DBInstanceIdentifier" => {
+                    obj.db_instance_identifier = Some(StringDeserializer::deserialize(
+                        "DBInstanceIdentifier",
+                        stack,
+                    )?);
+                }
+                "DBInstanceStatus" => {
+                    obj.db_instance_status =
+                        Some(StringDeserializer::deserialize("DBInstanceStatus", stack)?);
+                }
+                "DBName" => {
+                    obj.db_name = Some(StringDeserializer::deserialize("DBName", stack)?);
+                }
+                "DBParameterGroups" => {
+                    obj.db_parameter_groups.get_or_insert(vec![]).extend(
+                        DBParameterGroupStatusListDeserializer::deserialize(
+                            "DBParameterGroups",
+                            stack,
+                        )?,
+                    );
+                }
+                "DBSecurityGroups" => {
+                    obj.db_security_groups.get_or_insert(vec![]).extend(
+                        DBSecurityGroupMembershipListDeserializer::deserialize(
+                            "DBSecurityGroups",
+                            stack,
+                        )?,
+                    );
+                }
+                "DBSubnetGroup" => {
+                    obj.db_subnet_group = Some(DBSubnetGroupDeserializer::deserialize(
+                        "DBSubnetGroup",
+                        stack,
+                    )?);
+                }
+                "DbInstancePort" => {
+                    obj.db_instance_port =
+                        Some(IntegerDeserializer::deserialize("DbInstancePort", stack)?);
+                }
+                "DbiResourceId" => {
+                    obj.dbi_resource_id =
+                        Some(StringDeserializer::deserialize("DbiResourceId", stack)?);
+                }
+                "DomainMemberships" => {
+                    obj.domain_memberships.get_or_insert(vec![]).extend(
+                        DomainMembershipListDeserializer::deserialize("DomainMemberships", stack)?,
+                    );
+                }
+                "EnabledCloudwatchLogsExports" => {
+                    obj.enabled_cloudwatch_logs_exports
+                        .get_or_insert(vec![])
+                        .extend(LogTypeListDeserializer::deserialize(
+                            "EnabledCloudwatchLogsExports",
                             stack,
                         )?);
-                    }
-                    "AvailabilityZone" => {
-                        obj.availability_zone =
-                            Some(StringDeserializer::deserialize("AvailabilityZone", stack)?);
-                    }
-                    "BackupRetentionPeriod" => {
-                        obj.backup_retention_period = Some(IntegerDeserializer::deserialize(
-                            "BackupRetentionPeriod",
+                }
+                "Endpoint" => {
+                    obj.endpoint = Some(EndpointDeserializer::deserialize("Endpoint", stack)?);
+                }
+                "Engine" => {
+                    obj.engine = Some(StringDeserializer::deserialize("Engine", stack)?);
+                }
+                "EngineVersion" => {
+                    obj.engine_version =
+                        Some(StringDeserializer::deserialize("EngineVersion", stack)?);
+                }
+                "EnhancedMonitoringResourceArn" => {
+                    obj.enhanced_monitoring_resource_arn = Some(StringDeserializer::deserialize(
+                        "EnhancedMonitoringResourceArn",
+                        stack,
+                    )?);
+                }
+                "IAMDatabaseAuthenticationEnabled" => {
+                    obj.iam_database_authentication_enabled =
+                        Some(BooleanDeserializer::deserialize(
+                            "IAMDatabaseAuthenticationEnabled",
                             stack,
                         )?);
-                    }
-                    "CACertificateIdentifier" => {
-                        obj.ca_certificate_identifier = Some(StringDeserializer::deserialize(
-                            "CACertificateIdentifier",
+                }
+                "InstanceCreateTime" => {
+                    obj.instance_create_time = Some(TStampDeserializer::deserialize(
+                        "InstanceCreateTime",
+                        stack,
+                    )?);
+                }
+                "Iops" => {
+                    obj.iops = Some(IntegerOptionalDeserializer::deserialize("Iops", stack)?);
+                }
+                "KmsKeyId" => {
+                    obj.kms_key_id = Some(StringDeserializer::deserialize("KmsKeyId", stack)?);
+                }
+                "LatestRestorableTime" => {
+                    obj.latest_restorable_time = Some(TStampDeserializer::deserialize(
+                        "LatestRestorableTime",
+                        stack,
+                    )?);
+                }
+                "LicenseModel" => {
+                    obj.license_model =
+                        Some(StringDeserializer::deserialize("LicenseModel", stack)?);
+                }
+                "MasterUsername" => {
+                    obj.master_username =
+                        Some(StringDeserializer::deserialize("MasterUsername", stack)?);
+                }
+                "MonitoringInterval" => {
+                    obj.monitoring_interval = Some(IntegerOptionalDeserializer::deserialize(
+                        "MonitoringInterval",
+                        stack,
+                    )?);
+                }
+                "MonitoringRoleArn" => {
+                    obj.monitoring_role_arn =
+                        Some(StringDeserializer::deserialize("MonitoringRoleArn", stack)?);
+                }
+                "MultiAZ" => {
+                    obj.multi_az = Some(BooleanDeserializer::deserialize("MultiAZ", stack)?);
+                }
+                "OptionGroupMemberships" => {
+                    obj.option_group_memberships.get_or_insert(vec![]).extend(
+                        OptionGroupMembershipListDeserializer::deserialize(
+                            "OptionGroupMemberships",
+                            stack,
+                        )?,
+                    );
+                }
+                "PendingModifiedValues" => {
+                    obj.pending_modified_values =
+                        Some(PendingModifiedValuesDeserializer::deserialize(
+                            "PendingModifiedValues",
                             stack,
                         )?);
-                    }
-                    "CharacterSetName" => {
-                        obj.character_set_name =
-                            Some(StringDeserializer::deserialize("CharacterSetName", stack)?);
-                    }
-                    "CopyTagsToSnapshot" => {
-                        obj.copy_tags_to_snapshot = Some(BooleanDeserializer::deserialize(
-                            "CopyTagsToSnapshot",
+                }
+                "PerformanceInsightsEnabled" => {
+                    obj.performance_insights_enabled =
+                        Some(BooleanOptionalDeserializer::deserialize(
+                            "PerformanceInsightsEnabled",
                             stack,
                         )?);
-                    }
-                    "DBClusterIdentifier" => {
-                        obj.db_cluster_identifier = Some(StringDeserializer::deserialize(
-                            "DBClusterIdentifier",
+                }
+                "PerformanceInsightsKMSKeyId" => {
+                    obj.performance_insights_kms_key_id = Some(StringDeserializer::deserialize(
+                        "PerformanceInsightsKMSKeyId",
+                        stack,
+                    )?);
+                }
+                "PreferredBackupWindow" => {
+                    obj.preferred_backup_window = Some(StringDeserializer::deserialize(
+                        "PreferredBackupWindow",
+                        stack,
+                    )?);
+                }
+                "PreferredMaintenanceWindow" => {
+                    obj.preferred_maintenance_window = Some(StringDeserializer::deserialize(
+                        "PreferredMaintenanceWindow",
+                        stack,
+                    )?);
+                }
+                "PromotionTier" => {
+                    obj.promotion_tier = Some(IntegerOptionalDeserializer::deserialize(
+                        "PromotionTier",
+                        stack,
+                    )?);
+                }
+                "ReadReplicaDBClusterIdentifiers" => {
+                    obj.read_replica_db_cluster_identifiers
+                        .get_or_insert(vec![])
+                        .extend(ReadReplicaDBClusterIdentifierListDeserializer::deserialize(
+                            "ReadReplicaDBClusterIdentifiers",
                             stack,
                         )?);
-                    }
-                    "DBInstanceArn" => {
-                        obj.db_instance_arn =
-                            Some(StringDeserializer::deserialize("DBInstanceArn", stack)?);
-                    }
-                    "DBInstanceClass" => {
-                        obj.db_instance_class =
-                            Some(StringDeserializer::deserialize("DBInstanceClass", stack)?);
-                    }
-                    "DBInstanceIdentifier" => {
-                        obj.db_instance_identifier = Some(StringDeserializer::deserialize(
-                            "DBInstanceIdentifier",
-                            stack,
-                        )?);
-                    }
-                    "DBInstanceStatus" => {
-                        obj.db_instance_status =
-                            Some(StringDeserializer::deserialize("DBInstanceStatus", stack)?);
-                    }
-                    "DBName" => {
-                        obj.db_name = Some(StringDeserializer::deserialize("DBName", stack)?);
-                    }
-                    "DBParameterGroups" => {
-                        obj.db_parameter_groups = match obj.db_parameter_groups {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    DBParameterGroupStatusListDeserializer::deserialize(
-                                        "DBParameterGroups",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(DBParameterGroupStatusListDeserializer::deserialize(
-                                "DBParameterGroups",
+                }
+                "ReadReplicaDBInstanceIdentifiers" => {
+                    obj.read_replica_db_instance_identifiers
+                        .get_or_insert(vec![])
+                        .extend(
+                            ReadReplicaDBInstanceIdentifierListDeserializer::deserialize(
+                                "ReadReplicaDBInstanceIdentifiers",
                                 stack,
-                            )?),
-                        };
-                    }
-                    "DBSecurityGroups" => {
-                        obj.db_security_groups = match obj.db_security_groups {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    DBSecurityGroupMembershipListDeserializer::deserialize(
-                                        "DBSecurityGroups",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(DBSecurityGroupMembershipListDeserializer::deserialize(
-                                "DBSecurityGroups",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "DBSubnetGroup" => {
-                        obj.db_subnet_group = Some(DBSubnetGroupDeserializer::deserialize(
-                            "DBSubnetGroup",
-                            stack,
-                        )?);
-                    }
-                    "DbInstancePort" => {
-                        obj.db_instance_port =
-                            Some(IntegerDeserializer::deserialize("DbInstancePort", stack)?);
-                    }
-                    "DbiResourceId" => {
-                        obj.dbi_resource_id =
-                            Some(StringDeserializer::deserialize("DbiResourceId", stack)?);
-                    }
-                    "DomainMemberships" => {
-                        obj.domain_memberships = match obj.domain_memberships {
-                            Some(ref mut existing) => {
-                                existing.extend(DomainMembershipListDeserializer::deserialize(
-                                    "DomainMemberships",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(DomainMembershipListDeserializer::deserialize(
-                                "DomainMemberships",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "EnabledCloudwatchLogsExports" => {
-                        obj.enabled_cloudwatch_logs_exports =
-                            match obj.enabled_cloudwatch_logs_exports {
-                                Some(ref mut existing) => {
-                                    existing.extend(LogTypeListDeserializer::deserialize(
-                                        "EnabledCloudwatchLogsExports",
-                                        stack,
-                                    )?);
-                                    Some(existing.to_vec())
-                                }
-                                None => Some(LogTypeListDeserializer::deserialize(
-                                    "EnabledCloudwatchLogsExports",
-                                    stack,
-                                )?),
-                            };
-                    }
-                    "Endpoint" => {
-                        obj.endpoint = Some(EndpointDeserializer::deserialize("Endpoint", stack)?);
-                    }
-                    "Engine" => {
-                        obj.engine = Some(StringDeserializer::deserialize("Engine", stack)?);
-                    }
-                    "EngineVersion" => {
-                        obj.engine_version =
-                            Some(StringDeserializer::deserialize("EngineVersion", stack)?);
-                    }
-                    "EnhancedMonitoringResourceArn" => {
-                        obj.enhanced_monitoring_resource_arn =
-                            Some(StringDeserializer::deserialize(
-                                "EnhancedMonitoringResourceArn",
-                                stack,
-                            )?);
-                    }
-                    "IAMDatabaseAuthenticationEnabled" => {
-                        obj.iam_database_authentication_enabled =
-                            Some(BooleanDeserializer::deserialize(
-                                "IAMDatabaseAuthenticationEnabled",
-                                stack,
-                            )?);
-                    }
-                    "InstanceCreateTime" => {
-                        obj.instance_create_time = Some(TStampDeserializer::deserialize(
-                            "InstanceCreateTime",
-                            stack,
-                        )?);
-                    }
-                    "Iops" => {
-                        obj.iops = Some(IntegerOptionalDeserializer::deserialize("Iops", stack)?);
-                    }
-                    "KmsKeyId" => {
-                        obj.kms_key_id = Some(StringDeserializer::deserialize("KmsKeyId", stack)?);
-                    }
-                    "LatestRestorableTime" => {
-                        obj.latest_restorable_time = Some(TStampDeserializer::deserialize(
-                            "LatestRestorableTime",
-                            stack,
-                        )?);
-                    }
-                    "LicenseModel" => {
-                        obj.license_model =
-                            Some(StringDeserializer::deserialize("LicenseModel", stack)?);
-                    }
-                    "MasterUsername" => {
-                        obj.master_username =
-                            Some(StringDeserializer::deserialize("MasterUsername", stack)?);
-                    }
-                    "MonitoringInterval" => {
-                        obj.monitoring_interval = Some(IntegerOptionalDeserializer::deserialize(
-                            "MonitoringInterval",
-                            stack,
-                        )?);
-                    }
-                    "MonitoringRoleArn" => {
-                        obj.monitoring_role_arn =
-                            Some(StringDeserializer::deserialize("MonitoringRoleArn", stack)?);
-                    }
-                    "MultiAZ" => {
-                        obj.multi_az = Some(BooleanDeserializer::deserialize("MultiAZ", stack)?);
-                    }
-                    "OptionGroupMemberships" => {
-                        obj.option_group_memberships = match obj.option_group_memberships {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    OptionGroupMembershipListDeserializer::deserialize(
-                                        "OptionGroupMemberships",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(OptionGroupMembershipListDeserializer::deserialize(
-                                "OptionGroupMemberships",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "PendingModifiedValues" => {
-                        obj.pending_modified_values =
-                            Some(PendingModifiedValuesDeserializer::deserialize(
-                                "PendingModifiedValues",
-                                stack,
-                            )?);
-                    }
-                    "PerformanceInsightsEnabled" => {
-                        obj.performance_insights_enabled =
-                            Some(BooleanOptionalDeserializer::deserialize(
-                                "PerformanceInsightsEnabled",
-                                stack,
-                            )?);
-                    }
-                    "PerformanceInsightsKMSKeyId" => {
-                        obj.performance_insights_kms_key_id = Some(
-                            StringDeserializer::deserialize("PerformanceInsightsKMSKeyId", stack)?,
+                            )?,
                         );
-                    }
-                    "PreferredBackupWindow" => {
-                        obj.preferred_backup_window = Some(StringDeserializer::deserialize(
-                            "PreferredBackupWindow",
-                            stack,
-                        )?);
-                    }
-                    "PreferredMaintenanceWindow" => {
-                        obj.preferred_maintenance_window = Some(StringDeserializer::deserialize(
-                            "PreferredMaintenanceWindow",
-                            stack,
-                        )?);
-                    }
-                    "PromotionTier" => {
-                        obj.promotion_tier = Some(IntegerOptionalDeserializer::deserialize(
-                            "PromotionTier",
-                            stack,
-                        )?);
-                    }
-                    "ReadReplicaDBClusterIdentifiers" => {
-                        obj.read_replica_db_cluster_identifiers = match obj
-                            .read_replica_db_cluster_identifiers
-                        {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    ReadReplicaDBClusterIdentifierListDeserializer::deserialize(
-                                        "ReadReplicaDBClusterIdentifiers",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => {
-                                Some(ReadReplicaDBClusterIdentifierListDeserializer::deserialize(
-                                    "ReadReplicaDBClusterIdentifiers",
-                                    stack,
-                                )?)
-                            }
-                        };
-                    }
-                    "ReadReplicaDBInstanceIdentifiers" => {
-                        obj.read_replica_db_instance_identifiers = match obj
-                            .read_replica_db_instance_identifiers
-                        {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    ReadReplicaDBInstanceIdentifierListDeserializer::deserialize(
-                                        "ReadReplicaDBInstanceIdentifiers",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(
-                                ReadReplicaDBInstanceIdentifierListDeserializer::deserialize(
-                                    "ReadReplicaDBInstanceIdentifiers",
-                                    stack,
-                                )?,
-                            ),
-                        };
-                    }
-                    "ReadReplicaSourceDBInstanceIdentifier" => {
-                        obj.read_replica_source_db_instance_identifier =
-                            Some(StringDeserializer::deserialize(
-                                "ReadReplicaSourceDBInstanceIdentifier",
-                                stack,
-                            )?);
-                    }
-                    "SecondaryAvailabilityZone" => {
-                        obj.secondary_availability_zone = Some(StringDeserializer::deserialize(
-                            "SecondaryAvailabilityZone",
-                            stack,
-                        )?);
-                    }
-                    "StatusInfos" => {
-                        obj.status_infos = match obj.status_infos {
-                            Some(ref mut existing) => {
-                                existing.extend(DBInstanceStatusInfoListDeserializer::deserialize(
-                                    "StatusInfos",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(DBInstanceStatusInfoListDeserializer::deserialize(
-                                "StatusInfos",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "StorageEncrypted" => {
-                        obj.storage_encrypted =
-                            Some(BooleanDeserializer::deserialize("StorageEncrypted", stack)?);
-                    }
-                    "StorageType" => {
-                        obj.storage_type =
-                            Some(StringDeserializer::deserialize("StorageType", stack)?);
-                    }
-                    "TdeCredentialArn" => {
-                        obj.tde_credential_arn =
-                            Some(StringDeserializer::deserialize("TdeCredentialArn", stack)?);
-                    }
-                    "Timezone" => {
-                        obj.timezone = Some(StringDeserializer::deserialize("Timezone", stack)?);
-                    }
-                    "VpcSecurityGroups" => {
-                        obj.vpc_security_groups = match obj.vpc_security_groups {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    VpcSecurityGroupMembershipListDeserializer::deserialize(
-                                        "VpcSecurityGroups",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(VpcSecurityGroupMembershipListDeserializer::deserialize(
-                                "VpcSecurityGroups",
-                                stack,
-                            )?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                "ReadReplicaSourceDBInstanceIdentifier" => {
+                    obj.read_replica_source_db_instance_identifier =
+                        Some(StringDeserializer::deserialize(
+                            "ReadReplicaSourceDBInstanceIdentifier",
+                            stack,
+                        )?);
+                }
+                "SecondaryAvailabilityZone" => {
+                    obj.secondary_availability_zone = Some(StringDeserializer::deserialize(
+                        "SecondaryAvailabilityZone",
+                        stack,
+                    )?);
+                }
+                "StatusInfos" => {
+                    obj.status_infos.get_or_insert(vec![]).extend(
+                        DBInstanceStatusInfoListDeserializer::deserialize("StatusInfos", stack)?,
+                    );
+                }
+                "StorageEncrypted" => {
+                    obj.storage_encrypted =
+                        Some(BooleanDeserializer::deserialize("StorageEncrypted", stack)?);
+                }
+                "StorageType" => {
+                    obj.storage_type = Some(StringDeserializer::deserialize("StorageType", stack)?);
+                }
+                "TdeCredentialArn" => {
+                    obj.tde_credential_arn =
+                        Some(StringDeserializer::deserialize("TdeCredentialArn", stack)?);
+                }
+                "Timezone" => {
+                    obj.timezone = Some(StringDeserializer::deserialize("Timezone", stack)?);
+                }
+                "VpcSecurityGroups" => {
+                    obj.vpc_security_groups.get_or_insert(vec![]).extend(
+                        VpcSecurityGroupMembershipListDeserializer::deserialize(
+                            "VpcSecurityGroups",
+                            stack,
+                        )?,
+                    );
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct DBInstanceListDeserializer;
@@ -4095,37 +3019,14 @@ impl DBInstanceListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<DBInstance>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "DBInstance" {
-                        obj.push(DBInstanceDeserializer::deserialize("DBInstance", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "DBInstance" {
+                obj.push(DBInstanceDeserializer::deserialize("DBInstance", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p> Contains the result of a successful invocation of the <a>DescribeDBInstances</a> action. </p>
@@ -4144,51 +3045,20 @@ impl DBInstanceMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBInstanceMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBInstanceMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DBInstanceMessage, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DBInstances" => {
+                    obj.db_instances.get_or_insert(vec![]).extend(
+                        DBInstanceListDeserializer::deserialize("DBInstances", stack)?,
+                    );
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DBInstances" => {
-                        obj.db_instances = match obj.db_instances {
-                            Some(ref mut existing) => {
-                                existing.extend(DBInstanceListDeserializer::deserialize(
-                                    "DBInstances",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(DBInstanceListDeserializer::deserialize(
-                                "DBInstances",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "Marker" => {
-                        obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Marker" => {
+                    obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Provides a list of status information for a DB instance.</p>
@@ -4211,46 +3081,24 @@ impl DBInstanceStatusInfoDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBInstanceStatusInfo, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBInstanceStatusInfo::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DBInstanceStatusInfo, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Message" => {
+                    obj.message = Some(StringDeserializer::deserialize("Message", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Message" => {
-                        obj.message = Some(StringDeserializer::deserialize("Message", stack)?);
-                    }
-                    "Normal" => {
-                        obj.normal = Some(BooleanDeserializer::deserialize("Normal", stack)?);
-                    }
-                    "Status" => {
-                        obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
-                    }
-                    "StatusType" => {
-                        obj.status_type =
-                            Some(StringDeserializer::deserialize("StatusType", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Normal" => {
+                    obj.normal = Some(BooleanDeserializer::deserialize("Normal", stack)?);
                 }
+                "Status" => {
+                    obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
+                }
+                "StatusType" => {
+                    obj.status_type = Some(StringDeserializer::deserialize("StatusType", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct DBInstanceStatusInfoListDeserializer;
@@ -4260,40 +3108,17 @@ impl DBInstanceStatusInfoListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<DBInstanceStatusInfo>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "DBInstanceStatusInfo" {
-                        obj.push(DBInstanceStatusInfoDeserializer::deserialize(
-                            "DBInstanceStatusInfo",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "DBInstanceStatusInfo" {
+                obj.push(DBInstanceStatusInfoDeserializer::deserialize(
+                    "DBInstanceStatusInfo",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains the details of an Amazon Neptune DB parameter group. </p> <p>This data type is used as a response element in the <a>DescribeDBParameterGroups</a> action. </p>
@@ -4316,55 +3141,33 @@ impl DBParameterGroupDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBParameterGroup, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBParameterGroup::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DBParameterGroup, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DBParameterGroupArn" => {
+                    obj.db_parameter_group_arn = Some(StringDeserializer::deserialize(
+                        "DBParameterGroupArn",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DBParameterGroupArn" => {
-                        obj.db_parameter_group_arn = Some(StringDeserializer::deserialize(
-                            "DBParameterGroupArn",
-                            stack,
-                        )?);
-                    }
-                    "DBParameterGroupFamily" => {
-                        obj.db_parameter_group_family = Some(StringDeserializer::deserialize(
-                            "DBParameterGroupFamily",
-                            stack,
-                        )?);
-                    }
-                    "DBParameterGroupName" => {
-                        obj.db_parameter_group_name = Some(StringDeserializer::deserialize(
-                            "DBParameterGroupName",
-                            stack,
-                        )?);
-                    }
-                    "Description" => {
-                        obj.description =
-                            Some(StringDeserializer::deserialize("Description", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "DBParameterGroupFamily" => {
+                    obj.db_parameter_group_family = Some(StringDeserializer::deserialize(
+                        "DBParameterGroupFamily",
+                        stack,
+                    )?);
                 }
+                "DBParameterGroupName" => {
+                    obj.db_parameter_group_name = Some(StringDeserializer::deserialize(
+                        "DBParameterGroupName",
+                        stack,
+                    )?);
+                }
+                "Description" => {
+                    obj.description = Some(StringDeserializer::deserialize("Description", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p> Contains the result of a successful invocation of the <a>DescribeDBParameters</a> action. </p>
@@ -4383,51 +3186,24 @@ impl DBParameterGroupDetailsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBParameterGroupDetails, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBParameterGroupDetails::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DBParameterGroupDetails, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Marker" => {
                         obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                     }
                     "Parameters" => {
-                        obj.parameters = match obj.parameters {
-                            Some(ref mut existing) => {
-                                existing.extend(ParametersListDeserializer::deserialize(
-                                    "Parameters",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ParametersListDeserializer::deserialize(
-                                "Parameters",
-                                stack,
-                            )?),
-                        };
+                        obj.parameters.get_or_insert(vec![]).extend(
+                            ParametersListDeserializer::deserialize("Parameters", stack)?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct DBParameterGroupListDeserializer;
@@ -4437,40 +3213,17 @@ impl DBParameterGroupListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<DBParameterGroup>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "DBParameterGroup" {
-                        obj.push(DBParameterGroupDeserializer::deserialize(
-                            "DBParameterGroup",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "DBParameterGroup" {
+                obj.push(DBParameterGroupDeserializer::deserialize(
+                    "DBParameterGroup",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p> Contains the result of a successful invocation of the <a>ModifyDBParameterGroup</a> or <a>ResetDBParameterGroup</a> action. </p>
@@ -4487,21 +3240,11 @@ impl DBParameterGroupNameMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBParameterGroupNameMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBParameterGroupNameMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DBParameterGroupNameMessage, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DBParameterGroupName" => {
                         obj.db_parameter_group_name = Some(StringDeserializer::deserialize(
                             "DBParameterGroupName",
@@ -4509,17 +3252,10 @@ impl DBParameterGroupNameMessageDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p><p>The status of the DB parameter group.</p> <p>This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>CreateDBInstance</a> </p> </li> <li> <p> <a>DeleteDBInstance</a> </p> </li> <li> <p> <a>ModifyDBInstance</a> </p> </li> <li> <p> <a>RebootDBInstance</a> </p> </li> </ul></p>
@@ -4538,45 +3274,24 @@ impl DBParameterGroupStatusDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBParameterGroupStatus, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBParameterGroupStatus::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DBParameterGroupStatus, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DBParameterGroupName" => {
+                    obj.db_parameter_group_name = Some(StringDeserializer::deserialize(
+                        "DBParameterGroupName",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DBParameterGroupName" => {
-                        obj.db_parameter_group_name = Some(StringDeserializer::deserialize(
-                            "DBParameterGroupName",
-                            stack,
-                        )?);
-                    }
-                    "ParameterApplyStatus" => {
-                        obj.parameter_apply_status = Some(StringDeserializer::deserialize(
-                            "ParameterApplyStatus",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "ParameterApplyStatus" => {
+                    obj.parameter_apply_status = Some(StringDeserializer::deserialize(
+                        "ParameterApplyStatus",
+                        stack,
+                    )?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct DBParameterGroupStatusListDeserializer;
@@ -4586,40 +3301,17 @@ impl DBParameterGroupStatusListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<DBParameterGroupStatus>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "DBParameterGroup" {
-                        obj.push(DBParameterGroupStatusDeserializer::deserialize(
-                            "DBParameterGroup",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "DBParameterGroup" {
+                obj.push(DBParameterGroupStatusDeserializer::deserialize(
+                    "DBParameterGroup",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p> Contains the result of a successful invocation of the <a>DescribeDBParameterGroups</a> action. </p>
@@ -4638,51 +3330,27 @@ impl DBParameterGroupsMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBParameterGroupsMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBParameterGroupsMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DBParameterGroupsMessage, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DBParameterGroups" => {
-                        obj.db_parameter_groups = match obj.db_parameter_groups {
-                            Some(ref mut existing) => {
-                                existing.extend(DBParameterGroupListDeserializer::deserialize(
-                                    "DBParameterGroups",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(DBParameterGroupListDeserializer::deserialize(
+                        obj.db_parameter_groups.get_or_insert(vec![]).extend(
+                            DBParameterGroupListDeserializer::deserialize(
                                 "DBParameterGroups",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     "Marker" => {
                         obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p><p>This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>ModifyDBInstance</a> </p> </li> <li> <p> <a>RebootDBInstance</a> </p> </li> </ul></p>
@@ -4701,21 +3369,11 @@ impl DBSecurityGroupMembershipDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBSecurityGroupMembership, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBSecurityGroupMembership::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DBSecurityGroupMembership, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DBSecurityGroupName" => {
                         obj.db_security_group_name = Some(StringDeserializer::deserialize(
                             "DBSecurityGroupName",
@@ -4726,17 +3384,10 @@ impl DBSecurityGroupMembershipDeserializer {
                         obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct DBSecurityGroupMembershipListDeserializer;
@@ -4746,40 +3397,17 @@ impl DBSecurityGroupMembershipListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<DBSecurityGroupMembership>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "DBSecurityGroup" {
-                        obj.push(DBSecurityGroupMembershipDeserializer::deserialize(
-                            "DBSecurityGroup",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "DBSecurityGroup" {
+                obj.push(DBSecurityGroupMembershipDeserializer::deserialize(
+                    "DBSecurityGroup",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -4818,64 +3446,38 @@ impl DBSubnetGroupDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBSubnetGroup, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBSubnetGroup::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DBSubnetGroup, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DBSubnetGroupArn" => {
+                    obj.db_subnet_group_arn =
+                        Some(StringDeserializer::deserialize("DBSubnetGroupArn", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DBSubnetGroupArn" => {
-                        obj.db_subnet_group_arn =
-                            Some(StringDeserializer::deserialize("DBSubnetGroupArn", stack)?);
-                    }
-                    "DBSubnetGroupDescription" => {
-                        obj.db_subnet_group_description = Some(StringDeserializer::deserialize(
-                            "DBSubnetGroupDescription",
-                            stack,
-                        )?);
-                    }
-                    "DBSubnetGroupName" => {
-                        obj.db_subnet_group_name =
-                            Some(StringDeserializer::deserialize("DBSubnetGroupName", stack)?);
-                    }
-                    "SubnetGroupStatus" => {
-                        obj.subnet_group_status =
-                            Some(StringDeserializer::deserialize("SubnetGroupStatus", stack)?);
-                    }
-                    "Subnets" => {
-                        obj.subnets = match obj.subnets {
-                            Some(ref mut existing) => {
-                                existing
-                                    .extend(SubnetListDeserializer::deserialize("Subnets", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(SubnetListDeserializer::deserialize("Subnets", stack)?),
-                        };
-                    }
-                    "VpcId" => {
-                        obj.vpc_id = Some(StringDeserializer::deserialize("VpcId", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "DBSubnetGroupDescription" => {
+                    obj.db_subnet_group_description = Some(StringDeserializer::deserialize(
+                        "DBSubnetGroupDescription",
+                        stack,
+                    )?);
                 }
+                "DBSubnetGroupName" => {
+                    obj.db_subnet_group_name =
+                        Some(StringDeserializer::deserialize("DBSubnetGroupName", stack)?);
+                }
+                "SubnetGroupStatus" => {
+                    obj.subnet_group_status =
+                        Some(StringDeserializer::deserialize("SubnetGroupStatus", stack)?);
+                }
+                "Subnets" => {
+                    obj.subnets
+                        .get_or_insert(vec![])
+                        .extend(SubnetListDeserializer::deserialize("Subnets", stack)?);
+                }
+                "VpcId" => {
+                    obj.vpc_id = Some(StringDeserializer::deserialize("VpcId", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p> Contains the result of a successful invocation of the <a>DescribeDBSubnetGroups</a> action. </p>
@@ -4894,51 +3496,20 @@ impl DBSubnetGroupMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DBSubnetGroupMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DBSubnetGroupMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DBSubnetGroupMessage, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DBSubnetGroups" => {
+                    obj.db_subnet_groups.get_or_insert(vec![]).extend(
+                        DBSubnetGroupsDeserializer::deserialize("DBSubnetGroups", stack)?,
+                    );
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DBSubnetGroups" => {
-                        obj.db_subnet_groups = match obj.db_subnet_groups {
-                            Some(ref mut existing) => {
-                                existing.extend(DBSubnetGroupsDeserializer::deserialize(
-                                    "DBSubnetGroups",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(DBSubnetGroupsDeserializer::deserialize(
-                                "DBSubnetGroups",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "Marker" => {
-                        obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Marker" => {
+                    obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct DBSubnetGroupsDeserializer;
@@ -4948,40 +3519,17 @@ impl DBSubnetGroupsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<DBSubnetGroup>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "DBSubnetGroup" {
-                        obj.push(DBSubnetGroupDeserializer::deserialize(
-                            "DBSubnetGroup",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "DBSubnetGroup" {
+                obj.push(DBSubnetGroupDeserializer::deserialize(
+                    "DBSubnetGroup",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p><p/></p>
@@ -5058,37 +3606,15 @@ impl DeleteDBClusterResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DeleteDBClusterResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DeleteDBClusterResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DeleteDBClusterResult, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DBCluster" => {
+                    obj.db_cluster = Some(DBClusterDeserializer::deserialize("DBCluster", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DBCluster" => {
-                        obj.db_cluster =
-                            Some(DBClusterDeserializer::deserialize("DBCluster", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p><p/></p>
@@ -5126,21 +3652,11 @@ impl DeleteDBClusterSnapshotResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DeleteDBClusterSnapshotResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DeleteDBClusterSnapshotResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DeleteDBClusterSnapshotResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DBClusterSnapshot" => {
                         obj.db_cluster_snapshot = Some(DBClusterSnapshotDeserializer::deserialize(
                             "DBClusterSnapshot",
@@ -5148,17 +3664,10 @@ impl DeleteDBClusterSnapshotResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p><p/></p>
@@ -5212,37 +3721,16 @@ impl DeleteDBInstanceResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DeleteDBInstanceResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DeleteDBInstanceResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DeleteDBInstanceResult, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DBInstance" => {
+                    obj.db_instance =
+                        Some(DBInstanceDeserializer::deserialize("DBInstance", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DBInstance" => {
-                        obj.db_instance =
-                            Some(DBInstanceDeserializer::deserialize("DBInstance", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p><p/></p>
@@ -5326,21 +3814,11 @@ impl DeleteEventSubscriptionResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DeleteEventSubscriptionResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DeleteEventSubscriptionResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DeleteEventSubscriptionResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "EventSubscription" => {
                         obj.event_subscription = Some(EventSubscriptionDeserializer::deserialize(
                             "EventSubscription",
@@ -5348,17 +3826,10 @@ impl DeleteEventSubscriptionResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p><p/></p>
@@ -5497,21 +3968,11 @@ impl DescribeDBClusterSnapshotAttributesResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeDBClusterSnapshotAttributesResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeDBClusterSnapshotAttributesResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeDBClusterSnapshotAttributesResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DBClusterSnapshotAttributesResult" => {
                         obj.db_cluster_snapshot_attributes_result =
                             Some(DBClusterSnapshotAttributesResultDeserializer::deserialize(
@@ -5520,17 +3981,10 @@ impl DescribeDBClusterSnapshotAttributesResultDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p><p/></p>
@@ -5984,21 +4438,11 @@ impl DescribeEngineDefaultClusterParametersResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeEngineDefaultClusterParametersResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeEngineDefaultClusterParametersResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeEngineDefaultClusterParametersResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "EngineDefaults" => {
                         obj.engine_defaults = Some(EngineDefaultsDeserializer::deserialize(
                             "EngineDefaults",
@@ -6006,17 +4450,10 @@ impl DescribeEngineDefaultClusterParametersResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p><p/></p>
@@ -6076,21 +4513,11 @@ impl DescribeEngineDefaultParametersResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeEngineDefaultParametersResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeEngineDefaultParametersResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeEngineDefaultParametersResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "EngineDefaults" => {
                         obj.engine_defaults = Some(EngineDefaultsDeserializer::deserialize(
                             "EngineDefaults",
@@ -6098,17 +4525,10 @@ impl DescribeEngineDefaultParametersResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p><p/></p>
@@ -6407,21 +4827,11 @@ impl DescribeValidDBInstanceModificationsResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DescribeValidDBInstanceModificationsResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DescribeValidDBInstanceModificationsResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DescribeValidDBInstanceModificationsResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ValidDBInstanceModificationsMessage" => {
                         obj.valid_db_instance_modifications_message = Some(
                             ValidDBInstanceModificationsMessageDeserializer::deserialize(
@@ -6431,17 +4841,10 @@ impl DescribeValidDBInstanceModificationsResultDeserializer {
                         );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>An Active Directory Domain membership record associated with the DB instance.</p>
@@ -6464,46 +4867,25 @@ impl DomainMembershipDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DomainMembership, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DomainMembership::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DomainMembership, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Domain" => {
+                    obj.domain = Some(StringDeserializer::deserialize("Domain", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Domain" => {
-                        obj.domain = Some(StringDeserializer::deserialize("Domain", stack)?);
-                    }
-                    "FQDN" => {
-                        obj.fqdn = Some(StringDeserializer::deserialize("FQDN", stack)?);
-                    }
-                    "IAMRoleName" => {
-                        obj.iam_role_name =
-                            Some(StringDeserializer::deserialize("IAMRoleName", stack)?);
-                    }
-                    "Status" => {
-                        obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "FQDN" => {
+                    obj.fqdn = Some(StringDeserializer::deserialize("FQDN", stack)?);
                 }
+                "IAMRoleName" => {
+                    obj.iam_role_name =
+                        Some(StringDeserializer::deserialize("IAMRoleName", stack)?);
+                }
+                "Status" => {
+                    obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct DomainMembershipListDeserializer;
@@ -6513,40 +4895,17 @@ impl DomainMembershipListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<DomainMembership>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "DomainMembership" {
-                        obj.push(DomainMembershipDeserializer::deserialize(
-                            "DomainMembership",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "DomainMembership" {
+                obj.push(DomainMembershipDeserializer::deserialize(
+                    "DomainMembership",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct DoubleDeserializer;
@@ -6593,39 +4952,18 @@ impl DoubleRangeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DoubleRange, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DoubleRange::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DoubleRange, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "From" => {
+                    obj.from = Some(DoubleDeserializer::deserialize("From", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "From" => {
-                        obj.from = Some(DoubleDeserializer::deserialize("From", stack)?);
-                    }
-                    "To" => {
-                        obj.to = Some(DoubleDeserializer::deserialize("To", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "To" => {
+                    obj.to = Some(DoubleDeserializer::deserialize("To", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct DoubleRangeListDeserializer;
@@ -6635,37 +4973,14 @@ impl DoubleRangeListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<DoubleRange>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "DoubleRange" {
-                        obj.push(DoubleRangeDeserializer::deserialize("DoubleRange", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "DoubleRange" {
+                obj.push(DoubleRangeDeserializer::deserialize("DoubleRange", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p><p>This data type is used as a response element in the following actions:</p> <ul> <li> <p> <a>CreateDBInstance</a> </p> </li> <li> <p> <a>DescribeDBInstances</a> </p> </li> <li> <p> <a>DeleteDBInstance</a> </p> </li> </ul></p>
@@ -6686,43 +5001,22 @@ impl EndpointDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Endpoint, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Endpoint::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Endpoint, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Address" => {
+                    obj.address = Some(StringDeserializer::deserialize("Address", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Address" => {
-                        obj.address = Some(StringDeserializer::deserialize("Address", stack)?);
-                    }
-                    "HostedZoneId" => {
-                        obj.hosted_zone_id =
-                            Some(StringDeserializer::deserialize("HostedZoneId", stack)?);
-                    }
-                    "Port" => {
-                        obj.port = Some(IntegerDeserializer::deserialize("Port", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "HostedZoneId" => {
+                    obj.hosted_zone_id =
+                        Some(StringDeserializer::deserialize("HostedZoneId", stack)?);
                 }
+                "Port" => {
+                    obj.port = Some(IntegerDeserializer::deserialize("Port", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p> Contains the result of a successful invocation of the <a>DescribeEngineDefaultParameters</a> action. </p>
@@ -6743,57 +5037,26 @@ impl EngineDefaultsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<EngineDefaults, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = EngineDefaults::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, EngineDefaults, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DBParameterGroupFamily" => {
+                    obj.db_parameter_group_family = Some(StringDeserializer::deserialize(
+                        "DBParameterGroupFamily",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DBParameterGroupFamily" => {
-                        obj.db_parameter_group_family = Some(StringDeserializer::deserialize(
-                            "DBParameterGroupFamily",
-                            stack,
-                        )?);
-                    }
-                    "Marker" => {
-                        obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
-                    }
-                    "Parameters" => {
-                        obj.parameters = match obj.parameters {
-                            Some(ref mut existing) => {
-                                existing.extend(ParametersListDeserializer::deserialize(
-                                    "Parameters",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ParametersListDeserializer::deserialize(
-                                "Parameters",
-                                stack,
-                            )?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Marker" => {
+                    obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                 }
+                "Parameters" => {
+                    obj.parameters.get_or_insert(vec![]).extend(
+                        ParametersListDeserializer::deserialize("Parameters", stack)?,
+                    );
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p> This data type is used as a response element in the <a>DescribeEvents</a> action. </p>
@@ -6820,65 +5083,34 @@ impl EventDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Event, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Event::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Event, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Date" => {
+                    obj.date = Some(TStampDeserializer::deserialize("Date", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Date" => {
-                        obj.date = Some(TStampDeserializer::deserialize("Date", stack)?);
-                    }
-                    "EventCategories" => {
-                        obj.event_categories = match obj.event_categories {
-                            Some(ref mut existing) => {
-                                existing.extend(EventCategoriesListDeserializer::deserialize(
-                                    "EventCategories",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(EventCategoriesListDeserializer::deserialize(
-                                "EventCategories",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "Message" => {
-                        obj.message = Some(StringDeserializer::deserialize("Message", stack)?);
-                    }
-                    "SourceArn" => {
-                        obj.source_arn = Some(StringDeserializer::deserialize("SourceArn", stack)?);
-                    }
-                    "SourceIdentifier" => {
-                        obj.source_identifier =
-                            Some(StringDeserializer::deserialize("SourceIdentifier", stack)?);
-                    }
-                    "SourceType" => {
-                        obj.source_type =
-                            Some(SourceTypeDeserializer::deserialize("SourceType", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "EventCategories" => {
+                    obj.event_categories.get_or_insert(vec![]).extend(
+                        EventCategoriesListDeserializer::deserialize("EventCategories", stack)?,
+                    );
                 }
+                "Message" => {
+                    obj.message = Some(StringDeserializer::deserialize("Message", stack)?);
+                }
+                "SourceArn" => {
+                    obj.source_arn = Some(StringDeserializer::deserialize("SourceArn", stack)?);
+                }
+                "SourceIdentifier" => {
+                    obj.source_identifier =
+                        Some(StringDeserializer::deserialize("SourceIdentifier", stack)?);
+                }
+                "SourceType" => {
+                    obj.source_type =
+                        Some(SourceTypeDeserializer::deserialize("SourceType", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct EventCategoriesListDeserializer;
@@ -6888,37 +5120,14 @@ impl EventCategoriesListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "EventCategory" {
-                        obj.push(StringDeserializer::deserialize("EventCategory", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "EventCategory" {
+                obj.push(StringDeserializer::deserialize("EventCategory", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -6949,52 +5158,20 @@ impl EventCategoriesMapDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<EventCategoriesMap, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = EventCategoriesMap::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, EventCategoriesMap, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "EventCategories" => {
+                    obj.event_categories.get_or_insert(vec![]).extend(
+                        EventCategoriesListDeserializer::deserialize("EventCategories", stack)?,
+                    );
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "EventCategories" => {
-                        obj.event_categories = match obj.event_categories {
-                            Some(ref mut existing) => {
-                                existing.extend(EventCategoriesListDeserializer::deserialize(
-                                    "EventCategories",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(EventCategoriesListDeserializer::deserialize(
-                                "EventCategories",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "SourceType" => {
-                        obj.source_type =
-                            Some(StringDeserializer::deserialize("SourceType", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "SourceType" => {
+                    obj.source_type = Some(StringDeserializer::deserialize("SourceType", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct EventCategoriesMapListDeserializer;
@@ -7004,40 +5181,17 @@ impl EventCategoriesMapListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<EventCategoriesMap>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "EventCategoriesMap" {
-                        obj.push(EventCategoriesMapDeserializer::deserialize(
-                            "EventCategoriesMap",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "EventCategoriesMap" {
+                obj.push(EventCategoriesMapDeserializer::deserialize(
+                    "EventCategoriesMap",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Data returned from the <b>DescribeEventCategories</b> action.</p>
@@ -7054,48 +5208,20 @@ impl EventCategoriesMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<EventCategoriesMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = EventCategoriesMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, EventCategoriesMessage, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "EventCategoriesMapList" => {
+                    obj.event_categories_map_list.get_or_insert(vec![]).extend(
+                        EventCategoriesMapListDeserializer::deserialize(
+                            "EventCategoriesMapList",
+                            stack,
+                        )?,
+                    );
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "EventCategoriesMapList" => {
-                        obj.event_categories_map_list = match obj.event_categories_map_list {
-                            Some(ref mut existing) => {
-                                existing.extend(EventCategoriesMapListDeserializer::deserialize(
-                                    "EventCategoriesMapList",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(EventCategoriesMapListDeserializer::deserialize(
-                                "EventCategoriesMapList",
-                                stack,
-                            )?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct EventListDeserializer;
@@ -7105,37 +5231,14 @@ impl EventListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Event>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "Event" {
-                        obj.push(EventDeserializer::deserialize("Event", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "Event" {
+                obj.push(EventDeserializer::deserialize("Event", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains the results of a successful invocation of the <a>DescribeEventSubscriptions</a> action.</p>
@@ -7170,99 +5273,57 @@ impl EventSubscriptionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<EventSubscription, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = EventSubscription::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, EventSubscription, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CustSubscriptionId" => {
+                    obj.cust_subscription_id = Some(StringDeserializer::deserialize(
+                        "CustSubscriptionId",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CustSubscriptionId" => {
-                        obj.cust_subscription_id = Some(StringDeserializer::deserialize(
-                            "CustSubscriptionId",
-                            stack,
-                        )?);
-                    }
-                    "CustomerAwsId" => {
-                        obj.customer_aws_id =
-                            Some(StringDeserializer::deserialize("CustomerAwsId", stack)?);
-                    }
-                    "Enabled" => {
-                        obj.enabled = Some(BooleanDeserializer::deserialize("Enabled", stack)?);
-                    }
-                    "EventCategoriesList" => {
-                        obj.event_categories_list = match obj.event_categories_list {
-                            Some(ref mut existing) => {
-                                existing.extend(EventCategoriesListDeserializer::deserialize(
-                                    "EventCategoriesList",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(EventCategoriesListDeserializer::deserialize(
-                                "EventCategoriesList",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "EventSubscriptionArn" => {
-                        obj.event_subscription_arn = Some(StringDeserializer::deserialize(
-                            "EventSubscriptionArn",
-                            stack,
-                        )?);
-                    }
-                    "SnsTopicArn" => {
-                        obj.sns_topic_arn =
-                            Some(StringDeserializer::deserialize("SnsTopicArn", stack)?);
-                    }
-                    "SourceIdsList" => {
-                        obj.source_ids_list = match obj.source_ids_list {
-                            Some(ref mut existing) => {
-                                existing.extend(SourceIdsListDeserializer::deserialize(
-                                    "SourceIdsList",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(SourceIdsListDeserializer::deserialize(
-                                "SourceIdsList",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "SourceType" => {
-                        obj.source_type =
-                            Some(StringDeserializer::deserialize("SourceType", stack)?);
-                    }
-                    "Status" => {
-                        obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
-                    }
-                    "SubscriptionCreationTime" => {
-                        obj.subscription_creation_time = Some(StringDeserializer::deserialize(
-                            "SubscriptionCreationTime",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "CustomerAwsId" => {
+                    obj.customer_aws_id =
+                        Some(StringDeserializer::deserialize("CustomerAwsId", stack)?);
                 }
+                "Enabled" => {
+                    obj.enabled = Some(BooleanDeserializer::deserialize("Enabled", stack)?);
+                }
+                "EventCategoriesList" => {
+                    obj.event_categories_list.get_or_insert(vec![]).extend(
+                        EventCategoriesListDeserializer::deserialize("EventCategoriesList", stack)?,
+                    );
+                }
+                "EventSubscriptionArn" => {
+                    obj.event_subscription_arn = Some(StringDeserializer::deserialize(
+                        "EventSubscriptionArn",
+                        stack,
+                    )?);
+                }
+                "SnsTopicArn" => {
+                    obj.sns_topic_arn =
+                        Some(StringDeserializer::deserialize("SnsTopicArn", stack)?);
+                }
+                "SourceIdsList" => {
+                    obj.source_ids_list.get_or_insert(vec![]).extend(
+                        SourceIdsListDeserializer::deserialize("SourceIdsList", stack)?,
+                    );
+                }
+                "SourceType" => {
+                    obj.source_type = Some(StringDeserializer::deserialize("SourceType", stack)?);
+                }
+                "Status" => {
+                    obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
+                }
+                "SubscriptionCreationTime" => {
+                    obj.subscription_creation_time = Some(StringDeserializer::deserialize(
+                        "SubscriptionCreationTime",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct EventSubscriptionsListDeserializer;
@@ -7272,40 +5333,17 @@ impl EventSubscriptionsListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<EventSubscription>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "EventSubscription" {
-                        obj.push(EventSubscriptionDeserializer::deserialize(
-                            "EventSubscription",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "EventSubscription" {
+                obj.push(EventSubscriptionDeserializer::deserialize(
+                    "EventSubscription",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Data returned by the <b>DescribeEventSubscriptions</b> action.</p>
@@ -7324,51 +5362,27 @@ impl EventSubscriptionsMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<EventSubscriptionsMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = EventSubscriptionsMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, EventSubscriptionsMessage, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "EventSubscriptionsList" => {
-                        obj.event_subscriptions_list = match obj.event_subscriptions_list {
-                            Some(ref mut existing) => {
-                                existing.extend(EventSubscriptionsListDeserializer::deserialize(
-                                    "EventSubscriptionsList",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(EventSubscriptionsListDeserializer::deserialize(
+                        obj.event_subscriptions_list.get_or_insert(vec![]).extend(
+                            EventSubscriptionsListDeserializer::deserialize(
                                 "EventSubscriptionsList",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     "Marker" => {
                         obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p> Contains the result of a successful invocation of the <a>DescribeEvents</a> action. </p>
@@ -7387,46 +5401,20 @@ impl EventsMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<EventsMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = EventsMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, EventsMessage, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Events" => {
+                    obj.events
+                        .get_or_insert(vec![])
+                        .extend(EventListDeserializer::deserialize("Events", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Events" => {
-                        obj.events = match obj.events {
-                            Some(ref mut existing) => {
-                                existing
-                                    .extend(EventListDeserializer::deserialize("Events", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(EventListDeserializer::deserialize("Events", stack)?),
-                        };
-                    }
-                    "Marker" => {
-                        obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Marker" => {
+                    obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p><p/></p>
@@ -7474,37 +5462,20 @@ impl FailoverDBClusterResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<FailoverDBClusterResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = FailoverDBClusterResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, FailoverDBClusterResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DBCluster" => {
                         obj.db_cluster =
                             Some(DBClusterDeserializer::deserialize("DBCluster", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>This type is not currently supported.</p>
@@ -7632,37 +5603,14 @@ impl LogTypeListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(StringDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(StringDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -7827,37 +5775,15 @@ impl ModifyDBClusterResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ModifyDBClusterResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ModifyDBClusterResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ModifyDBClusterResult, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DBCluster" => {
+                    obj.db_cluster = Some(DBClusterDeserializer::deserialize("DBCluster", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DBCluster" => {
-                        obj.db_cluster =
-                            Some(DBClusterDeserializer::deserialize("DBCluster", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p><p/></p>
@@ -7919,21 +5845,11 @@ impl ModifyDBClusterSnapshotAttributeResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ModifyDBClusterSnapshotAttributeResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ModifyDBClusterSnapshotAttributeResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ModifyDBClusterSnapshotAttributeResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DBClusterSnapshotAttributesResult" => {
                         obj.db_cluster_snapshot_attributes_result =
                             Some(DBClusterSnapshotAttributesResultDeserializer::deserialize(
@@ -7942,17 +5858,10 @@ impl ModifyDBClusterSnapshotAttributeResultDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p><p/></p>
@@ -8230,37 +6139,16 @@ impl ModifyDBInstanceResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ModifyDBInstanceResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ModifyDBInstanceResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ModifyDBInstanceResult, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DBInstance" => {
+                    obj.db_instance =
+                        Some(DBInstanceDeserializer::deserialize("DBInstance", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DBInstance" => {
-                        obj.db_instance =
-                            Some(DBInstanceDeserializer::deserialize("DBInstance", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p><p/></p>
@@ -8343,21 +6231,11 @@ impl ModifyDBSubnetGroupResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ModifyDBSubnetGroupResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ModifyDBSubnetGroupResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ModifyDBSubnetGroupResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DBSubnetGroup" => {
                         obj.db_subnet_group = Some(DBSubnetGroupDeserializer::deserialize(
                             "DBSubnetGroup",
@@ -8365,17 +6243,10 @@ impl ModifyDBSubnetGroupResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p><p/></p>
@@ -8440,21 +6311,11 @@ impl ModifyEventSubscriptionResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ModifyEventSubscriptionResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ModifyEventSubscriptionResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ModifyEventSubscriptionResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "EventSubscription" => {
                         obj.event_subscription = Some(EventSubscriptionDeserializer::deserialize(
                             "EventSubscription",
@@ -8462,17 +6323,10 @@ impl ModifyEventSubscriptionResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Provides information on the option groups the DB instance is a member of.</p>
@@ -8491,40 +6345,19 @@ impl OptionGroupMembershipDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<OptionGroupMembership, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = OptionGroupMembership::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, OptionGroupMembership, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "OptionGroupName" => {
+                    obj.option_group_name =
+                        Some(StringDeserializer::deserialize("OptionGroupName", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "OptionGroupName" => {
-                        obj.option_group_name =
-                            Some(StringDeserializer::deserialize("OptionGroupName", stack)?);
-                    }
-                    "Status" => {
-                        obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Status" => {
+                    obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct OptionGroupMembershipListDeserializer;
@@ -8534,40 +6367,17 @@ impl OptionGroupMembershipListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<OptionGroupMembership>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "OptionGroupMembership" {
-                        obj.push(OptionGroupMembershipDeserializer::deserialize(
-                            "OptionGroupMembership",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "OptionGroupMembership" {
+                obj.push(OptionGroupMembershipDeserializer::deserialize(
+                    "OptionGroupMembership",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Contains a list of available options for a DB instance.</p> <p> This data type is used as a response element in the <a>DescribeOrderableDBInstanceOptions</a> action. </p>
@@ -8622,35 +6432,18 @@ impl OrderableDBInstanceOptionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<OrderableDBInstanceOption, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = OrderableDBInstanceOption::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, OrderableDBInstanceOption, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AvailabilityZones" => {
-                        obj.availability_zones = match obj.availability_zones {
-                            Some(ref mut existing) => {
-                                existing.extend(AvailabilityZoneListDeserializer::deserialize(
-                                    "AvailabilityZones",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(AvailabilityZoneListDeserializer::deserialize(
+                        obj.availability_zones.get_or_insert(vec![]).extend(
+                            AvailabilityZoneListDeserializer::deserialize(
                                 "AvailabilityZones",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     "DBInstanceClass" => {
                         obj.db_instance_class =
@@ -8752,17 +6545,10 @@ impl OrderableDBInstanceOptionDeserializer {
                         obj.vpc = Some(BooleanDeserializer::deserialize("Vpc", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct OrderableDBInstanceOptionsListDeserializer;
@@ -8772,40 +6558,17 @@ impl OrderableDBInstanceOptionsListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<OrderableDBInstanceOption>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "OrderableDBInstanceOption" {
-                        obj.push(OrderableDBInstanceOptionDeserializer::deserialize(
-                            "OrderableDBInstanceOption",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "OrderableDBInstanceOption" {
+                obj.push(OrderableDBInstanceOptionDeserializer::deserialize(
+                    "OrderableDBInstanceOption",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p> Contains the result of a successful invocation of the <a>DescribeOrderableDBInstanceOptions</a> action. </p>
@@ -8824,54 +6587,27 @@ impl OrderableDBInstanceOptionsMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<OrderableDBInstanceOptionsMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = OrderableDBInstanceOptionsMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, OrderableDBInstanceOptionsMessage, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Marker" => {
                         obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                     }
                     "OrderableDBInstanceOptions" => {
-                        obj.orderable_db_instance_options = match obj.orderable_db_instance_options
-                        {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    OrderableDBInstanceOptionsListDeserializer::deserialize(
-                                        "OrderableDBInstanceOptions",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(OrderableDBInstanceOptionsListDeserializer::deserialize(
+                        obj.orderable_db_instance_options
+                            .get_or_insert(vec![])
+                            .extend(OrderableDBInstanceOptionsListDeserializer::deserialize(
                                 "OrderableDBInstanceOptions",
                                 stack,
-                            )?),
-                        };
+                            )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p> This data type is used as a request parameter in the <a>ModifyDBParameterGroup</a> and <a>ResetDBParameterGroup</a> actions. </p> <p>This data type is used as a response element in the <a>DescribeEngineDefaultParameters</a> and <a>DescribeDBParameters</a> actions.</p>
@@ -8906,72 +6642,50 @@ impl ParameterDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Parameter, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Parameter::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Parameter, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AllowedValues" => {
+                    obj.allowed_values =
+                        Some(StringDeserializer::deserialize("AllowedValues", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AllowedValues" => {
-                        obj.allowed_values =
-                            Some(StringDeserializer::deserialize("AllowedValues", stack)?);
-                    }
-                    "ApplyMethod" => {
-                        obj.apply_method =
-                            Some(ApplyMethodDeserializer::deserialize("ApplyMethod", stack)?);
-                    }
-                    "ApplyType" => {
-                        obj.apply_type = Some(StringDeserializer::deserialize("ApplyType", stack)?);
-                    }
-                    "DataType" => {
-                        obj.data_type = Some(StringDeserializer::deserialize("DataType", stack)?);
-                    }
-                    "Description" => {
-                        obj.description =
-                            Some(StringDeserializer::deserialize("Description", stack)?);
-                    }
-                    "IsModifiable" => {
-                        obj.is_modifiable =
-                            Some(BooleanDeserializer::deserialize("IsModifiable", stack)?);
-                    }
-                    "MinimumEngineVersion" => {
-                        obj.minimum_engine_version = Some(StringDeserializer::deserialize(
-                            "MinimumEngineVersion",
-                            stack,
-                        )?);
-                    }
-                    "ParameterName" => {
-                        obj.parameter_name =
-                            Some(StringDeserializer::deserialize("ParameterName", stack)?);
-                    }
-                    "ParameterValue" => {
-                        obj.parameter_value =
-                            Some(StringDeserializer::deserialize("ParameterValue", stack)?);
-                    }
-                    "Source" => {
-                        obj.source = Some(StringDeserializer::deserialize("Source", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "ApplyMethod" => {
+                    obj.apply_method =
+                        Some(ApplyMethodDeserializer::deserialize("ApplyMethod", stack)?);
                 }
+                "ApplyType" => {
+                    obj.apply_type = Some(StringDeserializer::deserialize("ApplyType", stack)?);
+                }
+                "DataType" => {
+                    obj.data_type = Some(StringDeserializer::deserialize("DataType", stack)?);
+                }
+                "Description" => {
+                    obj.description = Some(StringDeserializer::deserialize("Description", stack)?);
+                }
+                "IsModifiable" => {
+                    obj.is_modifiable =
+                        Some(BooleanDeserializer::deserialize("IsModifiable", stack)?);
+                }
+                "MinimumEngineVersion" => {
+                    obj.minimum_engine_version = Some(StringDeserializer::deserialize(
+                        "MinimumEngineVersion",
+                        stack,
+                    )?);
+                }
+                "ParameterName" => {
+                    obj.parameter_name =
+                        Some(StringDeserializer::deserialize("ParameterName", stack)?);
+                }
+                "ParameterValue" => {
+                    obj.parameter_value =
+                        Some(StringDeserializer::deserialize("ParameterValue", stack)?);
+                }
+                "Source" => {
+                    obj.source = Some(StringDeserializer::deserialize("Source", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -9030,37 +6744,14 @@ impl ParametersListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Parameter>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "Parameter" {
-                        obj.push(ParameterDeserializer::deserialize("Parameter", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "Parameter" {
+                obj.push(ParameterDeserializer::deserialize("Parameter", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -9091,63 +6782,26 @@ impl PendingCloudwatchLogsExportsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<PendingCloudwatchLogsExports, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = PendingCloudwatchLogsExports::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, PendingCloudwatchLogsExports, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "LogTypesToDisable" => {
-                        obj.log_types_to_disable = match obj.log_types_to_disable {
-                            Some(ref mut existing) => {
-                                existing.extend(LogTypeListDeserializer::deserialize(
-                                    "LogTypesToDisable",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(LogTypeListDeserializer::deserialize(
-                                "LogTypesToDisable",
-                                stack,
-                            )?),
-                        };
+                        obj.log_types_to_disable.get_or_insert(vec![]).extend(
+                            LogTypeListDeserializer::deserialize("LogTypesToDisable", stack)?,
+                        );
                     }
                     "LogTypesToEnable" => {
-                        obj.log_types_to_enable = match obj.log_types_to_enable {
-                            Some(ref mut existing) => {
-                                existing.extend(LogTypeListDeserializer::deserialize(
-                                    "LogTypesToEnable",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(LogTypeListDeserializer::deserialize(
-                                "LogTypesToEnable",
-                                stack,
-                            )?),
-                        };
+                        obj.log_types_to_enable.get_or_insert(vec![]).extend(
+                            LogTypeListDeserializer::deserialize("LogTypesToEnable", stack)?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Provides information about a pending maintenance action for a resource.</p>
@@ -9174,21 +6828,11 @@ impl PendingMaintenanceActionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<PendingMaintenanceAction, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = PendingMaintenanceAction::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, PendingMaintenanceAction, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Action" => {
                         obj.action = Some(StringDeserializer::deserialize("Action", stack)?);
                     }
@@ -9215,17 +6859,10 @@ impl PendingMaintenanceActionDeserializer {
                             Some(StringDeserializer::deserialize("OptInStatus", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct PendingMaintenanceActionDetailsDeserializer;
@@ -9235,40 +6872,17 @@ impl PendingMaintenanceActionDetailsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<PendingMaintenanceAction>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "PendingMaintenanceAction" {
-                        obj.push(PendingMaintenanceActionDeserializer::deserialize(
-                            "PendingMaintenanceAction",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "PendingMaintenanceAction" {
+                obj.push(PendingMaintenanceActionDeserializer::deserialize(
+                    "PendingMaintenanceAction",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PendingMaintenanceActionsDeserializer;
@@ -9278,40 +6892,17 @@ impl PendingMaintenanceActionsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<ResourcePendingMaintenanceActions>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "ResourcePendingMaintenanceActions" {
-                        obj.push(ResourcePendingMaintenanceActionsDeserializer::deserialize(
-                            "ResourcePendingMaintenanceActions",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "ResourcePendingMaintenanceActions" {
+                obj.push(ResourcePendingMaintenanceActionsDeserializer::deserialize(
+                    "ResourcePendingMaintenanceActions",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Data returned from the <b>DescribePendingMaintenanceActions</b> action.</p>
@@ -9330,53 +6921,27 @@ impl PendingMaintenanceActionsMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<PendingMaintenanceActionsMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = PendingMaintenanceActionsMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, PendingMaintenanceActionsMessage, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Marker" => {
                         obj.marker = Some(StringDeserializer::deserialize("Marker", stack)?);
                     }
                     "PendingMaintenanceActions" => {
-                        obj.pending_maintenance_actions = match obj.pending_maintenance_actions {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    PendingMaintenanceActionsDeserializer::deserialize(
-                                        "PendingMaintenanceActions",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(PendingMaintenanceActionsDeserializer::deserialize(
+                        obj.pending_maintenance_actions
+                            .get_or_insert(vec![])
+                            .extend(PendingMaintenanceActionsDeserializer::deserialize(
                                 "PendingMaintenanceActions",
                                 stack,
-                            )?),
-                        };
+                            )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p> This data type is used as a response element in the <a>ModifyDBInstance</a> action. </p>
@@ -9418,101 +6983,78 @@ impl PendingModifiedValuesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<PendingModifiedValues, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = PendingModifiedValues::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, PendingModifiedValues, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AllocatedStorage" => {
+                    obj.allocated_storage = Some(IntegerOptionalDeserializer::deserialize(
+                        "AllocatedStorage",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AllocatedStorage" => {
-                        obj.allocated_storage = Some(IntegerOptionalDeserializer::deserialize(
-                            "AllocatedStorage",
-                            stack,
-                        )?);
-                    }
-                    "BackupRetentionPeriod" => {
-                        obj.backup_retention_period =
-                            Some(IntegerOptionalDeserializer::deserialize(
-                                "BackupRetentionPeriod",
-                                stack,
-                            )?);
-                    }
-                    "CACertificateIdentifier" => {
-                        obj.ca_certificate_identifier = Some(StringDeserializer::deserialize(
-                            "CACertificateIdentifier",
-                            stack,
-                        )?);
-                    }
-                    "DBInstanceClass" => {
-                        obj.db_instance_class =
-                            Some(StringDeserializer::deserialize("DBInstanceClass", stack)?);
-                    }
-                    "DBInstanceIdentifier" => {
-                        obj.db_instance_identifier = Some(StringDeserializer::deserialize(
-                            "DBInstanceIdentifier",
-                            stack,
-                        )?);
-                    }
-                    "DBSubnetGroupName" => {
-                        obj.db_subnet_group_name =
-                            Some(StringDeserializer::deserialize("DBSubnetGroupName", stack)?);
-                    }
-                    "EngineVersion" => {
-                        obj.engine_version =
-                            Some(StringDeserializer::deserialize("EngineVersion", stack)?);
-                    }
-                    "Iops" => {
-                        obj.iops = Some(IntegerOptionalDeserializer::deserialize("Iops", stack)?);
-                    }
-                    "LicenseModel" => {
-                        obj.license_model =
-                            Some(StringDeserializer::deserialize("LicenseModel", stack)?);
-                    }
-                    "MasterUserPassword" => {
-                        obj.master_user_password = Some(StringDeserializer::deserialize(
-                            "MasterUserPassword",
-                            stack,
-                        )?);
-                    }
-                    "MultiAZ" => {
-                        obj.multi_az =
-                            Some(BooleanOptionalDeserializer::deserialize("MultiAZ", stack)?);
-                    }
-                    "PendingCloudwatchLogsExports" => {
-                        obj.pending_cloudwatch_logs_exports =
-                            Some(PendingCloudwatchLogsExportsDeserializer::deserialize(
-                                "PendingCloudwatchLogsExports",
-                                stack,
-                            )?);
-                    }
-                    "Port" => {
-                        obj.port = Some(IntegerOptionalDeserializer::deserialize("Port", stack)?);
-                    }
-                    "StorageType" => {
-                        obj.storage_type =
-                            Some(StringDeserializer::deserialize("StorageType", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "BackupRetentionPeriod" => {
+                    obj.backup_retention_period = Some(IntegerOptionalDeserializer::deserialize(
+                        "BackupRetentionPeriod",
+                        stack,
+                    )?);
                 }
+                "CACertificateIdentifier" => {
+                    obj.ca_certificate_identifier = Some(StringDeserializer::deserialize(
+                        "CACertificateIdentifier",
+                        stack,
+                    )?);
+                }
+                "DBInstanceClass" => {
+                    obj.db_instance_class =
+                        Some(StringDeserializer::deserialize("DBInstanceClass", stack)?);
+                }
+                "DBInstanceIdentifier" => {
+                    obj.db_instance_identifier = Some(StringDeserializer::deserialize(
+                        "DBInstanceIdentifier",
+                        stack,
+                    )?);
+                }
+                "DBSubnetGroupName" => {
+                    obj.db_subnet_group_name =
+                        Some(StringDeserializer::deserialize("DBSubnetGroupName", stack)?);
+                }
+                "EngineVersion" => {
+                    obj.engine_version =
+                        Some(StringDeserializer::deserialize("EngineVersion", stack)?);
+                }
+                "Iops" => {
+                    obj.iops = Some(IntegerOptionalDeserializer::deserialize("Iops", stack)?);
+                }
+                "LicenseModel" => {
+                    obj.license_model =
+                        Some(StringDeserializer::deserialize("LicenseModel", stack)?);
+                }
+                "MasterUserPassword" => {
+                    obj.master_user_password = Some(StringDeserializer::deserialize(
+                        "MasterUserPassword",
+                        stack,
+                    )?);
+                }
+                "MultiAZ" => {
+                    obj.multi_az =
+                        Some(BooleanOptionalDeserializer::deserialize("MultiAZ", stack)?);
+                }
+                "PendingCloudwatchLogsExports" => {
+                    obj.pending_cloudwatch_logs_exports =
+                        Some(PendingCloudwatchLogsExportsDeserializer::deserialize(
+                            "PendingCloudwatchLogsExports",
+                            stack,
+                        )?);
+                }
+                "Port" => {
+                    obj.port = Some(IntegerOptionalDeserializer::deserialize("Port", stack)?);
+                }
+                "StorageType" => {
+                    obj.storage_type = Some(StringDeserializer::deserialize("StorageType", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p><p/></p>
@@ -9550,37 +7092,20 @@ impl PromoteReadReplicaDBClusterResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<PromoteReadReplicaDBClusterResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = PromoteReadReplicaDBClusterResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, PromoteReadReplicaDBClusterResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DBCluster" => {
                         obj.db_cluster =
                             Some(DBClusterDeserializer::deserialize("DBCluster", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A range of integer values.</p>
@@ -9601,42 +7126,21 @@ impl RangeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Range, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Range::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Range, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "From" => {
+                    obj.from = Some(IntegerDeserializer::deserialize("From", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "From" => {
-                        obj.from = Some(IntegerDeserializer::deserialize("From", stack)?);
-                    }
-                    "Step" => {
-                        obj.step = Some(IntegerOptionalDeserializer::deserialize("Step", stack)?);
-                    }
-                    "To" => {
-                        obj.to = Some(IntegerDeserializer::deserialize("To", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Step" => {
+                    obj.step = Some(IntegerOptionalDeserializer::deserialize("Step", stack)?);
                 }
+                "To" => {
+                    obj.to = Some(IntegerDeserializer::deserialize("To", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct RangeListDeserializer;
@@ -9646,37 +7150,14 @@ impl RangeListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Range>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "Range" {
-                        obj.push(RangeDeserializer::deserialize("Range", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "Range" {
+                obj.push(RangeDeserializer::deserialize("Range", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ReadReplicaDBClusterIdentifierListDeserializer;
@@ -9686,40 +7167,17 @@ impl ReadReplicaDBClusterIdentifierListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "ReadReplicaDBClusterIdentifier" {
-                        obj.push(StringDeserializer::deserialize(
-                            "ReadReplicaDBClusterIdentifier",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "ReadReplicaDBClusterIdentifier" {
+                obj.push(StringDeserializer::deserialize(
+                    "ReadReplicaDBClusterIdentifier",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ReadReplicaDBInstanceIdentifierListDeserializer;
@@ -9729,40 +7187,17 @@ impl ReadReplicaDBInstanceIdentifierListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "ReadReplicaDBInstanceIdentifier" {
-                        obj.push(StringDeserializer::deserialize(
-                            "ReadReplicaDBInstanceIdentifier",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "ReadReplicaDBInstanceIdentifier" {
+                obj.push(StringDeserializer::deserialize(
+                    "ReadReplicaDBInstanceIdentifier",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ReadReplicaIdentifierListDeserializer;
@@ -9772,40 +7207,17 @@ impl ReadReplicaIdentifierListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "ReadReplicaIdentifier" {
-                        obj.push(StringDeserializer::deserialize(
-                            "ReadReplicaIdentifier",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "ReadReplicaIdentifier" {
+                obj.push(StringDeserializer::deserialize(
+                    "ReadReplicaIdentifier",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p><p/></p>
@@ -9851,37 +7263,16 @@ impl RebootDBInstanceResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<RebootDBInstanceResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = RebootDBInstanceResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, RebootDBInstanceResult, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DBInstance" => {
+                    obj.db_instance =
+                        Some(DBInstanceDeserializer::deserialize("DBInstance", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DBInstance" => {
-                        obj.db_instance =
-                            Some(DBInstanceDeserializer::deserialize("DBInstance", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -9954,21 +7345,11 @@ impl RemoveSourceIdentifierFromSubscriptionResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<RemoveSourceIdentifierFromSubscriptionResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = RemoveSourceIdentifierFromSubscriptionResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, RemoveSourceIdentifierFromSubscriptionResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "EventSubscription" => {
                         obj.event_subscription = Some(EventSubscriptionDeserializer::deserialize(
                             "EventSubscription",
@@ -9976,17 +7357,10 @@ impl RemoveSourceIdentifierFromSubscriptionResultDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p><p/></p>
@@ -10108,39 +7482,18 @@ impl ResourcePendingMaintenanceActionsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ResourcePendingMaintenanceActions, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ResourcePendingMaintenanceActions::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ResourcePendingMaintenanceActions, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "PendingMaintenanceActionDetails" => {
-                        obj.pending_maintenance_action_details = match obj
-                            .pending_maintenance_action_details
-                        {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    PendingMaintenanceActionDetailsDeserializer::deserialize(
-                                        "PendingMaintenanceActionDetails",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(PendingMaintenanceActionDetailsDeserializer::deserialize(
+                        obj.pending_maintenance_action_details
+                            .get_or_insert(vec![])
+                            .extend(PendingMaintenanceActionDetailsDeserializer::deserialize(
                                 "PendingMaintenanceActionDetails",
                                 stack,
-                            )?),
-                        };
+                            )?);
                     }
                     "ResourceIdentifier" => {
                         obj.resource_identifier = Some(StringDeserializer::deserialize(
@@ -10149,17 +7502,10 @@ impl ResourcePendingMaintenanceActionsDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p><p/></p>
@@ -10267,37 +7613,20 @@ impl RestoreDBClusterFromSnapshotResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<RestoreDBClusterFromSnapshotResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = RestoreDBClusterFromSnapshotResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, RestoreDBClusterFromSnapshotResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DBCluster" => {
                         obj.db_cluster =
                             Some(DBClusterDeserializer::deserialize("DBCluster", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p><p/></p>
@@ -10400,37 +7729,20 @@ impl RestoreDBClusterToPointInTimeResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<RestoreDBClusterToPointInTimeResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = RestoreDBClusterToPointInTimeResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, RestoreDBClusterToPointInTimeResult, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DBCluster" => {
                         obj.db_cluster =
                             Some(DBClusterDeserializer::deserialize("DBCluster", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct SourceIdsListDeserializer;
@@ -10440,37 +7752,14 @@ impl SourceIdsListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "SourceId" {
-                        obj.push(StringDeserializer::deserialize("SourceId", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "SourceId" {
+                obj.push(StringDeserializer::deserialize("SourceId", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -10530,48 +7819,26 @@ impl SubnetDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Subnet, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Subnet::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Subnet, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "SubnetAvailabilityZone" => {
+                    obj.subnet_availability_zone = Some(AvailabilityZoneDeserializer::deserialize(
+                        "SubnetAvailabilityZone",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "SubnetAvailabilityZone" => {
-                        obj.subnet_availability_zone =
-                            Some(AvailabilityZoneDeserializer::deserialize(
-                                "SubnetAvailabilityZone",
-                                stack,
-                            )?);
-                    }
-                    "SubnetIdentifier" => {
-                        obj.subnet_identifier =
-                            Some(StringDeserializer::deserialize("SubnetIdentifier", stack)?);
-                    }
-                    "SubnetStatus" => {
-                        obj.subnet_status =
-                            Some(StringDeserializer::deserialize("SubnetStatus", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "SubnetIdentifier" => {
+                    obj.subnet_identifier =
+                        Some(StringDeserializer::deserialize("SubnetIdentifier", stack)?);
                 }
+                "SubnetStatus" => {
+                    obj.subnet_status =
+                        Some(StringDeserializer::deserialize("SubnetStatus", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -10593,37 +7860,14 @@ impl SubnetListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Subnet>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "Subnet" {
-                        obj.push(SubnetDeserializer::deserialize("Subnet", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "Subnet" {
+                obj.push(SubnetDeserializer::deserialize("Subnet", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct SupportedCharacterSetsListDeserializer;
@@ -10633,40 +7877,17 @@ impl SupportedCharacterSetsListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<CharacterSet>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "CharacterSet" {
-                        obj.push(CharacterSetDeserializer::deserialize(
-                            "CharacterSet",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "CharacterSet" {
+                obj.push(CharacterSetDeserializer::deserialize(
+                    "CharacterSet",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct SupportedTimezonesListDeserializer;
@@ -10676,37 +7897,14 @@ impl SupportedTimezonesListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Timezone>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "Timezone" {
-                        obj.push(TimezoneDeserializer::deserialize("Timezone", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "Timezone" {
+                obj.push(TimezoneDeserializer::deserialize("Timezone", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct TStampDeserializer;
@@ -10739,39 +7937,18 @@ impl TagDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Tag, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Tag::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Tag, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Key" => {
+                    obj.key = Some(StringDeserializer::deserialize("Key", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Key" => {
-                        obj.key = Some(StringDeserializer::deserialize("Key", stack)?);
-                    }
-                    "Value" => {
-                        obj.value = Some(StringDeserializer::deserialize("Value", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Value" => {
+                    obj.value = Some(StringDeserializer::deserialize("Value", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -10800,37 +7977,14 @@ impl TagListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Tag>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "Tag" {
-                        obj.push(TagDeserializer::deserialize("Tag", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "Tag" {
+                obj.push(TagDeserializer::deserialize("Tag", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -10859,43 +8013,17 @@ impl TagListMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<TagListMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = TagListMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, TagListMessage, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "TagList" => {
+                    obj.tag_list
+                        .get_or_insert(vec![])
+                        .extend(TagListDeserializer::deserialize("TagList", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "TagList" => {
-                        obj.tag_list = match obj.tag_list {
-                            Some(ref mut existing) => {
-                                existing
-                                    .extend(TagListDeserializer::deserialize("TagList", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(TagListDeserializer::deserialize("TagList", stack)?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>A time zone associated with a <a>DBInstance</a>. This data type is an element in the response to the <a>DescribeDBInstances</a>, and the <a>DescribeDBEngineVersions</a> actions. </p>
@@ -10912,37 +8040,16 @@ impl TimezoneDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Timezone, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Timezone::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Timezone, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "TimezoneName" => {
+                    obj.timezone_name =
+                        Some(StringDeserializer::deserialize("TimezoneName", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "TimezoneName" => {
-                        obj.timezone_name =
-                            Some(StringDeserializer::deserialize("TimezoneName", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>The version of the database engine that a DB instance can be upgraded to.</p>
@@ -10967,54 +8074,32 @@ impl UpgradeTargetDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UpgradeTarget, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = UpgradeTarget::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, UpgradeTarget, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AutoUpgrade" => {
+                    obj.auto_upgrade =
+                        Some(BooleanDeserializer::deserialize("AutoUpgrade", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AutoUpgrade" => {
-                        obj.auto_upgrade =
-                            Some(BooleanDeserializer::deserialize("AutoUpgrade", stack)?);
-                    }
-                    "Description" => {
-                        obj.description =
-                            Some(StringDeserializer::deserialize("Description", stack)?);
-                    }
-                    "Engine" => {
-                        obj.engine = Some(StringDeserializer::deserialize("Engine", stack)?);
-                    }
-                    "EngineVersion" => {
-                        obj.engine_version =
-                            Some(StringDeserializer::deserialize("EngineVersion", stack)?);
-                    }
-                    "IsMajorVersionUpgrade" => {
-                        obj.is_major_version_upgrade = Some(BooleanDeserializer::deserialize(
-                            "IsMajorVersionUpgrade",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Description" => {
+                    obj.description = Some(StringDeserializer::deserialize("Description", stack)?);
                 }
+                "Engine" => {
+                    obj.engine = Some(StringDeserializer::deserialize("Engine", stack)?);
+                }
+                "EngineVersion" => {
+                    obj.engine_version =
+                        Some(StringDeserializer::deserialize("EngineVersion", stack)?);
+                }
+                "IsMajorVersionUpgrade" => {
+                    obj.is_major_version_upgrade = Some(BooleanDeserializer::deserialize(
+                        "IsMajorVersionUpgrade",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Information about valid modifications that you can make to your DB instance. Contains the result of a successful call to the <a>DescribeValidDBInstanceModifications</a> action. You can use this information when you call <a>ModifyDBInstance</a>. </p>
@@ -11031,46 +8116,21 @@ impl ValidDBInstanceModificationsMessageDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ValidDBInstanceModificationsMessage, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ValidDBInstanceModificationsMessage::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ValidDBInstanceModificationsMessage, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Storage" => {
-                        obj.storage = match obj.storage {
-                            Some(ref mut existing) => {
-                                existing.extend(ValidStorageOptionsListDeserializer::deserialize(
-                                    "Storage", stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ValidStorageOptionsListDeserializer::deserialize(
-                                "Storage", stack,
-                            )?),
-                        };
+                        obj.storage.get_or_insert(vec![]).extend(
+                            ValidStorageOptionsListDeserializer::deserialize("Storage", stack)?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Information about valid modifications that you can make to your DB instance. Contains the result of a successful call to the <a>DescribeValidDBInstanceModifications</a> action. </p>
@@ -11093,79 +8153,30 @@ impl ValidStorageOptionsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ValidStorageOptions, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ValidStorageOptions::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ValidStorageOptions, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "IopsToStorageRatio" => {
+                    obj.iops_to_storage_ratio.get_or_insert(vec![]).extend(
+                        DoubleRangeListDeserializer::deserialize("IopsToStorageRatio", stack)?,
+                    );
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "IopsToStorageRatio" => {
-                        obj.iops_to_storage_ratio = match obj.iops_to_storage_ratio {
-                            Some(ref mut existing) => {
-                                existing.extend(DoubleRangeListDeserializer::deserialize(
-                                    "IopsToStorageRatio",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(DoubleRangeListDeserializer::deserialize(
-                                "IopsToStorageRatio",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "ProvisionedIops" => {
-                        obj.provisioned_iops = match obj.provisioned_iops {
-                            Some(ref mut existing) => {
-                                existing.extend(RangeListDeserializer::deserialize(
-                                    "ProvisionedIops",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(RangeListDeserializer::deserialize(
-                                "ProvisionedIops",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "StorageSize" => {
-                        obj.storage_size = match obj.storage_size {
-                            Some(ref mut existing) => {
-                                existing.extend(RangeListDeserializer::deserialize(
-                                    "StorageSize",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(RangeListDeserializer::deserialize("StorageSize", stack)?),
-                        };
-                    }
-                    "StorageType" => {
-                        obj.storage_type =
-                            Some(StringDeserializer::deserialize("StorageType", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "ProvisionedIops" => {
+                    obj.provisioned_iops.get_or_insert(vec![]).extend(
+                        RangeListDeserializer::deserialize("ProvisionedIops", stack)?,
+                    );
                 }
+                "StorageSize" => {
+                    obj.storage_size
+                        .get_or_insert(vec![])
+                        .extend(RangeListDeserializer::deserialize("StorageSize", stack)?);
+                }
+                "StorageType" => {
+                    obj.storage_type = Some(StringDeserializer::deserialize("StorageType", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ValidStorageOptionsListDeserializer;
@@ -11175,40 +8186,17 @@ impl ValidStorageOptionsListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<ValidStorageOptions>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "ValidStorageOptions" {
-                        obj.push(ValidStorageOptionsDeserializer::deserialize(
-                            "ValidStorageOptions",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "ValidStorageOptions" {
+                obj.push(ValidStorageOptionsDeserializer::deserialize(
+                    "ValidStorageOptions",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ValidUpgradeTargetListDeserializer;
@@ -11218,40 +8206,17 @@ impl ValidUpgradeTargetListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<UpgradeTarget>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "UpgradeTarget" {
-                        obj.push(UpgradeTargetDeserializer::deserialize(
-                            "UpgradeTarget",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "UpgradeTarget" {
+                obj.push(UpgradeTargetDeserializer::deserialize(
+                    "UpgradeTarget",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -11282,21 +8247,11 @@ impl VpcSecurityGroupMembershipDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<VpcSecurityGroupMembership, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = VpcSecurityGroupMembership::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, VpcSecurityGroupMembership, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Status" => {
                         obj.status = Some(StringDeserializer::deserialize("Status", stack)?);
                     }
@@ -11307,17 +8262,10 @@ impl VpcSecurityGroupMembershipDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct VpcSecurityGroupMembershipListDeserializer;
@@ -11327,40 +8275,17 @@ impl VpcSecurityGroupMembershipListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<VpcSecurityGroupMembership>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "VpcSecurityGroupMembership" {
-                        obj.push(VpcSecurityGroupMembershipDeserializer::deserialize(
-                            "VpcSecurityGroupMembership",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "VpcSecurityGroupMembership" {
+                obj.push(VpcSecurityGroupMembershipDeserializer::deserialize(
+                    "VpcSecurityGroupMembership",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// Errors returned by AddRoleToDBCluster

--- a/rusoto/services/route53/src/generated.rs
+++ b/rusoto/services/route53/src/generated.rs
@@ -25,21 +25,17 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
 use rusoto_core::xmlutil::{
-    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+    characters, deserialize_elements, end_element, find_start_element, peek_at_name, skip_tree,
+    start_element,
 };
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use std::io::Write;
 use std::str::FromStr;
 use xml;
 use xml::reader::ParserConfig;
-use xml::reader::XmlEvent;
 use xml::EventReader;
 use xml::EventWriter;
-enum DeserializerNext {
-    Close,
-    Skip,
-    Element(String),
-}
+
 /// <p>A complex type that contains the type of limit that you specified in the request and the current value for that limit.</p>
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct AccountLimit {
@@ -56,39 +52,18 @@ impl AccountLimitDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AccountLimit, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AccountLimit::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, AccountLimit, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Type" => {
+                    obj.type_ = AccountLimitTypeDeserializer::deserialize("Type", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Type" => {
-                        obj.type_ = AccountLimitTypeDeserializer::deserialize("Type", stack)?;
-                    }
-                    "Value" => {
-                        obj.value = LimitValueDeserializer::deserialize("Value", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Value" => {
+                    obj.value = LimitValueDeserializer::deserialize("Value", stack)?;
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct AccountLimitTypeDeserializer;
@@ -142,39 +117,18 @@ impl AlarmIdentifierDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AlarmIdentifier, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AlarmIdentifier::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, AlarmIdentifier, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Name" => {
+                    obj.name = AlarmNameDeserializer::deserialize("Name", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Name" => {
-                        obj.name = AlarmNameDeserializer::deserialize("Name", stack)?;
-                    }
-                    "Region" => {
-                        obj.region = CloudWatchRegionDeserializer::deserialize("Region", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Region" => {
+                    obj.region = CloudWatchRegionDeserializer::deserialize("Region", stack)?;
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -294,46 +248,23 @@ impl AliasTargetDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AliasTarget, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AliasTarget::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, AliasTarget, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DNSName" => {
+                    obj.dns_name = DNSNameDeserializer::deserialize("DNSName", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DNSName" => {
-                        obj.dns_name = DNSNameDeserializer::deserialize("DNSName", stack)?;
-                    }
-                    "EvaluateTargetHealth" => {
-                        obj.evaluate_target_health = AliasHealthEnabledDeserializer::deserialize(
-                            "EvaluateTargetHealth",
-                            stack,
-                        )?;
-                    }
-                    "HostedZoneId" => {
-                        obj.hosted_zone_id =
-                            ResourceIdDeserializer::deserialize("HostedZoneId", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "EvaluateTargetHealth" => {
+                    obj.evaluate_target_health =
+                        AliasHealthEnabledDeserializer::deserialize("EvaluateTargetHealth", stack)?;
                 }
+                "HostedZoneId" => {
+                    obj.hosted_zone_id =
+                        ResourceIdDeserializer::deserialize("HostedZoneId", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -436,36 +367,19 @@ impl AssociateVPCWithHostedZoneResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AssociateVPCWithHostedZoneResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AssociateVPCWithHostedZoneResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, AssociateVPCWithHostedZoneResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ChangeInfo" => {
                         obj.change_info = ChangeInfoDeserializer::deserialize("ChangeInfo", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>The information for each resource record set that you want to change.</p>
@@ -578,48 +492,26 @@ impl ChangeInfoDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ChangeInfo, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ChangeInfo::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ChangeInfo, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Comment" => {
+                    obj.comment = Some(ResourceDescriptionDeserializer::deserialize(
+                        "Comment", stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Comment" => {
-                        obj.comment = Some(ResourceDescriptionDeserializer::deserialize(
-                            "Comment", stack,
-                        )?);
-                    }
-                    "Id" => {
-                        obj.id = ResourceIdDeserializer::deserialize("Id", stack)?;
-                    }
-                    "Status" => {
-                        obj.status = ChangeStatusDeserializer::deserialize("Status", stack)?;
-                    }
-                    "SubmittedAt" => {
-                        obj.submitted_at =
-                            TimeStampDeserializer::deserialize("SubmittedAt", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Id" => {
+                    obj.id = ResourceIdDeserializer::deserialize("Id", stack)?;
                 }
+                "Status" => {
+                    obj.status = ChangeStatusDeserializer::deserialize("Status", stack)?;
+                }
+                "SubmittedAt" => {
+                    obj.submitted_at = TimeStampDeserializer::deserialize("SubmittedAt", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>A complex type that contains change information for the resource record set.</p>
@@ -662,36 +554,19 @@ impl ChangeResourceRecordSetsResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ChangeResourceRecordSetsResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ChangeResourceRecordSetsResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ChangeResourceRecordSetsResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ChangeInfo" => {
                         obj.change_info = ChangeInfoDeserializer::deserialize("ChangeInfo", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct ChangeStatusDeserializer;
@@ -791,37 +666,14 @@ impl CheckerIpRangesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(IPAddressCidrDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(IPAddressCidrDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ChildHealthCheckListDeserializer;
@@ -831,40 +683,17 @@ impl ChildHealthCheckListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "ChildHealthCheck" {
-                        obj.push(HealthCheckIdDeserializer::deserialize(
-                            "ChildHealthCheck",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "ChildHealthCheck" {
+                obj.push(HealthCheckIdDeserializer::deserialize(
+                    "ChildHealthCheck",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -916,21 +745,11 @@ impl CloudWatchAlarmConfigurationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CloudWatchAlarmConfiguration, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CloudWatchAlarmConfiguration::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CloudWatchAlarmConfiguration, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ComparisonOperator" => {
                         obj.comparison_operator = ComparisonOperatorDeserializer::deserialize(
                             "ComparisonOperator",
@@ -938,18 +757,9 @@ impl CloudWatchAlarmConfigurationDeserializer {
                         )?;
                     }
                     "Dimensions" => {
-                        obj.dimensions = match obj.dimensions {
-                            Some(ref mut existing) => {
-                                existing.extend(DimensionListDeserializer::deserialize(
-                                    "Dimensions",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => {
-                                Some(DimensionListDeserializer::deserialize("Dimensions", stack)?)
-                            }
-                        };
+                        obj.dimensions
+                            .get_or_insert(vec![])
+                            .extend(DimensionListDeserializer::deserialize("Dimensions", stack)?);
                     }
                     "EvaluationPeriods" => {
                         obj.evaluation_periods =
@@ -971,17 +781,10 @@ impl CloudWatchAlarmConfigurationDeserializer {
                         obj.threshold = ThresholdDeserializer::deserialize("Threshold", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct CloudWatchLogsLogGroupArnDeserializer;
@@ -1119,37 +922,20 @@ impl CreateHealthCheckResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateHealthCheckResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateHealthCheckResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateHealthCheckResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "HealthCheck" => {
                         obj.health_check =
                             HealthCheckDeserializer::deserialize("HealthCheck", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A complex type that contains information about the request to create a public or private hosted zone.</p>
@@ -1216,21 +1002,11 @@ impl CreateHostedZoneResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateHostedZoneResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateHostedZoneResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateHostedZoneResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ChangeInfo" => {
                         obj.change_info = ChangeInfoDeserializer::deserialize("ChangeInfo", stack)?;
                     }
@@ -1245,17 +1021,10 @@ impl CreateHostedZoneResponseDeserializer {
                         obj.vpc = Some(VPCDeserializer::deserialize("VPC", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -1303,21 +1072,11 @@ impl CreateQueryLoggingConfigResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateQueryLoggingConfigResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateQueryLoggingConfigResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateQueryLoggingConfigResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "QueryLoggingConfig" => {
                         obj.query_logging_config = QueryLoggingConfigDeserializer::deserialize(
                             "QueryLoggingConfig",
@@ -1325,17 +1084,10 @@ impl CreateQueryLoggingConfigResponseDeserializer {
                         )?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -1381,37 +1133,20 @@ impl CreateReusableDelegationSetResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateReusableDelegationSetResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateReusableDelegationSetResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateReusableDelegationSetResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DelegationSet" => {
                         obj.delegation_set =
                             DelegationSetDeserializer::deserialize("DelegationSet", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A complex type that contains information about the resource record sets that you want to create based on a specified traffic policy.</p>
@@ -1474,21 +1209,11 @@ impl CreateTrafficPolicyInstanceResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateTrafficPolicyInstanceResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateTrafficPolicyInstanceResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateTrafficPolicyInstanceResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "TrafficPolicyInstance" => {
                         obj.traffic_policy_instance =
                             TrafficPolicyInstanceDeserializer::deserialize(
@@ -1497,17 +1222,10 @@ impl CreateTrafficPolicyInstanceResponseDeserializer {
                             )?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A complex type that contains information about the traffic policy that you want to create.</p>
@@ -1558,37 +1276,20 @@ impl CreateTrafficPolicyResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateTrafficPolicyResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateTrafficPolicyResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateTrafficPolicyResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "TrafficPolicy" => {
                         obj.traffic_policy =
                             TrafficPolicyDeserializer::deserialize("TrafficPolicy", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A complex type that contains information about the traffic policy that you want to create a new version for.</p>
@@ -1638,37 +1339,20 @@ impl CreateTrafficPolicyVersionResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateTrafficPolicyVersionResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateTrafficPolicyVersionResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateTrafficPolicyVersionResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "TrafficPolicy" => {
                         obj.traffic_policy =
                             TrafficPolicyDeserializer::deserialize("TrafficPolicy", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A complex type that contains information about the request to authorize associating a VPC with your private hosted zone. Authorization is only required when a private hosted zone and a VPC were created by using different accounts.</p>
@@ -1713,21 +1397,11 @@ impl CreateVPCAssociationAuthorizationResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateVPCAssociationAuthorizationResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateVPCAssociationAuthorizationResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateVPCAssociationAuthorizationResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "HostedZoneId" => {
                         obj.hosted_zone_id =
                             ResourceIdDeserializer::deserialize("HostedZoneId", stack)?;
@@ -1736,17 +1410,10 @@ impl CreateVPCAssociationAuthorizationResponseDeserializer {
                         obj.vpc = VPCDeserializer::deserialize("VPC", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct DNSNameDeserializer;
@@ -1816,47 +1483,26 @@ impl DelegationSetDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DelegationSet, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DelegationSet::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DelegationSet, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CallerReference" => {
+                    obj.caller_reference =
+                        Some(NonceDeserializer::deserialize("CallerReference", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CallerReference" => {
-                        obj.caller_reference =
-                            Some(NonceDeserializer::deserialize("CallerReference", stack)?);
-                    }
-                    "Id" => {
-                        obj.id = Some(ResourceIdDeserializer::deserialize("Id", stack)?);
-                    }
-                    "NameServers" => {
-                        obj.name_servers
-                            .extend(DelegationSetNameServersDeserializer::deserialize(
-                                "NameServers",
-                                stack,
-                            )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Id" => {
+                    obj.id = Some(ResourceIdDeserializer::deserialize("Id", stack)?);
                 }
+                "NameServers" => {
+                    obj.name_servers
+                        .extend(DelegationSetNameServersDeserializer::deserialize(
+                            "NameServers",
+                            stack,
+                        )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct DelegationSetNameServersDeserializer;
@@ -1866,37 +1512,14 @@ impl DelegationSetNameServersDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "NameServer" {
-                        obj.push(DNSNameDeserializer::deserialize("NameServer", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "NameServer" {
+                obj.push(DNSNameDeserializer::deserialize("NameServer", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct DelegationSetsDeserializer;
@@ -1906,40 +1529,17 @@ impl DelegationSetsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<DelegationSet>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "DelegationSet" {
-                        obj.push(DelegationSetDeserializer::deserialize(
-                            "DelegationSet",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "DelegationSet" {
+                obj.push(DelegationSetDeserializer::deserialize(
+                    "DelegationSet",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>This action deletes a health check.</p>
@@ -1990,36 +1590,19 @@ impl DeleteHostedZoneResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DeleteHostedZoneResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DeleteHostedZoneResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DeleteHostedZoneResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ChangeInfo" => {
                         obj.change_info = ChangeInfoDeserializer::deserialize("ChangeInfo", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -2192,39 +1775,18 @@ impl DimensionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Dimension, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Dimension::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Dimension, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Name" => {
+                    obj.name = DimensionFieldDeserializer::deserialize("Name", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Name" => {
-                        obj.name = DimensionFieldDeserializer::deserialize("Name", stack)?;
-                    }
-                    "Value" => {
-                        obj.value = DimensionFieldDeserializer::deserialize("Value", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Value" => {
+                    obj.value = DimensionFieldDeserializer::deserialize("Value", stack)?;
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct DimensionFieldDeserializer;
@@ -2248,37 +1810,14 @@ impl DimensionListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Dimension>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "Dimension" {
-                        obj.push(DimensionDeserializer::deserialize("Dimension", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "Dimension" {
+                obj.push(DimensionDeserializer::deserialize("Dimension", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct DisabledDeserializer;
@@ -2381,36 +1920,19 @@ impl DisassociateVPCFromHostedZoneResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DisassociateVPCFromHostedZoneResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DisassociateVPCFromHostedZoneResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DisassociateVPCFromHostedZoneResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ChangeInfo" => {
                         obj.change_info = ChangeInfoDeserializer::deserialize("ChangeInfo", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct EnableSNIDeserializer;
@@ -2550,53 +2072,31 @@ impl GeoLocationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GeoLocation, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GeoLocation::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, GeoLocation, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "ContinentCode" => {
+                    obj.continent_code = Some(GeoLocationContinentCodeDeserializer::deserialize(
+                        "ContinentCode",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "ContinentCode" => {
-                        obj.continent_code =
-                            Some(GeoLocationContinentCodeDeserializer::deserialize(
-                                "ContinentCode",
-                                stack,
-                            )?);
-                    }
-                    "CountryCode" => {
-                        obj.country_code = Some(GeoLocationCountryCodeDeserializer::deserialize(
-                            "CountryCode",
+                "CountryCode" => {
+                    obj.country_code = Some(GeoLocationCountryCodeDeserializer::deserialize(
+                        "CountryCode",
+                        stack,
+                    )?);
+                }
+                "SubdivisionCode" => {
+                    obj.subdivision_code =
+                        Some(GeoLocationSubdivisionCodeDeserializer::deserialize(
+                            "SubdivisionCode",
                             stack,
                         )?);
-                    }
-                    "SubdivisionCode" => {
-                        obj.subdivision_code =
-                            Some(GeoLocationSubdivisionCodeDeserializer::deserialize(
-                                "SubdivisionCode",
-                                stack,
-                            )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -2762,73 +2262,50 @@ impl GeoLocationDetailsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GeoLocationDetails, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GeoLocationDetails::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, GeoLocationDetails, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "ContinentCode" => {
+                    obj.continent_code = Some(GeoLocationContinentCodeDeserializer::deserialize(
+                        "ContinentCode",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "ContinentCode" => {
-                        obj.continent_code =
-                            Some(GeoLocationContinentCodeDeserializer::deserialize(
-                                "ContinentCode",
-                                stack,
-                            )?);
-                    }
-                    "ContinentName" => {
-                        obj.continent_name =
-                            Some(GeoLocationContinentNameDeserializer::deserialize(
-                                "ContinentName",
-                                stack,
-                            )?);
-                    }
-                    "CountryCode" => {
-                        obj.country_code = Some(GeoLocationCountryCodeDeserializer::deserialize(
-                            "CountryCode",
+                "ContinentName" => {
+                    obj.continent_name = Some(GeoLocationContinentNameDeserializer::deserialize(
+                        "ContinentName",
+                        stack,
+                    )?);
+                }
+                "CountryCode" => {
+                    obj.country_code = Some(GeoLocationCountryCodeDeserializer::deserialize(
+                        "CountryCode",
+                        stack,
+                    )?);
+                }
+                "CountryName" => {
+                    obj.country_name = Some(GeoLocationCountryNameDeserializer::deserialize(
+                        "CountryName",
+                        stack,
+                    )?);
+                }
+                "SubdivisionCode" => {
+                    obj.subdivision_code =
+                        Some(GeoLocationSubdivisionCodeDeserializer::deserialize(
+                            "SubdivisionCode",
                             stack,
                         )?);
-                    }
-                    "CountryName" => {
-                        obj.country_name = Some(GeoLocationCountryNameDeserializer::deserialize(
-                            "CountryName",
+                }
+                "SubdivisionName" => {
+                    obj.subdivision_name =
+                        Some(GeoLocationSubdivisionNameDeserializer::deserialize(
+                            "SubdivisionName",
                             stack,
                         )?);
-                    }
-                    "SubdivisionCode" => {
-                        obj.subdivision_code =
-                            Some(GeoLocationSubdivisionCodeDeserializer::deserialize(
-                                "SubdivisionCode",
-                                stack,
-                            )?);
-                    }
-                    "SubdivisionName" => {
-                        obj.subdivision_name =
-                            Some(GeoLocationSubdivisionNameDeserializer::deserialize(
-                                "SubdivisionName",
-                                stack,
-                            )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct GeoLocationDetailsListDeserializer;
@@ -2838,40 +2315,17 @@ impl GeoLocationDetailsListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<GeoLocationDetails>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "GeoLocationDetails" {
-                        obj.push(GeoLocationDetailsDeserializer::deserialize(
-                            "GeoLocationDetails",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "GeoLocationDetails" {
+                obj.push(GeoLocationDetailsDeserializer::deserialize(
+                    "GeoLocationDetails",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct GeoLocationSubdivisionCodeDeserializer;
@@ -2946,21 +2400,11 @@ impl GetAccountLimitResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetAccountLimitResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetAccountLimitResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetAccountLimitResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Count" => {
                         obj.count = UsageCountDeserializer::deserialize("Count", stack)?;
                     }
@@ -2968,17 +2412,10 @@ impl GetAccountLimitResponseDeserializer {
                         obj.limit = AccountLimitDeserializer::deserialize("Limit", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>The input for a GetChange request.</p>
@@ -3002,36 +2439,15 @@ impl GetChangeResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetChangeResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetChangeResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, GetChangeResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "ChangeInfo" => {
+                    obj.change_info = ChangeInfoDeserializer::deserialize("ChangeInfo", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "ChangeInfo" => {
-                        obj.change_info = ChangeInfoDeserializer::deserialize("ChangeInfo", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -3049,21 +2465,11 @@ impl GetCheckerIpRangesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetCheckerIpRangesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetCheckerIpRangesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetCheckerIpRangesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CheckerIpRanges" => {
                         obj.checker_ip_ranges
                             .extend(CheckerIpRangesDeserializer::deserialize(
@@ -3072,17 +2478,10 @@ impl GetCheckerIpRangesResponseDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A request for information about whether a specified geographic location is supported for Amazon Route 53 geolocation resource record sets.</p>
@@ -3110,39 +2509,16 @@ impl GetGeoLocationResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetGeoLocationResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetGeoLocationResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, GetGeoLocationResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "GeoLocationDetails" => {
+                    obj.geo_location_details =
+                        GeoLocationDetailsDeserializer::deserialize("GeoLocationDetails", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "GeoLocationDetails" => {
-                        obj.geo_location_details = GeoLocationDetailsDeserializer::deserialize(
-                            "GeoLocationDetails",
-                            stack,
-                        )?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>A request for the number of health checks that are associated with the current AWS account.</p>
@@ -3163,37 +2539,20 @@ impl GetHealthCheckCountResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetHealthCheckCountResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetHealthCheckCountResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetHealthCheckCountResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "HealthCheckCount" => {
                         obj.health_check_count =
                             HealthCheckCountDeserializer::deserialize("HealthCheckCount", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A request for the reason that a health check failed most recently.</p>
@@ -3217,21 +2576,11 @@ impl GetHealthCheckLastFailureReasonResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetHealthCheckLastFailureReasonResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetHealthCheckLastFailureReasonResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetHealthCheckLastFailureReasonResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "HealthCheckObservations" => {
                         obj.health_check_observations.extend(
                             HealthCheckObservationsDeserializer::deserialize(
@@ -3241,17 +2590,10 @@ impl GetHealthCheckLastFailureReasonResponseDeserializer {
                         );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A request to get information about a specified health check. </p>
@@ -3275,37 +2617,15 @@ impl GetHealthCheckResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetHealthCheckResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetHealthCheckResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, GetHealthCheckResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "HealthCheck" => {
+                    obj.health_check = HealthCheckDeserializer::deserialize("HealthCheck", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "HealthCheck" => {
-                        obj.health_check =
-                            HealthCheckDeserializer::deserialize("HealthCheck", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>A request to get the status for a health check.</p>
@@ -3329,21 +2649,11 @@ impl GetHealthCheckStatusResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetHealthCheckStatusResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetHealthCheckStatusResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetHealthCheckStatusResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "HealthCheckObservations" => {
                         obj.health_check_observations.extend(
                             HealthCheckObservationsDeserializer::deserialize(
@@ -3353,17 +2663,10 @@ impl GetHealthCheckStatusResponseDeserializer {
                         );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A request to retrieve a count of all the hosted zones that are associated with the current AWS account.</p>
@@ -3384,37 +2687,20 @@ impl GetHostedZoneCountResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetHostedZoneCountResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetHostedZoneCountResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetHostedZoneCountResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "HostedZoneCount" => {
                         obj.hosted_zone_count =
                             HostedZoneCountDeserializer::deserialize("HostedZoneCount", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A complex type that contains information about the request to create a hosted zone.</p>
@@ -3442,21 +2728,11 @@ impl GetHostedZoneLimitResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetHostedZoneLimitResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetHostedZoneLimitResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetHostedZoneLimitResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Count" => {
                         obj.count = UsageCountDeserializer::deserialize("Count", stack)?;
                     }
@@ -3464,17 +2740,10 @@ impl GetHostedZoneLimitResponseDeserializer {
                         obj.limit = HostedZoneLimitDeserializer::deserialize("Limit", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A request to get information about a specified hosted zone. </p>
@@ -3502,51 +2771,26 @@ impl GetHostedZoneResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetHostedZoneResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetHostedZoneResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, GetHostedZoneResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DelegationSet" => {
+                    obj.delegation_set = Some(DelegationSetDeserializer::deserialize(
+                        "DelegationSet",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DelegationSet" => {
-                        obj.delegation_set = Some(DelegationSetDeserializer::deserialize(
-                            "DelegationSet",
-                            stack,
-                        )?);
-                    }
-                    "HostedZone" => {
-                        obj.hosted_zone = HostedZoneDeserializer::deserialize("HostedZone", stack)?;
-                    }
-                    "VPCs" => {
-                        obj.vp_cs = match obj.vp_cs {
-                            Some(ref mut existing) => {
-                                existing.extend(VPCsDeserializer::deserialize("VPCs", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(VPCsDeserializer::deserialize("VPCs", stack)?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "HostedZone" => {
+                    obj.hosted_zone = HostedZoneDeserializer::deserialize("HostedZone", stack)?;
                 }
+                "VPCs" => {
+                    obj.vp_cs
+                        .get_or_insert(vec![])
+                        .extend(VPCsDeserializer::deserialize("VPCs", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -3568,21 +2812,11 @@ impl GetQueryLoggingConfigResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetQueryLoggingConfigResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetQueryLoggingConfigResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetQueryLoggingConfigResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "QueryLoggingConfig" => {
                         obj.query_logging_config = QueryLoggingConfigDeserializer::deserialize(
                             "QueryLoggingConfig",
@@ -3590,17 +2824,10 @@ impl GetQueryLoggingConfigResponseDeserializer {
                         )?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A complex type that contains information about the request to create a hosted zone.</p>
@@ -3628,21 +2855,11 @@ impl GetReusableDelegationSetLimitResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetReusableDelegationSetLimitResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetReusableDelegationSetLimitResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetReusableDelegationSetLimitResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Count" => {
                         obj.count = UsageCountDeserializer::deserialize("Count", stack)?;
                     }
@@ -3651,17 +2868,10 @@ impl GetReusableDelegationSetLimitResponseDeserializer {
                             ReusableDelegationSetLimitDeserializer::deserialize("Limit", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A request to get information about a specified reusable delegation set.</p>
@@ -3685,37 +2895,20 @@ impl GetReusableDelegationSetResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetReusableDelegationSetResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetReusableDelegationSetResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetReusableDelegationSetResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DelegationSet" => {
                         obj.delegation_set =
                             DelegationSetDeserializer::deserialize("DelegationSet", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Request to get the number of traffic policy instances that are associated with the current AWS account.</p>
@@ -3736,21 +2929,11 @@ impl GetTrafficPolicyInstanceCountResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetTrafficPolicyInstanceCountResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetTrafficPolicyInstanceCountResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetTrafficPolicyInstanceCountResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "TrafficPolicyInstanceCount" => {
                         obj.traffic_policy_instance_count =
                             TrafficPolicyInstanceCountDeserializer::deserialize(
@@ -3759,17 +2942,10 @@ impl GetTrafficPolicyInstanceCountResponseDeserializer {
                             )?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Gets information about a specified traffic policy instance.</p>
@@ -3793,21 +2969,11 @@ impl GetTrafficPolicyInstanceResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetTrafficPolicyInstanceResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetTrafficPolicyInstanceResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetTrafficPolicyInstanceResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "TrafficPolicyInstance" => {
                         obj.traffic_policy_instance =
                             TrafficPolicyInstanceDeserializer::deserialize(
@@ -3816,17 +2982,10 @@ impl GetTrafficPolicyInstanceResponseDeserializer {
                             )?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Gets information about a specific traffic policy version.</p>
@@ -3852,37 +3011,20 @@ impl GetTrafficPolicyResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetTrafficPolicyResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetTrafficPolicyResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetTrafficPolicyResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "TrafficPolicy" => {
                         obj.traffic_policy =
                             TrafficPolicyDeserializer::deserialize("TrafficPolicy", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A complex type that contains information about one health check that is associated with the current AWS account.</p>
@@ -3909,63 +3051,40 @@ impl HealthCheckDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<HealthCheck, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = HealthCheck::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, HealthCheck, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CallerReference" => {
+                    obj.caller_reference =
+                        HealthCheckNonceDeserializer::deserialize("CallerReference", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CallerReference" => {
-                        obj.caller_reference =
-                            HealthCheckNonceDeserializer::deserialize("CallerReference", stack)?;
-                    }
-                    "CloudWatchAlarmConfiguration" => {
-                        obj.cloud_watch_alarm_configuration =
-                            Some(CloudWatchAlarmConfigurationDeserializer::deserialize(
-                                "CloudWatchAlarmConfiguration",
-                                stack,
-                            )?);
-                    }
-                    "HealthCheckConfig" => {
-                        obj.health_check_config =
-                            HealthCheckConfigDeserializer::deserialize("HealthCheckConfig", stack)?;
-                    }
-                    "HealthCheckVersion" => {
-                        obj.health_check_version = HealthCheckVersionDeserializer::deserialize(
-                            "HealthCheckVersion",
-                            stack,
-                        )?;
-                    }
-                    "Id" => {
-                        obj.id = HealthCheckIdDeserializer::deserialize("Id", stack)?;
-                    }
-                    "LinkedService" => {
-                        obj.linked_service = Some(LinkedServiceDeserializer::deserialize(
-                            "LinkedService",
+                "CloudWatchAlarmConfiguration" => {
+                    obj.cloud_watch_alarm_configuration =
+                        Some(CloudWatchAlarmConfigurationDeserializer::deserialize(
+                            "CloudWatchAlarmConfiguration",
                             stack,
                         )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                "HealthCheckConfig" => {
+                    obj.health_check_config =
+                        HealthCheckConfigDeserializer::deserialize("HealthCheckConfig", stack)?;
+                }
+                "HealthCheckVersion" => {
+                    obj.health_check_version =
+                        HealthCheckVersionDeserializer::deserialize("HealthCheckVersion", stack)?;
+                }
+                "Id" => {
+                    obj.id = HealthCheckIdDeserializer::deserialize("Id", stack)?;
+                }
+                "LinkedService" => {
+                    obj.linked_service = Some(LinkedServiceDeserializer::deserialize(
+                        "LinkedService",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>A complex type that contains information about the health check.</p>
@@ -4014,137 +3133,96 @@ impl HealthCheckConfigDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<HealthCheckConfig, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = HealthCheckConfig::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, HealthCheckConfig, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AlarmIdentifier" => {
+                    obj.alarm_identifier = Some(AlarmIdentifierDeserializer::deserialize(
+                        "AlarmIdentifier",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AlarmIdentifier" => {
-                        obj.alarm_identifier = Some(AlarmIdentifierDeserializer::deserialize(
-                            "AlarmIdentifier",
-                            stack,
-                        )?);
-                    }
-                    "ChildHealthChecks" => {
-                        obj.child_health_checks = match obj.child_health_checks {
-                            Some(ref mut existing) => {
-                                existing.extend(ChildHealthCheckListDeserializer::deserialize(
-                                    "ChildHealthChecks",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ChildHealthCheckListDeserializer::deserialize(
-                                "ChildHealthChecks",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "Disabled" => {
-                        obj.disabled = Some(DisabledDeserializer::deserialize("Disabled", stack)?);
-                    }
-                    "EnableSNI" => {
-                        obj.enable_sni =
-                            Some(EnableSNIDeserializer::deserialize("EnableSNI", stack)?);
-                    }
-                    "FailureThreshold" => {
-                        obj.failure_threshold = Some(FailureThresholdDeserializer::deserialize(
-                            "FailureThreshold",
-                            stack,
-                        )?);
-                    }
-                    "FullyQualifiedDomainName" => {
-                        obj.fully_qualified_domain_name =
-                            Some(FullyQualifiedDomainNameDeserializer::deserialize(
-                                "FullyQualifiedDomainName",
-                                stack,
-                            )?);
-                    }
-                    "HealthThreshold" => {
-                        obj.health_threshold = Some(HealthThresholdDeserializer::deserialize(
-                            "HealthThreshold",
-                            stack,
-                        )?);
-                    }
-                    "IPAddress" => {
-                        obj.ip_address =
-                            Some(IPAddressDeserializer::deserialize("IPAddress", stack)?);
-                    }
-                    "InsufficientDataHealthStatus" => {
-                        obj.insufficient_data_health_status =
-                            Some(InsufficientDataHealthStatusDeserializer::deserialize(
-                                "InsufficientDataHealthStatus",
-                                stack,
-                            )?);
-                    }
-                    "Inverted" => {
-                        obj.inverted = Some(InvertedDeserializer::deserialize("Inverted", stack)?);
-                    }
-                    "MeasureLatency" => {
-                        obj.measure_latency = Some(MeasureLatencyDeserializer::deserialize(
-                            "MeasureLatency",
-                            stack,
-                        )?);
-                    }
-                    "Port" => {
-                        obj.port = Some(PortDeserializer::deserialize("Port", stack)?);
-                    }
-                    "Regions" => {
-                        obj.regions = match obj.regions {
-                            Some(ref mut existing) => {
-                                existing.extend(HealthCheckRegionListDeserializer::deserialize(
-                                    "Regions", stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(HealthCheckRegionListDeserializer::deserialize(
-                                "Regions", stack,
-                            )?),
-                        };
-                    }
-                    "RequestInterval" => {
-                        obj.request_interval = Some(RequestIntervalDeserializer::deserialize(
-                            "RequestInterval",
-                            stack,
-                        )?);
-                    }
-                    "ResourcePath" => {
-                        obj.resource_path = Some(ResourcePathDeserializer::deserialize(
-                            "ResourcePath",
-                            stack,
-                        )?);
-                    }
-                    "SearchString" => {
-                        obj.search_string = Some(SearchStringDeserializer::deserialize(
-                            "SearchString",
-                            stack,
-                        )?);
-                    }
-                    "Type" => {
-                        obj.type_ = HealthCheckTypeDeserializer::deserialize("Type", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "ChildHealthChecks" => {
+                    obj.child_health_checks.get_or_insert(vec![]).extend(
+                        ChildHealthCheckListDeserializer::deserialize("ChildHealthChecks", stack)?,
+                    );
                 }
+                "Disabled" => {
+                    obj.disabled = Some(DisabledDeserializer::deserialize("Disabled", stack)?);
+                }
+                "EnableSNI" => {
+                    obj.enable_sni = Some(EnableSNIDeserializer::deserialize("EnableSNI", stack)?);
+                }
+                "FailureThreshold" => {
+                    obj.failure_threshold = Some(FailureThresholdDeserializer::deserialize(
+                        "FailureThreshold",
+                        stack,
+                    )?);
+                }
+                "FullyQualifiedDomainName" => {
+                    obj.fully_qualified_domain_name =
+                        Some(FullyQualifiedDomainNameDeserializer::deserialize(
+                            "FullyQualifiedDomainName",
+                            stack,
+                        )?);
+                }
+                "HealthThreshold" => {
+                    obj.health_threshold = Some(HealthThresholdDeserializer::deserialize(
+                        "HealthThreshold",
+                        stack,
+                    )?);
+                }
+                "IPAddress" => {
+                    obj.ip_address = Some(IPAddressDeserializer::deserialize("IPAddress", stack)?);
+                }
+                "InsufficientDataHealthStatus" => {
+                    obj.insufficient_data_health_status =
+                        Some(InsufficientDataHealthStatusDeserializer::deserialize(
+                            "InsufficientDataHealthStatus",
+                            stack,
+                        )?);
+                }
+                "Inverted" => {
+                    obj.inverted = Some(InvertedDeserializer::deserialize("Inverted", stack)?);
+                }
+                "MeasureLatency" => {
+                    obj.measure_latency = Some(MeasureLatencyDeserializer::deserialize(
+                        "MeasureLatency",
+                        stack,
+                    )?);
+                }
+                "Port" => {
+                    obj.port = Some(PortDeserializer::deserialize("Port", stack)?);
+                }
+                "Regions" => {
+                    obj.regions.get_or_insert(vec![]).extend(
+                        HealthCheckRegionListDeserializer::deserialize("Regions", stack)?,
+                    );
+                }
+                "RequestInterval" => {
+                    obj.request_interval = Some(RequestIntervalDeserializer::deserialize(
+                        "RequestInterval",
+                        stack,
+                    )?);
+                }
+                "ResourcePath" => {
+                    obj.resource_path = Some(ResourcePathDeserializer::deserialize(
+                        "ResourcePath",
+                        stack,
+                    )?);
+                }
+                "SearchString" => {
+                    obj.search_string = Some(SearchStringDeserializer::deserialize(
+                        "SearchString",
+                        stack,
+                    )?);
+                }
+                "Type" => {
+                    obj.type_ = HealthCheckTypeDeserializer::deserialize("Type", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -4389,47 +3467,24 @@ impl HealthCheckObservationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<HealthCheckObservation, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = HealthCheckObservation::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, HealthCheckObservation, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "IPAddress" => {
+                    obj.ip_address = Some(IPAddressDeserializer::deserialize("IPAddress", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "IPAddress" => {
-                        obj.ip_address =
-                            Some(IPAddressDeserializer::deserialize("IPAddress", stack)?);
-                    }
-                    "Region" => {
-                        obj.region =
-                            Some(HealthCheckRegionDeserializer::deserialize("Region", stack)?);
-                    }
-                    "StatusReport" => {
-                        obj.status_report = Some(StatusReportDeserializer::deserialize(
-                            "StatusReport",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Region" => {
+                    obj.region = Some(HealthCheckRegionDeserializer::deserialize("Region", stack)?);
                 }
+                "StatusReport" => {
+                    obj.status_report = Some(StatusReportDeserializer::deserialize(
+                        "StatusReport",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct HealthCheckObservationsDeserializer;
@@ -4439,40 +3494,17 @@ impl HealthCheckObservationsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<HealthCheckObservation>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "HealthCheckObservation" {
-                        obj.push(HealthCheckObservationDeserializer::deserialize(
-                            "HealthCheckObservation",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "HealthCheckObservation" {
+                obj.push(HealthCheckObservationDeserializer::deserialize(
+                    "HealthCheckObservation",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct HealthCheckRegionDeserializer;
@@ -4517,37 +3549,14 @@ impl HealthCheckRegionListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "Region" {
-                        obj.push(HealthCheckRegionDeserializer::deserialize("Region", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "Region" {
+                obj.push(HealthCheckRegionDeserializer::deserialize("Region", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -4648,37 +3657,14 @@ impl HealthChecksDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<HealthCheck>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "HealthCheck" {
-                        obj.push(HealthCheckDeserializer::deserialize("HealthCheck", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "HealthCheck" {
+                obj.push(HealthCheckDeserializer::deserialize("HealthCheck", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct HealthThresholdDeserializer;
@@ -4740,60 +3726,38 @@ impl HostedZoneDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<HostedZone, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = HostedZone::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, HostedZone, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CallerReference" => {
+                    obj.caller_reference =
+                        NonceDeserializer::deserialize("CallerReference", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CallerReference" => {
-                        obj.caller_reference =
-                            NonceDeserializer::deserialize("CallerReference", stack)?;
-                    }
-                    "Config" => {
-                        obj.config =
-                            Some(HostedZoneConfigDeserializer::deserialize("Config", stack)?);
-                    }
-                    "Id" => {
-                        obj.id = ResourceIdDeserializer::deserialize("Id", stack)?;
-                    }
-                    "LinkedService" => {
-                        obj.linked_service = Some(LinkedServiceDeserializer::deserialize(
-                            "LinkedService",
+                "Config" => {
+                    obj.config = Some(HostedZoneConfigDeserializer::deserialize("Config", stack)?);
+                }
+                "Id" => {
+                    obj.id = ResourceIdDeserializer::deserialize("Id", stack)?;
+                }
+                "LinkedService" => {
+                    obj.linked_service = Some(LinkedServiceDeserializer::deserialize(
+                        "LinkedService",
+                        stack,
+                    )?);
+                }
+                "Name" => {
+                    obj.name = DNSNameDeserializer::deserialize("Name", stack)?;
+                }
+                "ResourceRecordSetCount" => {
+                    obj.resource_record_set_count =
+                        Some(HostedZoneRRSetCountDeserializer::deserialize(
+                            "ResourceRecordSetCount",
                             stack,
                         )?);
-                    }
-                    "Name" => {
-                        obj.name = DNSNameDeserializer::deserialize("Name", stack)?;
-                    }
-                    "ResourceRecordSetCount" => {
-                        obj.resource_record_set_count =
-                            Some(HostedZoneRRSetCountDeserializer::deserialize(
-                                "ResourceRecordSetCount",
-                                stack,
-                            )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>A complex type that contains an optional comment about your hosted zone. If you don't want to specify a comment, omit both the <code>HostedZoneConfig</code> and <code>Comment</code> elements.</p>
@@ -4812,44 +3776,23 @@ impl HostedZoneConfigDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<HostedZoneConfig, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = HostedZoneConfig::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, HostedZoneConfig, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Comment" => {
+                    obj.comment = Some(ResourceDescriptionDeserializer::deserialize(
+                        "Comment", stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Comment" => {
-                        obj.comment = Some(ResourceDescriptionDeserializer::deserialize(
-                            "Comment", stack,
-                        )?);
-                    }
-                    "PrivateZone" => {
-                        obj.private_zone = Some(IsPrivateZoneDeserializer::deserialize(
-                            "PrivateZone",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "PrivateZone" => {
+                    obj.private_zone = Some(IsPrivateZoneDeserializer::deserialize(
+                        "PrivateZone",
+                        stack,
+                    )?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -4915,39 +3858,18 @@ impl HostedZoneLimitDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<HostedZoneLimit, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = HostedZoneLimit::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, HostedZoneLimit, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Type" => {
+                    obj.type_ = HostedZoneLimitTypeDeserializer::deserialize("Type", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Type" => {
-                        obj.type_ = HostedZoneLimitTypeDeserializer::deserialize("Type", stack)?;
-                    }
-                    "Value" => {
-                        obj.value = LimitValueDeserializer::deserialize("Value", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Value" => {
+                    obj.value = LimitValueDeserializer::deserialize("Value", stack)?;
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct HostedZoneLimitTypeDeserializer;
@@ -5006,37 +3928,14 @@ impl HostedZonesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<HostedZone>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "HostedZone" {
-                        obj.push(HostedZoneDeserializer::deserialize("HostedZone", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "HostedZone" {
+                obj.push(HostedZoneDeserializer::deserialize("HostedZone", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct IPAddressDeserializer;
@@ -5223,45 +4122,24 @@ impl LinkedServiceDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<LinkedService, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = LinkedService::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, LinkedService, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Description" => {
+                    obj.description = Some(ResourceDescriptionDeserializer::deserialize(
+                        "Description",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Description" => {
-                        obj.description = Some(ResourceDescriptionDeserializer::deserialize(
-                            "Description",
-                            stack,
-                        )?);
-                    }
-                    "ServicePrincipal" => {
-                        obj.service_principal = Some(ServicePrincipalDeserializer::deserialize(
-                            "ServicePrincipal",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "ServicePrincipal" => {
+                    obj.service_principal = Some(ServicePrincipalDeserializer::deserialize(
+                        "ServicePrincipal",
+                        stack,
+                    )?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>A request to get a list of geographic locations that Amazon Route 53 supports for geolocation resource record sets. </p>
@@ -5301,21 +4179,11 @@ impl ListGeoLocationsResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListGeoLocationsResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListGeoLocationsResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListGeoLocationsResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "GeoLocationDetailsList" => {
                         obj.geo_location_details_list.extend(
                             GeoLocationDetailsListDeserializer::deserialize(
@@ -5353,17 +4221,10 @@ impl ListGeoLocationsResponseDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A request to retrieve a list of the health checks that are associated with the current AWS account.</p>
@@ -5397,21 +4258,11 @@ impl ListHealthChecksResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListHealthChecksResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListHealthChecksResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListHealthChecksResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "HealthChecks" => {
                         obj.health_checks
                             .extend(HealthChecksDeserializer::deserialize(
@@ -5434,17 +4285,10 @@ impl ListHealthChecksResponseDeserializer {
                             Some(PageMarkerDeserializer::deserialize("NextMarker", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Retrieves a list of the public and private hosted zones that are associated with the current AWS account in ASCII order by domain name. </p>
@@ -5484,21 +4328,11 @@ impl ListHostedZonesByNameResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListHostedZonesByNameResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListHostedZonesByNameResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListHostedZonesByNameResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DNSName" => {
                         obj.dns_name = Some(DNSNameDeserializer::deserialize("DNSName", stack)?);
                     }
@@ -5528,17 +4362,10 @@ impl ListHostedZonesByNameResponseDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A request to retrieve a list of the public and private hosted zones that are associated with the current AWS account.</p>
@@ -5573,21 +4400,11 @@ impl ListHostedZonesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListHostedZonesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListHostedZonesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListHostedZonesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "HostedZones" => {
                         obj.hosted_zones
                             .extend(HostedZonesDeserializer::deserialize("HostedZones", stack)?);
@@ -5607,17 +4424,10 @@ impl ListHostedZonesResponseDeserializer {
                             Some(PageMarkerDeserializer::deserialize("NextMarker", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -5645,21 +4455,11 @@ impl ListQueryLoggingConfigsResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListQueryLoggingConfigsResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListQueryLoggingConfigsResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListQueryLoggingConfigsResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "NextToken" => {
                         obj.next_token = Some(PaginationTokenDeserializer::deserialize(
                             "NextToken",
@@ -5675,17 +4475,10 @@ impl ListQueryLoggingConfigsResponseDeserializer {
                         );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A request for the resource record sets that are associated with a specified hosted zone.</p>
@@ -5727,21 +4520,11 @@ impl ListResourceRecordSetsResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListResourceRecordSetsResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListResourceRecordSetsResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListResourceRecordSetsResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "IsTruncated" => {
                         obj.is_truncated =
                             PageTruncatedDeserializer::deserialize("IsTruncated", stack)?;
@@ -5773,17 +4556,10 @@ impl ListResourceRecordSetsResponseDeserializer {
                         );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A request to get a list of the reusable delegation sets that are associated with the current AWS account.</p>
@@ -5817,21 +4593,11 @@ impl ListReusableDelegationSetsResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListReusableDelegationSetsResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListReusableDelegationSetsResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListReusableDelegationSetsResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DelegationSets" => {
                         obj.delegation_sets
                             .extend(DelegationSetsDeserializer::deserialize(
@@ -5854,17 +4620,10 @@ impl ListReusableDelegationSetsResponseDeserializer {
                             Some(PageMarkerDeserializer::deserialize("NextMarker", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A complex type containing information about a request for a list of the tags that are associated with an individual resource.</p>
@@ -5890,37 +4649,20 @@ impl ListTagsForResourceResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListTagsForResourceResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListTagsForResourceResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListTagsForResourceResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ResourceTagSet" => {
                         obj.resource_tag_set =
                             ResourceTagSetDeserializer::deserialize("ResourceTagSet", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A complex type that contains information about the health checks or hosted zones for which you want to list tags.</p>
@@ -5963,21 +4705,11 @@ impl ListTagsForResourcesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListTagsForResourcesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListTagsForResourcesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListTagsForResourcesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ResourceTagSets" => {
                         obj.resource_tag_sets
                             .extend(ResourceTagSetListDeserializer::deserialize(
@@ -5986,17 +4718,10 @@ impl ListTagsForResourcesResponseDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A complex type that contains the information about the request to list the traffic policies that are associated with the current AWS account.</p>
@@ -6028,21 +4753,11 @@ impl ListTrafficPoliciesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListTrafficPoliciesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListTrafficPoliciesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListTrafficPoliciesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "IsTruncated" => {
                         obj.is_truncated =
                             PageTruncatedDeserializer::deserialize("IsTruncated", stack)?;
@@ -6065,17 +4780,10 @@ impl ListTrafficPoliciesResponseDeserializer {
                         );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A request for the traffic policy instances that you created in a specified hosted zone.</p>
@@ -6113,21 +4821,11 @@ impl ListTrafficPolicyInstancesByHostedZoneResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListTrafficPolicyInstancesByHostedZoneResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListTrafficPolicyInstancesByHostedZoneResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListTrafficPolicyInstancesByHostedZoneResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "IsTruncated" => {
                         obj.is_truncated =
                             PageTruncatedDeserializer::deserialize("IsTruncated", stack)?;
@@ -6158,17 +4856,10 @@ impl ListTrafficPolicyInstancesByHostedZoneResponseDeserializer {
                         );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A complex type that contains the information about the request to list your traffic policy instances.</p>
@@ -6212,21 +4903,11 @@ impl ListTrafficPolicyInstancesByPolicyResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListTrafficPolicyInstancesByPolicyResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListTrafficPolicyInstancesByPolicyResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListTrafficPolicyInstancesByPolicyResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "HostedZoneIdMarker" => {
                         obj.hosted_zone_id_marker = Some(ResourceIdDeserializer::deserialize(
                             "HostedZoneIdMarker",
@@ -6263,17 +4944,10 @@ impl ListTrafficPolicyInstancesByPolicyResponseDeserializer {
                         );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A request to get information about the traffic policy instances that you created by using the current AWS account.</p>
@@ -6313,21 +4987,11 @@ impl ListTrafficPolicyInstancesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListTrafficPolicyInstancesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListTrafficPolicyInstancesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListTrafficPolicyInstancesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "HostedZoneIdMarker" => {
                         obj.hosted_zone_id_marker = Some(ResourceIdDeserializer::deserialize(
                             "HostedZoneIdMarker",
@@ -6364,17 +5028,10 @@ impl ListTrafficPolicyInstancesResponseDeserializer {
                         );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A complex type that contains the information about the request to list your traffic policies.</p>
@@ -6408,21 +5065,11 @@ impl ListTrafficPolicyVersionsResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListTrafficPolicyVersionsResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListTrafficPolicyVersionsResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListTrafficPolicyVersionsResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "IsTruncated" => {
                         obj.is_truncated =
                             PageTruncatedDeserializer::deserialize("IsTruncated", stack)?;
@@ -6445,17 +5092,10 @@ impl ListTrafficPolicyVersionsResponseDeserializer {
                             )?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A complex type that contains information about that can be associated with your hosted zone.</p>
@@ -6487,21 +5127,11 @@ impl ListVPCAssociationAuthorizationsResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListVPCAssociationAuthorizationsResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListVPCAssociationAuthorizationsResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListVPCAssociationAuthorizationsResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "HostedZoneId" => {
                         obj.hosted_zone_id =
                             ResourceIdDeserializer::deserialize("HostedZoneId", stack)?;
@@ -6517,17 +5147,10 @@ impl ListVPCAssociationAuthorizationsResponseDeserializer {
                             .extend(VPCsDeserializer::deserialize("VPCs", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -6863,47 +5486,26 @@ impl QueryLoggingConfigDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<QueryLoggingConfig, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = QueryLoggingConfig::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, QueryLoggingConfig, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CloudWatchLogsLogGroupArn" => {
+                    obj.cloud_watch_logs_log_group_arn =
+                        CloudWatchLogsLogGroupArnDeserializer::deserialize(
+                            "CloudWatchLogsLogGroupArn",
+                            stack,
+                        )?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CloudWatchLogsLogGroupArn" => {
-                        obj.cloud_watch_logs_log_group_arn =
-                            CloudWatchLogsLogGroupArnDeserializer::deserialize(
-                                "CloudWatchLogsLogGroupArn",
-                                stack,
-                            )?;
-                    }
-                    "HostedZoneId" => {
-                        obj.hosted_zone_id =
-                            ResourceIdDeserializer::deserialize("HostedZoneId", stack)?;
-                    }
-                    "Id" => {
-                        obj.id = QueryLoggingConfigIdDeserializer::deserialize("Id", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "HostedZoneId" => {
+                    obj.hosted_zone_id =
+                        ResourceIdDeserializer::deserialize("HostedZoneId", stack)?;
                 }
+                "Id" => {
+                    obj.id = QueryLoggingConfigIdDeserializer::deserialize("Id", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct QueryLoggingConfigIdDeserializer;
@@ -6948,40 +5550,17 @@ impl QueryLoggingConfigsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<QueryLoggingConfig>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "QueryLoggingConfig" {
-                        obj.push(QueryLoggingConfigDeserializer::deserialize(
-                            "QueryLoggingConfig",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "QueryLoggingConfig" {
+                obj.push(QueryLoggingConfigDeserializer::deserialize(
+                    "QueryLoggingConfig",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct RDataDeserializer;
@@ -7061,40 +5640,17 @@ impl RecordDataDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "RecordDataEntry" {
-                        obj.push(RecordDataEntryDeserializer::deserialize(
-                            "RecordDataEntry",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "RecordDataEntry" {
+                obj.push(RecordDataEntryDeserializer::deserialize(
+                    "RecordDataEntry",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct RecordDataEntryDeserializer;
@@ -7305,36 +5861,15 @@ impl ResourceRecordDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ResourceRecord, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ResourceRecord::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ResourceRecord, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Value" => {
+                    obj.value = RDataDeserializer::deserialize("Value", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Value" => {
-                        obj.value = RDataDeserializer::deserialize("Value", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -7398,107 +5933,76 @@ impl ResourceRecordSetDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ResourceRecordSet, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ResourceRecordSet::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ResourceRecordSet, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AliasTarget" => {
+                    obj.alias_target =
+                        Some(AliasTargetDeserializer::deserialize("AliasTarget", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AliasTarget" => {
-                        obj.alias_target =
-                            Some(AliasTargetDeserializer::deserialize("AliasTarget", stack)?);
-                    }
-                    "Failover" => {
-                        obj.failover = Some(ResourceRecordSetFailoverDeserializer::deserialize(
-                            "Failover", stack,
-                        )?);
-                    }
-                    "GeoLocation" => {
-                        obj.geo_location =
-                            Some(GeoLocationDeserializer::deserialize("GeoLocation", stack)?);
-                    }
-                    "HealthCheckId" => {
-                        obj.health_check_id = Some(HealthCheckIdDeserializer::deserialize(
-                            "HealthCheckId",
+                "Failover" => {
+                    obj.failover = Some(ResourceRecordSetFailoverDeserializer::deserialize(
+                        "Failover", stack,
+                    )?);
+                }
+                "GeoLocation" => {
+                    obj.geo_location =
+                        Some(GeoLocationDeserializer::deserialize("GeoLocation", stack)?);
+                }
+                "HealthCheckId" => {
+                    obj.health_check_id = Some(HealthCheckIdDeserializer::deserialize(
+                        "HealthCheckId",
+                        stack,
+                    )?);
+                }
+                "MultiValueAnswer" => {
+                    obj.multi_value_answer =
+                        Some(ResourceRecordSetMultiValueAnswerDeserializer::deserialize(
+                            "MultiValueAnswer",
                             stack,
                         )?);
-                    }
-                    "MultiValueAnswer" => {
-                        obj.multi_value_answer =
-                            Some(ResourceRecordSetMultiValueAnswerDeserializer::deserialize(
-                                "MultiValueAnswer",
-                                stack,
-                            )?);
-                    }
-                    "Name" => {
-                        obj.name = DNSNameDeserializer::deserialize("Name", stack)?;
-                    }
-                    "Region" => {
-                        obj.region = Some(ResourceRecordSetRegionDeserializer::deserialize(
-                            "Region", stack,
-                        )?);
-                    }
-                    "ResourceRecords" => {
-                        obj.resource_records = match obj.resource_records {
-                            Some(ref mut existing) => {
-                                existing.extend(ResourceRecordsDeserializer::deserialize(
-                                    "ResourceRecords",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ResourceRecordsDeserializer::deserialize(
-                                "ResourceRecords",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "SetIdentifier" => {
-                        obj.set_identifier =
-                            Some(ResourceRecordSetIdentifierDeserializer::deserialize(
-                                "SetIdentifier",
-                                stack,
-                            )?);
-                    }
-                    "TTL" => {
-                        obj.ttl = Some(TTLDeserializer::deserialize("TTL", stack)?);
-                    }
-                    "TrafficPolicyInstanceId" => {
-                        obj.traffic_policy_instance_id =
-                            Some(TrafficPolicyInstanceIdDeserializer::deserialize(
-                                "TrafficPolicyInstanceId",
-                                stack,
-                            )?);
-                    }
-                    "Type" => {
-                        obj.type_ = RRTypeDeserializer::deserialize("Type", stack)?;
-                    }
-                    "Weight" => {
-                        obj.weight = Some(ResourceRecordSetWeightDeserializer::deserialize(
-                            "Weight", stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                "Name" => {
+                    obj.name = DNSNameDeserializer::deserialize("Name", stack)?;
+                }
+                "Region" => {
+                    obj.region = Some(ResourceRecordSetRegionDeserializer::deserialize(
+                        "Region", stack,
+                    )?);
+                }
+                "ResourceRecords" => {
+                    obj.resource_records.get_or_insert(vec![]).extend(
+                        ResourceRecordsDeserializer::deserialize("ResourceRecords", stack)?,
+                    );
+                }
+                "SetIdentifier" => {
+                    obj.set_identifier =
+                        Some(ResourceRecordSetIdentifierDeserializer::deserialize(
+                            "SetIdentifier",
+                            stack,
+                        )?);
+                }
+                "TTL" => {
+                    obj.ttl = Some(TTLDeserializer::deserialize("TTL", stack)?);
+                }
+                "TrafficPolicyInstanceId" => {
+                    obj.traffic_policy_instance_id =
+                        Some(TrafficPolicyInstanceIdDeserializer::deserialize(
+                            "TrafficPolicyInstanceId",
+                            stack,
+                        )?);
+                }
+                "Type" => {
+                    obj.type_ = RRTypeDeserializer::deserialize("Type", stack)?;
+                }
+                "Weight" => {
+                    obj.weight = Some(ResourceRecordSetWeightDeserializer::deserialize(
+                        "Weight", stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -7787,40 +6291,17 @@ impl ResourceRecordSetsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<ResourceRecordSet>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "ResourceRecordSet" {
-                        obj.push(ResourceRecordSetDeserializer::deserialize(
-                            "ResourceRecordSet",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "ResourceRecordSet" {
+                obj.push(ResourceRecordSetDeserializer::deserialize(
+                    "ResourceRecordSet",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ResourceRecordsDeserializer;
@@ -7830,40 +6311,17 @@ impl ResourceRecordsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<ResourceRecord>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "ResourceRecord" {
-                        obj.push(ResourceRecordDeserializer::deserialize(
-                            "ResourceRecord",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "ResourceRecord" {
+                obj.push(ResourceRecordDeserializer::deserialize(
+                    "ResourceRecord",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -7905,52 +6363,27 @@ impl ResourceTagSetDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ResourceTagSet, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ResourceTagSet::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ResourceTagSet, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "ResourceId" => {
+                    obj.resource_id =
+                        Some(TagResourceIdDeserializer::deserialize("ResourceId", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "ResourceId" => {
-                        obj.resource_id =
-                            Some(TagResourceIdDeserializer::deserialize("ResourceId", stack)?);
-                    }
-                    "ResourceType" => {
-                        obj.resource_type = Some(TagResourceTypeDeserializer::deserialize(
-                            "ResourceType",
-                            stack,
-                        )?);
-                    }
-                    "Tags" => {
-                        obj.tags = match obj.tags {
-                            Some(ref mut existing) => {
-                                existing.extend(TagListDeserializer::deserialize("Tags", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(TagListDeserializer::deserialize("Tags", stack)?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "ResourceType" => {
+                    obj.resource_type = Some(TagResourceTypeDeserializer::deserialize(
+                        "ResourceType",
+                        stack,
+                    )?);
                 }
+                "Tags" => {
+                    obj.tags
+                        .get_or_insert(vec![])
+                        .extend(TagListDeserializer::deserialize("Tags", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ResourceTagSetListDeserializer;
@@ -7960,40 +6393,17 @@ impl ResourceTagSetListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<ResourceTagSet>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "ResourceTagSet" {
-                        obj.push(ResourceTagSetDeserializer::deserialize(
-                            "ResourceTagSet",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "ResourceTagSet" {
+                obj.push(ResourceTagSetDeserializer::deserialize(
+                    "ResourceTagSet",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>A complex type that contains the type of limit that you specified in the request and the current value for that limit.</p>
@@ -8012,21 +6422,11 @@ impl ReusableDelegationSetLimitDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ReusableDelegationSetLimit, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ReusableDelegationSetLimit::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ReusableDelegationSetLimit, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Type" => {
                         obj.type_ =
                             ReusableDelegationSetLimitTypeDeserializer::deserialize("Type", stack)?;
@@ -8035,17 +6435,10 @@ impl ReusableDelegationSetLimitDeserializer {
                         obj.value = LimitValueDeserializer::deserialize("Value", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct ReusableDelegationSetLimitTypeDeserializer;
@@ -8176,40 +6569,19 @@ impl StatusReportDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<StatusReport, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = StatusReport::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, StatusReport, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CheckedTime" => {
+                    obj.checked_time =
+                        Some(TimeStampDeserializer::deserialize("CheckedTime", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CheckedTime" => {
-                        obj.checked_time =
-                            Some(TimeStampDeserializer::deserialize("CheckedTime", stack)?);
-                    }
-                    "Status" => {
-                        obj.status = Some(StatusDeserializer::deserialize("Status", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Status" => {
+                    obj.status = Some(StatusDeserializer::deserialize("Status", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -8284,39 +6656,18 @@ impl TagDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Tag, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Tag::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Tag, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Key" => {
+                    obj.key = Some(TagKeyDeserializer::deserialize("Key", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Key" => {
-                        obj.key = Some(TagKeyDeserializer::deserialize("Key", stack)?);
-                    }
-                    "Value" => {
-                        obj.value = Some(TagValueDeserializer::deserialize("Value", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Value" => {
+                    obj.value = Some(TagValueDeserializer::deserialize("Value", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -8414,37 +6765,14 @@ impl TagListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Tag>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "Tag" {
-                        obj.push(TagDeserializer::deserialize("Tag", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "Tag" {
+                obj.push(TagDeserializer::deserialize("Tag", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -8634,54 +6962,31 @@ impl TestDNSAnswerResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<TestDNSAnswerResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = TestDNSAnswerResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, TestDNSAnswerResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Nameserver" => {
+                    obj.nameserver = NameserverDeserializer::deserialize("Nameserver", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Nameserver" => {
-                        obj.nameserver = NameserverDeserializer::deserialize("Nameserver", stack)?;
-                    }
-                    "Protocol" => {
-                        obj.protocol =
-                            TransportProtocolDeserializer::deserialize("Protocol", stack)?;
-                    }
-                    "RecordData" => {
-                        obj.record_data
-                            .extend(RecordDataDeserializer::deserialize("RecordData", stack)?);
-                    }
-                    "RecordName" => {
-                        obj.record_name = DNSNameDeserializer::deserialize("RecordName", stack)?;
-                    }
-                    "RecordType" => {
-                        obj.record_type = RRTypeDeserializer::deserialize("RecordType", stack)?;
-                    }
-                    "ResponseCode" => {
-                        obj.response_code =
-                            DNSRCodeDeserializer::deserialize("ResponseCode", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Protocol" => {
+                    obj.protocol = TransportProtocolDeserializer::deserialize("Protocol", stack)?;
                 }
+                "RecordData" => {
+                    obj.record_data
+                        .extend(RecordDataDeserializer::deserialize("RecordData", stack)?);
+                }
+                "RecordName" => {
+                    obj.record_name = DNSNameDeserializer::deserialize("RecordName", stack)?;
+                }
+                "RecordType" => {
+                    obj.record_type = RRTypeDeserializer::deserialize("RecordType", stack)?;
+                }
+                "ResponseCode" => {
+                    obj.response_code = DNSRCodeDeserializer::deserialize("ResponseCode", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ThresholdDeserializer;
@@ -8719,40 +7024,17 @@ impl TrafficPoliciesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<TrafficPolicy>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "TrafficPolicy" {
-                        obj.push(TrafficPolicyDeserializer::deserialize(
-                            "TrafficPolicy",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "TrafficPolicy" {
+                obj.push(TrafficPolicyDeserializer::deserialize(
+                    "TrafficPolicy",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>A complex type that contains settings for a traffic policy.</p>
@@ -8779,55 +7061,33 @@ impl TrafficPolicyDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<TrafficPolicy, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = TrafficPolicy::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, TrafficPolicy, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Comment" => {
+                    obj.comment = Some(TrafficPolicyCommentDeserializer::deserialize(
+                        "Comment", stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Comment" => {
-                        obj.comment = Some(TrafficPolicyCommentDeserializer::deserialize(
-                            "Comment", stack,
-                        )?);
-                    }
-                    "Document" => {
-                        obj.document =
-                            TrafficPolicyDocumentDeserializer::deserialize("Document", stack)?;
-                    }
-                    "Id" => {
-                        obj.id = TrafficPolicyIdDeserializer::deserialize("Id", stack)?;
-                    }
-                    "Name" => {
-                        obj.name = TrafficPolicyNameDeserializer::deserialize("Name", stack)?;
-                    }
-                    "Type" => {
-                        obj.type_ = RRTypeDeserializer::deserialize("Type", stack)?;
-                    }
-                    "Version" => {
-                        obj.version =
-                            TrafficPolicyVersionDeserializer::deserialize("Version", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Document" => {
+                    obj.document =
+                        TrafficPolicyDocumentDeserializer::deserialize("Document", stack)?;
                 }
+                "Id" => {
+                    obj.id = TrafficPolicyIdDeserializer::deserialize("Id", stack)?;
+                }
+                "Name" => {
+                    obj.name = TrafficPolicyNameDeserializer::deserialize("Name", stack)?;
+                }
+                "Type" => {
+                    obj.type_ = RRTypeDeserializer::deserialize("Type", stack)?;
+                }
+                "Version" => {
+                    obj.version = TrafficPolicyVersionDeserializer::deserialize("Version", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct TrafficPolicyCommentDeserializer;
@@ -8965,67 +7225,46 @@ impl TrafficPolicyInstanceDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<TrafficPolicyInstance, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = TrafficPolicyInstance::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, TrafficPolicyInstance, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "HostedZoneId" => {
+                    obj.hosted_zone_id =
+                        ResourceIdDeserializer::deserialize("HostedZoneId", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "HostedZoneId" => {
-                        obj.hosted_zone_id =
-                            ResourceIdDeserializer::deserialize("HostedZoneId", stack)?;
-                    }
-                    "Id" => {
-                        obj.id = TrafficPolicyInstanceIdDeserializer::deserialize("Id", stack)?;
-                    }
-                    "Message" => {
-                        obj.message = MessageDeserializer::deserialize("Message", stack)?;
-                    }
-                    "Name" => {
-                        obj.name = DNSNameDeserializer::deserialize("Name", stack)?;
-                    }
-                    "State" => {
-                        obj.state =
-                            TrafficPolicyInstanceStateDeserializer::deserialize("State", stack)?;
-                    }
-                    "TTL" => {
-                        obj.ttl = TTLDeserializer::deserialize("TTL", stack)?;
-                    }
-                    "TrafficPolicyId" => {
-                        obj.traffic_policy_id =
-                            TrafficPolicyIdDeserializer::deserialize("TrafficPolicyId", stack)?;
-                    }
-                    "TrafficPolicyType" => {
-                        obj.traffic_policy_type =
-                            RRTypeDeserializer::deserialize("TrafficPolicyType", stack)?;
-                    }
-                    "TrafficPolicyVersion" => {
-                        obj.traffic_policy_version = TrafficPolicyVersionDeserializer::deserialize(
-                            "TrafficPolicyVersion",
-                            stack,
-                        )?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Id" => {
+                    obj.id = TrafficPolicyInstanceIdDeserializer::deserialize("Id", stack)?;
                 }
+                "Message" => {
+                    obj.message = MessageDeserializer::deserialize("Message", stack)?;
+                }
+                "Name" => {
+                    obj.name = DNSNameDeserializer::deserialize("Name", stack)?;
+                }
+                "State" => {
+                    obj.state =
+                        TrafficPolicyInstanceStateDeserializer::deserialize("State", stack)?;
+                }
+                "TTL" => {
+                    obj.ttl = TTLDeserializer::deserialize("TTL", stack)?;
+                }
+                "TrafficPolicyId" => {
+                    obj.traffic_policy_id =
+                        TrafficPolicyIdDeserializer::deserialize("TrafficPolicyId", stack)?;
+                }
+                "TrafficPolicyType" => {
+                    obj.traffic_policy_type =
+                        RRTypeDeserializer::deserialize("TrafficPolicyType", stack)?;
+                }
+                "TrafficPolicyVersion" => {
+                    obj.traffic_policy_version = TrafficPolicyVersionDeserializer::deserialize(
+                        "TrafficPolicyVersion",
+                        stack,
+                    )?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct TrafficPolicyInstanceCountDeserializer;
@@ -9098,40 +7337,17 @@ impl TrafficPolicyInstancesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<TrafficPolicyInstance>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "TrafficPolicyInstance" {
-                        obj.push(TrafficPolicyInstanceDeserializer::deserialize(
-                            "TrafficPolicyInstance",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "TrafficPolicyInstance" {
+                obj.push(TrafficPolicyInstanceDeserializer::deserialize(
+                    "TrafficPolicyInstance",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct TrafficPolicyNameDeserializer;
@@ -9176,40 +7392,17 @@ impl TrafficPolicySummariesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<TrafficPolicySummary>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "TrafficPolicySummary" {
-                        obj.push(TrafficPolicySummaryDeserializer::deserialize(
-                            "TrafficPolicySummary",
-                            stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "TrafficPolicySummary" {
+                obj.push(TrafficPolicySummaryDeserializer::deserialize(
+                    "TrafficPolicySummary",
+                    stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>A complex type that contains information about the latest version of one traffic policy that is associated with the current AWS account.</p>
@@ -9234,52 +7427,29 @@ impl TrafficPolicySummaryDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<TrafficPolicySummary, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = TrafficPolicySummary::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, TrafficPolicySummary, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Id" => {
+                    obj.id = TrafficPolicyIdDeserializer::deserialize("Id", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Id" => {
-                        obj.id = TrafficPolicyIdDeserializer::deserialize("Id", stack)?;
-                    }
-                    "LatestVersion" => {
-                        obj.latest_version =
-                            TrafficPolicyVersionDeserializer::deserialize("LatestVersion", stack)?;
-                    }
-                    "Name" => {
-                        obj.name = TrafficPolicyNameDeserializer::deserialize("Name", stack)?;
-                    }
-                    "TrafficPolicyCount" => {
-                        obj.traffic_policy_count = TrafficPolicyVersionDeserializer::deserialize(
-                            "TrafficPolicyCount",
-                            stack,
-                        )?;
-                    }
-                    "Type" => {
-                        obj.type_ = RRTypeDeserializer::deserialize("Type", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "LatestVersion" => {
+                    obj.latest_version =
+                        TrafficPolicyVersionDeserializer::deserialize("LatestVersion", stack)?;
                 }
+                "Name" => {
+                    obj.name = TrafficPolicyNameDeserializer::deserialize("Name", stack)?;
+                }
+                "TrafficPolicyCount" => {
+                    obj.traffic_policy_count =
+                        TrafficPolicyVersionDeserializer::deserialize("TrafficPolicyCount", stack)?;
+                }
+                "Type" => {
+                    obj.type_ = RRTypeDeserializer::deserialize("Type", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct TrafficPolicyVersionDeserializer;
@@ -9490,37 +7660,20 @@ impl UpdateHealthCheckResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UpdateHealthCheckResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = UpdateHealthCheckResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, UpdateHealthCheckResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "HealthCheck" => {
                         obj.health_check =
                             HealthCheckDeserializer::deserialize("HealthCheck", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A request to update the comment for a hosted zone.</p>
@@ -9565,36 +7718,19 @@ impl UpdateHostedZoneCommentResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UpdateHostedZoneCommentResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = UpdateHostedZoneCommentResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, UpdateHostedZoneCommentResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "HostedZone" => {
                         obj.hosted_zone = HostedZoneDeserializer::deserialize("HostedZone", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A complex type that contains information about the traffic policy that you want to update the comment for.</p>
@@ -9639,37 +7775,20 @@ impl UpdateTrafficPolicyCommentResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UpdateTrafficPolicyCommentResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = UpdateTrafficPolicyCommentResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, UpdateTrafficPolicyCommentResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "TrafficPolicy" => {
                         obj.traffic_policy =
                             TrafficPolicyDeserializer::deserialize("TrafficPolicy", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>A complex type that contains information about the resource record sets that you want to update based on a specified traffic policy instance.</p>
@@ -9726,21 +7845,11 @@ impl UpdateTrafficPolicyInstanceResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<UpdateTrafficPolicyInstanceResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = UpdateTrafficPolicyInstanceResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, UpdateTrafficPolicyInstanceResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "TrafficPolicyInstance" => {
                         obj.traffic_policy_instance =
                             TrafficPolicyInstanceDeserializer::deserialize(
@@ -9749,17 +7858,10 @@ impl UpdateTrafficPolicyInstanceResponseDeserializer {
                             )?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct UsageCountDeserializer;
@@ -9791,40 +7893,18 @@ impl VPCDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<VPC, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = VPC::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, VPC, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "VPCId" => {
+                    obj.vpc_id = Some(VPCIdDeserializer::deserialize("VPCId", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "VPCId" => {
-                        obj.vpc_id = Some(VPCIdDeserializer::deserialize("VPCId", stack)?);
-                    }
-                    "VPCRegion" => {
-                        obj.vpc_region =
-                            Some(VPCRegionDeserializer::deserialize("VPCRegion", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "VPCRegion" => {
+                    obj.vpc_region = Some(VPCRegionDeserializer::deserialize("VPCRegion", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -9937,37 +8017,14 @@ impl VPCsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<VPC>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "VPC" {
-                        obj.push(VPCDeserializer::deserialize("VPC", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "VPC" {
+                obj.push(VPCDeserializer::deserialize("VPC", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// Errors returned by AssociateVPCWithHostedZone

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -25,21 +25,17 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
 use rusoto_core::xmlutil::{
-    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+    characters, deserialize_elements, end_element, find_start_element, peek_at_name, skip_tree,
+    start_element,
 };
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use std::io::Write;
 use std::str::FromStr;
 use xml;
 use xml::reader::ParserConfig;
-use xml::reader::XmlEvent;
 use xml::EventReader;
 use xml::EventWriter;
-enum DeserializerNext {
-    Close,
-    Skip,
-    Element(String),
-}
+
 /// <p>Specifies the days since the initiation of an Incomplete Multipart Upload that Lifecycle will wait before permanently removing all parts of the upload.</p>
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct AbortIncompleteMultipartUpload {
@@ -54,21 +50,11 @@ impl AbortIncompleteMultipartUploadDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AbortIncompleteMultipartUpload, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AbortIncompleteMultipartUpload::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, AbortIncompleteMultipartUpload, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DaysAfterInitiation" => {
                         obj.days_after_initiation =
                             Some(DaysAfterInitiationDeserializer::deserialize(
@@ -77,17 +63,10 @@ impl AbortIncompleteMultipartUploadDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -217,36 +196,19 @@ impl AccessControlTranslationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AccessControlTranslation, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AccessControlTranslation::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, AccessControlTranslation, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Owner" => {
                         obj.owner = OwnerOverrideDeserializer::deserialize("Owner", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -373,7 +335,9 @@ impl AllowedHeadersDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -452,7 +416,9 @@ impl AllowedMethodsDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -531,7 +497,9 @@ impl AllowedOriginsDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -579,45 +547,20 @@ impl AnalyticsAndOperatorDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AnalyticsAndOperator, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AnalyticsAndOperator::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, AnalyticsAndOperator, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Prefix" => {
+                    obj.prefix = Some(PrefixDeserializer::deserialize("Prefix", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Prefix" => {
-                        obj.prefix = Some(PrefixDeserializer::deserialize("Prefix", stack)?);
-                    }
-                    "Tag" => {
-                        obj.tags = match obj.tags {
-                            Some(ref mut existing) => {
-                                existing.extend(TagSetDeserializer::deserialize("Tag", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(TagSetDeserializer::deserialize("Tag", stack)?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Tag" => {
+                    obj.tags
+                        .get_or_insert(vec![])
+                        .extend(TagSetDeserializer::deserialize("Tag", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -665,46 +608,24 @@ impl AnalyticsConfigurationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AnalyticsConfiguration, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AnalyticsConfiguration::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, AnalyticsConfiguration, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Filter" => {
+                    obj.filter = Some(AnalyticsFilterDeserializer::deserialize("Filter", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Filter" => {
-                        obj.filter =
-                            Some(AnalyticsFilterDeserializer::deserialize("Filter", stack)?);
-                    }
-                    "Id" => {
-                        obj.id = AnalyticsIdDeserializer::deserialize("Id", stack)?;
-                    }
-                    "StorageClassAnalysis" => {
-                        obj.storage_class_analysis = StorageClassAnalysisDeserializer::deserialize(
-                            "StorageClassAnalysis",
-                            stack,
-                        )?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Id" => {
+                    obj.id = AnalyticsIdDeserializer::deserialize("Id", stack)?;
                 }
+                "StorageClassAnalysis" => {
+                    obj.storage_class_analysis = StorageClassAnalysisDeserializer::deserialize(
+                        "StorageClassAnalysis",
+                        stack,
+                    )?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -749,7 +670,9 @@ impl AnalyticsConfigurationListDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -778,21 +701,11 @@ impl AnalyticsExportDestinationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AnalyticsExportDestination, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AnalyticsExportDestination::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, AnalyticsExportDestination, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "S3BucketDestination" => {
                         obj.s3_bucket_destination =
                             AnalyticsS3BucketDestinationDeserializer::deserialize(
@@ -801,17 +714,10 @@ impl AnalyticsExportDestinationDeserializer {
                             )?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -853,43 +759,21 @@ impl AnalyticsFilterDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AnalyticsFilter, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AnalyticsFilter::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, AnalyticsFilter, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "And" => {
+                    obj.and = Some(AnalyticsAndOperatorDeserializer::deserialize("And", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "And" => {
-                        obj.and =
-                            Some(AnalyticsAndOperatorDeserializer::deserialize("And", stack)?);
-                    }
-                    "Prefix" => {
-                        obj.prefix = Some(PrefixDeserializer::deserialize("Prefix", stack)?);
-                    }
-                    "Tag" => {
-                        obj.tag = Some(TagDeserializer::deserialize("Tag", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Prefix" => {
+                    obj.prefix = Some(PrefixDeserializer::deserialize("Prefix", stack)?);
                 }
+                "Tag" => {
+                    obj.tag = Some(TagDeserializer::deserialize("Tag", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -977,21 +861,11 @@ impl AnalyticsS3BucketDestinationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AnalyticsS3BucketDestination, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AnalyticsS3BucketDestination::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, AnalyticsS3BucketDestination, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Bucket" => {
                         obj.bucket = BucketNameDeserializer::deserialize("Bucket", stack)?;
                     }
@@ -1009,17 +883,10 @@ impl AnalyticsS3BucketDestinationDeserializer {
                         obj.prefix = Some(PrefixDeserializer::deserialize("Prefix", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -1153,42 +1020,21 @@ impl BucketDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Bucket, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Bucket::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Bucket, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CreationDate" => {
+                    obj.creation_date = Some(CreationDateDeserializer::deserialize(
+                        "CreationDate",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CreationDate" => {
-                        obj.creation_date = Some(CreationDateDeserializer::deserialize(
-                            "CreationDate",
-                            stack,
-                        )?);
-                    }
-                    "Name" => {
-                        obj.name = Some(BucketNameDeserializer::deserialize("Name", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Name" => {
+                    obj.name = Some(BucketNameDeserializer::deserialize("Name", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct BucketAccelerateStatusDeserializer;
@@ -1419,37 +1265,14 @@ impl BucketsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Bucket>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "Bucket" {
-                        obj.push(BucketDeserializer::deserialize("Bucket", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "Bucket" {
+                obj.push(BucketDeserializer::deserialize("Bucket", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct BytesProcessedDeserializer;
@@ -1537,83 +1360,42 @@ impl CORSRuleDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CORSRule, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CORSRule::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CORSRule, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AllowedHeader" => {
+                    obj.allowed_headers.get_or_insert(vec![]).extend(
+                        AllowedHeadersDeserializer::deserialize("AllowedHeader", stack)?,
+                    );
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AllowedHeader" => {
-                        obj.allowed_headers = match obj.allowed_headers {
-                            Some(ref mut existing) => {
-                                existing.extend(AllowedHeadersDeserializer::deserialize(
-                                    "AllowedHeader",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(AllowedHeadersDeserializer::deserialize(
-                                "AllowedHeader",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "AllowedMethod" => {
-                        obj.allowed_methods
-                            .extend(AllowedMethodsDeserializer::deserialize(
-                                "AllowedMethod",
-                                stack,
-                            )?);
-                    }
-                    "AllowedOrigin" => {
-                        obj.allowed_origins
-                            .extend(AllowedOriginsDeserializer::deserialize(
-                                "AllowedOrigin",
-                                stack,
-                            )?);
-                    }
-                    "ExposeHeader" => {
-                        obj.expose_headers = match obj.expose_headers {
-                            Some(ref mut existing) => {
-                                existing.extend(ExposeHeadersDeserializer::deserialize(
-                                    "ExposeHeader",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ExposeHeadersDeserializer::deserialize(
-                                "ExposeHeader",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "MaxAgeSeconds" => {
-                        obj.max_age_seconds = Some(MaxAgeSecondsDeserializer::deserialize(
-                            "MaxAgeSeconds",
+                "AllowedMethod" => {
+                    obj.allowed_methods
+                        .extend(AllowedMethodsDeserializer::deserialize(
+                            "AllowedMethod",
                             stack,
                         )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                "AllowedOrigin" => {
+                    obj.allowed_origins
+                        .extend(AllowedOriginsDeserializer::deserialize(
+                            "AllowedOrigin",
+                            stack,
+                        )?);
+                }
+                "ExposeHeader" => {
+                    obj.expose_headers.get_or_insert(vec![]).extend(
+                        ExposeHeadersDeserializer::deserialize("ExposeHeader", stack)?,
+                    );
+                }
+                "MaxAgeSeconds" => {
+                    obj.max_age_seconds = Some(MaxAgeSecondsDeserializer::deserialize(
+                        "MaxAgeSeconds",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -1660,7 +1442,9 @@ impl CORSRulesDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -1907,21 +1691,11 @@ impl CloudFunctionConfigurationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CloudFunctionConfiguration, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CloudFunctionConfiguration::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CloudFunctionConfiguration, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CloudFunction" => {
                         obj.cloud_function = Some(CloudFunctionDeserializer::deserialize(
                             "CloudFunction",
@@ -1929,14 +1703,9 @@ impl CloudFunctionConfigurationDeserializer {
                         )?);
                     }
                     "Event" => {
-                        obj.events = match obj.events {
-                            Some(ref mut existing) => {
-                                existing
-                                    .extend(EventListDeserializer::deserialize("Event", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(EventListDeserializer::deserialize("Event", stack)?),
-                        };
+                        obj.events
+                            .get_or_insert(vec![])
+                            .extend(EventListDeserializer::deserialize("Event", stack)?);
                     }
                     "Id" => {
                         obj.id = Some(NotificationIdDeserializer::deserialize("Id", stack)?);
@@ -1949,17 +1718,10 @@ impl CloudFunctionConfigurationDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -2088,36 +1850,15 @@ impl CommonPrefixDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CommonPrefix, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CommonPrefix::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CommonPrefix, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Prefix" => {
+                    obj.prefix = Some(PrefixDeserializer::deserialize("Prefix", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Prefix" => {
-                        obj.prefix = Some(PrefixDeserializer::deserialize("Prefix", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct CommonPrefixListDeserializer;
@@ -2131,7 +1872,9 @@ impl CommonPrefixListDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -2170,21 +1913,11 @@ impl CompleteMultipartUploadOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CompleteMultipartUploadOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CompleteMultipartUploadOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CompleteMultipartUploadOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Bucket" => {
                         obj.bucket = Some(BucketNameDeserializer::deserialize("Bucket", stack)?);
                     }
@@ -2198,17 +1931,10 @@ impl CompleteMultipartUploadOutputDeserializer {
                         obj.location = Some(LocationDeserializer::deserialize("Location", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -2337,46 +2063,25 @@ impl ConditionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Condition, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Condition::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "HttpErrorCodeReturnedEquals" => {
-                        obj.http_error_code_returned_equals =
-                            Some(HttpErrorCodeReturnedEqualsDeserializer::deserialize(
-                                "HttpErrorCodeReturnedEquals",
-                                stack,
-                            )?);
-                    }
-                    "KeyPrefixEquals" => {
-                        obj.key_prefix_equals = Some(KeyPrefixEqualsDeserializer::deserialize(
-                            "KeyPrefixEquals",
+        deserialize_elements::<_, Condition, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "HttpErrorCodeReturnedEquals" => {
+                    obj.http_error_code_returned_equals =
+                        Some(HttpErrorCodeReturnedEqualsDeserializer::deserialize(
+                            "HttpErrorCodeReturnedEquals",
                             stack,
                         )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                "KeyPrefixEquals" => {
+                    obj.key_prefix_equals = Some(KeyPrefixEqualsDeserializer::deserialize(
+                        "KeyPrefixEquals",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -2554,42 +2259,21 @@ impl CopyObjectResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CopyObjectResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CopyObjectResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CopyObjectResult, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "ETag" => {
+                    obj.e_tag = Some(ETagDeserializer::deserialize("ETag", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "ETag" => {
-                        obj.e_tag = Some(ETagDeserializer::deserialize("ETag", stack)?);
-                    }
-                    "LastModified" => {
-                        obj.last_modified = Some(LastModifiedDeserializer::deserialize(
-                            "LastModified",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "LastModified" => {
+                    obj.last_modified = Some(LastModifiedDeserializer::deserialize(
+                        "LastModified",
+                        stack,
+                    )?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -2607,42 +2291,21 @@ impl CopyPartResultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CopyPartResult, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CopyPartResult::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CopyPartResult, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "ETag" => {
+                    obj.e_tag = Some(ETagDeserializer::deserialize("ETag", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "ETag" => {
-                        obj.e_tag = Some(ETagDeserializer::deserialize("ETag", stack)?);
-                    }
-                    "LastModified" => {
-                        obj.last_modified = Some(LastModifiedDeserializer::deserialize(
-                            "LastModified",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "LastModified" => {
+                    obj.last_modified = Some(LastModifiedDeserializer::deserialize(
+                        "LastModified",
+                        stack,
+                    )?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -2746,21 +2409,11 @@ impl CreateMultipartUploadOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateMultipartUploadOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateMultipartUploadOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreateMultipartUploadOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Bucket" => {
                         obj.bucket = Some(BucketNameDeserializer::deserialize("Bucket", stack)?);
                     }
@@ -2773,17 +2426,10 @@ impl CreateMultipartUploadOutputDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -2976,44 +2622,23 @@ impl DefaultRetentionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DefaultRetention, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DefaultRetention::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DefaultRetention, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Days" => {
+                    obj.days = Some(DaysDeserializer::deserialize("Days", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Days" => {
-                        obj.days = Some(DaysDeserializer::deserialize("Days", stack)?);
-                    }
-                    "Mode" => {
-                        obj.mode = Some(ObjectLockRetentionModeDeserializer::deserialize(
-                            "Mode", stack,
-                        )?);
-                    }
-                    "Years" => {
-                        obj.years = Some(YearsDeserializer::deserialize("Years", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Mode" => {
+                    obj.mode = Some(ObjectLockRetentionModeDeserializer::deserialize(
+                        "Mode", stack,
+                    )?);
                 }
+                "Years" => {
+                    obj.years = Some(YearsDeserializer::deserialize("Years", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -3189,54 +2814,33 @@ impl DeleteMarkerEntryDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DeleteMarkerEntry, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DeleteMarkerEntry::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DeleteMarkerEntry, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "IsLatest" => {
+                    obj.is_latest = Some(IsLatestDeserializer::deserialize("IsLatest", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "IsLatest" => {
-                        obj.is_latest = Some(IsLatestDeserializer::deserialize("IsLatest", stack)?);
-                    }
-                    "Key" => {
-                        obj.key = Some(ObjectKeyDeserializer::deserialize("Key", stack)?);
-                    }
-                    "LastModified" => {
-                        obj.last_modified = Some(LastModifiedDeserializer::deserialize(
-                            "LastModified",
-                            stack,
-                        )?);
-                    }
-                    "Owner" => {
-                        obj.owner = Some(OwnerDeserializer::deserialize("Owner", stack)?);
-                    }
-                    "VersionId" => {
-                        obj.version_id = Some(ObjectVersionIdDeserializer::deserialize(
-                            "VersionId",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Key" => {
+                    obj.key = Some(ObjectKeyDeserializer::deserialize("Key", stack)?);
                 }
+                "LastModified" => {
+                    obj.last_modified = Some(LastModifiedDeserializer::deserialize(
+                        "LastModified",
+                        stack,
+                    )?);
+                }
+                "Owner" => {
+                    obj.owner = Some(OwnerDeserializer::deserialize("Owner", stack)?);
+                }
+                "VersionId" => {
+                    obj.version_id = Some(ObjectVersionIdDeserializer::deserialize(
+                        "VersionId",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Specifies whether Amazon S3 should replicate delete makers.</p>
@@ -3253,38 +2857,21 @@ impl DeleteMarkerReplicationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DeleteMarkerReplication, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DeleteMarkerReplication::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DeleteMarkerReplication, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Status" => {
                         obj.status = Some(DeleteMarkerReplicationStatusDeserializer::deserialize(
                             "Status", stack,
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -3372,7 +2959,9 @@ impl DeleteMarkersDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -3468,55 +3057,22 @@ impl DeleteObjectsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DeleteObjectsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DeleteObjectsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DeleteObjectsOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Deleted" => {
+                    obj.deleted
+                        .get_or_insert(vec![])
+                        .extend(DeletedObjectsDeserializer::deserialize("Deleted", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Deleted" => {
-                        obj.deleted = match obj.deleted {
-                            Some(ref mut existing) => {
-                                existing.extend(DeletedObjectsDeserializer::deserialize(
-                                    "Deleted", stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => {
-                                Some(DeletedObjectsDeserializer::deserialize("Deleted", stack)?)
-                            }
-                        };
-                    }
-                    "Error" => {
-                        obj.errors = match obj.errors {
-                            Some(ref mut existing) => {
-                                existing.extend(ErrorsDeserializer::deserialize("Error", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ErrorsDeserializer::deserialize("Error", stack)?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Error" => {
+                    obj.errors
+                        .get_or_insert(vec![])
+                        .extend(ErrorsDeserializer::deserialize("Error", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -3551,55 +3107,34 @@ impl DeletedObjectDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DeletedObject, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DeletedObject::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, DeletedObject, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DeleteMarker" => {
+                    obj.delete_marker = Some(DeleteMarkerDeserializer::deserialize(
+                        "DeleteMarker",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DeleteMarker" => {
-                        obj.delete_marker = Some(DeleteMarkerDeserializer::deserialize(
-                            "DeleteMarker",
+                "DeleteMarkerVersionId" => {
+                    obj.delete_marker_version_id =
+                        Some(DeleteMarkerVersionIdDeserializer::deserialize(
+                            "DeleteMarkerVersionId",
                             stack,
                         )?);
-                    }
-                    "DeleteMarkerVersionId" => {
-                        obj.delete_marker_version_id =
-                            Some(DeleteMarkerVersionIdDeserializer::deserialize(
-                                "DeleteMarkerVersionId",
-                                stack,
-                            )?);
-                    }
-                    "Key" => {
-                        obj.key = Some(ObjectKeyDeserializer::deserialize("Key", stack)?);
-                    }
-                    "VersionId" => {
-                        obj.version_id = Some(ObjectVersionIdDeserializer::deserialize(
-                            "VersionId",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                "Key" => {
+                    obj.key = Some(ObjectKeyDeserializer::deserialize("Key", stack)?);
+                }
+                "VersionId" => {
+                    obj.version_id = Some(ObjectVersionIdDeserializer::deserialize(
+                        "VersionId",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct DeletedObjectsDeserializer;
@@ -3613,7 +3148,9 @@ impl DeletedObjectsDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -3704,59 +3241,38 @@ impl DestinationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Destination, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Destination::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AccessControlTranslation" => {
-                        obj.access_control_translation =
-                            Some(AccessControlTranslationDeserializer::deserialize(
-                                "AccessControlTranslation",
-                                stack,
-                            )?);
-                    }
-                    "Account" => {
-                        obj.account = Some(AccountIdDeserializer::deserialize("Account", stack)?);
-                    }
-                    "Bucket" => {
-                        obj.bucket = BucketNameDeserializer::deserialize("Bucket", stack)?;
-                    }
-                    "EncryptionConfiguration" => {
-                        obj.encryption_configuration =
-                            Some(EncryptionConfigurationDeserializer::deserialize(
-                                "EncryptionConfiguration",
-                                stack,
-                            )?);
-                    }
-                    "StorageClass" => {
-                        obj.storage_class = Some(StorageClassDeserializer::deserialize(
-                            "StorageClass",
+        deserialize_elements::<_, Destination, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AccessControlTranslation" => {
+                    obj.access_control_translation =
+                        Some(AccessControlTranslationDeserializer::deserialize(
+                            "AccessControlTranslation",
                             stack,
                         )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                "Account" => {
+                    obj.account = Some(AccountIdDeserializer::deserialize("Account", stack)?);
+                }
+                "Bucket" => {
+                    obj.bucket = BucketNameDeserializer::deserialize("Bucket", stack)?;
+                }
+                "EncryptionConfiguration" => {
+                    obj.encryption_configuration =
+                        Some(EncryptionConfigurationDeserializer::deserialize(
+                            "EncryptionConfiguration",
+                            stack,
+                        )?);
+                }
+                "StorageClass" => {
+                    obj.storage_class = Some(StorageClassDeserializer::deserialize(
+                        "StorageClass",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -4035,21 +3551,11 @@ impl EncryptionConfigurationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<EncryptionConfiguration, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = EncryptionConfiguration::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, EncryptionConfiguration, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ReplicaKmsKeyID" => {
                         obj.replica_kms_key_id = Some(ReplicaKmsKeyIDDeserializer::deserialize(
                             "ReplicaKmsKeyID",
@@ -4057,17 +3563,10 @@ impl EncryptionConfigurationDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -4129,48 +3628,27 @@ impl S3ErrorDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<S3Error, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = S3Error::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, S3Error, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Code" => {
+                    obj.code = Some(CodeDeserializer::deserialize("Code", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Code" => {
-                        obj.code = Some(CodeDeserializer::deserialize("Code", stack)?);
-                    }
-                    "Key" => {
-                        obj.key = Some(ObjectKeyDeserializer::deserialize("Key", stack)?);
-                    }
-                    "Message" => {
-                        obj.message = Some(MessageDeserializer::deserialize("Message", stack)?);
-                    }
-                    "VersionId" => {
-                        obj.version_id = Some(ObjectVersionIdDeserializer::deserialize(
-                            "VersionId",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Key" => {
+                    obj.key = Some(ObjectKeyDeserializer::deserialize("Key", stack)?);
                 }
+                "Message" => {
+                    obj.message = Some(MessageDeserializer::deserialize("Message", stack)?);
+                }
+                "VersionId" => {
+                    obj.version_id = Some(ObjectVersionIdDeserializer::deserialize(
+                        "VersionId",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -4186,36 +3664,15 @@ impl ErrorDocumentDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ErrorDocument, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ErrorDocument::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ErrorDocument, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Key" => {
+                    obj.key = ObjectKeyDeserializer::deserialize("Key", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Key" => {
-                        obj.key = ObjectKeyDeserializer::deserialize("Key", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -4252,7 +3709,9 @@ impl ErrorsDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -4312,7 +3771,9 @@ impl EventListDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -4461,7 +3922,9 @@ impl ExposeHeadersDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -4609,39 +4072,18 @@ impl FilterRuleDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<FilterRule, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = FilterRule::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, FilterRule, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Name" => {
+                    obj.name = Some(FilterRuleNameDeserializer::deserialize("Name", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Name" => {
-                        obj.name = Some(FilterRuleNameDeserializer::deserialize("Name", stack)?);
-                    }
-                    "Value" => {
-                        obj.value = Some(FilterRuleValueDeserializer::deserialize("Value", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Value" => {
+                    obj.value = Some(FilterRuleValueDeserializer::deserialize("Value", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -4688,7 +4130,9 @@ impl FilterRuleListDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -4804,38 +4248,21 @@ impl GetBucketAccelerateConfigurationOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetBucketAccelerateConfigurationOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetBucketAccelerateConfigurationOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetBucketAccelerateConfigurationOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Status" => {
                         obj.status = Some(BucketAccelerateStatusDeserializer::deserialize(
                             "Status", stack,
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -4858,50 +4285,20 @@ impl GetBucketAclOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetBucketAclOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetBucketAclOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, GetBucketAclOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AccessControlList" => {
+                    obj.grants
+                        .get_or_insert(vec![])
+                        .extend(GrantsDeserializer::deserialize("AccessControlList", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AccessControlList" => {
-                        obj.grants = match obj.grants {
-                            Some(ref mut existing) => {
-                                existing.extend(GrantsDeserializer::deserialize(
-                                    "AccessControlList",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => {
-                                Some(GrantsDeserializer::deserialize("AccessControlList", stack)?)
-                            }
-                        };
-                    }
-                    "Owner" => {
-                        obj.owner = Some(OwnerDeserializer::deserialize("Owner", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Owner" => {
+                    obj.owner = Some(OwnerDeserializer::deserialize("Owner", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -4951,43 +4348,17 @@ impl GetBucketCorsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetBucketCorsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetBucketCorsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, GetBucketCorsOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CORSRule" => {
+                    obj.cors_rules
+                        .get_or_insert(vec![])
+                        .extend(CORSRulesDeserializer::deserialize("CORSRule", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CORSRule" => {
-                        obj.cors_rules = match obj.cors_rules {
-                            Some(ref mut existing) => {
-                                existing
-                                    .extend(CORSRulesDeserializer::deserialize("CORSRule", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(CORSRulesDeserializer::deserialize("CORSRule", stack)?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -5066,44 +4437,21 @@ impl GetBucketLifecycleConfigurationOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetBucketLifecycleConfigurationOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetBucketLifecycleConfigurationOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetBucketLifecycleConfigurationOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Rule" => {
-                        obj.rules = match obj.rules {
-                            Some(ref mut existing) => {
-                                existing.extend(LifecycleRulesDeserializer::deserialize(
-                                    "Rule", stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(LifecycleRulesDeserializer::deserialize("Rule", stack)?),
-                        };
+                        obj.rules
+                            .get_or_insert(vec![])
+                            .extend(LifecycleRulesDeserializer::deserialize("Rule", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -5123,42 +4471,21 @@ impl GetBucketLifecycleOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetBucketLifecycleOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetBucketLifecycleOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetBucketLifecycleOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Rule" => {
-                        obj.rules = match obj.rules {
-                            Some(ref mut existing) => {
-                                existing.extend(RulesDeserializer::deserialize("Rule", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(RulesDeserializer::deserialize("Rule", stack)?),
-                        };
+                        obj.rules
+                            .get_or_insert(vec![])
+                            .extend(RulesDeserializer::deserialize("Rule", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -5203,39 +4530,18 @@ impl GetBucketLoggingOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetBucketLoggingOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetBucketLoggingOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, GetBucketLoggingOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "LoggingEnabled" => {
+                    obj.logging_enabled = Some(LoggingEnabledDeserializer::deserialize(
+                        "LoggingEnabled",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "LoggingEnabled" => {
-                        obj.logging_enabled = Some(LoggingEnabledDeserializer::deserialize(
-                            "LoggingEnabled",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -5357,36 +4663,19 @@ impl GetBucketRequestPaymentOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetBucketRequestPaymentOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetBucketRequestPaymentOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetBucketRequestPaymentOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Payer" => {
                         obj.payer = Some(PayerDeserializer::deserialize("Payer", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -5406,37 +4695,16 @@ impl GetBucketTaggingOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetBucketTaggingOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetBucketTaggingOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, GetBucketTaggingOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "TagSet" => {
+                    obj.tag_set
+                        .extend(TagSetDeserializer::deserialize("TagSet", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "TagSet" => {
-                        obj.tag_set
-                            .extend(TagSetDeserializer::deserialize("TagSet", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -5459,21 +4727,11 @@ impl GetBucketVersioningOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetBucketVersioningOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetBucketVersioningOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetBucketVersioningOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "MfaDelete" => {
                         obj.mfa_delete = Some(MFADeleteStatusDeserializer::deserialize(
                             "MfaDelete",
@@ -5486,17 +4744,10 @@ impl GetBucketVersioningOutputDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -5519,67 +4770,36 @@ impl GetBucketWebsiteOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetBucketWebsiteOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetBucketWebsiteOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, GetBucketWebsiteOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "ErrorDocument" => {
+                    obj.error_document = Some(ErrorDocumentDeserializer::deserialize(
+                        "ErrorDocument",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "ErrorDocument" => {
-                        obj.error_document = Some(ErrorDocumentDeserializer::deserialize(
-                            "ErrorDocument",
+                "IndexDocument" => {
+                    obj.index_document = Some(IndexDocumentDeserializer::deserialize(
+                        "IndexDocument",
+                        stack,
+                    )?);
+                }
+                "RedirectAllRequestsTo" => {
+                    obj.redirect_all_requests_to =
+                        Some(RedirectAllRequestsToDeserializer::deserialize(
+                            "RedirectAllRequestsTo",
                             stack,
                         )?);
-                    }
-                    "IndexDocument" => {
-                        obj.index_document = Some(IndexDocumentDeserializer::deserialize(
-                            "IndexDocument",
-                            stack,
-                        )?);
-                    }
-                    "RedirectAllRequestsTo" => {
-                        obj.redirect_all_requests_to =
-                            Some(RedirectAllRequestsToDeserializer::deserialize(
-                                "RedirectAllRequestsTo",
-                                stack,
-                            )?);
-                    }
-                    "RoutingRules" => {
-                        obj.routing_rules = match obj.routing_rules {
-                            Some(ref mut existing) => {
-                                existing.extend(RoutingRulesDeserializer::deserialize(
-                                    "RoutingRules",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(RoutingRulesDeserializer::deserialize(
-                                "RoutingRules",
-                                stack,
-                            )?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                "RoutingRules" => {
+                    obj.routing_rules.get_or_insert(vec![]).extend(
+                        RoutingRulesDeserializer::deserialize("RoutingRules", stack)?,
+                    );
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -5602,50 +4822,20 @@ impl GetObjectAclOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetObjectAclOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetObjectAclOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, GetObjectAclOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AccessControlList" => {
+                    obj.grants
+                        .get_or_insert(vec![])
+                        .extend(GrantsDeserializer::deserialize("AccessControlList", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AccessControlList" => {
-                        obj.grants = match obj.grants {
-                            Some(ref mut existing) => {
-                                existing.extend(GrantsDeserializer::deserialize(
-                                    "AccessControlList",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => {
-                                Some(GrantsDeserializer::deserialize("AccessControlList", stack)?)
-                            }
-                        };
-                    }
-                    "Owner" => {
-                        obj.owner = Some(OwnerDeserializer::deserialize("Owner", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Owner" => {
+                    obj.owner = Some(OwnerDeserializer::deserialize("Owner", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -5865,37 +5055,16 @@ impl GetObjectTaggingOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetObjectTaggingOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetObjectTaggingOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, GetObjectTaggingOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "TagSet" => {
+                    obj.tag_set
+                        .extend(TagSetDeserializer::deserialize("TagSet", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "TagSet" => {
-                        obj.tag_set
-                            .extend(TagSetDeserializer::deserialize("TagSet", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -5990,40 +5159,19 @@ impl GrantDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Grant, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Grant::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Grant, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Grantee" => {
+                    obj.grantee = Some(GranteeDeserializer::deserialize("Grantee", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Grantee" => {
-                        obj.grantee = Some(GranteeDeserializer::deserialize("Grantee", stack)?);
-                    }
-                    "Permission" => {
-                        obj.permission =
-                            Some(PermissionDeserializer::deserialize("Permission", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Permission" => {
+                    obj.permission =
+                        Some(PermissionDeserializer::deserialize("Permission", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -6075,52 +5223,31 @@ impl GranteeDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Grantee, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Grantee::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Grantee, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DisplayName" => {
+                    obj.display_name =
+                        Some(DisplayNameDeserializer::deserialize("DisplayName", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DisplayName" => {
-                        obj.display_name =
-                            Some(DisplayNameDeserializer::deserialize("DisplayName", stack)?);
-                    }
-                    "EmailAddress" => {
-                        obj.email_address = Some(EmailAddressDeserializer::deserialize(
-                            "EmailAddress",
-                            stack,
-                        )?);
-                    }
-                    "ID" => {
-                        obj.id = Some(IDDeserializer::deserialize("ID", stack)?);
-                    }
-                    "xsi:type" => {
-                        obj.type_ = TypeDeserializer::deserialize("xsi:type", stack)?;
-                    }
-                    "URI" => {
-                        obj.uri = Some(URIDeserializer::deserialize("URI", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "EmailAddress" => {
+                    obj.email_address = Some(EmailAddressDeserializer::deserialize(
+                        "EmailAddress",
+                        stack,
+                    )?);
                 }
+                "ID" => {
+                    obj.id = Some(IDDeserializer::deserialize("ID", stack)?);
+                }
+                "xsi:type" => {
+                    obj.type_ = TypeDeserializer::deserialize("xsi:type", stack)?;
+                }
+                "URI" => {
+                    obj.uri = Some(URIDeserializer::deserialize("URI", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -6185,37 +5312,14 @@ impl GrantsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Grant>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "Grant" {
-                        obj.push(GrantDeserializer::deserialize("Grant", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "Grant" {
+                obj.push(GrantDeserializer::deserialize("Grant", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -6496,36 +5600,15 @@ impl IndexDocumentDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<IndexDocument, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = IndexDocument::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, IndexDocument, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Suffix" => {
+                    obj.suffix = SuffixDeserializer::deserialize("Suffix", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Suffix" => {
-                        obj.suffix = SuffixDeserializer::deserialize("Suffix", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -6580,40 +5663,19 @@ impl InitiatorDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Initiator, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Initiator::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Initiator, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DisplayName" => {
+                    obj.display_name =
+                        Some(DisplayNameDeserializer::deserialize("DisplayName", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DisplayName" => {
-                        obj.display_name =
-                            Some(DisplayNameDeserializer::deserialize("DisplayName", stack)?);
-                    }
-                    "ID" => {
-                        obj.id = Some(IDDeserializer::deserialize("ID", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "ID" => {
+                    obj.id = Some(IDDeserializer::deserialize("ID", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Describes the serialization format of the object.</p>
@@ -6687,73 +5749,40 @@ impl InventoryConfigurationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<InventoryConfiguration, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = InventoryConfiguration::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, InventoryConfiguration, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Destination" => {
+                    obj.destination =
+                        InventoryDestinationDeserializer::deserialize("Destination", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Destination" => {
-                        obj.destination =
-                            InventoryDestinationDeserializer::deserialize("Destination", stack)?;
-                    }
-                    "Filter" => {
-                        obj.filter =
-                            Some(InventoryFilterDeserializer::deserialize("Filter", stack)?);
-                    }
-                    "Id" => {
-                        obj.id = InventoryIdDeserializer::deserialize("Id", stack)?;
-                    }
-                    "IncludedObjectVersions" => {
-                        obj.included_object_versions =
-                            InventoryIncludedObjectVersionsDeserializer::deserialize(
-                                "IncludedObjectVersions",
-                                stack,
-                            )?;
-                    }
-                    "IsEnabled" => {
-                        obj.is_enabled = IsEnabledDeserializer::deserialize("IsEnabled", stack)?;
-                    }
-                    "OptionalFields" => {
-                        obj.optional_fields = match obj.optional_fields {
-                            Some(ref mut existing) => {
-                                existing.extend(InventoryOptionalFieldsDeserializer::deserialize(
-                                    "OptionalFields",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(InventoryOptionalFieldsDeserializer::deserialize(
-                                "OptionalFields",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "Schedule" => {
-                        obj.schedule =
-                            InventoryScheduleDeserializer::deserialize("Schedule", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Filter" => {
+                    obj.filter = Some(InventoryFilterDeserializer::deserialize("Filter", stack)?);
                 }
+                "Id" => {
+                    obj.id = InventoryIdDeserializer::deserialize("Id", stack)?;
+                }
+                "IncludedObjectVersions" => {
+                    obj.included_object_versions =
+                        InventoryIncludedObjectVersionsDeserializer::deserialize(
+                            "IncludedObjectVersions",
+                            stack,
+                        )?;
+                }
+                "IsEnabled" => {
+                    obj.is_enabled = IsEnabledDeserializer::deserialize("IsEnabled", stack)?;
+                }
+                "OptionalFields" => {
+                    obj.optional_fields.get_or_insert(vec![]).extend(
+                        InventoryOptionalFieldsDeserializer::deserialize("OptionalFields", stack)?,
+                    );
+                }
+                "Schedule" => {
+                    obj.schedule = InventoryScheduleDeserializer::deserialize("Schedule", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -6812,7 +5841,9 @@ impl InventoryConfigurationListDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -6841,40 +5872,19 @@ impl InventoryDestinationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<InventoryDestination, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = InventoryDestination::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, InventoryDestination, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "S3BucketDestination" => {
+                    obj.s3_bucket_destination =
+                        InventoryS3BucketDestinationDeserializer::deserialize(
+                            "S3BucketDestination",
+                            stack,
+                        )?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "S3BucketDestination" => {
-                        obj.s3_bucket_destination =
-                            InventoryS3BucketDestinationDeserializer::deserialize(
-                                "S3BucketDestination",
-                                stack,
-                            )?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -6915,39 +5925,18 @@ impl InventoryEncryptionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<InventoryEncryption, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = InventoryEncryption::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, InventoryEncryption, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "SSE-KMS" => {
+                    obj.ssekms = Some(SSEKMSDeserializer::deserialize("SSE-KMS", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "SSE-KMS" => {
-                        obj.ssekms = Some(SSEKMSDeserializer::deserialize("SSE-KMS", stack)?);
-                    }
-                    "SSE-S3" => {
-                        obj.sses3 = Some(SSES3Deserializer::deserialize("SSE-S3", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "SSE-S3" => {
+                    obj.sses3 = Some(SSES3Deserializer::deserialize("SSE-S3", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -6986,36 +5975,15 @@ impl InventoryFilterDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<InventoryFilter, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = InventoryFilter::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, InventoryFilter, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Prefix" => {
+                    obj.prefix = PrefixDeserializer::deserialize("Prefix", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Prefix" => {
-                        obj.prefix = PrefixDeserializer::deserialize("Prefix", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -7223,39 +6191,16 @@ impl InventoryOptionalFieldsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "Field" {
-                        obj.push(InventoryOptionalFieldDeserializer::deserialize(
-                            "Field", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "Field" {
+                obj.push(InventoryOptionalFieldDeserializer::deserialize(
+                    "Field", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -7300,21 +6245,11 @@ impl InventoryS3BucketDestinationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<InventoryS3BucketDestination, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = InventoryS3BucketDestination::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, InventoryS3BucketDestination, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AccountId" => {
                         obj.account_id =
                             Some(AccountIdDeserializer::deserialize("AccountId", stack)?);
@@ -7335,17 +6270,10 @@ impl InventoryS3BucketDestinationDeserializer {
                         obj.prefix = Some(PrefixDeserializer::deserialize("Prefix", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -7409,37 +6337,16 @@ impl InventoryScheduleDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<InventorySchedule, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = InventorySchedule::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, InventorySchedule, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Frequency" => {
+                    obj.frequency =
+                        InventoryFrequencyDeserializer::deserialize("Frequency", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Frequency" => {
-                        obj.frequency =
-                            InventoryFrequencyDeserializer::deserialize("Frequency", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -7778,21 +6685,11 @@ impl LambdaFunctionConfigurationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<LambdaFunctionConfiguration, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = LambdaFunctionConfiguration::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, LambdaFunctionConfiguration, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Event" => {
                         obj.events
                             .extend(EventListDeserializer::deserialize("Event", stack)?);
@@ -7811,17 +6708,10 @@ impl LambdaFunctionConfigurationDeserializer {
                             LambdaFunctionArnDeserializer::deserialize("CloudFunction", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -7870,7 +6760,9 @@ impl LambdaFunctionConfigurationListDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -7958,46 +6850,25 @@ impl LifecycleExpirationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<LifecycleExpiration, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = LifecycleExpiration::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, LifecycleExpiration, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Date" => {
+                    obj.date = Some(DateDeserializer::deserialize("Date", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Date" => {
-                        obj.date = Some(DateDeserializer::deserialize("Date", stack)?);
-                    }
-                    "Days" => {
-                        obj.days = Some(DaysDeserializer::deserialize("Days", stack)?);
-                    }
-                    "ExpiredObjectDeleteMarker" => {
-                        obj.expired_object_delete_marker =
-                            Some(ExpiredObjectDeleteMarkerDeserializer::deserialize(
-                                "ExpiredObjectDeleteMarker",
-                                stack,
-                            )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Days" => {
+                    obj.days = Some(DaysDeserializer::deserialize("Days", stack)?);
                 }
+                "ExpiredObjectDeleteMarker" => {
+                    obj.expired_object_delete_marker =
+                        Some(ExpiredObjectDeleteMarkerDeserializer::deserialize(
+                            "ExpiredObjectDeleteMarker",
+                            stack,
+                        )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -8064,98 +6935,56 @@ impl LifecycleRuleDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<LifecycleRule, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = LifecycleRule::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AbortIncompleteMultipartUpload" => {
-                        obj.abort_incomplete_multipart_upload =
-                            Some(AbortIncompleteMultipartUploadDeserializer::deserialize(
-                                "AbortIncompleteMultipartUpload",
-                                stack,
-                            )?);
-                    }
-                    "Expiration" => {
-                        obj.expiration = Some(LifecycleExpirationDeserializer::deserialize(
-                            "Expiration",
+        deserialize_elements::<_, LifecycleRule, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AbortIncompleteMultipartUpload" => {
+                    obj.abort_incomplete_multipart_upload =
+                        Some(AbortIncompleteMultipartUploadDeserializer::deserialize(
+                            "AbortIncompleteMultipartUpload",
                             stack,
                         )?);
-                    }
-                    "Filter" => {
-                        obj.filter = Some(LifecycleRuleFilterDeserializer::deserialize(
-                            "Filter", stack,
-                        )?);
-                    }
-                    "ID" => {
-                        obj.id = Some(IDDeserializer::deserialize("ID", stack)?);
-                    }
-                    "NoncurrentVersionExpiration" => {
-                        obj.noncurrent_version_expiration =
-                            Some(NoncurrentVersionExpirationDeserializer::deserialize(
-                                "NoncurrentVersionExpiration",
-                                stack,
-                            )?);
-                    }
-                    "NoncurrentVersionTransition" => {
-                        obj.noncurrent_version_transitions = match obj
-                            .noncurrent_version_transitions
-                        {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    NoncurrentVersionTransitionListDeserializer::deserialize(
-                                        "NoncurrentVersionTransition",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(NoncurrentVersionTransitionListDeserializer::deserialize(
-                                "NoncurrentVersionTransition",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "Status" => {
-                        obj.status = ExpirationStatusDeserializer::deserialize("Status", stack)?;
-                    }
-                    "Transition" => {
-                        obj.transitions = match obj.transitions {
-                            Some(ref mut existing) => {
-                                existing.extend(TransitionListDeserializer::deserialize(
-                                    "Transition",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(TransitionListDeserializer::deserialize(
-                                "Transition",
-                                stack,
-                            )?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                "Expiration" => {
+                    obj.expiration = Some(LifecycleExpirationDeserializer::deserialize(
+                        "Expiration",
+                        stack,
+                    )?);
+                }
+                "Filter" => {
+                    obj.filter = Some(LifecycleRuleFilterDeserializer::deserialize(
+                        "Filter", stack,
+                    )?);
+                }
+                "ID" => {
+                    obj.id = Some(IDDeserializer::deserialize("ID", stack)?);
+                }
+                "NoncurrentVersionExpiration" => {
+                    obj.noncurrent_version_expiration =
+                        Some(NoncurrentVersionExpirationDeserializer::deserialize(
+                            "NoncurrentVersionExpiration",
+                            stack,
+                        )?);
+                }
+                "NoncurrentVersionTransition" => {
+                    obj.noncurrent_version_transitions
+                        .get_or_insert(vec![])
+                        .extend(NoncurrentVersionTransitionListDeserializer::deserialize(
+                            "NoncurrentVersionTransition",
+                            stack,
+                        )?);
+                }
+                "Status" => {
+                    obj.status = ExpirationStatusDeserializer::deserialize("Status", stack)?;
+                }
+                "Transition" => {
+                    obj.transitions.get_or_insert(vec![]).extend(
+                        TransitionListDeserializer::deserialize("Transition", stack)?,
+                    );
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -8234,45 +7063,24 @@ impl LifecycleRuleAndOperatorDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<LifecycleRuleAndOperator, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = LifecycleRuleAndOperator::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, LifecycleRuleAndOperator, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Prefix" => {
                         obj.prefix = Some(PrefixDeserializer::deserialize("Prefix", stack)?);
                     }
                     "Tag" => {
-                        obj.tags = match obj.tags {
-                            Some(ref mut existing) => {
-                                existing.extend(TagSetDeserializer::deserialize("Tag", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(TagSetDeserializer::deserialize("Tag", stack)?),
-                        };
+                        obj.tags
+                            .get_or_insert(vec![])
+                            .extend(TagSetDeserializer::deserialize("Tag", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -8320,44 +7128,23 @@ impl LifecycleRuleFilterDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<LifecycleRuleFilter, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = LifecycleRuleFilter::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, LifecycleRuleFilter, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "And" => {
+                    obj.and = Some(LifecycleRuleAndOperatorDeserializer::deserialize(
+                        "And", stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "And" => {
-                        obj.and = Some(LifecycleRuleAndOperatorDeserializer::deserialize(
-                            "And", stack,
-                        )?);
-                    }
-                    "Prefix" => {
-                        obj.prefix = Some(PrefixDeserializer::deserialize("Prefix", stack)?);
-                    }
-                    "Tag" => {
-                        obj.tag = Some(TagDeserializer::deserialize("Tag", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Prefix" => {
+                    obj.prefix = Some(PrefixDeserializer::deserialize("Prefix", stack)?);
                 }
+                "Tag" => {
+                    obj.tag = Some(TagDeserializer::deserialize("Tag", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -8402,7 +7189,9 @@ impl LifecycleRulesDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -8454,37 +7243,18 @@ impl ListBucketAnalyticsConfigurationsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListBucketAnalyticsConfigurationsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListBucketAnalyticsConfigurationsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListBucketAnalyticsConfigurationsOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AnalyticsConfiguration" => {
-                        obj.analytics_configuration_list = match obj.analytics_configuration_list {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    AnalyticsConfigurationListDeserializer::deserialize(
-                                        "AnalyticsConfiguration",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(AnalyticsConfigurationListDeserializer::deserialize(
+                        obj.analytics_configuration_list
+                            .get_or_insert(vec![])
+                            .extend(AnalyticsConfigurationListDeserializer::deserialize(
                                 "AnalyticsConfiguration",
                                 stack,
-                            )?),
-                        };
+                            )?);
                     }
                     "ContinuationToken" => {
                         obj.continuation_token =
@@ -8501,17 +7271,10 @@ impl ListBucketAnalyticsConfigurationsOutputDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -8541,41 +7304,22 @@ impl ListBucketInventoryConfigurationsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListBucketInventoryConfigurationsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListBucketInventoryConfigurationsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListBucketInventoryConfigurationsOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ContinuationToken" => {
                         obj.continuation_token =
                             Some(TokenDeserializer::deserialize("ContinuationToken", stack)?);
                     }
                     "InventoryConfiguration" => {
-                        obj.inventory_configuration_list = match obj.inventory_configuration_list {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    InventoryConfigurationListDeserializer::deserialize(
-                                        "InventoryConfiguration",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(InventoryConfigurationListDeserializer::deserialize(
+                        obj.inventory_configuration_list
+                            .get_or_insert(vec![])
+                            .extend(InventoryConfigurationListDeserializer::deserialize(
                                 "InventoryConfiguration",
                                 stack,
-                            )?),
-                        };
+                            )?);
                     }
                     "IsTruncated" => {
                         obj.is_truncated =
@@ -8588,17 +7332,10 @@ impl ListBucketInventoryConfigurationsOutputDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -8628,21 +7365,11 @@ impl ListBucketMetricsConfigurationsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListBucketMetricsConfigurationsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListBucketMetricsConfigurationsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListBucketMetricsConfigurationsOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ContinuationToken" => {
                         obj.continuation_token =
                             Some(TokenDeserializer::deserialize("ContinuationToken", stack)?);
@@ -8652,19 +7379,12 @@ impl ListBucketMetricsConfigurationsOutputDeserializer {
                             Some(IsTruncatedDeserializer::deserialize("IsTruncated", stack)?);
                     }
                     "MetricsConfiguration" => {
-                        obj.metrics_configuration_list = match obj.metrics_configuration_list {
-                            Some(ref mut existing) => {
-                                existing.extend(MetricsConfigurationListDeserializer::deserialize(
-                                    "MetricsConfiguration",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(MetricsConfigurationListDeserializer::deserialize(
+                        obj.metrics_configuration_list.get_or_insert(vec![]).extend(
+                            MetricsConfigurationListDeserializer::deserialize(
                                 "MetricsConfiguration",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     "NextContinuationToken" => {
                         obj.next_continuation_token = Some(NextTokenDeserializer::deserialize(
@@ -8673,17 +7393,10 @@ impl ListBucketMetricsConfigurationsOutputDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -8707,46 +7420,20 @@ impl ListBucketsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListBucketsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListBucketsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ListBucketsOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Buckets" => {
+                    obj.buckets
+                        .get_or_insert(vec![])
+                        .extend(BucketsDeserializer::deserialize("Buckets", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Buckets" => {
-                        obj.buckets = match obj.buckets {
-                            Some(ref mut existing) => {
-                                existing
-                                    .extend(BucketsDeserializer::deserialize("Buckets", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(BucketsDeserializer::deserialize("Buckets", stack)?),
-                        };
-                    }
-                    "Owner" => {
-                        obj.owner = Some(OwnerDeserializer::deserialize("Owner", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Owner" => {
+                    obj.owner = Some(OwnerDeserializer::deserialize("Owner", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -8781,38 +7468,18 @@ impl ListMultipartUploadsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListMultipartUploadsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListMultipartUploadsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListMultipartUploadsOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Bucket" => {
                         obj.bucket = Some(BucketNameDeserializer::deserialize("Bucket", stack)?);
                     }
                     "CommonPrefixes" => {
-                        obj.common_prefixes = match obj.common_prefixes {
-                            Some(ref mut existing) => {
-                                existing.extend(CommonPrefixListDeserializer::deserialize(
-                                    "CommonPrefixes",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(CommonPrefixListDeserializer::deserialize(
-                                "CommonPrefixes",
-                                stack,
-                            )?),
-                        };
+                        obj.common_prefixes.get_or_insert(vec![]).extend(
+                            CommonPrefixListDeserializer::deserialize("CommonPrefixes", stack)?,
+                        );
                     }
                     "Delimiter" => {
                         obj.delimiter =
@@ -8859,30 +7526,15 @@ impl ListMultipartUploadsOutputDeserializer {
                         )?);
                     }
                     "Upload" => {
-                        obj.uploads = match obj.uploads {
-                            Some(ref mut existing) => {
-                                existing.extend(MultipartUploadListDeserializer::deserialize(
-                                    "Upload", stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(MultipartUploadListDeserializer::deserialize(
-                                "Upload", stack,
-                            )?),
-                        };
+                        obj.uploads.get_or_insert(vec![]).extend(
+                            MultipartUploadListDeserializer::deserialize("Upload", stack)?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -8930,50 +7582,20 @@ impl ListObjectVersionsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListObjectVersionsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListObjectVersionsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListObjectVersionsOutput, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CommonPrefixes" => {
-                        obj.common_prefixes = match obj.common_prefixes {
-                            Some(ref mut existing) => {
-                                existing.extend(CommonPrefixListDeserializer::deserialize(
-                                    "CommonPrefixes",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(CommonPrefixListDeserializer::deserialize(
-                                "CommonPrefixes",
-                                stack,
-                            )?),
-                        };
+                        obj.common_prefixes.get_or_insert(vec![]).extend(
+                            CommonPrefixListDeserializer::deserialize("CommonPrefixes", stack)?,
+                        );
                     }
                     "DeleteMarker" => {
-                        obj.delete_markers = match obj.delete_markers {
-                            Some(ref mut existing) => {
-                                existing.extend(DeleteMarkersDeserializer::deserialize(
-                                    "DeleteMarker",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(DeleteMarkersDeserializer::deserialize(
-                                "DeleteMarker",
-                                stack,
-                            )?),
-                        };
+                        obj.delete_markers.get_or_insert(vec![]).extend(
+                            DeleteMarkersDeserializer::deserialize("DeleteMarker", stack)?,
+                        );
                     }
                     "Delimiter" => {
                         obj.delimiter =
@@ -9022,30 +7644,15 @@ impl ListObjectVersionsOutputDeserializer {
                         )?);
                     }
                     "Version" => {
-                        obj.versions = match obj.versions {
-                            Some(ref mut existing) => {
-                                existing.extend(ObjectVersionListDeserializer::deserialize(
-                                    "Version", stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ObjectVersionListDeserializer::deserialize(
-                                "Version", stack,
-                            )?),
-                        };
+                        obj.versions.get_or_insert(vec![]).extend(
+                            ObjectVersionListDeserializer::deserialize("Version", stack)?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -9088,89 +7695,51 @@ impl ListObjectsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListObjectsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListObjectsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ListObjectsOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CommonPrefixes" => {
+                    obj.common_prefixes.get_or_insert(vec![]).extend(
+                        CommonPrefixListDeserializer::deserialize("CommonPrefixes", stack)?,
+                    );
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CommonPrefixes" => {
-                        obj.common_prefixes = match obj.common_prefixes {
-                            Some(ref mut existing) => {
-                                existing.extend(CommonPrefixListDeserializer::deserialize(
-                                    "CommonPrefixes",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(CommonPrefixListDeserializer::deserialize(
-                                "CommonPrefixes",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "Contents" => {
-                        obj.contents = match obj.contents {
-                            Some(ref mut existing) => {
-                                existing.extend(ObjectListDeserializer::deserialize(
-                                    "Contents", stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ObjectListDeserializer::deserialize("Contents", stack)?),
-                        };
-                    }
-                    "Delimiter" => {
-                        obj.delimiter =
-                            Some(DelimiterDeserializer::deserialize("Delimiter", stack)?);
-                    }
-                    "EncodingType" => {
-                        obj.encoding_type = Some(EncodingTypeDeserializer::deserialize(
-                            "EncodingType",
-                            stack,
-                        )?);
-                    }
-                    "IsTruncated" => {
-                        obj.is_truncated =
-                            Some(IsTruncatedDeserializer::deserialize("IsTruncated", stack)?);
-                    }
-                    "Marker" => {
-                        obj.marker = Some(MarkerDeserializer::deserialize("Marker", stack)?);
-                    }
-                    "MaxKeys" => {
-                        obj.max_keys = Some(MaxKeysDeserializer::deserialize("MaxKeys", stack)?);
-                    }
-                    "Name" => {
-                        obj.name = Some(BucketNameDeserializer::deserialize("Name", stack)?);
-                    }
-                    "NextMarker" => {
-                        obj.next_marker =
-                            Some(NextMarkerDeserializer::deserialize("NextMarker", stack)?);
-                    }
-                    "Prefix" => {
-                        obj.prefix = Some(PrefixDeserializer::deserialize("Prefix", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Contents" => {
+                    obj.contents
+                        .get_or_insert(vec![])
+                        .extend(ObjectListDeserializer::deserialize("Contents", stack)?);
                 }
+                "Delimiter" => {
+                    obj.delimiter = Some(DelimiterDeserializer::deserialize("Delimiter", stack)?);
+                }
+                "EncodingType" => {
+                    obj.encoding_type = Some(EncodingTypeDeserializer::deserialize(
+                        "EncodingType",
+                        stack,
+                    )?);
+                }
+                "IsTruncated" => {
+                    obj.is_truncated =
+                        Some(IsTruncatedDeserializer::deserialize("IsTruncated", stack)?);
+                }
+                "Marker" => {
+                    obj.marker = Some(MarkerDeserializer::deserialize("Marker", stack)?);
+                }
+                "MaxKeys" => {
+                    obj.max_keys = Some(MaxKeysDeserializer::deserialize("MaxKeys", stack)?);
+                }
+                "Name" => {
+                    obj.name = Some(BucketNameDeserializer::deserialize("Name", stack)?);
+                }
+                "NextMarker" => {
+                    obj.next_marker =
+                        Some(NextMarkerDeserializer::deserialize("NextMarker", stack)?);
+                }
+                "Prefix" => {
+                    obj.prefix = Some(PrefixDeserializer::deserialize("Prefix", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -9224,99 +7793,61 @@ impl ListObjectsV2OutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListObjectsV2Output, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListObjectsV2Output::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ListObjectsV2Output, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "CommonPrefixes" => {
+                    obj.common_prefixes.get_or_insert(vec![]).extend(
+                        CommonPrefixListDeserializer::deserialize("CommonPrefixes", stack)?,
+                    );
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "CommonPrefixes" => {
-                        obj.common_prefixes = match obj.common_prefixes {
-                            Some(ref mut existing) => {
-                                existing.extend(CommonPrefixListDeserializer::deserialize(
-                                    "CommonPrefixes",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(CommonPrefixListDeserializer::deserialize(
-                                "CommonPrefixes",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "Contents" => {
-                        obj.contents = match obj.contents {
-                            Some(ref mut existing) => {
-                                existing.extend(ObjectListDeserializer::deserialize(
-                                    "Contents", stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ObjectListDeserializer::deserialize("Contents", stack)?),
-                        };
-                    }
-                    "ContinuationToken" => {
-                        obj.continuation_token =
-                            Some(TokenDeserializer::deserialize("ContinuationToken", stack)?);
-                    }
-                    "Delimiter" => {
-                        obj.delimiter =
-                            Some(DelimiterDeserializer::deserialize("Delimiter", stack)?);
-                    }
-                    "EncodingType" => {
-                        obj.encoding_type = Some(EncodingTypeDeserializer::deserialize(
-                            "EncodingType",
-                            stack,
-                        )?);
-                    }
-                    "IsTruncated" => {
-                        obj.is_truncated =
-                            Some(IsTruncatedDeserializer::deserialize("IsTruncated", stack)?);
-                    }
-                    "KeyCount" => {
-                        obj.key_count = Some(KeyCountDeserializer::deserialize("KeyCount", stack)?);
-                    }
-                    "MaxKeys" => {
-                        obj.max_keys = Some(MaxKeysDeserializer::deserialize("MaxKeys", stack)?);
-                    }
-                    "Name" => {
-                        obj.name = Some(BucketNameDeserializer::deserialize("Name", stack)?);
-                    }
-                    "NextContinuationToken" => {
-                        obj.next_continuation_token = Some(NextTokenDeserializer::deserialize(
-                            "NextContinuationToken",
-                            stack,
-                        )?);
-                    }
-                    "Prefix" => {
-                        obj.prefix = Some(PrefixDeserializer::deserialize("Prefix", stack)?);
-                    }
-                    "StartAfter" => {
-                        obj.start_after =
-                            Some(StartAfterDeserializer::deserialize("StartAfter", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Contents" => {
+                    obj.contents
+                        .get_or_insert(vec![])
+                        .extend(ObjectListDeserializer::deserialize("Contents", stack)?);
                 }
+                "ContinuationToken" => {
+                    obj.continuation_token =
+                        Some(TokenDeserializer::deserialize("ContinuationToken", stack)?);
+                }
+                "Delimiter" => {
+                    obj.delimiter = Some(DelimiterDeserializer::deserialize("Delimiter", stack)?);
+                }
+                "EncodingType" => {
+                    obj.encoding_type = Some(EncodingTypeDeserializer::deserialize(
+                        "EncodingType",
+                        stack,
+                    )?);
+                }
+                "IsTruncated" => {
+                    obj.is_truncated =
+                        Some(IsTruncatedDeserializer::deserialize("IsTruncated", stack)?);
+                }
+                "KeyCount" => {
+                    obj.key_count = Some(KeyCountDeserializer::deserialize("KeyCount", stack)?);
+                }
+                "MaxKeys" => {
+                    obj.max_keys = Some(MaxKeysDeserializer::deserialize("MaxKeys", stack)?);
+                }
+                "Name" => {
+                    obj.name = Some(BucketNameDeserializer::deserialize("Name", stack)?);
+                }
+                "NextContinuationToken" => {
+                    obj.next_continuation_token = Some(NextTokenDeserializer::deserialize(
+                        "NextContinuationToken",
+                        stack,
+                    )?);
+                }
+                "Prefix" => {
+                    obj.prefix = Some(PrefixDeserializer::deserialize("Prefix", stack)?);
+                }
+                "StartAfter" => {
+                    obj.start_after =
+                        Some(StartAfterDeserializer::deserialize("StartAfter", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -9377,86 +7908,60 @@ impl ListPartsOutputDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListPartsOutput, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListPartsOutput::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ListPartsOutput, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Bucket" => {
+                    obj.bucket = Some(BucketNameDeserializer::deserialize("Bucket", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Bucket" => {
-                        obj.bucket = Some(BucketNameDeserializer::deserialize("Bucket", stack)?);
-                    }
-                    "Initiator" => {
-                        obj.initiator =
-                            Some(InitiatorDeserializer::deserialize("Initiator", stack)?);
-                    }
-                    "IsTruncated" => {
-                        obj.is_truncated =
-                            Some(IsTruncatedDeserializer::deserialize("IsTruncated", stack)?);
-                    }
-                    "Key" => {
-                        obj.key = Some(ObjectKeyDeserializer::deserialize("Key", stack)?);
-                    }
-                    "MaxParts" => {
-                        obj.max_parts = Some(MaxPartsDeserializer::deserialize("MaxParts", stack)?);
-                    }
-                    "NextPartNumberMarker" => {
-                        obj.next_part_number_marker =
-                            Some(NextPartNumberMarkerDeserializer::deserialize(
-                                "NextPartNumberMarker",
-                                stack,
-                            )?);
-                    }
-                    "Owner" => {
-                        obj.owner = Some(OwnerDeserializer::deserialize("Owner", stack)?);
-                    }
-                    "PartNumberMarker" => {
-                        obj.part_number_marker = Some(PartNumberMarkerDeserializer::deserialize(
-                            "PartNumberMarker",
+                "Initiator" => {
+                    obj.initiator = Some(InitiatorDeserializer::deserialize("Initiator", stack)?);
+                }
+                "IsTruncated" => {
+                    obj.is_truncated =
+                        Some(IsTruncatedDeserializer::deserialize("IsTruncated", stack)?);
+                }
+                "Key" => {
+                    obj.key = Some(ObjectKeyDeserializer::deserialize("Key", stack)?);
+                }
+                "MaxParts" => {
+                    obj.max_parts = Some(MaxPartsDeserializer::deserialize("MaxParts", stack)?);
+                }
+                "NextPartNumberMarker" => {
+                    obj.next_part_number_marker =
+                        Some(NextPartNumberMarkerDeserializer::deserialize(
+                            "NextPartNumberMarker",
                             stack,
                         )?);
-                    }
-                    "Part" => {
-                        obj.parts = match obj.parts {
-                            Some(ref mut existing) => {
-                                existing.extend(PartsDeserializer::deserialize("Part", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(PartsDeserializer::deserialize("Part", stack)?),
-                        };
-                    }
-                    "StorageClass" => {
-                        obj.storage_class = Some(StorageClassDeserializer::deserialize(
-                            "StorageClass",
-                            stack,
-                        )?);
-                    }
-                    "UploadId" => {
-                        obj.upload_id = Some(MultipartUploadIdDeserializer::deserialize(
-                            "UploadId", stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                "Owner" => {
+                    obj.owner = Some(OwnerDeserializer::deserialize("Owner", stack)?);
+                }
+                "PartNumberMarker" => {
+                    obj.part_number_marker = Some(PartNumberMarkerDeserializer::deserialize(
+                        "PartNumberMarker",
+                        stack,
+                    )?);
+                }
+                "Part" => {
+                    obj.parts
+                        .get_or_insert(vec![])
+                        .extend(PartsDeserializer::deserialize("Part", stack)?);
+                }
+                "StorageClass" => {
+                    obj.storage_class = Some(StorageClassDeserializer::deserialize(
+                        "StorageClass",
+                        stack,
+                    )?);
+                }
+                "UploadId" => {
+                    obj.upload_id = Some(MultipartUploadIdDeserializer::deserialize(
+                        "UploadId", stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -9524,56 +8029,25 @@ impl LoggingEnabledDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<LoggingEnabled, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = LoggingEnabled::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, LoggingEnabled, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "TargetBucket" => {
+                    obj.target_bucket =
+                        TargetBucketDeserializer::deserialize("TargetBucket", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "TargetBucket" => {
-                        obj.target_bucket =
-                            TargetBucketDeserializer::deserialize("TargetBucket", stack)?;
-                    }
-                    "TargetGrants" => {
-                        obj.target_grants = match obj.target_grants {
-                            Some(ref mut existing) => {
-                                existing.extend(TargetGrantsDeserializer::deserialize(
-                                    "TargetGrants",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(TargetGrantsDeserializer::deserialize(
-                                "TargetGrants",
-                                stack,
-                            )?),
-                        };
-                    }
-                    "TargetPrefix" => {
-                        obj.target_prefix =
-                            TargetPrefixDeserializer::deserialize("TargetPrefix", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "TargetGrants" => {
+                    obj.target_grants.get_or_insert(vec![]).extend(
+                        TargetGrantsDeserializer::deserialize("TargetGrants", stack)?,
+                    );
                 }
+                "TargetPrefix" => {
+                    obj.target_prefix =
+                        TargetPrefixDeserializer::deserialize("TargetPrefix", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -9925,45 +8399,20 @@ impl MetricsAndOperatorDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<MetricsAndOperator, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = MetricsAndOperator::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, MetricsAndOperator, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Prefix" => {
+                    obj.prefix = Some(PrefixDeserializer::deserialize("Prefix", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Prefix" => {
-                        obj.prefix = Some(PrefixDeserializer::deserialize("Prefix", stack)?);
-                    }
-                    "Tag" => {
-                        obj.tags = match obj.tags {
-                            Some(ref mut existing) => {
-                                existing.extend(TagSetDeserializer::deserialize("Tag", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(TagSetDeserializer::deserialize("Tag", stack)?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Tag" => {
+                    obj.tags
+                        .get_or_insert(vec![])
+                        .extend(TagSetDeserializer::deserialize("Tag", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -10009,39 +8458,18 @@ impl MetricsConfigurationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<MetricsConfiguration, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = MetricsConfiguration::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, MetricsConfiguration, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Filter" => {
+                    obj.filter = Some(MetricsFilterDeserializer::deserialize("Filter", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Filter" => {
-                        obj.filter = Some(MetricsFilterDeserializer::deserialize("Filter", stack)?);
-                    }
-                    "Id" => {
-                        obj.id = MetricsIdDeserializer::deserialize("Id", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Id" => {
+                    obj.id = MetricsIdDeserializer::deserialize("Id", stack)?;
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -10081,7 +8509,9 @@ impl MetricsConfigurationListDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -10114,42 +8544,21 @@ impl MetricsFilterDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<MetricsFilter, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = MetricsFilter::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, MetricsFilter, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "And" => {
+                    obj.and = Some(MetricsAndOperatorDeserializer::deserialize("And", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "And" => {
-                        obj.and = Some(MetricsAndOperatorDeserializer::deserialize("And", stack)?);
-                    }
-                    "Prefix" => {
-                        obj.prefix = Some(PrefixDeserializer::deserialize("Prefix", stack)?);
-                    }
-                    "Tag" => {
-                        obj.tag = Some(TagDeserializer::deserialize("Tag", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Prefix" => {
+                    obj.prefix = Some(PrefixDeserializer::deserialize("Prefix", stack)?);
                 }
+                "Tag" => {
+                    obj.tag = Some(TagDeserializer::deserialize("Tag", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -10240,58 +8649,35 @@ impl MultipartUploadDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<MultipartUpload, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = MultipartUpload::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, MultipartUpload, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Initiated" => {
+                    obj.initiated = Some(InitiatedDeserializer::deserialize("Initiated", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Initiated" => {
-                        obj.initiated =
-                            Some(InitiatedDeserializer::deserialize("Initiated", stack)?);
-                    }
-                    "Initiator" => {
-                        obj.initiator =
-                            Some(InitiatorDeserializer::deserialize("Initiator", stack)?);
-                    }
-                    "Key" => {
-                        obj.key = Some(ObjectKeyDeserializer::deserialize("Key", stack)?);
-                    }
-                    "Owner" => {
-                        obj.owner = Some(OwnerDeserializer::deserialize("Owner", stack)?);
-                    }
-                    "StorageClass" => {
-                        obj.storage_class = Some(StorageClassDeserializer::deserialize(
-                            "StorageClass",
-                            stack,
-                        )?);
-                    }
-                    "UploadId" => {
-                        obj.upload_id = Some(MultipartUploadIdDeserializer::deserialize(
-                            "UploadId", stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Initiator" => {
+                    obj.initiator = Some(InitiatorDeserializer::deserialize("Initiator", stack)?);
                 }
+                "Key" => {
+                    obj.key = Some(ObjectKeyDeserializer::deserialize("Key", stack)?);
+                }
+                "Owner" => {
+                    obj.owner = Some(OwnerDeserializer::deserialize("Owner", stack)?);
+                }
+                "StorageClass" => {
+                    obj.storage_class = Some(StorageClassDeserializer::deserialize(
+                        "StorageClass",
+                        stack,
+                    )?);
+                }
+                "UploadId" => {
+                    obj.upload_id = Some(MultipartUploadIdDeserializer::deserialize(
+                        "UploadId", stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct MultipartUploadIdDeserializer;
@@ -10340,7 +8726,9 @@ impl MultipartUploadListDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -10452,37 +8840,20 @@ impl NoncurrentVersionExpirationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<NoncurrentVersionExpiration, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = NoncurrentVersionExpiration::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, NoncurrentVersionExpiration, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "NoncurrentDays" => {
                         obj.noncurrent_days =
                             Some(DaysDeserializer::deserialize("NoncurrentDays", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -10526,21 +8897,11 @@ impl NoncurrentVersionTransitionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<NoncurrentVersionTransition, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = NoncurrentVersionTransition::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, NoncurrentVersionTransition, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "NoncurrentDays" => {
                         obj.noncurrent_days =
                             Some(DaysDeserializer::deserialize("NoncurrentDays", stack)?);
@@ -10552,17 +8913,10 @@ impl NoncurrentVersionTransitionDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -10609,7 +8963,9 @@ impl NoncurrentVersionTransitionListDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -10659,82 +9015,40 @@ impl NotificationConfigurationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<NotificationConfiguration, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = NotificationConfiguration::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, NotificationConfiguration, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CloudFunctionConfiguration" => {
-                        obj.lambda_function_configurations = match obj
-                            .lambda_function_configurations
-                        {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    LambdaFunctionConfigurationListDeserializer::deserialize(
-                                        "CloudFunctionConfiguration",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(LambdaFunctionConfigurationListDeserializer::deserialize(
+                        obj.lambda_function_configurations
+                            .get_or_insert(vec![])
+                            .extend(LambdaFunctionConfigurationListDeserializer::deserialize(
                                 "CloudFunctionConfiguration",
                                 stack,
-                            )?),
-                        };
+                            )?);
                     }
                     "QueueConfiguration" => {
-                        obj.queue_configurations = match obj.queue_configurations {
-                            Some(ref mut existing) => {
-                                existing.extend(QueueConfigurationListDeserializer::deserialize(
-                                    "QueueConfiguration",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(QueueConfigurationListDeserializer::deserialize(
+                        obj.queue_configurations.get_or_insert(vec![]).extend(
+                            QueueConfigurationListDeserializer::deserialize(
                                 "QueueConfiguration",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     "TopicConfiguration" => {
-                        obj.topic_configurations = match obj.topic_configurations {
-                            Some(ref mut existing) => {
-                                existing.extend(TopicConfigurationListDeserializer::deserialize(
-                                    "TopicConfiguration",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(TopicConfigurationListDeserializer::deserialize(
+                        obj.topic_configurations.get_or_insert(vec![]).extend(
+                            TopicConfigurationListDeserializer::deserialize(
                                 "TopicConfiguration",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -10781,21 +9095,11 @@ impl NotificationConfigurationDeprecatedDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<NotificationConfigurationDeprecated, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = NotificationConfigurationDeprecated::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, NotificationConfigurationDeprecated, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "CloudFunctionConfiguration" => {
                         obj.cloud_function_configuration =
                             Some(CloudFunctionConfigurationDeserializer::deserialize(
@@ -10818,17 +9122,10 @@ impl NotificationConfigurationDeprecatedDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -10882,36 +9179,19 @@ impl NotificationConfigurationFilterDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<NotificationConfigurationFilter, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = NotificationConfigurationFilter::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, NotificationConfigurationFilter, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "S3Key" => {
                         obj.key = Some(S3KeyFilterDeserializer::deserialize("S3Key", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -10987,57 +9267,36 @@ impl ObjectDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Object, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Object::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Object, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "ETag" => {
+                    obj.e_tag = Some(ETagDeserializer::deserialize("ETag", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "ETag" => {
-                        obj.e_tag = Some(ETagDeserializer::deserialize("ETag", stack)?);
-                    }
-                    "Key" => {
-                        obj.key = Some(ObjectKeyDeserializer::deserialize("Key", stack)?);
-                    }
-                    "LastModified" => {
-                        obj.last_modified = Some(LastModifiedDeserializer::deserialize(
-                            "LastModified",
-                            stack,
-                        )?);
-                    }
-                    "Owner" => {
-                        obj.owner = Some(OwnerDeserializer::deserialize("Owner", stack)?);
-                    }
-                    "Size" => {
-                        obj.size = Some(SizeDeserializer::deserialize("Size", stack)?);
-                    }
-                    "StorageClass" => {
-                        obj.storage_class = Some(ObjectStorageClassDeserializer::deserialize(
-                            "StorageClass",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Key" => {
+                    obj.key = Some(ObjectKeyDeserializer::deserialize("Key", stack)?);
                 }
+                "LastModified" => {
+                    obj.last_modified = Some(LastModifiedDeserializer::deserialize(
+                        "LastModified",
+                        stack,
+                    )?);
+                }
+                "Owner" => {
+                    obj.owner = Some(OwnerDeserializer::deserialize("Owner", stack)?);
+                }
+                "Size" => {
+                    obj.size = Some(SizeDeserializer::deserialize("Size", stack)?);
+                }
+                "StorageClass" => {
+                    obj.storage_class = Some(ObjectStorageClassDeserializer::deserialize(
+                        "StorageClass",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -11163,7 +9422,9 @@ impl ObjectListDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -11193,21 +9454,11 @@ impl ObjectLockConfigurationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ObjectLockConfiguration, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ObjectLockConfiguration::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ObjectLockConfiguration, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ObjectLockEnabled" => {
                         obj.object_lock_enabled = Some(ObjectLockEnabledDeserializer::deserialize(
                             "ObjectLockEnabled",
@@ -11218,17 +9469,10 @@ impl ObjectLockConfigurationDeserializer {
                         obj.rule = Some(ObjectLockRuleDeserializer::deserialize("Rule", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -11308,38 +9552,17 @@ impl ObjectLockLegalHoldDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ObjectLockLegalHold, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ObjectLockLegalHold::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ObjectLockLegalHold, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Status" => {
+                    obj.status = Some(ObjectLockLegalHoldStatusDeserializer::deserialize(
+                        "Status", stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Status" => {
-                        obj.status = Some(ObjectLockLegalHoldStatusDeserializer::deserialize(
-                            "Status", stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -11418,42 +9641,21 @@ impl ObjectLockRetentionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ObjectLockRetention, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ObjectLockRetention::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ObjectLockRetention, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Mode" => {
+                    obj.mode = Some(ObjectLockRetentionModeDeserializer::deserialize(
+                        "Mode", stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Mode" => {
-                        obj.mode = Some(ObjectLockRetentionModeDeserializer::deserialize(
-                            "Mode", stack,
-                        )?);
-                    }
-                    "RetainUntilDate" => {
-                        obj.retain_until_date =
-                            Some(DateDeserializer::deserialize("RetainUntilDate", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "RetainUntilDate" => {
+                    obj.retain_until_date =
+                        Some(DateDeserializer::deserialize("RetainUntilDate", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -11538,39 +9740,18 @@ impl ObjectLockRuleDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ObjectLockRule, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ObjectLockRule::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ObjectLockRule, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DefaultRetention" => {
+                    obj.default_retention = Some(DefaultRetentionDeserializer::deserialize(
+                        "DefaultRetention",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DefaultRetention" => {
-                        obj.default_retention = Some(DefaultRetentionDeserializer::deserialize(
-                            "DefaultRetention",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -11632,67 +9813,45 @@ impl ObjectVersionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ObjectVersion, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ObjectVersion::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ObjectVersion, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "ETag" => {
+                    obj.e_tag = Some(ETagDeserializer::deserialize("ETag", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "ETag" => {
-                        obj.e_tag = Some(ETagDeserializer::deserialize("ETag", stack)?);
-                    }
-                    "IsLatest" => {
-                        obj.is_latest = Some(IsLatestDeserializer::deserialize("IsLatest", stack)?);
-                    }
-                    "Key" => {
-                        obj.key = Some(ObjectKeyDeserializer::deserialize("Key", stack)?);
-                    }
-                    "LastModified" => {
-                        obj.last_modified = Some(LastModifiedDeserializer::deserialize(
-                            "LastModified",
-                            stack,
-                        )?);
-                    }
-                    "Owner" => {
-                        obj.owner = Some(OwnerDeserializer::deserialize("Owner", stack)?);
-                    }
-                    "Size" => {
-                        obj.size = Some(SizeDeserializer::deserialize("Size", stack)?);
-                    }
-                    "StorageClass" => {
-                        obj.storage_class =
-                            Some(ObjectVersionStorageClassDeserializer::deserialize(
-                                "StorageClass",
-                                stack,
-                            )?);
-                    }
-                    "VersionId" => {
-                        obj.version_id = Some(ObjectVersionIdDeserializer::deserialize(
-                            "VersionId",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "IsLatest" => {
+                    obj.is_latest = Some(IsLatestDeserializer::deserialize("IsLatest", stack)?);
                 }
+                "Key" => {
+                    obj.key = Some(ObjectKeyDeserializer::deserialize("Key", stack)?);
+                }
+                "LastModified" => {
+                    obj.last_modified = Some(LastModifiedDeserializer::deserialize(
+                        "LastModified",
+                        stack,
+                    )?);
+                }
+                "Owner" => {
+                    obj.owner = Some(OwnerDeserializer::deserialize("Owner", stack)?);
+                }
+                "Size" => {
+                    obj.size = Some(SizeDeserializer::deserialize("Size", stack)?);
+                }
+                "StorageClass" => {
+                    obj.storage_class = Some(ObjectVersionStorageClassDeserializer::deserialize(
+                        "StorageClass",
+                        stack,
+                    )?);
+                }
+                "VersionId" => {
+                    obj.version_id = Some(ObjectVersionIdDeserializer::deserialize(
+                        "VersionId",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ObjectVersionIdDeserializer;
@@ -11741,7 +9900,9 @@ impl ObjectVersionListDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -11839,40 +10000,19 @@ impl OwnerDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Owner, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Owner::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Owner, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DisplayName" => {
+                    obj.display_name =
+                        Some(DisplayNameDeserializer::deserialize("DisplayName", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DisplayName" => {
-                        obj.display_name =
-                            Some(DisplayNameDeserializer::deserialize("DisplayName", stack)?);
-                    }
-                    "ID" => {
-                        obj.id = Some(IDDeserializer::deserialize("ID", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "ID" => {
+                    obj.id = Some(IDDeserializer::deserialize("ID", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -11981,49 +10121,28 @@ impl PartDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Part, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Part::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Part, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "ETag" => {
+                    obj.e_tag = Some(ETagDeserializer::deserialize("ETag", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "ETag" => {
-                        obj.e_tag = Some(ETagDeserializer::deserialize("ETag", stack)?);
-                    }
-                    "LastModified" => {
-                        obj.last_modified = Some(LastModifiedDeserializer::deserialize(
-                            "LastModified",
-                            stack,
-                        )?);
-                    }
-                    "PartNumber" => {
-                        obj.part_number =
-                            Some(PartNumberDeserializer::deserialize("PartNumber", stack)?);
-                    }
-                    "Size" => {
-                        obj.size = Some(SizeDeserializer::deserialize("Size", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "LastModified" => {
+                    obj.last_modified = Some(LastModifiedDeserializer::deserialize(
+                        "LastModified",
+                        stack,
+                    )?);
                 }
+                "PartNumber" => {
+                    obj.part_number =
+                        Some(PartNumberDeserializer::deserialize("PartNumber", stack)?);
+                }
+                "Size" => {
+                    obj.size = Some(SizeDeserializer::deserialize("Size", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PartNumberDeserializer;
@@ -12107,7 +10226,9 @@ impl PartsDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -12225,36 +10346,15 @@ impl PolicyStatusDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<PolicyStatus, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = PolicyStatus::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, PolicyStatus, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "IsPublic" => {
+                    obj.is_public = Some(IsPublicDeserializer::deserialize("IsPublic", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "IsPublic" => {
-                        obj.is_public = Some(IsPublicDeserializer::deserialize("IsPublic", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct PrefixDeserializer;
@@ -12344,51 +10444,30 @@ impl ProgressDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Progress, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Progress::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Progress, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "BytesProcessed" => {
+                    obj.bytes_processed = Some(BytesProcessedDeserializer::deserialize(
+                        "BytesProcessed",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "BytesProcessed" => {
-                        obj.bytes_processed = Some(BytesProcessedDeserializer::deserialize(
-                            "BytesProcessed",
-                            stack,
-                        )?);
-                    }
-                    "BytesReturned" => {
-                        obj.bytes_returned = Some(BytesReturnedDeserializer::deserialize(
-                            "BytesReturned",
-                            stack,
-                        )?);
-                    }
-                    "BytesScanned" => {
-                        obj.bytes_scanned = Some(BytesScannedDeserializer::deserialize(
-                            "BytesScanned",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "BytesReturned" => {
+                    obj.bytes_returned = Some(BytesReturnedDeserializer::deserialize(
+                        "BytesReturned",
+                        stack,
+                    )?);
                 }
+                "BytesScanned" => {
+                    obj.bytes_scanned = Some(BytesScannedDeserializer::deserialize(
+                        "BytesScanned",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -12404,36 +10483,15 @@ impl ProgressEventDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ProgressEvent, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ProgressEvent::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ProgressEvent, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Details" => {
+                    obj.details = Some(ProgressDeserializer::deserialize("Details", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Details" => {
-                        obj.details = Some(ProgressDeserializer::deserialize("Details", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ProtocolDeserializer;
@@ -12490,21 +10548,11 @@ impl PublicAccessBlockConfigurationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<PublicAccessBlockConfiguration, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = PublicAccessBlockConfiguration::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, PublicAccessBlockConfiguration, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "BlockPublicAcls" => {
                         obj.block_public_acls =
                             Some(SettingDeserializer::deserialize("BlockPublicAcls", stack)?);
@@ -12526,17 +10574,10 @@ impl PublicAccessBlockConfigurationDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -13082,49 +11123,27 @@ impl QueueConfigurationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<QueueConfiguration, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = QueueConfiguration::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, QueueConfiguration, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Event" => {
+                    obj.events
+                        .extend(EventListDeserializer::deserialize("Event", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Event" => {
-                        obj.events
-                            .extend(EventListDeserializer::deserialize("Event", stack)?);
-                    }
-                    "Filter" => {
-                        obj.filter =
-                            Some(NotificationConfigurationFilterDeserializer::deserialize(
-                                "Filter", stack,
-                            )?);
-                    }
-                    "Id" => {
-                        obj.id = Some(NotificationIdDeserializer::deserialize("Id", stack)?);
-                    }
-                    "Queue" => {
-                        obj.queue_arn = QueueArnDeserializer::deserialize("Queue", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Filter" => {
+                    obj.filter = Some(NotificationConfigurationFilterDeserializer::deserialize(
+                        "Filter", stack,
+                    )?);
                 }
+                "Id" => {
+                    obj.id = Some(NotificationIdDeserializer::deserialize("Id", stack)?);
+                }
+                "Queue" => {
+                    obj.queue_arn = QueueArnDeserializer::deserialize("Queue", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -13176,30 +11195,15 @@ impl QueueConfigurationDeprecatedDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<QueueConfigurationDeprecated, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = QueueConfigurationDeprecated::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, QueueConfigurationDeprecated, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Event" => {
-                        obj.events = match obj.events {
-                            Some(ref mut existing) => {
-                                existing
-                                    .extend(EventListDeserializer::deserialize("Event", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(EventListDeserializer::deserialize("Event", stack)?),
-                        };
+                        obj.events
+                            .get_or_insert(vec![])
+                            .extend(EventListDeserializer::deserialize("Event", stack)?);
                     }
                     "Id" => {
                         obj.id = Some(NotificationIdDeserializer::deserialize("Id", stack)?);
@@ -13208,17 +11212,10 @@ impl QueueConfigurationDeprecatedDeserializer {
                         obj.queue = Some(QueueArnDeserializer::deserialize("Queue", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -13268,7 +11265,9 @@ impl QueueConfigurationListDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -13416,36 +11415,15 @@ impl RecordsEventDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<RecordsEvent, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = RecordsEvent::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, RecordsEvent, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Payload" => {
+                    obj.payload = Some(BodyDeserializer::deserialize("Payload", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Payload" => {
-                        obj.payload = Some(BodyDeserializer::deserialize("Payload", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -13469,58 +11447,37 @@ impl RedirectDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Redirect, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Redirect::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Redirect, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "HostName" => {
+                    obj.host_name = Some(HostNameDeserializer::deserialize("HostName", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "HostName" => {
-                        obj.host_name = Some(HostNameDeserializer::deserialize("HostName", stack)?);
-                    }
-                    "HttpRedirectCode" => {
-                        obj.http_redirect_code = Some(HttpRedirectCodeDeserializer::deserialize(
-                            "HttpRedirectCode",
+                "HttpRedirectCode" => {
+                    obj.http_redirect_code = Some(HttpRedirectCodeDeserializer::deserialize(
+                        "HttpRedirectCode",
+                        stack,
+                    )?);
+                }
+                "Protocol" => {
+                    obj.protocol = Some(ProtocolDeserializer::deserialize("Protocol", stack)?);
+                }
+                "ReplaceKeyPrefixWith" => {
+                    obj.replace_key_prefix_with =
+                        Some(ReplaceKeyPrefixWithDeserializer::deserialize(
+                            "ReplaceKeyPrefixWith",
                             stack,
                         )?);
-                    }
-                    "Protocol" => {
-                        obj.protocol = Some(ProtocolDeserializer::deserialize("Protocol", stack)?);
-                    }
-                    "ReplaceKeyPrefixWith" => {
-                        obj.replace_key_prefix_with =
-                            Some(ReplaceKeyPrefixWithDeserializer::deserialize(
-                                "ReplaceKeyPrefixWith",
-                                stack,
-                            )?);
-                    }
-                    "ReplaceKeyWith" => {
-                        obj.replace_key_with = Some(ReplaceKeyWithDeserializer::deserialize(
-                            "ReplaceKeyWith",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                "ReplaceKeyWith" => {
+                    obj.replace_key_with = Some(ReplaceKeyWithDeserializer::deserialize(
+                        "ReplaceKeyWith",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -13595,39 +11552,18 @@ impl RedirectAllRequestsToDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<RedirectAllRequestsTo, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = RedirectAllRequestsTo::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, RedirectAllRequestsTo, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "HostName" => {
+                    obj.host_name = HostNameDeserializer::deserialize("HostName", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "HostName" => {
-                        obj.host_name = HostNameDeserializer::deserialize("HostName", stack)?;
-                    }
-                    "Protocol" => {
-                        obj.protocol = Some(ProtocolDeserializer::deserialize("Protocol", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Protocol" => {
+                    obj.protocol = Some(ProtocolDeserializer::deserialize("Protocol", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -13782,21 +11718,11 @@ impl ReplicationConfigurationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ReplicationConfiguration, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ReplicationConfiguration::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ReplicationConfiguration, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Role" => {
                         obj.role = RoleDeserializer::deserialize("Role", stack)?;
                     }
@@ -13805,17 +11731,10 @@ impl ReplicationConfigurationDeserializer {
                             .extend(ReplicationRulesDeserializer::deserialize("Rule", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -13866,66 +11785,43 @@ impl ReplicationRuleDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ReplicationRule, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ReplicationRule::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DeleteMarkerReplication" => {
-                        obj.delete_marker_replication =
-                            Some(DeleteMarkerReplicationDeserializer::deserialize(
-                                "DeleteMarkerReplication",
-                                stack,
-                            )?);
-                    }
-                    "Destination" => {
-                        obj.destination =
-                            DestinationDeserializer::deserialize("Destination", stack)?;
-                    }
-                    "Filter" => {
-                        obj.filter = Some(ReplicationRuleFilterDeserializer::deserialize(
-                            "Filter", stack,
+        deserialize_elements::<_, ReplicationRule, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DeleteMarkerReplication" => {
+                    obj.delete_marker_replication =
+                        Some(DeleteMarkerReplicationDeserializer::deserialize(
+                            "DeleteMarkerReplication",
+                            stack,
                         )?);
-                    }
-                    "ID" => {
-                        obj.id = Some(IDDeserializer::deserialize("ID", stack)?);
-                    }
-                    "Priority" => {
-                        obj.priority = Some(PriorityDeserializer::deserialize("Priority", stack)?);
-                    }
-                    "SourceSelectionCriteria" => {
-                        obj.source_selection_criteria =
-                            Some(SourceSelectionCriteriaDeserializer::deserialize(
-                                "SourceSelectionCriteria",
-                                stack,
-                            )?);
-                    }
-                    "Status" => {
-                        obj.status =
-                            ReplicationRuleStatusDeserializer::deserialize("Status", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                "Destination" => {
+                    obj.destination = DestinationDeserializer::deserialize("Destination", stack)?;
+                }
+                "Filter" => {
+                    obj.filter = Some(ReplicationRuleFilterDeserializer::deserialize(
+                        "Filter", stack,
+                    )?);
+                }
+                "ID" => {
+                    obj.id = Some(IDDeserializer::deserialize("ID", stack)?);
+                }
+                "Priority" => {
+                    obj.priority = Some(PriorityDeserializer::deserialize("Priority", stack)?);
+                }
+                "SourceSelectionCriteria" => {
+                    obj.source_selection_criteria =
+                        Some(SourceSelectionCriteriaDeserializer::deserialize(
+                            "SourceSelectionCriteria",
+                            stack,
+                        )?);
+                }
+                "Status" => {
+                    obj.status = ReplicationRuleStatusDeserializer::deserialize("Status", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -13998,45 +11894,24 @@ impl ReplicationRuleAndOperatorDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ReplicationRuleAndOperator, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ReplicationRuleAndOperator::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ReplicationRuleAndOperator, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Prefix" => {
                         obj.prefix = Some(PrefixDeserializer::deserialize("Prefix", stack)?);
                     }
                     "Tag" => {
-                        obj.tags = match obj.tags {
-                            Some(ref mut existing) => {
-                                existing.extend(TagSetDeserializer::deserialize("Tag", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(TagSetDeserializer::deserialize("Tag", stack)?),
-                        };
+                        obj.tags
+                            .get_or_insert(vec![])
+                            .extend(TagSetDeserializer::deserialize("Tag", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -14085,44 +11960,23 @@ impl ReplicationRuleFilterDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ReplicationRuleFilter, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ReplicationRuleFilter::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ReplicationRuleFilter, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "And" => {
+                    obj.and = Some(ReplicationRuleAndOperatorDeserializer::deserialize(
+                        "And", stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "And" => {
-                        obj.and = Some(ReplicationRuleAndOperatorDeserializer::deserialize(
-                            "And", stack,
-                        )?);
-                    }
-                    "Prefix" => {
-                        obj.prefix = Some(PrefixDeserializer::deserialize("Prefix", stack)?);
-                    }
-                    "Tag" => {
-                        obj.tag = Some(TagDeserializer::deserialize("Tag", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Prefix" => {
+                    obj.prefix = Some(PrefixDeserializer::deserialize("Prefix", stack)?);
                 }
+                "Tag" => {
+                    obj.tag = Some(TagDeserializer::deserialize("Tag", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -14202,7 +12056,9 @@ impl ReplicationRulesDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -14591,40 +12447,18 @@ impl RoutingRuleDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<RoutingRule, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = RoutingRule::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, RoutingRule, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Condition" => {
+                    obj.condition = Some(ConditionDeserializer::deserialize("Condition", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Condition" => {
-                        obj.condition =
-                            Some(ConditionDeserializer::deserialize("Condition", stack)?);
-                    }
-                    "Redirect" => {
-                        obj.redirect = RedirectDeserializer::deserialize("Redirect", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Redirect" => {
+                    obj.redirect = RedirectDeserializer::deserialize("Redirect", stack)?;
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -14655,37 +12489,14 @@ impl RoutingRulesDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<RoutingRule>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "RoutingRule" {
-                        obj.push(RoutingRuleDeserializer::deserialize("RoutingRule", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "RoutingRule" {
+                obj.push(RoutingRuleDeserializer::deserialize("RoutingRule", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -14731,73 +12542,52 @@ impl RuleDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Rule, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Rule::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AbortIncompleteMultipartUpload" => {
-                        obj.abort_incomplete_multipart_upload =
-                            Some(AbortIncompleteMultipartUploadDeserializer::deserialize(
-                                "AbortIncompleteMultipartUpload",
-                                stack,
-                            )?);
-                    }
-                    "Expiration" => {
-                        obj.expiration = Some(LifecycleExpirationDeserializer::deserialize(
-                            "Expiration",
+        deserialize_elements::<_, Rule, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AbortIncompleteMultipartUpload" => {
+                    obj.abort_incomplete_multipart_upload =
+                        Some(AbortIncompleteMultipartUploadDeserializer::deserialize(
+                            "AbortIncompleteMultipartUpload",
                             stack,
                         )?);
-                    }
-                    "ID" => {
-                        obj.id = Some(IDDeserializer::deserialize("ID", stack)?);
-                    }
-                    "NoncurrentVersionExpiration" => {
-                        obj.noncurrent_version_expiration =
-                            Some(NoncurrentVersionExpirationDeserializer::deserialize(
-                                "NoncurrentVersionExpiration",
-                                stack,
-                            )?);
-                    }
-                    "NoncurrentVersionTransition" => {
-                        obj.noncurrent_version_transition =
-                            Some(NoncurrentVersionTransitionDeserializer::deserialize(
-                                "NoncurrentVersionTransition",
-                                stack,
-                            )?);
-                    }
-                    "Prefix" => {
-                        obj.prefix = PrefixDeserializer::deserialize("Prefix", stack)?;
-                    }
-                    "Status" => {
-                        obj.status = ExpirationStatusDeserializer::deserialize("Status", stack)?;
-                    }
-                    "Transition" => {
-                        obj.transition =
-                            Some(TransitionDeserializer::deserialize("Transition", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
+                "Expiration" => {
+                    obj.expiration = Some(LifecycleExpirationDeserializer::deserialize(
+                        "Expiration",
+                        stack,
+                    )?);
+                }
+                "ID" => {
+                    obj.id = Some(IDDeserializer::deserialize("ID", stack)?);
+                }
+                "NoncurrentVersionExpiration" => {
+                    obj.noncurrent_version_expiration =
+                        Some(NoncurrentVersionExpirationDeserializer::deserialize(
+                            "NoncurrentVersionExpiration",
+                            stack,
+                        )?);
+                }
+                "NoncurrentVersionTransition" => {
+                    obj.noncurrent_version_transition =
+                        Some(NoncurrentVersionTransitionDeserializer::deserialize(
+                            "NoncurrentVersionTransition",
+                            stack,
+                        )?);
+                }
+                "Prefix" => {
+                    obj.prefix = PrefixDeserializer::deserialize("Prefix", stack)?;
+                }
+                "Status" => {
+                    obj.status = ExpirationStatusDeserializer::deserialize("Status", stack)?;
+                }
+                "Transition" => {
+                    obj.transition =
+                        Some(TransitionDeserializer::deserialize("Transition", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -14875,7 +12665,9 @@ impl RulesDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -14921,48 +12713,17 @@ impl S3KeyFilterDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<S3KeyFilter, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = S3KeyFilter::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, S3KeyFilter, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "FilterRule" => {
+                    obj.filter_rules.get_or_insert(vec![]).extend(
+                        FilterRuleListDeserializer::deserialize("FilterRule", stack)?,
+                    );
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "FilterRule" => {
-                        obj.filter_rules = match obj.filter_rules {
-                            Some(ref mut existing) => {
-                                existing.extend(FilterRuleListDeserializer::deserialize(
-                                    "FilterRule",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(FilterRuleListDeserializer::deserialize(
-                                "FilterRule",
-                                stack,
-                            )?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -15075,36 +12836,15 @@ impl SSEKMSDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<SSEKMS, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = SSEKMS::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, SSEKMS, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "KeyId" => {
+                    obj.key_id = SSEKMSKeyIdDeserializer::deserialize("KeyId", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "KeyId" => {
-                        obj.key_id = SSEKMSKeyIdDeserializer::deserialize("KeyId", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -15223,21 +12963,11 @@ impl SelectObjectContentEventStreamDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<SelectObjectContentEventStream, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = SelectObjectContentEventStream::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, SelectObjectContentEventStream, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Cont" => {
                         obj.cont = Some(ContinuationEventDeserializer::deserialize("Cont", stack)?);
                     }
@@ -15256,17 +12986,10 @@ impl SelectObjectContentEventStreamDeserializer {
                         obj.stats = Some(StatsEventDeserializer::deserialize("Stats", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -15447,21 +13170,11 @@ impl ServerSideEncryptionByDefaultDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ServerSideEncryptionByDefault, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ServerSideEncryptionByDefault::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ServerSideEncryptionByDefault, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "KMSMasterKeyID" => {
                         obj.kms_master_key_id = Some(SSEKMSKeyIdDeserializer::deserialize(
                             "KMSMasterKeyID",
@@ -15473,17 +13186,10 @@ impl ServerSideEncryptionByDefaultDeserializer {
                             ServerSideEncryptionDeserializer::deserialize("SSEAlgorithm", stack)?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -15531,21 +13237,11 @@ impl ServerSideEncryptionConfigurationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ServerSideEncryptionConfiguration, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ServerSideEncryptionConfiguration::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ServerSideEncryptionConfiguration, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Rule" => {
                         obj.rules
                             .extend(ServerSideEncryptionRulesDeserializer::deserialize(
@@ -15553,17 +13249,10 @@ impl ServerSideEncryptionConfigurationDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -15598,21 +13287,11 @@ impl ServerSideEncryptionRuleDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ServerSideEncryptionRule, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ServerSideEncryptionRule::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ServerSideEncryptionRule, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "ApplyServerSideEncryptionByDefault" => {
                         obj.apply_server_side_encryption_by_default =
                             Some(ServerSideEncryptionByDefaultDeserializer::deserialize(
@@ -15621,17 +13300,10 @@ impl ServerSideEncryptionRuleDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -15669,7 +13341,9 @@ impl ServerSideEncryptionRulesDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -15767,21 +13441,11 @@ impl SourceSelectionCriteriaDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<SourceSelectionCriteria, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = SourceSelectionCriteria::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, SourceSelectionCriteria, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "SseKmsEncryptedObjects" => {
                         obj.sse_kms_encrypted_objects =
                             Some(SseKmsEncryptedObjectsDeserializer::deserialize(
@@ -15790,17 +13454,10 @@ impl SourceSelectionCriteriaDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -15841,37 +13498,16 @@ impl SseKmsEncryptedObjectsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<SseKmsEncryptedObjects, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = SseKmsEncryptedObjects::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, SseKmsEncryptedObjects, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Status" => {
+                    obj.status =
+                        SseKmsEncryptedObjectsStatusDeserializer::deserialize("Status", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Status" => {
-                        obj.status =
-                            SseKmsEncryptedObjectsStatusDeserializer::deserialize("Status", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -15984,51 +13620,30 @@ impl StatsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Stats, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Stats::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Stats, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "BytesProcessed" => {
+                    obj.bytes_processed = Some(BytesProcessedDeserializer::deserialize(
+                        "BytesProcessed",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "BytesProcessed" => {
-                        obj.bytes_processed = Some(BytesProcessedDeserializer::deserialize(
-                            "BytesProcessed",
-                            stack,
-                        )?);
-                    }
-                    "BytesReturned" => {
-                        obj.bytes_returned = Some(BytesReturnedDeserializer::deserialize(
-                            "BytesReturned",
-                            stack,
-                        )?);
-                    }
-                    "BytesScanned" => {
-                        obj.bytes_scanned = Some(BytesScannedDeserializer::deserialize(
-                            "BytesScanned",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "BytesReturned" => {
+                    obj.bytes_returned = Some(BytesReturnedDeserializer::deserialize(
+                        "BytesReturned",
+                        stack,
+                    )?);
                 }
+                "BytesScanned" => {
+                    obj.bytes_scanned = Some(BytesScannedDeserializer::deserialize(
+                        "BytesScanned",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -16044,36 +13659,15 @@ impl StatsEventDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<StatsEvent, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = StatsEvent::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, StatsEvent, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Details" => {
+                    obj.details = Some(StatsDeserializer::deserialize("Details", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Details" => {
-                        obj.details = Some(StatsDeserializer::deserialize("Details", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct StorageClassDeserializer;
@@ -16124,40 +13718,19 @@ impl StorageClassAnalysisDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<StorageClassAnalysis, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = StorageClassAnalysis::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, StorageClassAnalysis, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "DataExport" => {
+                    obj.data_export =
+                        Some(StorageClassAnalysisDataExportDeserializer::deserialize(
+                            "DataExport",
+                            stack,
+                        )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "DataExport" => {
-                        obj.data_export =
-                            Some(StorageClassAnalysisDataExportDeserializer::deserialize(
-                                "DataExport",
-                                stack,
-                            )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -16195,21 +13768,11 @@ impl StorageClassAnalysisDataExportDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<StorageClassAnalysisDataExport, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = StorageClassAnalysisDataExport::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, StorageClassAnalysisDataExport, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Destination" => {
                         obj.destination = AnalyticsExportDestinationDeserializer::deserialize(
                             "Destination",
@@ -16224,17 +13787,10 @@ impl StorageClassAnalysisDataExportDeserializer {
                             )?;
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -16350,39 +13906,18 @@ impl TagDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Tag, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Tag::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Tag, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Key" => {
+                    obj.key = ObjectKeyDeserializer::deserialize("Key", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Key" => {
-                        obj.key = ObjectKeyDeserializer::deserialize("Key", stack)?;
-                    }
-                    "Value" => {
-                        obj.value = ValueDeserializer::deserialize("Value", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Value" => {
+                    obj.value = ValueDeserializer::deserialize("Value", stack)?;
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -16421,37 +13956,14 @@ impl TagSetDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Tag>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "Tag" {
-                        obj.push(TagDeserializer::deserialize("Tag", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "Tag" {
+                obj.push(TagDeserializer::deserialize("Tag", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -16546,42 +14058,21 @@ impl TargetGrantDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<TargetGrant, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = TargetGrant::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, TargetGrant, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Grantee" => {
+                    obj.grantee = Some(GranteeDeserializer::deserialize("Grantee", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Grantee" => {
-                        obj.grantee = Some(GranteeDeserializer::deserialize("Grantee", stack)?);
-                    }
-                    "Permission" => {
-                        obj.permission = Some(BucketLogsPermissionDeserializer::deserialize(
-                            "Permission",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Permission" => {
+                    obj.permission = Some(BucketLogsPermissionDeserializer::deserialize(
+                        "Permission",
+                        stack,
+                    )?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -16619,37 +14110,14 @@ impl TargetGrantsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<TargetGrant>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "Grant" {
-                        obj.push(TargetGrantDeserializer::deserialize("Grant", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "Grant" {
+                obj.push(TargetGrantDeserializer::deserialize("Grant", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -16815,49 +14283,27 @@ impl TopicConfigurationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<TopicConfiguration, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = TopicConfiguration::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, TopicConfiguration, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Event" => {
+                    obj.events
+                        .extend(EventListDeserializer::deserialize("Event", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Event" => {
-                        obj.events
-                            .extend(EventListDeserializer::deserialize("Event", stack)?);
-                    }
-                    "Filter" => {
-                        obj.filter =
-                            Some(NotificationConfigurationFilterDeserializer::deserialize(
-                                "Filter", stack,
-                            )?);
-                    }
-                    "Id" => {
-                        obj.id = Some(NotificationIdDeserializer::deserialize("Id", stack)?);
-                    }
-                    "Topic" => {
-                        obj.topic_arn = TopicArnDeserializer::deserialize("Topic", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Filter" => {
+                    obj.filter = Some(NotificationConfigurationFilterDeserializer::deserialize(
+                        "Filter", stack,
+                    )?);
                 }
+                "Id" => {
+                    obj.id = Some(NotificationIdDeserializer::deserialize("Id", stack)?);
+                }
+                "Topic" => {
+                    obj.topic_arn = TopicArnDeserializer::deserialize("Topic", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -16910,30 +14356,15 @@ impl TopicConfigurationDeprecatedDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<TopicConfigurationDeprecated, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = TopicConfigurationDeprecated::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, TopicConfigurationDeprecated, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Event" => {
-                        obj.events = match obj.events {
-                            Some(ref mut existing) => {
-                                existing
-                                    .extend(EventListDeserializer::deserialize("Event", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(EventListDeserializer::deserialize("Event", stack)?),
-                        };
+                        obj.events
+                            .get_or_insert(vec![])
+                            .extend(EventListDeserializer::deserialize("Event", stack)?);
                     }
                     "Id" => {
                         obj.id = Some(NotificationIdDeserializer::deserialize("Id", stack)?);
@@ -16942,17 +14373,10 @@ impl TopicConfigurationDeprecatedDeserializer {
                         obj.topic = Some(TopicArnDeserializer::deserialize("Topic", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -17002,7 +14426,9 @@ impl TopicConfigurationListDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 
@@ -17054,45 +14480,24 @@ impl TransitionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Transition, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Transition::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Transition, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Date" => {
+                    obj.date = Some(DateDeserializer::deserialize("Date", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Date" => {
-                        obj.date = Some(DateDeserializer::deserialize("Date", stack)?);
-                    }
-                    "Days" => {
-                        obj.days = Some(DaysDeserializer::deserialize("Days", stack)?);
-                    }
-                    "StorageClass" => {
-                        obj.storage_class = Some(TransitionStorageClassDeserializer::deserialize(
-                            "StorageClass",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Days" => {
+                    obj.days = Some(DaysDeserializer::deserialize("Days", stack)?);
                 }
+                "StorageClass" => {
+                    obj.storage_class = Some(TransitionStorageClassDeserializer::deserialize(
+                        "StorageClass",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -17147,7 +14552,9 @@ impl TransitionListDeserializer {
 
         loop {
             let consume_next_tag = match stack.peek() {
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => name.local_name == tag_name,
+                Some(&Ok(xml::reader::XmlEvent::StartElement { ref name, .. })) => {
+                    name.local_name == tag_name
+                }
                 _ => false,
             };
 

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -25,20 +25,15 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
 use rusoto_core::xmlutil::{
-    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+    characters, deserialize_elements, end_element, find_start_element, peek_at_name, skip_tree,
+    start_element,
 };
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;
-use xml::reader::XmlEvent;
 use xml::EventReader;
 
-enum DeserializerNext {
-    Close,
-    Skip,
-    Element(String),
-}
 struct AccountDeserializer;
 impl AccountDeserializer {
     #[allow(unused_variables)]
@@ -177,37 +172,20 @@ impl CheckIfPhoneNumberIsOptedOutResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CheckIfPhoneNumberIsOptedOutResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CheckIfPhoneNumberIsOptedOutResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CheckIfPhoneNumberIsOptedOutResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "isOptedOut" => {
                         obj.is_opted_out =
                             Some(BooleanDeserializer::deserialize("isOptedOut", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Input for ConfirmSubscription action.</p>
@@ -255,21 +233,11 @@ impl ConfirmSubscriptionResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ConfirmSubscriptionResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ConfirmSubscriptionResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ConfirmSubscriptionResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "SubscriptionArn" => {
                         obj.subscription_arn = Some(SubscriptionARNDeserializer::deserialize(
                             "SubscriptionArn",
@@ -277,17 +245,10 @@ impl ConfirmSubscriptionResponseDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Response from CreateEndpoint action.</p>
@@ -304,37 +265,15 @@ impl CreateEndpointResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateEndpointResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateEndpointResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CreateEndpointResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "EndpointArn" => {
+                    obj.endpoint_arn = Some(StringDeserializer::deserialize("EndpointArn", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "EndpointArn" => {
-                        obj.endpoint_arn =
-                            Some(StringDeserializer::deserialize("EndpointArn", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Input for CreatePlatformApplication action.</p>
@@ -381,21 +320,11 @@ impl CreatePlatformApplicationResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreatePlatformApplicationResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreatePlatformApplicationResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, CreatePlatformApplicationResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "PlatformApplicationArn" => {
                         obj.platform_application_arn = Some(StringDeserializer::deserialize(
                             "PlatformApplicationArn",
@@ -403,17 +332,10 @@ impl CreatePlatformApplicationResponseDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Input for CreatePlatformEndpoint action.</p>
@@ -499,36 +421,15 @@ impl CreateTopicResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<CreateTopicResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = CreateTopicResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, CreateTopicResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "TopicArn" => {
+                    obj.topic_arn = Some(TopicARNDeserializer::deserialize("TopicArn", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "TopicArn" => {
-                        obj.topic_arn = Some(TopicARNDeserializer::deserialize("TopicArn", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 
@@ -653,21 +554,11 @@ impl GetEndpointAttributesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetEndpointAttributesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetEndpointAttributesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetEndpointAttributesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Attributes" => {
                         obj.attributes = Some(MapStringToStringDeserializer::deserialize(
                             "Attributes",
@@ -675,17 +566,10 @@ impl GetEndpointAttributesResponseDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Input for GetPlatformApplicationAttributes action.</p>
@@ -725,21 +609,11 @@ impl GetPlatformApplicationAttributesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetPlatformApplicationAttributesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetPlatformApplicationAttributesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetPlatformApplicationAttributesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Attributes" => {
                         obj.attributes = Some(MapStringToStringDeserializer::deserialize(
                             "Attributes",
@@ -747,17 +621,10 @@ impl GetPlatformApplicationAttributesResponseDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>The input for the <code>GetSMSAttributes</code> request.</p>
@@ -800,21 +667,11 @@ impl GetSMSAttributesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetSMSAttributesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetSMSAttributesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetSMSAttributesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "attributes" => {
                         obj.attributes = Some(MapStringToStringDeserializer::deserialize(
                             "attributes",
@@ -822,17 +679,10 @@ impl GetSMSAttributesResponseDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Input for GetSubscriptionAttributes.</p>
@@ -872,21 +722,11 @@ impl GetSubscriptionAttributesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetSubscriptionAttributesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetSubscriptionAttributesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetSubscriptionAttributesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Attributes" => {
                         obj.attributes = Some(SubscriptionAttributesMapDeserializer::deserialize(
                             "Attributes",
@@ -894,17 +734,10 @@ impl GetSubscriptionAttributesResponseDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Input for GetTopicAttributes action.</p>
@@ -941,21 +774,11 @@ impl GetTopicAttributesResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetTopicAttributesResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetTopicAttributesResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetTopicAttributesResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Attributes" => {
                         obj.attributes = Some(TopicAttributesMapDeserializer::deserialize(
                             "Attributes",
@@ -963,17 +786,10 @@ impl GetTopicAttributesResponseDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Input for ListEndpointsByPlatformApplication action.</p>
@@ -1020,51 +836,24 @@ impl ListEndpointsByPlatformApplicationResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListEndpointsByPlatformApplicationResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListEndpointsByPlatformApplicationResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListEndpointsByPlatformApplicationResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Endpoints" => {
-                        obj.endpoints = match obj.endpoints {
-                            Some(ref mut existing) => {
-                                existing.extend(ListOfEndpointsDeserializer::deserialize(
-                                    "Endpoints",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ListOfEndpointsDeserializer::deserialize(
-                                "Endpoints",
-                                stack,
-                            )?),
-                        };
+                        obj.endpoints.get_or_insert(vec![]).extend(
+                            ListOfEndpointsDeserializer::deserialize("Endpoints", stack)?,
+                        );
                     }
                     "NextToken" => {
                         obj.next_token = Some(StringDeserializer::deserialize("NextToken", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct ListOfEndpointsDeserializer;
@@ -1074,37 +863,14 @@ impl ListOfEndpointsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(EndpointDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(EndpointDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ListOfPlatformApplicationsDeserializer;
@@ -1114,39 +880,16 @@ impl ListOfPlatformApplicationsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<PlatformApplication>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(PlatformApplicationDeserializer::deserialize(
-                            "member", stack,
-                        )?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(PlatformApplicationDeserializer::deserialize(
+                    "member", stack,
+                )?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>The input for the <code>ListPhoneNumbersOptedOut</code> action.</p>
@@ -1187,51 +930,24 @@ impl ListPhoneNumbersOptedOutResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListPhoneNumbersOptedOutResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListPhoneNumbersOptedOutResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListPhoneNumbersOptedOutResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "nextToken" => {
                         obj.next_token = Some(StringDeserializer::deserialize("nextToken", stack)?);
                     }
                     "phoneNumbers" => {
-                        obj.phone_numbers = match obj.phone_numbers {
-                            Some(ref mut existing) => {
-                                existing.extend(PhoneNumberListDeserializer::deserialize(
-                                    "phoneNumbers",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(PhoneNumberListDeserializer::deserialize(
-                                "phoneNumbers",
-                                stack,
-                            )?),
-                        };
+                        obj.phone_numbers.get_or_insert(vec![]).extend(
+                            PhoneNumberListDeserializer::deserialize("phoneNumbers", stack)?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Input for ListPlatformApplications action.</p>
@@ -1272,53 +988,27 @@ impl ListPlatformApplicationsResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListPlatformApplicationsResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListPlatformApplicationsResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListPlatformApplicationsResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "NextToken" => {
                         obj.next_token = Some(StringDeserializer::deserialize("NextToken", stack)?);
                     }
                     "PlatformApplications" => {
-                        obj.platform_applications = match obj.platform_applications {
-                            Some(ref mut existing) => {
-                                existing.extend(
-                                    ListOfPlatformApplicationsDeserializer::deserialize(
-                                        "PlatformApplications",
-                                        stack,
-                                    )?,
-                                );
-                                Some(existing.to_vec())
-                            }
-                            None => Some(ListOfPlatformApplicationsDeserializer::deserialize(
+                        obj.platform_applications.get_or_insert(vec![]).extend(
+                            ListOfPlatformApplicationsDeserializer::deserialize(
                                 "PlatformApplications",
                                 stack,
-                            )?),
-                        };
+                            )?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 
@@ -1374,52 +1064,25 @@ impl ListSubscriptionsByTopicResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListSubscriptionsByTopicResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListSubscriptionsByTopicResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListSubscriptionsByTopicResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "NextToken" => {
                         obj.next_token =
                             Some(NextTokenDeserializer::deserialize("NextToken", stack)?);
                     }
                     "Subscriptions" => {
-                        obj.subscriptions = match obj.subscriptions {
-                            Some(ref mut existing) => {
-                                existing.extend(SubscriptionsListDeserializer::deserialize(
-                                    "Subscriptions",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(SubscriptionsListDeserializer::deserialize(
-                                "Subscriptions",
-                                stack,
-                            )?),
-                        };
+                        obj.subscriptions.get_or_insert(vec![]).extend(
+                            SubscriptionsListDeserializer::deserialize("Subscriptions", stack)?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 /// <p>Input for ListSubscriptions action.</p>
@@ -1460,52 +1123,25 @@ impl ListSubscriptionsResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListSubscriptionsResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListSubscriptionsResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, ListSubscriptionsResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "NextToken" => {
                         obj.next_token =
                             Some(NextTokenDeserializer::deserialize("NextToken", stack)?);
                     }
                     "Subscriptions" => {
-                        obj.subscriptions = match obj.subscriptions {
-                            Some(ref mut existing) => {
-                                existing.extend(SubscriptionsListDeserializer::deserialize(
-                                    "Subscriptions",
-                                    stack,
-                                )?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(SubscriptionsListDeserializer::deserialize(
-                                "Subscriptions",
-                                stack,
-                            )?),
-                        };
+                        obj.subscriptions.get_or_insert(vec![]).extend(
+                            SubscriptionsListDeserializer::deserialize("Subscriptions", stack)?,
+                        );
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -1545,47 +1181,20 @@ impl ListTopicsResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<ListTopicsResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = ListTopicsResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, ListTopicsResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "NextToken" => {
+                    obj.next_token = Some(NextTokenDeserializer::deserialize("NextToken", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "NextToken" => {
-                        obj.next_token =
-                            Some(NextTokenDeserializer::deserialize("NextToken", stack)?);
-                    }
-                    "Topics" => {
-                        obj.topics = match obj.topics {
-                            Some(ref mut existing) => {
-                                existing
-                                    .extend(TopicsListDeserializer::deserialize("Topics", stack)?);
-                                Some(existing.to_vec())
-                            }
-                            None => Some(TopicsListDeserializer::deserialize("Topics", stack)?),
-                        };
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Topics" => {
+                    obj.topics
+                        .get_or_insert(vec![])
+                        .extend(TopicsListDeserializer::deserialize("Topics", stack)?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct MapStringToStringDeserializer;
@@ -1770,37 +1379,14 @@ impl PhoneNumberListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<String>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(PhoneNumberDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(PhoneNumberDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Platform application object.</p>
@@ -1819,45 +1405,24 @@ impl PlatformApplicationDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<PlatformApplication, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = PlatformApplication::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, PlatformApplication, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Attributes" => {
+                    obj.attributes = Some(MapStringToStringDeserializer::deserialize(
+                        "Attributes",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Attributes" => {
-                        obj.attributes = Some(MapStringToStringDeserializer::deserialize(
-                            "Attributes",
-                            stack,
-                        )?);
-                    }
-                    "PlatformApplicationArn" => {
-                        obj.platform_application_arn = Some(StringDeserializer::deserialize(
-                            "PlatformApplicationArn",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "PlatformApplicationArn" => {
+                    obj.platform_application_arn = Some(StringDeserializer::deserialize(
+                        "PlatformApplicationArn",
+                        stack,
+                    )?);
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct ProtocolDeserializer;
@@ -1942,37 +1507,15 @@ impl PublishResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<PublishResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = PublishResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, PublishResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "MessageId" => {
+                    obj.message_id = Some(MessageIdDeserializer::deserialize("MessageId", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "MessageId" => {
-                        obj.message_id =
-                            Some(MessageIdDeserializer::deserialize("MessageId", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Input for RemovePermission action.</p>
@@ -2237,39 +1780,18 @@ impl SubscribeResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<SubscribeResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = SubscribeResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, SubscribeResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "SubscriptionArn" => {
+                    obj.subscription_arn = Some(SubscriptionARNDeserializer::deserialize(
+                        "SubscriptionArn",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "SubscriptionArn" => {
-                        obj.subscription_arn = Some(SubscriptionARNDeserializer::deserialize(
-                            "SubscriptionArn",
-                            stack,
-                        )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>A wrapper type for the attributes of an Amazon SNS subscription.</p>
@@ -2294,51 +1816,30 @@ impl SubscriptionDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Subscription, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Subscription::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Subscription, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Endpoint" => {
+                    obj.endpoint = Some(EndpointDeserializer::deserialize("Endpoint", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Endpoint" => {
-                        obj.endpoint = Some(EndpointDeserializer::deserialize("Endpoint", stack)?);
-                    }
-                    "Owner" => {
-                        obj.owner = Some(AccountDeserializer::deserialize("Owner", stack)?);
-                    }
-                    "Protocol" => {
-                        obj.protocol = Some(ProtocolDeserializer::deserialize("Protocol", stack)?);
-                    }
-                    "SubscriptionArn" => {
-                        obj.subscription_arn = Some(SubscriptionARNDeserializer::deserialize(
-                            "SubscriptionArn",
-                            stack,
-                        )?);
-                    }
-                    "TopicArn" => {
-                        obj.topic_arn = Some(TopicARNDeserializer::deserialize("TopicArn", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Owner" => {
+                    obj.owner = Some(AccountDeserializer::deserialize("Owner", stack)?);
                 }
+                "Protocol" => {
+                    obj.protocol = Some(ProtocolDeserializer::deserialize("Protocol", stack)?);
+                }
+                "SubscriptionArn" => {
+                    obj.subscription_arn = Some(SubscriptionARNDeserializer::deserialize(
+                        "SubscriptionArn",
+                        stack,
+                    )?);
+                }
+                "TopicArn" => {
+                    obj.topic_arn = Some(TopicARNDeserializer::deserialize("TopicArn", stack)?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct SubscriptionARNDeserializer;
@@ -2402,37 +1903,14 @@ impl SubscriptionsListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Subscription>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(SubscriptionDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(SubscriptionDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>A wrapper type for the topic's Amazon Resource Name (ARN). To retrieve a topic's attributes, use <code>GetTopicAttributes</code>.</p>
@@ -2449,36 +1927,15 @@ impl TopicDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Topic, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Topic::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Topic, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "TopicArn" => {
+                    obj.topic_arn = Some(TopicARNDeserializer::deserialize("TopicArn", stack)?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "TopicArn" => {
-                        obj.topic_arn = Some(TopicARNDeserializer::deserialize("TopicArn", stack)?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct TopicARNDeserializer;
@@ -2542,37 +1999,14 @@ impl TopicsListDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Vec<Topic>, XmlParseError> {
-        let mut obj = vec![];
-        start_element(tag_name, stack)?;
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => {
-                    if name == "member" {
-                        obj.push(TopicDeserializer::deserialize("member", stack)?);
-                    } else {
-                        skip_tree(stack);
-                    }
-                }
-                DeserializerNext::Close => {
-                    end_element(tag_name, stack)?;
-                    break;
-                }
-                DeserializerNext::Skip => {
-                    stack.next();
-                }
+        deserialize_elements::<_, Vec<_>, _>(tag_name, stack, |name, stack, obj| {
+            if name == "member" {
+                obj.push(TopicDeserializer::deserialize("member", stack)?);
+            } else {
+                skip_tree(stack);
             }
-        }
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 /// <p>Input for Unsubscribe action.</p>

--- a/rusoto/services/sts/src/generated.rs
+++ b/rusoto/services/sts/src/generated.rs
@@ -25,20 +25,15 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::signature::SignedRequest;
 use rusoto_core::xmlerror::*;
 use rusoto_core::xmlutil::{
-    characters, end_element, find_start_element, peek_at_name, skip_tree, start_element,
+    characters, deserialize_elements, end_element, find_start_element, peek_at_name, skip_tree,
+    start_element,
 };
 use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
 use serde_urlencoded;
 use std::str::FromStr;
 use xml::reader::ParserConfig;
-use xml::reader::XmlEvent;
 use xml::EventReader;
 
-enum DeserializerNext {
-    Close,
-    Skip,
-    Element(String),
-}
 struct AccessKeyIdTypeDeserializer;
 impl AccessKeyIdTypeDeserializer {
     #[allow(unused_variables)]
@@ -166,50 +161,28 @@ impl AssumeRoleResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AssumeRoleResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AssumeRoleResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, AssumeRoleResponse, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AssumedRoleUser" => {
+                    obj.assumed_role_user = Some(AssumedRoleUserDeserializer::deserialize(
+                        "AssumedRoleUser",
+                        stack,
+                    )?);
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AssumedRoleUser" => {
-                        obj.assumed_role_user = Some(AssumedRoleUserDeserializer::deserialize(
-                            "AssumedRoleUser",
-                            stack,
-                        )?);
-                    }
-                    "Credentials" => {
-                        obj.credentials =
-                            Some(CredentialsDeserializer::deserialize("Credentials", stack)?);
-                    }
-                    "PackedPolicySize" => {
-                        obj.packed_policy_size =
-                            Some(NonNegativeIntegerTypeDeserializer::deserialize(
-                                "PackedPolicySize",
-                                stack,
-                            )?);
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Credentials" => {
+                    obj.credentials =
+                        Some(CredentialsDeserializer::deserialize("Credentials", stack)?);
                 }
+                "PackedPolicySize" => {
+                    obj.packed_policy_size = Some(NonNegativeIntegerTypeDeserializer::deserialize(
+                        "PackedPolicySize",
+                        stack,
+                    )?);
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -281,21 +254,11 @@ impl AssumeRoleWithSAMLResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AssumeRoleWithSAMLResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AssumeRoleWithSAMLResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, AssumeRoleWithSAMLResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AssumedRoleUser" => {
                         obj.assumed_role_user = Some(AssumedRoleUserDeserializer::deserialize(
                             "AssumedRoleUser",
@@ -333,17 +296,10 @@ impl AssumeRoleWithSAMLResponseDeserializer {
                             Some(SubjectTypeDeserializer::deserialize("SubjectType", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -419,21 +375,11 @@ impl AssumeRoleWithWebIdentityResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AssumeRoleWithWebIdentityResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AssumeRoleWithWebIdentityResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, AssumeRoleWithWebIdentityResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "AssumedRoleUser" => {
                         obj.assumed_role_user = Some(AssumedRoleUserDeserializer::deserialize(
                             "AssumedRoleUser",
@@ -465,17 +411,10 @@ impl AssumeRoleWithWebIdentityResponseDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct AssumedRoleIdTypeDeserializer;
@@ -508,40 +447,19 @@ impl AssumedRoleUserDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<AssumedRoleUser, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = AssumedRoleUser::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, AssumedRoleUser, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Arn" => {
+                    obj.arn = ArnTypeDeserializer::deserialize("Arn", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Arn" => {
-                        obj.arn = ArnTypeDeserializer::deserialize("Arn", stack)?;
-                    }
-                    "AssumedRoleId" => {
-                        obj.assumed_role_id =
-                            AssumedRoleIdTypeDeserializer::deserialize("AssumedRoleId", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "AssumedRoleId" => {
+                    obj.assumed_role_id =
+                        AssumedRoleIdTypeDeserializer::deserialize("AssumedRoleId", stack)?;
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct AudienceDeserializer;
@@ -578,48 +496,26 @@ impl CredentialsDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<Credentials, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = Credentials::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, Credentials, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "AccessKeyId" => {
+                    obj.access_key_id =
+                        AccessKeyIdTypeDeserializer::deserialize("AccessKeyId", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "AccessKeyId" => {
-                        obj.access_key_id =
-                            AccessKeyIdTypeDeserializer::deserialize("AccessKeyId", stack)?;
-                    }
-                    "Expiration" => {
-                        obj.expiration = DateTypeDeserializer::deserialize("Expiration", stack)?;
-                    }
-                    "SecretAccessKey" => {
-                        obj.secret_access_key =
-                            AccessKeySecretTypeDeserializer::deserialize("SecretAccessKey", stack)?;
-                    }
-                    "SessionToken" => {
-                        obj.session_token =
-                            TokenTypeDeserializer::deserialize("SessionToken", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "Expiration" => {
+                    obj.expiration = DateTypeDeserializer::deserialize("Expiration", stack)?;
                 }
+                "SecretAccessKey" => {
+                    obj.secret_access_key =
+                        AccessKeySecretTypeDeserializer::deserialize("SecretAccessKey", stack)?;
+                }
+                "SessionToken" => {
+                    obj.session_token = TokenTypeDeserializer::deserialize("SessionToken", stack)?;
+                }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 struct DateTypeDeserializer;
@@ -672,21 +568,11 @@ impl DecodeAuthorizationMessageResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<DecodeAuthorizationMessageResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = DecodeAuthorizationMessageResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, DecodeAuthorizationMessageResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "DecodedMessage" => {
                         obj.decoded_message = Some(DecodedMessageTypeDeserializer::deserialize(
                             "DecodedMessage",
@@ -694,17 +580,10 @@ impl DecodeAuthorizationMessageResponseDeserializer {
                         )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct DecodedMessageTypeDeserializer;
@@ -751,40 +630,19 @@ impl FederatedUserDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<FederatedUser, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = FederatedUser::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
+        deserialize_elements::<_, FederatedUser, _>(tag_name, stack, |name, stack, obj| {
+            match name {
+                "Arn" => {
+                    obj.arn = ArnTypeDeserializer::deserialize("Arn", stack)?;
                 }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
-                    "Arn" => {
-                        obj.arn = ArnTypeDeserializer::deserialize("Arn", stack)?;
-                    }
-                    "FederatedUserId" => {
-                        obj.federated_user_id =
-                            FederatedIdTypeDeserializer::deserialize("FederatedUserId", stack)?;
-                    }
-                    _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
+                "FederatedUserId" => {
+                    obj.federated_user_id =
+                        FederatedIdTypeDeserializer::deserialize("FederatedUserId", stack)?;
                 }
+                _ => skip_tree(stack),
             }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+            Ok(())
+        })
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -819,21 +677,11 @@ impl GetCallerIdentityResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetCallerIdentityResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetCallerIdentityResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetCallerIdentityResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Account" => {
                         obj.account = Some(AccountTypeDeserializer::deserialize("Account", stack)?);
                     }
@@ -844,17 +692,10 @@ impl GetCallerIdentityResponseDeserializer {
                         obj.user_id = Some(UserIdTypeDeserializer::deserialize("UserId", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -907,21 +748,11 @@ impl GetFederationTokenResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetFederationTokenResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetFederationTokenResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetFederationTokenResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Credentials" => {
                         obj.credentials =
                             Some(CredentialsDeserializer::deserialize("Credentials", stack)?);
@@ -940,17 +771,10 @@ impl GetFederationTokenResponseDeserializer {
                             )?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -1001,37 +825,20 @@ impl GetSessionTokenResponseDeserializer {
         tag_name: &str,
         stack: &mut T,
     ) -> Result<GetSessionTokenResponse, XmlParseError> {
-        start_element(tag_name, stack)?;
-
-        let mut obj = GetSessionTokenResponse::default();
-
-        loop {
-            let next_event = match stack.peek() {
-                Some(&Ok(XmlEvent::EndElement { ref name, .. })) => DeserializerNext::Close,
-                Some(&Ok(XmlEvent::StartElement { ref name, .. })) => {
-                    DeserializerNext::Element(name.local_name.to_owned())
-                }
-                _ => DeserializerNext::Skip,
-            };
-
-            match next_event {
-                DeserializerNext::Element(name) => match &name[..] {
+        deserialize_elements::<_, GetSessionTokenResponse, _>(
+            tag_name,
+            stack,
+            |name, stack, obj| {
+                match name {
                     "Credentials" => {
                         obj.credentials =
                             Some(CredentialsDeserializer::deserialize("Credentials", stack)?);
                     }
                     _ => skip_tree(stack),
-                },
-                DeserializerNext::Close => break,
-                DeserializerNext::Skip => {
-                    stack.next();
                 }
-            }
-        }
-
-        end_element(tag_name, stack)?;
-
-        Ok(obj)
+                Ok(())
+            },
+        )
     }
 }
 struct IssuerDeserializer;

--- a/service_crategen/src/commands/generate/codegen/query.rs
+++ b/service_crategen/src/commands/generate/codegen/query.rs
@@ -76,17 +76,11 @@ impl GenerateProtocol for QueryGenerator {
             use xml::reader::ParserConfig;
             use rusoto_core::param::{{Params, ServiceParams}};
             use rusoto_core::signature::SignedRequest;
-            use xml::reader::XmlEvent;
             use rusoto_core::xmlutil::{{Next, Peek, XmlParseError, XmlResponse}};
-            use rusoto_core::xmlutil::{{characters, end_element, find_start_element, start_element, skip_tree, peek_at_name}};
+            use rusoto_core::xmlutil::{{characters, end_element, find_start_element, start_element, skip_tree, peek_at_name, deserialize_elements}};
             use rusoto_core::xmlerror::*;
             use serde_urlencoded;
-
-            enum DeserializerNext {{
-                Close,
-                Skip,
-                Element(String),
-        }}")
+            ")
     }
 
     fn generate_serializer(&self, name: &str, shape: &Shape, service: &Service) -> Option<String> {

--- a/service_crategen/src/commands/generate/codegen/rest_xml.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_xml.rs
@@ -91,15 +91,10 @@ impl GenerateProtocol for RestXmlGenerator {
             use xml;
             use xml::EventReader;
             use xml::EventWriter;
-            use xml::reader::XmlEvent;
             use rusoto_core::xmlerror::*;
             use rusoto_core::xmlutil::{Next, Peek, XmlParseError, XmlResponse};
-            use rusoto_core::xmlutil::{peek_at_name, characters, end_element, find_start_element, start_element, skip_tree};
-            enum DeserializerNext {
-                Close,
-                Skip,
-                Element(String),
-            }"
+            use rusoto_core::xmlutil::{peek_at_name, characters, end_element, find_start_element, start_element, skip_tree, deserialize_elements};
+            "
             .to_owned();
 
         writeln!(writer, "{}", imports)


### PR DESCRIPTION
(note: #1302 precedes this PR and should be merged first)

Continuing to pick the lower-hanging fruit for putting our crates on a diet, this time moving some of the XML parsing logic into `rusoto_core::xmlutil`. Longer term I'd like to see if we can find a higher-level XML parsing crate for this, which could abstract even more of the required logic.

This has an especially large effect on the EC2 crate, which goes from 98,186 to 80,541 lines of code. Overall I'm seeing a drop from 957,712 down to 899,414 lines of code, which is a reduction of ~6%.

```
old: cargo check --all  1069.94s user 70.27s system 326% cpu 5:48.70 total
new: cargo check --all  1032.94s user 66.71s system 344% cpu 5:18.76 total
```
