### PR TITLE
Fix de/serialization of DynamoDB binary set attribute values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 (Please put notes here)
 
+- Fix de/serialization of DynamoDB binary set attribute values
+
 ## [0.38.0] - 2019-04-17
 
 - Add `RusotoError` enum as base error type for all services

--- a/rusoto/services/dynamodb/src/custom/custom_tests.rs
+++ b/rusoto/services/dynamodb/src/custom/custom_tests.rs
@@ -31,3 +31,18 @@ fn attribute_value_with_number_contains_only_number() {
     let serialized = serde_json::to_string(&all_default).unwrap();
     assert_eq!(&serialized, r#"{"N":"1234"}"#);
 }
+
+#[test]
+fn attribute_value_with_binary_set() {
+    let all_default = AttributeValue{
+        bs: Some(vec![
+            "foo".bytes().collect(),
+            "bar".bytes().collect(),
+            "baz".bytes().collect()
+        ]),
+        ..Default::default()
+    };
+
+    let serialized = serde_json::to_string(&all_default).unwrap();
+    assert_eq!(&serialized, r#"{"BS":["Zm9v","YmFy","YmF6"]}"#);
+}

--- a/rusoto/services/dynamodb/src/generated.rs
+++ b/rusoto/services/dynamodb/src/generated.rs
@@ -54,6 +54,11 @@ pub struct AttributeValue {
     pub bool: Option<bool>,
     /// <p>An attribute of type Binary Set. For example:</p> <p> <code>"BS": ["U3Vubnk=", "UmFpbnk=", "U25vd3k="]</code> </p>
     #[serde(rename = "BS")]
+    #[serde(
+        deserialize_with = "::rusoto_core::serialization::SerdeBlobList::deserialize_blob_list",
+        serialize_with = "::rusoto_core::serialization::SerdeBlobList::serialize_blob_list",
+        default
+    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bs: Option<Vec<Vec<u8>>>,
     /// <p>An attribute of type List. For example:</p> <p> <code>"L": [ {"S": "Cookies"} , {"S": "Coffee"}, {"N", "3.14159"}]</code> </p>

--- a/rusoto/services/dynamodbstreams/src/generated.rs
+++ b/rusoto/services/dynamodbstreams/src/generated.rs
@@ -44,6 +44,11 @@ pub struct AttributeValue {
     pub bool: Option<bool>,
     /// <p>A Binary Set data type.</p>
     #[serde(rename = "BS")]
+    #[serde(
+        deserialize_with = "::rusoto_core::serialization::SerdeBlobList::deserialize_blob_list",
+        serialize_with = "::rusoto_core::serialization::SerdeBlobList::serialize_blob_list",
+        default
+    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bs: Option<Vec<Vec<u8>>>,
     /// <p>A List data type.</p>

--- a/rusoto/services/iotanalytics/src/generated.rs
+++ b/rusoto/services/iotanalytics/src/generated.rs
@@ -1257,6 +1257,11 @@ pub struct RetentionPeriod {
 pub struct RunPipelineActivityRequest {
     /// <p>The sample message payloads on which the pipeline activity is run.</p>
     #[serde(rename = "payloads")]
+    #[serde(
+        deserialize_with = "::rusoto_core::serialization::SerdeBlobList::deserialize_blob_list",
+        serialize_with = "::rusoto_core::serialization::SerdeBlobList::serialize_blob_list",
+        default
+    )]
     pub payloads: Vec<Vec<u8>>,
     /// <p>The pipeline activity that is run. This must not be a 'channel' activity or a 'datastore' activity because these activities are used in a pipeline only to load the original message and to store the (possibly) transformed message. If a 'lambda' activity is specified, only short-running Lambda functions (those with a timeout of less than 30 seconds or less) can be used.</p>
     #[serde(rename = "pipelineActivity")]
@@ -1272,6 +1277,11 @@ pub struct RunPipelineActivityResponse {
     pub log_result: Option<String>,
     /// <p>The enriched or transformed sample message payloads as base64-encoded strings. (The results of running the pipeline activity on each input sample message payload, encoded in base64.)</p>
     #[serde(rename = "payloads")]
+    #[serde(
+        deserialize_with = "::rusoto_core::serialization::SerdeBlobList::deserialize_blob_list",
+        serialize_with = "::rusoto_core::serialization::SerdeBlobList::serialize_blob_list",
+        default
+    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payloads: Option<Vec<Vec<u8>>>,
 }
@@ -1300,6 +1310,11 @@ pub struct SampleChannelDataRequest {
 pub struct SampleChannelDataResponse {
     /// <p>The list of message samples. Each sample message is returned as a base64-encoded string.</p>
     #[serde(rename = "payloads")]
+    #[serde(
+        deserialize_with = "::rusoto_core::serialization::SerdeBlobList::deserialize_blob_list",
+        serialize_with = "::rusoto_core::serialization::SerdeBlobList::serialize_blob_list",
+        default
+    )]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payloads: Option<Vec<Vec<u8>>>,
 }


### PR DESCRIPTION
Stumbled over this trying to change the blob type from `Vec<u8>` to `Bytes`. Currently, we will serialize a binary set as an array-of-array-of-bytes, when it should be an array of base64-encoded values.

Kind of suprised no one's got bitten by this before, but I guess `BinarySet` is a relatively uncommon attribute value type?