### PR TITLE
Fix malformed SNS Subscribe and CreateTopic requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix hostname derivation for custom Region endpoints
 - Support presigned URLs for multipart uploads to S3
 - Add Us-Gov-East region
+- Fix a bug in SNS CreateTopic and Subscribe
 
 ## [0.37.0] - 2019-03-12
 

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -1889,7 +1889,7 @@ impl SubscriptionAttributesMapSerializer {
         obj: &::std::collections::HashMap<String, String>,
     ) {
         for (index, (key, value)) in obj.iter().enumerate() {
-            let prefix = format!("{}.{}", name, index + 1);
+            let prefix = format!("{}.entry.{}", name, index + 1);
             params.put(&format!("{}.{}", prefix, "key"), &key);
             params.put(&format!("{}.{}", prefix, "Value"), &value);
         }
@@ -1985,7 +1985,7 @@ impl TopicAttributesMapSerializer {
         obj: &::std::collections::HashMap<String, String>,
     ) {
         for (index, (key, value)) in obj.iter().enumerate() {
-            let prefix = format!("{}.{}", name, index + 1);
+            let prefix = format!("{}.entry.{}", name, index + 1);
             params.put(&format!("{}.{}", prefix, "key"), &key);
             params.put(&format!("{}.{}", prefix, "Value"), &value);
         }

--- a/service_crategen/src/commands/generate/codegen/query.rs
+++ b/service_crategen/src/commands/generate/codegen/query.rs
@@ -220,7 +220,8 @@ fn generate_map_serializer(service: &Service, shape: &Shape) -> String {
     let prefix_snip: String;
     if service.service_id() == Some("SNS")
         && shape.value.is_some()
-        && shape.value.as_ref().unwrap().shape == "MessageAttributeValue"
+        && (shape.value.as_ref().unwrap().shape == "MessageAttributeValue"
+            || shape.value.as_ref().unwrap().shape == "AttributeValue")
     {
         prefix_snip = "let prefix = format!(\"{}.entry.{}\", name, index+1);".to_string();
     } else {


### PR DESCRIPTION
This fixes an issue with malformed requests for the SNS  [Subscribe](https://docs.aws.amazon.com/sns/latest/api/API_Subscribe.html) and [CreateTopic](https://docs.aws.amazon.com/sns/latest/api/API_CreateTopic.html) endpoints.

Much like the fix in #1229 this change fixes both the Subscribe and CreateTopic endpoint requests, which require the `.entry.` format in their query parameters for attributes.