### PR TITLE
(WIP) support auto-paginating variants of paginatable operations

### DIFF
--- a/service_crategen/src/botocore.rs
+++ b/service_crategen/src/botocore.rs
@@ -478,7 +478,15 @@ pub struct Paginators {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Pagination {
+    // fixme: a very small set of
+    // services (s3 & route53)
+    // have pagination a input_token
+    // represented as multiple fields
     pub input_token: String,
+    // fixme: a very small set of
+    // services (s3 & route53)
+    // have pagination a input_token
+    // represented as multiple fields
     pub output_token: String,
     pub result_key: PainationResultKey,
 }

--- a/service_crategen/src/commands/generate/codegen/json.rs
+++ b/service_crategen/src/commands/generate/codegen/json.rs
@@ -19,7 +19,7 @@ impl GenerateProtocol for JsonGenerator {
                 {method_signature} -> RusotoFuture<{output_type}, {error_type}>;
                 ",
                 documentation = generate_documentation(operation).unwrap_or_else(|| "".to_owned()),
-                method_signature = generate_method_signature(service, operation, false),
+                method_signature = generate_method_signature(operation_name, service, operation, false),
                 error_type = error_type_name(service, operation_name),
                 output_type = output_type
             )?;
@@ -75,7 +75,7 @@ impl GenerateProtocol for JsonGenerator {
                         )
                     }}
                     ",
-                    method_signature = generate_method_signature(service, operation, true),
+                    method_signature = generate_method_signature(operation_name, service, operation, true),
                     item_type = item_type,
                     error_type = error_type_name(service, operation_name),
                     input_token = pagination.input_token.to_snake_case(),
@@ -115,7 +115,7 @@ impl GenerateProtocol for JsonGenerator {
                 }}
                 ",
                      documentation = generate_documentation(operation).unwrap_or_else(|| "".to_owned()),
-                     method_signature = generate_method_signature(service, operation, false),
+                     method_signature = generate_method_signature(operation_name, service, operation, false),
                      payload = generate_payload(service, operation),
                      signing_name = service.signing_name(),
                      modify_endpoint_prefix = generate_endpoint_modification(service)
@@ -166,9 +166,9 @@ fn generate_endpoint_modification(service: &Service) -> Option<String> {
     }
 }
 
-fn generate_method_signature(service: &Service, operation: &Operation, auto_paging: bool) -> String {
-    let method_name = if auto_paging {
-        format!("{}_pages", operation.name.to_snake_case())
+fn generate_method_signature(operation_name: &str, service: &Service, operation: &Operation, auto_paging: bool) -> String {
+    let fn_name = if auto_paging {
+        format!("{}_pages", operation_name.to_snake_case())
     } else {
         operation.name.to_snake_case()
     };
@@ -186,15 +186,15 @@ fn generate_method_signature(service: &Service, operation: &Operation, auto_pagi
             .unwrap_or(false)
     {
         format!(
-            "fn {method_name}({reciever}, input: {input_type}) ",
-            method_name = method_name,
+            "fn {fn_name}({reciever}, input: {input_type}) ",
+            fn_name = fn_name,
             reciever = reciever,
             input_type = operation.input_shape(),
         )
     } else {
         format!(
-            "fn {method_name}({reciever}) ",
-            method_name = method_name,
+            "fn {fn_name}({reciever}) ",
+            fn_name = fn_name,
             reciever = reciever
         )
     }

--- a/service_crategen/src/commands/generate/codegen/query.rs
+++ b/service_crategen/src/commands/generate/codegen/query.rs
@@ -23,7 +23,12 @@ impl GenerateProtocol for QueryGenerator {
                 ",
                 documentation = generate_documentation(operation),
                 method_signature = generate_method_signature(operation_name, operation, service),
-            )?
+            )?;
+
+
+            if let Some(pagination) = service.pagination(operation_name) {
+                // todo generate paginator signature
+            }
         }
         Ok(())
     }
@@ -65,6 +70,11 @@ impl GenerateProtocol for QueryGenerator {
                      request_uri = &operation.http.request_uri,
                      serialize_input = generate_method_input_serialization(operation),
                      set_input_params = generate_set_input_params(operation))?;
+
+
+            if let Some(pagination) = service.pagination(operation_name) {
+                // todo generate paginator impl
+            }
         }
         Ok(())
     }

