### PR TITLE
Timing with makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,7 @@ rustls_unit_test:
 .PHONY: check_service_defintions
 check_service_defintions:
 	(cd service_crategen && cargo +$$RUST_VERSION run -- check -c ./services.json)
+
+.PHONY: time_credentials
+time_credentials:
+	(cd rusoto/credential && cargo clean --package rusoto_credential && touch src/lib.rs && time cargo +$$RUST_VERSION build)


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Add a Makefile target for timing the credential crate build time for https://github.com/rusoto/rusoto/issues/1323 .

Builds on https://github.com/rusoto/rusoto/pull/1261 .