### PR TITLE
Improve error messages for Unknown(BufferedHttpResponse) variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Add `RusotoError` enum as base error type for all services
+- Improve error messages for BufferedHttpResponse in Unknown error variants.
 
 ## [0.37.0] - 2019-03-12
 

--- a/rusoto/core/src/error.rs
+++ b/rusoto/core/src/error.rs
@@ -72,7 +72,7 @@ impl<E: Error + 'static> Error for RusotoError<E> {
             RusotoError::Credentials(ref err) => err.description(),
             RusotoError::HttpDispatch(ref dispatch_error) => dispatch_error.description(),
             RusotoError::ParseError(ref cause) => cause,
-            RusotoError::Unknown(_) => "unknown error",
+            RusotoError::Unknown(ref cause) => cause.body_as_str(),
         }
     }
 

--- a/rusoto/core/src/request.rs
+++ b/rusoto/core/src/request.rs
@@ -102,7 +102,7 @@ pub struct HttpResponse {
 }
 
 /// Stores the buffered response from a HTTP request.
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
 pub struct BufferedHttpResponse {
     /// Status code of HTTP Request
     pub status: StatusCode,
@@ -110,6 +110,34 @@ pub struct BufferedHttpResponse {
     pub body: Vec<u8>,
     /// Response headers
     pub headers: Headers,
+}
+
+impl BufferedHttpResponse {
+    ///! Best effort to turn response body into more readable &str.
+    pub fn body_as_str(&self) -> &str {
+        match std::str::from_utf8(&self.body) {
+            Ok(msg) => msg,
+            _ => "unknown error",
+        }
+    }
+}
+
+/// Best effort based Debug implementation to make generic error's body more readable.
+impl fmt::Debug for BufferedHttpResponse {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match std::str::from_utf8(&self.body) {
+            Ok(msg) => write!(
+                f,
+                "BufferedHttpResponse {{status: {:?}, body: {:?}, headers: {:?} }}",
+                self.status, msg, self.headers
+            ),
+            _ => write!(
+                f,
+                "BufferedHttpResponse {{ status: {:?}, body: {:?}, headers: {:?} }}",
+                self.status, self.body, self.headers
+            ),
+        }
+    }
 }
 
 /// Future returned from `HttpResponse::buffer`.


### PR DESCRIPTION
So far, user facing error messages as produced by Debug::fmt and Display::fmt implementations for Unknown(BufferedHttpResponse) API errors are rather hard to read for humans. They look like this:

```
Error: Unknown(BufferedHttpResponse { 
   status: 403, 
   body: [60, 69, 114, 114, 111, ..., 115, 101, 62, 10], 
   headers: Headers({"content-length": "377", "content-type": "text/xml", "x-amzn-requestid": "cb603b7d-469a-11e9-bd29-35318a6078a9", "date": "Thu, 14 Mar 2019 20:50:26 GMT"}) 
})
```

The `body` is just printed as sequence of byte values, which is not easy to interpret for humans. With this pull request it will be rendered like this instead if the body can be interpreted as UTF8 string:

```
Error: Unknown(BufferedHttpResponse {
   status: 403, 
   body: "<ErrorResponse xmlns=\"http://autoscaling.amazonaws.com/doc/2011-01-01/\">\n  <Error>\n    <Type>Sender</Type>\n    <Code>AccessDenied</Code>\n    <Message>User: arn:aws:iam::000000000000:user/betty is not authorized to perform: autoscaling:DescribeAutoScalingGroups</Message>\n  </Error>\n  <RequestId>690ff7bb-469b-11e9-bed3-695c29fad5bd</RequestId>\n</ErrorResponse>\n", 
   headers: Headers({"content-length": "377", "date": "Thu, 14 Mar 2019 20:54:50 GMT", "content-type": "text/xml", "x-amzn-requestid": "690ff7bb-469b-11e9-bed3-695c29fad5bd"}) })
```