--- a/service_crategen/src/commands/generate/codegen/query.rs
+++ b/service_crategen/src/commands/generate/codegen/query.rs
@@ -27,7 +27,7 @@ impl GenerateProtocol for QueryGenerator {
 
 
             if let Some(pagination) = service.pagination(operation_name) {
-                // todo generate paginator signature
+                // todo generate paginator default fn
             }
         }
         Ok(())
@@ -70,11 +70,6 @@ impl GenerateProtocol for QueryGenerator {
                      request_uri = &operation.http.request_uri,
                      serialize_input = generate_method_input_serialization(operation),
                      set_input_params = generate_set_input_params(operation))?;
-
-
-            if let Some(pagination) = service.pagination(operation_name) {
-                // todo generate paginator impl
-            }
         }
         Ok(())
     }

--- a/service_crategen/src/commands/generate/codegen/rest_json.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_json.rs
@@ -31,7 +31,12 @@ impl GenerateProtocol for RestJsonGenerator {
                 method_signature = generate_method_signature(operation, input_shape),
                 error_type = error_type_name(service, operation_name),
                 output_type = output_type
-            )?
+            )?;
+
+            if let Some(pagination) = service.pagination(operation_name) {
+                // todo generate paginator signature
+            }
+
         }
         Ok(())
     }
@@ -98,7 +103,11 @@ impl GenerateProtocol for RestJsonGenerator {
                 load_params = rest_request_generator::generate_params_loading_string(service, operation).unwrap_or_else(|| "".to_string()),
                 default_headers = generate_default_headers(service),
                 set_headers = generate_headers(service).unwrap_or_else(|| "".to_string()),
-            )?
+            )?;
+
+            if let Some(pagination) = service.pagination(operation_name) {
+                // todo generate paginator impl
+            }
         }
         Ok(())
     }

--- a/service_crategen/src/commands/generate/codegen/rest_json.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_json.rs
@@ -34,7 +34,7 @@ impl GenerateProtocol for RestJsonGenerator {
             )?;
 
             if let Some(pagination) = service.pagination(operation_name) {
-                // todo generate paginator signature
+                // todo generate paginator default fn
             }
 
         }
@@ -104,10 +104,6 @@ impl GenerateProtocol for RestJsonGenerator {
                 default_headers = generate_default_headers(service),
                 set_headers = generate_headers(service).unwrap_or_else(|| "".to_string()),
             )?;
-
-            if let Some(pagination) = service.pagination(operation_name) {
-                // todo generate paginator impl
-            }
         }
         Ok(())
     }

--- a/service_crategen/src/commands/generate/codegen/rest_xml.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_xml.rs
@@ -23,7 +23,11 @@ impl GenerateProtocol for RestXmlGenerator {
                 ",
                 documentation = generate_documentation(operation, service),
                 method_signature = generate_method_signature(operation_name, operation, service),
-            )?
+            )?;
+
+            if let Some(pagination) = service.pagination(operation_name) {
+                // todo generate paginator signature
+            }
         }
         Ok(())
     }
@@ -77,6 +81,10 @@ impl GenerateProtocol for RestXmlGenerator {
                              .unwrap_or_else(|| "".to_string()),
                      parse_response_body =
                          xml_payload_parser::generate_response_parser(service, operation, true, &parse_non_payload))?;
+
+            if let Some(pagination) = service.pagination(operation_name) {
+                // todo generate paginator impl
+            }
         }
         Ok(())
     }

--- a/service_crategen/src/commands/generate/codegen/rest_xml.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_xml.rs
@@ -26,7 +26,7 @@ impl GenerateProtocol for RestXmlGenerator {
             )?;
 
             if let Some(pagination) = service.pagination(operation_name) {
-                // todo generate paginator signature
+                // todo generate paginator default fn
             }
         }
         Ok(())
