### PR TITLE
Exclude test files from published credentials crate.

### DIFF
--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -11,6 +11,7 @@ name = "rusoto_credential"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.16.0"
+exclude = ["tests/sample-data/*"]
 
 [dependencies]
 chrono = { version = "0.4.0", features = ["serde"] }


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Excludes test files from published credentials crate.

Somewhat related to https://github.com/rusoto/rusoto/issues/1323 . Verified the test files didn't show up in `rusoto_credential-0.16.0` after `cargo package -v`.