### PR TITLE
Update credentials crate to Rust 2018 edition.

### DIFF
--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.16.0"
 exclude = ["tests/sample-data/*"]
+edition = "2018"
 
 [dependencies]
 chrono = { version = "0.4.0", features = ["serde"] }

--- a/rusoto/credential/src/container.rs
+++ b/rusoto/credential/src/container.rs
@@ -7,8 +7,8 @@ use futures::future::{err, FutureResult};
 use futures::{Async, Future, Poll};
 use hyper::{Body, Request};
 
-use request::{HttpClient, HttpClientFuture};
-use {
+use crate::request::{HttpClient, HttpClientFuture};
+use crate::{
     non_empty_env_var, parse_credentials_from_aws_service, AwsCredentials, CredentialsError,
     ProvideAwsCredentials,
 };
@@ -164,7 +164,7 @@ fn new_request(uri: &str, env_var_name: &str) -> Result<Request<Body>, Credentia
 mod tests {
     use super::*;
     use std::env;
-    use test_utils::{lock, ENV_MUTEX};
+    use crate::test_utils::{lock, ENV_MUTEX};
 
     #[test]
     fn request_from_relative_uri() {

--- a/rusoto/credential/src/environment.rs
+++ b/rusoto/credential/src/environment.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, FixedOffset, Utc};
 use futures::future::{result, FutureResult};
 use futures::{Future, Poll};
 
-use {non_empty_env_var, AwsCredentials, CredentialsError, ProvideAwsCredentials};
+use crate::{non_empty_env_var, AwsCredentials, CredentialsError, ProvideAwsCredentials};
 
 /// Provides AWS credentials from environment variables.
 ///
@@ -193,7 +193,7 @@ mod tests {
     use super::*;
     use chrono::Utc;
     use std::env;
-    use test_utils::{lock, ENV_MUTEX};
+    use crate::test_utils::{lock, ENV_MUTEX};
 
     static AWS_ACCESS_KEY_ID: &str = "AWS_ACCESS_KEY_ID";
     static AWS_SECRET_ACCESS_KEY: &str = "AWS_SECRET_ACCESS_KEY";

--- a/rusoto/credential/src/instance_metadata.rs
+++ b/rusoto/credential/src/instance_metadata.rs
@@ -6,8 +6,8 @@ use futures::future::{result, FutureResult};
 use futures::{Future, Poll};
 use hyper::Uri;
 
-use request::{HttpClient, HttpClientFuture};
-use {parse_credentials_from_aws_service, AwsCredentials, CredentialsError, ProvideAwsCredentials};
+use crate::request::{HttpClient, HttpClientFuture};
+use crate::{parse_credentials_from_aws_service, AwsCredentials, CredentialsError, ProvideAwsCredentials};
 
 const AWS_CREDENTIALS_PROVIDER_IP: &str = "169.254.169.254";
 const AWS_CREDENTIALS_PROVIDER_PATH: &str = "latest/meta-data/iam/security-credentials";

--- a/rusoto/credential/src/lib.rs
+++ b/rusoto/credential/src/lib.rs
@@ -21,11 +21,11 @@ extern crate shlex;
 extern crate tokio_process;
 extern crate tokio_timer;
 
-pub use container::{ContainerProvider, ContainerProviderFuture};
-pub use environment::{EnvironmentProvider, EnvironmentProviderFuture};
-pub use instance_metadata::{InstanceMetadataProvider, InstanceMetadataProviderFuture};
-pub use profile::{ProfileProvider, ProfileProviderFuture};
-pub use static_provider::StaticProvider;
+pub use crate::container::{ContainerProvider, ContainerProviderFuture};
+pub use crate::environment::{EnvironmentProvider, EnvironmentProviderFuture};
+pub use crate::instance_metadata::{InstanceMetadataProvider, InstanceMetadataProviderFuture};
+pub use crate::profile::{ProfileProvider, ProfileProviderFuture};
+pub use crate::static_provider::StaticProvider;
 
 pub mod claims;
 mod container;
@@ -540,7 +540,7 @@ mod tests {
     use std::path::Path;
 
     use futures::Future;
-    use test_utils::{is_secret_hidden_behind_asterisks, lock, ENV_MUTEX, SECRET};
+    use crate::test_utils::{is_secret_hidden_behind_asterisks, lock, ENV_MUTEX, SECRET};
 
     use super::*;
 
@@ -617,7 +617,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[cfg(test)]
     quickcheck! {
         fn test_aws_credentials_secrets_not_in_debug(
             key: String,

--- a/rusoto/credential/src/profile.rs
+++ b/rusoto/credential/src/profile.rs
@@ -13,7 +13,7 @@ use futures::{Future, Poll};
 use regex::Regex;
 use tokio_process::{CommandExt, OutputAsync};
 
-use {non_empty_env_var, AwsCredentials, CredentialsError, ProvideAwsCredentials};
+use crate::{non_empty_env_var, AwsCredentials, CredentialsError, ProvideAwsCredentials};
 
 const AWS_CONFIG_FILE: &str = "AWS_CONFIG_FILE";
 const AWS_PROFILE: &str = "AWS_PROFILE";
@@ -432,8 +432,8 @@ mod tests {
     use std::path::Path;
 
     use super::*;
-    use test_utils::{lock, ENV_MUTEX};
-    use {CredentialsError, ProvideAwsCredentials};
+    use crate::test_utils::{lock, ENV_MUTEX};
+    use crate::{CredentialsError, ProvideAwsCredentials};
 
     #[test]
     fn parse_config_file_default_profile() {

--- a/rusoto/credential/src/static_provider.rs
+++ b/rusoto/credential/src/static_provider.rs
@@ -4,7 +4,7 @@
 use chrono::{Duration, Utc};
 use futures::future::{ok, FutureResult};
 
-use {AwsCredentials, CredentialsError, ProvideAwsCredentials};
+use crate::{AwsCredentials, CredentialsError, ProvideAwsCredentials};
 
 /// Provides AWS credentials from statically/programmatically provided strings.
 #[derive(Clone, Debug)]
@@ -84,8 +84,8 @@ mod tests {
     use std::time;
 
     use super::*;
-    use test_utils::{is_secret_hidden_behind_asterisks, SECRET};
-    use ProvideAwsCredentials;
+    use crate::test_utils::{is_secret_hidden_behind_asterisks, SECRET};
+    use crate::ProvideAwsCredentials;
 
     #[test]
     fn test_static_provider_creation() {
@@ -143,7 +143,7 @@ mod tests {
         assert!(creds1.expires_at() < creds2.expires_at());
     }
 
-    #[test]
+    #[cfg(test)]
     quickcheck! {
         fn test_static_provider_secrets_not_in_debug(
             access_key: String,


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Move credentials crate to Rust 2018.

I need to poke at a couple tests that got a different tag on them to ensure they still run, but here's a start! 🎉  `cargo fix --edition` on Rust 1.33.0 worked well.