@@ -81,10 +81,6 @@ impl GenerateProtocol for RestXmlGenerator {
                              .unwrap_or_else(|| "".to_string()),
                      parse_response_body =
                          xml_payload_parser::generate_response_parser(service, operation, true, &parse_non_payload))?;
-
-            if let Some(pagination) = service.pagination(operation_name) {
-                // todo generate paginator impl
-            }
         }
         Ok(())
     }

--- a/service_crategen/src/commands/generate/mod.rs
+++ b/service_crategen/src/commands/generate/mod.rs
@@ -14,7 +14,7 @@ use toml;
 mod codegen;
 
 use cargo;
-use {Service, ServiceConfig, ServiceDefinition};
+use {Service, ServiceConfig, ServiceDefinition, Paginators};
 
 fn generate_examples(crate_dir_path: &Path) -> Option<String> {
     let examples_dir_path = crate_dir_path.join("examples");
@@ -75,7 +75,11 @@ pub fn generate_services(
 
         let sw = Stopwatch::start_new();
         let service = match ServiceDefinition::load(name, &service_config.protocol_version) {
-            Ok(sd) => Service::new(service_config, sd),
+            Ok(sd) => {
+                let paginators = Paginators::load(name, &service_config.protocol_version)
+                    .unwrap_or_else(|err| panic!("Failed to load paginators for service {}. Make sure the botocore submodule has been initialized!: {}", name, err));
+                Service::new(service_config, sd, paginators)
+            },
             Err(_) => panic!("Failed to load service {}. Make sure the botocore submodule has been initialized!", name),
         };
 
@@ -171,7 +175,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/service_crategen/src/main.rs
+++ b/service_crategen/src/main.rs
@@ -30,7 +30,7 @@ use std::path::Path;
 
 use clap::{App, Arg, SubCommand};
 
-use botocore::ServiceDefinition;
+use botocore::{ServiceDefinition, Paginators};
 use config::ServiceConfig;
 use service::Service;
 

--- a/service_crategen/src/service.rs
+++ b/service_crategen/src/service.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use botocore::{Member, Operation, ServiceDefinition, Shape, ShapeType, Value};
+use botocore::{Member, Operation, Paginators, Pagination, ServiceDefinition, Shape, ShapeType, Value};
 use cargo;
 use config::ServiceConfig;
 
@@ -8,13 +8,15 @@ use config::ServiceConfig;
 pub struct Service<'a> {
     config: &'a ::ServiceConfig,
     definition: ServiceDefinition,
+    paginators: Option<Paginators>
 }
 
 impl<'b> Service<'b> {
-    pub fn new(config: &'b ServiceConfig, definition: ServiceDefinition) -> Self {
+    pub fn new(config: &'b ServiceConfig, definition: ServiceDefinition, paginators: Option<Paginators>) -> Self {
         Service {
-            config: config,
-            definition: definition,
+            config,
+            definition,
+            paginators
         }
     }
 
@@ -190,5 +192,9 @@ impl<'b> Service<'b> {
         }
 
         dev_dependencies
+    }
+
+    pub fn pagination(&self, operation_name: &str) -> Option<Pagination> {
+        self.paginators.clone().and_then(|pages| pages.pagination.get(operation_name).cloned())
     }
 }


### PR DESCRIPTION
Async stream-based approach based on [dynomite DynamoDB extensions](https://github.com/softprops/dynomite/blob/d2268c257e9635b7235f0d502a9ee2d6a191d57c/dynomite/src/ext.rs#L49).

fixes: #1319 

This is a WIP branch to gather feedback early in the process of translating hand rolled auto paginating interfaces to interfaces derived directly from paginating definitions botocore provides.

### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

added new auto-paginating interfaces for service operations that support pagination

Current status

- [X] add support for loading botocore pagination definitions
- [X] create implementation for json protocol services 
- [ ] create implementation for json rest protocol services 
- [ ] create implementation for query protocol services 
- [ ] create implementation for xml rest protocol services 
- [ ] regenerate services
- [ ] integration tests?