### PR TITLE
Support presigned urls for multipart uploads

### DIFF
--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -27,5 +27,5 @@ Dependencies:
 * Python3
 * Python3 library requests (e.g. `apt install python3-requests` or `pip3 install --user requests`)
 
-**Ceph**: Execute `../.semaphoreci/test_20_ceph.sh` while you're in this directory.
-**Minio**: Execute `../.semaphoreci/test_30_minio.sh` while you're in this directory.
+**Ceph**: Execute `../.semaphoreci/test_10_ceph.sh` while you're in this directory.
+**Minio**: Execute `../.semaphoreci/test_20_minio.sh` while you're in this directory

--- a/integration_tests/tests/s3.rs
+++ b/integration_tests/tests/s3.rs
@@ -13,6 +13,7 @@ use std::env;
 use std::fs::File;
 use std::io::Read;
 use std::str;
+use std::time::Duration;
 use time::get_time;
 
 use futures::{Future, Stream};
@@ -76,7 +77,7 @@ fn test_all_the_things() {
     list_items_in_bucket(&client, &test_bucket);
 
     // do a multipart upload
-    test_multipart_upload(&client, &test_bucket, &multipart_filename);
+    test_multipart_upload(&client, &region, &credentials, &test_bucket, &multipart_filename);
 
     // modify the bucket's CORS properties
     if cfg!(not(feature = "disable_minio_unsupported")) {
@@ -203,7 +204,7 @@ fn test_all_the_things() {
     test_delete_bucket(&client, &test_bucket);
 }
 
-fn test_multipart_upload(client: &TestClient, bucket: &str, filename: &str) {
+fn test_multipart_upload(client: &TestClient, region: &Region, credentials: &AwsCredentials, bucket: &str, filename: &str) {
     let create_multipart_req = CreateMultipartUploadRequest {
         bucket: bucket.to_owned(),
         key: filename.to_owned(),
@@ -234,18 +235,39 @@ fn test_multipart_upload(client: &TestClient, bucket: &str, filename: &str) {
     let part_req1 = create_upload_part(vec!['a' as u8; 1024 * 1024 * 5], 1);
     let part_req2 = create_upload_part("foo".as_bytes().to_vec(), 2);
 
-    // upload 2 parts and note the etags generated for them
+    // upload the parts and note the etags generated for them
     let mut completed_parts = Vec::new();
-    for req in vec![part_req1, part_req2].into_iter() {
-        let part_number = req.part_number;
+    {
+        let part_number = part_req1.part_number;
         let response = client
-            .upload_part(req)
+            .upload_part(part_req1)
             .sync()
             .expect("Couldn't upload a file part");
         println!("{:#?}", response);
         completed_parts.push(CompletedPart {
             e_tag: response.e_tag.clone(),
             part_number: Some(part_number),
+        });
+    }
+    // upload the second part via a pre-signed url
+    {
+        let options = PreSignedRequestOption {
+            expires_in: Duration::from_secs(60 * 30),
+        };
+        let presigned_multipart_put = part_req2.get_presigned_url(region, credentials, &options);
+        println!("presigned multipart put: {:#?}", presigned_multipart_put);
+        let client = reqwest::Client::new();
+        let res = client
+            .put(&presigned_multipart_put)
+            .body(String::from("foo"))
+            .send()
+            .expect("Multipart put with presigned url failed");
+        assert_eq!(res.status(), reqwest::StatusCode::Ok);
+        let e_tag = res.headers().get::<reqwest::header::ETag>()
+            .map(|e| e.tag().clone().to_string());
+        completed_parts.push(CompletedPart {
+            e_tag,
+            part_number: Some(part_req2.part_number),
         });
     }
 


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:
Add support for generating presigned urls for multi-part upload requests

The integration tests (via `/.semaphoreci/test_20_minio.sh`) passed locally for me. Please let me know what else might need to happen ahead of merge