### PR TITLE
Keep test data out of rusoto_core crate.

### DIFF
--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -15,6 +15,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.37.0"
 homepage = "https://www.rusoto.org/"
+exclude = ["test_resources/*"]
 
 [badges]
 travis-ci = { repository = "rusoto/rusoto", branch = "master" }


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Keep test data out of published rusoto_core crate.

Somewhat related to https://github.com/rusoto/rusoto/issues/1323 .