### PR TITLE
Refactor/leverage to param trait impls

### DIFF
--- a/rusoto/services/autoscaling/src/generated.rs
+++ b/rusoto/services/autoscaling/src/generated.rs
@@ -731,10 +731,7 @@ impl AutoScalingGroupNamesTypeSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -1249,10 +1246,7 @@ impl BlockDeviceMappingSerializer {
             EbsSerializer::serialize(params, &format!("{}{}", prefix, "Ebs"), field_value);
         }
         if let Some(ref field_value) = obj.no_device {
-            params.put(
-                &format!("{}{}", prefix, "NoDevice"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "NoDevice"), &field_value);
         }
         if let Some(ref field_value) = obj.virtual_name {
             params.put(&format!("{}{}", prefix, "VirtualName"), &field_value);
@@ -1469,21 +1463,15 @@ impl CreateAutoScalingGroupTypeSerializer {
             );
         }
         if let Some(ref field_value) = obj.default_cooldown {
-            params.put(
-                &format!("{}{}", prefix, "DefaultCooldown"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DefaultCooldown"), &field_value);
         }
         if let Some(ref field_value) = obj.desired_capacity {
-            params.put(
-                &format!("{}{}", prefix, "DesiredCapacity"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DesiredCapacity"), &field_value);
         }
         if let Some(ref field_value) = obj.health_check_grace_period {
             params.put(
                 &format!("{}{}", prefix, "HealthCheckGracePeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.health_check_type {
@@ -1519,14 +1507,8 @@ impl CreateAutoScalingGroupTypeSerializer {
                 field_value,
             );
         }
-        params.put(
-            &format!("{}{}", prefix, "MaxSize"),
-            &obj.max_size.to_string(),
-        );
-        params.put(
-            &format!("{}{}", prefix, "MinSize"),
-            &obj.min_size.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "MaxSize"), &obj.max_size);
+        params.put(&format!("{}{}", prefix, "MinSize"), &obj.min_size);
         if let Some(ref field_value) = obj.mixed_instances_policy {
             MixedInstancesPolicySerializer::serialize(
                 params,
@@ -1537,7 +1519,7 @@ impl CreateAutoScalingGroupTypeSerializer {
         if let Some(ref field_value) = obj.new_instances_protected_from_scale_in {
             params.put(
                 &format!("{}{}", prefix, "NewInstancesProtectedFromScaleIn"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.placement_group {
@@ -1624,7 +1606,7 @@ impl CreateLaunchConfigurationTypeSerializer {
         if let Some(ref field_value) = obj.associate_public_ip_address {
             params.put(
                 &format!("{}{}", prefix, "AssociatePublicIpAddress"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.block_device_mappings {
@@ -1645,10 +1627,7 @@ impl CreateLaunchConfigurationTypeSerializer {
             );
         }
         if let Some(ref field_value) = obj.ebs_optimized {
-            params.put(
-                &format!("{}{}", prefix, "EbsOptimized"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "EbsOptimized"), &field_value);
         }
         if let Some(ref field_value) = obj.iam_instance_profile {
             params.put(&format!("{}{}", prefix, "IamInstanceProfile"), &field_value);
@@ -1821,10 +1800,7 @@ impl DeleteAutoScalingGroupTypeSerializer {
             &obj.auto_scaling_group_name,
         );
         if let Some(ref field_value) = obj.force_delete {
-            params.put(
-                &format!("{}{}", prefix, "ForceDelete"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ForceDelete"), &field_value);
         }
     }
 }
@@ -2091,10 +2067,7 @@ impl DescribeAutoScalingInstancesTypeSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -2253,10 +2226,7 @@ impl DescribeLoadBalancerTargetGroupsRequestSerializer {
             &obj.auto_scaling_group_name,
         );
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -2327,10 +2297,7 @@ impl DescribeLoadBalancersRequestSerializer {
             &obj.auto_scaling_group_name,
         );
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -2480,10 +2447,7 @@ impl DescribeNotificationConfigurationsTypeSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -2521,10 +2485,7 @@ impl DescribePoliciesTypeSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -2581,10 +2542,7 @@ impl DescribeScalingActivitiesTypeSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -2627,10 +2585,7 @@ impl DescribeScheduledActionsTypeSerializer {
             params.put(&format!("{}{}", prefix, "EndTime"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -2671,10 +2626,7 @@ impl DescribeTagsTypeSerializer {
             FiltersSerializer::serialize(params, &format!("{}{}", prefix, "Filters"), field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -2773,7 +2725,7 @@ impl DetachInstancesQuerySerializer {
         }
         params.put(
             &format!("{}{}", prefix, "ShouldDecrementDesiredCapacity"),
-            &obj.should_decrement_desired_capacity.to_string(),
+            &obj.should_decrement_desired_capacity,
         );
     }
 }
@@ -2994,26 +2946,20 @@ impl EbsSerializer {
         if let Some(ref field_value) = obj.delete_on_termination {
             params.put(
                 &format!("{}{}", prefix, "DeleteOnTermination"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.encrypted {
-            params.put(
-                &format!("{}{}", prefix, "Encrypted"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Encrypted"), &field_value);
         }
         if let Some(ref field_value) = obj.iops {
-            params.put(&format!("{}{}", prefix, "Iops"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Iops"), &field_value);
         }
         if let Some(ref field_value) = obj.snapshot_id {
             params.put(&format!("{}{}", prefix, "SnapshotId"), &field_value);
         }
         if let Some(ref field_value) = obj.volume_size {
-            params.put(
-                &format!("{}{}", prefix, "VolumeSize"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "VolumeSize"), &field_value);
         }
         if let Some(ref field_value) = obj.volume_type {
             params.put(&format!("{}{}", prefix, "VolumeType"), &field_value);
@@ -3175,7 +3121,7 @@ impl EnterStandbyQuerySerializer {
         }
         params.put(
             &format!("{}{}", prefix, "ShouldDecrementDesiredCapacity"),
-            &obj.should_decrement_desired_capacity.to_string(),
+            &obj.should_decrement_desired_capacity,
         );
     }
 }
@@ -3224,22 +3170,13 @@ impl ExecutePolicyTypeSerializer {
             );
         }
         if let Some(ref field_value) = obj.breach_threshold {
-            params.put(
-                &format!("{}{}", prefix, "BreachThreshold"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "BreachThreshold"), &field_value);
         }
         if let Some(ref field_value) = obj.honor_cooldown {
-            params.put(
-                &format!("{}{}", prefix, "HonorCooldown"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "HonorCooldown"), &field_value);
         }
         if let Some(ref field_value) = obj.metric_value {
-            params.put(
-                &format!("{}{}", prefix, "MetricValue"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MetricValue"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "PolicyName"), &obj.policy_name);
     }
@@ -3567,10 +3504,7 @@ impl InstanceMonitoringSerializer {
         }
 
         if let Some(ref field_value) = obj.enabled {
-            params.put(
-                &format!("{}{}", prefix, "Enabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Enabled"), &field_value);
         }
     }
 }
@@ -3694,13 +3628,13 @@ impl InstancesDistributionSerializer {
         if let Some(ref field_value) = obj.on_demand_base_capacity {
             params.put(
                 &format!("{}{}", prefix, "OnDemandBaseCapacity"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.on_demand_percentage_above_base_capacity {
             params.put(
                 &format!("{}{}", prefix, "OnDemandPercentageAboveBaseCapacity"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.spot_allocation_strategy {
@@ -3710,10 +3644,7 @@ impl InstancesDistributionSerializer {
             );
         }
         if let Some(ref field_value) = obj.spot_instance_pools {
-            params.put(
-                &format!("{}{}", prefix, "SpotInstancePools"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SpotInstancePools"), &field_value);
         }
         if let Some(ref field_value) = obj.spot_max_price {
             params.put(&format!("{}{}", prefix, "SpotMaxPrice"), &field_value);
@@ -3941,10 +3872,7 @@ impl LaunchConfigurationNamesTypeSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -4352,10 +4280,7 @@ impl LifecycleHookSpecificationSerializer {
             params.put(&format!("{}{}", prefix, "DefaultResult"), &field_value);
         }
         if let Some(ref field_value) = obj.heartbeat_timeout {
-            params.put(
-                &format!("{}{}", prefix, "HeartbeatTimeout"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "HeartbeatTimeout"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "LifecycleHookName"),
@@ -5492,10 +5417,7 @@ impl PutLifecycleHookTypeSerializer {
             params.put(&format!("{}{}", prefix, "DefaultResult"), &field_value);
         }
         if let Some(ref field_value) = obj.heartbeat_timeout {
-            params.put(
-                &format!("{}{}", prefix, "HeartbeatTimeout"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "HeartbeatTimeout"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "LifecycleHookName"),
@@ -5602,15 +5524,12 @@ impl PutScalingPolicyTypeSerializer {
             &obj.auto_scaling_group_name,
         );
         if let Some(ref field_value) = obj.cooldown {
-            params.put(
-                &format!("{}{}", prefix, "Cooldown"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Cooldown"), &field_value);
         }
         if let Some(ref field_value) = obj.estimated_instance_warmup {
             params.put(
                 &format!("{}{}", prefix, "EstimatedInstanceWarmup"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.metric_aggregation_type {
@@ -5622,24 +5541,18 @@ impl PutScalingPolicyTypeSerializer {
         if let Some(ref field_value) = obj.min_adjustment_magnitude {
             params.put(
                 &format!("{}{}", prefix, "MinAdjustmentMagnitude"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.min_adjustment_step {
-            params.put(
-                &format!("{}{}", prefix, "MinAdjustmentStep"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MinAdjustmentStep"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "PolicyName"), &obj.policy_name);
         if let Some(ref field_value) = obj.policy_type {
             params.put(&format!("{}{}", prefix, "PolicyType"), &field_value);
         }
         if let Some(ref field_value) = obj.scaling_adjustment {
-            params.put(
-                &format!("{}{}", prefix, "ScalingAdjustment"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ScalingAdjustment"), &field_value);
         }
         if let Some(ref field_value) = obj.step_adjustments {
             StepAdjustmentsSerializer::serialize(
@@ -5694,25 +5607,16 @@ impl PutScheduledUpdateGroupActionTypeSerializer {
             &obj.auto_scaling_group_name,
         );
         if let Some(ref field_value) = obj.desired_capacity {
-            params.put(
-                &format!("{}{}", prefix, "DesiredCapacity"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DesiredCapacity"), &field_value);
         }
         if let Some(ref field_value) = obj.end_time {
             params.put(&format!("{}{}", prefix, "EndTime"), &field_value);
         }
         if let Some(ref field_value) = obj.max_size {
-            params.put(
-                &format!("{}{}", prefix, "MaxSize"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxSize"), &field_value);
         }
         if let Some(ref field_value) = obj.min_size {
-            params.put(
-                &format!("{}{}", prefix, "MinSize"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MinSize"), &field_value);
         }
         if let Some(ref field_value) = obj.recurrence {
             params.put(&format!("{}{}", prefix, "Recurrence"), &field_value);
@@ -6165,25 +6069,16 @@ impl ScheduledUpdateGroupActionRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.desired_capacity {
-            params.put(
-                &format!("{}{}", prefix, "DesiredCapacity"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DesiredCapacity"), &field_value);
         }
         if let Some(ref field_value) = obj.end_time {
             params.put(&format!("{}{}", prefix, "EndTime"), &field_value);
         }
         if let Some(ref field_value) = obj.max_size {
-            params.put(
-                &format!("{}{}", prefix, "MaxSize"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxSize"), &field_value);
         }
         if let Some(ref field_value) = obj.min_size {
-            params.put(
-                &format!("{}{}", prefix, "MinSize"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MinSize"), &field_value);
         }
         if let Some(ref field_value) = obj.recurrence {
             params.put(&format!("{}{}", prefix, "Recurrence"), &field_value);
@@ -6282,13 +6177,10 @@ impl SetDesiredCapacityTypeSerializer {
         );
         params.put(
             &format!("{}{}", prefix, "DesiredCapacity"),
-            &obj.desired_capacity.to_string(),
+            &obj.desired_capacity,
         );
         if let Some(ref field_value) = obj.honor_cooldown {
-            params.put(
-                &format!("{}{}", prefix, "HonorCooldown"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "HonorCooldown"), &field_value);
         }
     }
 }
@@ -6317,7 +6209,7 @@ impl SetInstanceHealthQuerySerializer {
         if let Some(ref field_value) = obj.should_respect_grace_period {
             params.put(
                 &format!("{}{}", prefix, "ShouldRespectGracePeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
     }
@@ -6372,7 +6264,7 @@ impl SetInstanceProtectionQuerySerializer {
         );
         params.put(
             &format!("{}{}", prefix, "ProtectedFromScaleIn"),
-            &obj.protected_from_scale_in.to_string(),
+            &obj.protected_from_scale_in,
         );
     }
 }
@@ -6460,18 +6352,18 @@ impl StepAdjustmentSerializer {
         if let Some(ref field_value) = obj.metric_interval_lower_bound {
             params.put(
                 &format!("{}{}", prefix, "MetricIntervalLowerBound"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.metric_interval_upper_bound {
             params.put(
                 &format!("{}{}", prefix, "MetricIntervalUpperBound"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         params.put(
             &format!("{}{}", prefix, "ScalingAdjustment"),
-            &obj.scaling_adjustment.to_string(),
+            &obj.scaling_adjustment,
         );
     }
 }
@@ -6584,10 +6476,7 @@ impl TagSerializer {
 
         params.put(&format!("{}{}", prefix, "Key"), &obj.key);
         if let Some(ref field_value) = obj.propagate_at_launch {
-            params.put(
-                &format!("{}{}", prefix, "PropagateAtLaunch"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PropagateAtLaunch"), &field_value);
         }
         if let Some(ref field_value) = obj.resource_id {
             params.put(&format!("{}{}", prefix, "ResourceId"), &field_value);
@@ -6844,10 +6733,7 @@ impl TargetTrackingConfigurationSerializer {
             );
         }
         if let Some(ref field_value) = obj.disable_scale_in {
-            params.put(
-                &format!("{}{}", prefix, "DisableScaleIn"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DisableScaleIn"), &field_value);
         }
         if let Some(ref field_value) = obj.predefined_metric_specification {
             PredefinedMetricSpecificationSerializer::serialize(
@@ -6856,10 +6742,7 @@ impl TargetTrackingConfigurationSerializer {
                 field_value,
             );
         }
-        params.put(
-            &format!("{}{}", prefix, "TargetValue"),
-            &obj.target_value.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "TargetValue"), &obj.target_value);
     }
 }
 
@@ -6883,7 +6766,7 @@ impl TerminateInstanceInAutoScalingGroupTypeSerializer {
         params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
         params.put(
             &format!("{}{}", prefix, "ShouldDecrementDesiredCapacity"),
-            &obj.should_decrement_desired_capacity.to_string(),
+            &obj.should_decrement_desired_capacity,
         );
     }
 }
@@ -6990,21 +6873,15 @@ impl UpdateAutoScalingGroupTypeSerializer {
             );
         }
         if let Some(ref field_value) = obj.default_cooldown {
-            params.put(
-                &format!("{}{}", prefix, "DefaultCooldown"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DefaultCooldown"), &field_value);
         }
         if let Some(ref field_value) = obj.desired_capacity {
-            params.put(
-                &format!("{}{}", prefix, "DesiredCapacity"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DesiredCapacity"), &field_value);
         }
         if let Some(ref field_value) = obj.health_check_grace_period {
             params.put(
                 &format!("{}{}", prefix, "HealthCheckGracePeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.health_check_type {
@@ -7024,16 +6901,10 @@ impl UpdateAutoScalingGroupTypeSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_size {
-            params.put(
-                &format!("{}{}", prefix, "MaxSize"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxSize"), &field_value);
         }
         if let Some(ref field_value) = obj.min_size {
-            params.put(
-                &format!("{}{}", prefix, "MinSize"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MinSize"), &field_value);
         }
         if let Some(ref field_value) = obj.mixed_instances_policy {
             MixedInstancesPolicySerializer::serialize(
@@ -7045,7 +6916,7 @@ impl UpdateAutoScalingGroupTypeSerializer {
         if let Some(ref field_value) = obj.new_instances_protected_from_scale_in {
             params.put(
                 &format!("{}{}", prefix, "NewInstancesProtectedFromScaleIn"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.placement_group {

--- a/rusoto/services/cloudformation/src/generated.rs
+++ b/rusoto/services/cloudformation/src/generated.rs
@@ -748,7 +748,7 @@ impl CreateChangeSetInputSerializer {
         if let Some(ref field_value) = obj.use_previous_template {
             params.put(
                 &format!("{}{}", prefix, "UsePreviousTemplate"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
     }
@@ -843,15 +843,12 @@ impl CreateStackInputSerializer {
             params.put(&format!("{}{}", prefix, "ClientRequestToken"), &field_value);
         }
         if let Some(ref field_value) = obj.disable_rollback {
-            params.put(
-                &format!("{}{}", prefix, "DisableRollback"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DisableRollback"), &field_value);
         }
         if let Some(ref field_value) = obj.enable_termination_protection {
             params.put(
                 &format!("{}{}", prefix, "EnableTerminationProtection"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.notification_ar_ns {
@@ -905,10 +902,7 @@ impl CreateStackInputSerializer {
             params.put(&format!("{}{}", prefix, "TemplateURL"), &field_value);
         }
         if let Some(ref field_value) = obj.timeout_in_minutes {
-            params.put(
-                &format!("{}{}", prefix, "TimeoutInMinutes"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "TimeoutInMinutes"), &field_value);
         }
     }
 }
@@ -1269,10 +1263,7 @@ impl DeleteStackInstancesInputSerializer {
             );
         }
         RegionListSerializer::serialize(params, &format!("{}{}", prefix, "Regions"), &obj.regions);
-        params.put(
-            &format!("{}{}", prefix, "RetainStacks"),
-            &obj.retain_stacks.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "RetainStacks"), &obj.retain_stacks);
         params.put(
             &format!("{}{}", prefix, "StackSetName"),
             &obj.stack_set_name,
@@ -1842,10 +1833,7 @@ impl DescribeStackResourceDriftsInputSerializer {
         }
 
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -3123,10 +3111,7 @@ impl ListStackInstancesInputSerializer {
         }
 
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -3273,10 +3258,7 @@ impl ListStackSetOperationResultsInputSerializer {
         }
 
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -3348,10 +3330,7 @@ impl ListStackSetOperationsInputSerializer {
         }
 
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -3422,10 +3401,7 @@ impl ListStackSetsInputSerializer {
         }
 
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -3843,10 +3819,7 @@ impl ParameterSerializer {
             params.put(&format!("{}{}", prefix, "ResolvedValue"), &field_value);
         }
         if let Some(ref field_value) = obj.use_previous_value {
-            params.put(
-                &format!("{}{}", prefix, "UsePreviousValue"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "UsePreviousValue"), &field_value);
         }
     }
 }
@@ -4688,7 +4661,7 @@ impl RollbackConfigurationSerializer {
         if let Some(ref field_value) = obj.monitoring_time_in_minutes {
             params.put(
                 &format!("{}{}", prefix, "MonitoringTimeInMinutes"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.rollback_triggers {
@@ -6284,25 +6257,22 @@ impl StackSetOperationPreferencesSerializer {
         if let Some(ref field_value) = obj.failure_tolerance_count {
             params.put(
                 &format!("{}{}", prefix, "FailureToleranceCount"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.failure_tolerance_percentage {
             params.put(
                 &format!("{}{}", prefix, "FailureTolerancePercentage"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.max_concurrent_count {
-            params.put(
-                &format!("{}{}", prefix, "MaxConcurrentCount"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxConcurrentCount"), &field_value);
         }
         if let Some(ref field_value) = obj.max_concurrent_percentage {
             params.put(
                 &format!("{}{}", prefix, "MaxConcurrentPercentage"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.region_order {
@@ -7198,7 +7168,7 @@ impl UpdateStackInputSerializer {
         if let Some(ref field_value) = obj.use_previous_template {
             params.put(
                 &format!("{}{}", prefix, "UsePreviousTemplate"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
     }
@@ -7422,7 +7392,7 @@ impl UpdateStackSetInputSerializer {
         if let Some(ref field_value) = obj.use_previous_template {
             params.put(
                 &format!("{}{}", prefix, "UsePreviousTemplate"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
     }
@@ -7474,7 +7444,7 @@ impl UpdateTerminationProtectionInputSerializer {
 
         params.put(
             &format!("{}{}", prefix, "EnableTerminationProtection"),
-            &obj.enable_termination_protection.to_string(),
+            &obj.enable_termination_protection,
         );
         params.put(&format!("{}{}", prefix, "StackName"), &obj.stack_name);
     }

--- a/rusoto/services/cloudsearch/src/generated.rs
+++ b/rusoto/services/cloudsearch/src/generated.rs
@@ -529,22 +529,13 @@ impl DateArrayOptionsSerializer {
             params.put(&format!("{}{}", prefix, "DefaultValue"), &field_value);
         }
         if let Some(ref field_value) = obj.facet_enabled {
-            params.put(
-                &format!("{}{}", prefix, "FacetEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "FacetEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.return_enabled {
-            params.put(
-                &format!("{}{}", prefix, "ReturnEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ReturnEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.search_enabled {
-            params.put(
-                &format!("{}{}", prefix, "SearchEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SearchEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.source_fields {
             params.put(&format!("{}{}", prefix, "SourceFields"), &field_value);
@@ -621,28 +612,16 @@ impl DateOptionsSerializer {
             params.put(&format!("{}{}", prefix, "DefaultValue"), &field_value);
         }
         if let Some(ref field_value) = obj.facet_enabled {
-            params.put(
-                &format!("{}{}", prefix, "FacetEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "FacetEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.return_enabled {
-            params.put(
-                &format!("{}{}", prefix, "ReturnEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ReturnEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.search_enabled {
-            params.put(
-                &format!("{}{}", prefix, "SearchEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SearchEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.sort_enabled {
-            params.put(
-                &format!("{}{}", prefix, "SortEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SortEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.source_field {
             params.put(&format!("{}{}", prefix, "SourceField"), &field_value);
@@ -1162,10 +1141,7 @@ impl DescribeAnalysisSchemesRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.deployed {
-            params.put(
-                &format!("{}{}", prefix, "Deployed"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Deployed"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
     }
@@ -1224,10 +1200,7 @@ impl DescribeAvailabilityOptionsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.deployed {
-            params.put(
-                &format!("{}{}", prefix, "Deployed"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Deployed"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
     }
@@ -1345,10 +1318,7 @@ impl DescribeExpressionsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.deployed {
-            params.put(
-                &format!("{}{}", prefix, "Deployed"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Deployed"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
         if let Some(ref field_value) = obj.expression_names {
@@ -1415,10 +1385,7 @@ impl DescribeIndexFieldsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.deployed {
-            params.put(
-                &format!("{}{}", prefix, "Deployed"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Deployed"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
         if let Some(ref field_value) = obj.field_names {
@@ -1533,10 +1500,7 @@ impl DescribeServiceAccessPoliciesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.deployed {
-            params.put(
-                &format!("{}{}", prefix, "Deployed"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Deployed"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
     }
@@ -1593,10 +1557,7 @@ impl DescribeSuggestersRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.deployed {
-            params.put(
-                &format!("{}{}", prefix, "Deployed"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Deployed"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
         if let Some(ref field_value) = obj.suggester_names {
@@ -1960,28 +1921,16 @@ impl DoubleArrayOptionsSerializer {
         }
 
         if let Some(ref field_value) = obj.default_value {
-            params.put(
-                &format!("{}{}", prefix, "DefaultValue"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DefaultValue"), &field_value);
         }
         if let Some(ref field_value) = obj.facet_enabled {
-            params.put(
-                &format!("{}{}", prefix, "FacetEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "FacetEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.return_enabled {
-            params.put(
-                &format!("{}{}", prefix, "ReturnEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ReturnEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.search_enabled {
-            params.put(
-                &format!("{}{}", prefix, "SearchEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SearchEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.source_fields {
             params.put(&format!("{}{}", prefix, "SourceFields"), &field_value);
@@ -2056,34 +2005,19 @@ impl DoubleOptionsSerializer {
         }
 
         if let Some(ref field_value) = obj.default_value {
-            params.put(
-                &format!("{}{}", prefix, "DefaultValue"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DefaultValue"), &field_value);
         }
         if let Some(ref field_value) = obj.facet_enabled {
-            params.put(
-                &format!("{}{}", prefix, "FacetEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "FacetEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.return_enabled {
-            params.put(
-                &format!("{}{}", prefix, "ReturnEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ReturnEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.search_enabled {
-            params.put(
-                &format!("{}{}", prefix, "SearchEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SearchEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.sort_enabled {
-            params.put(
-                &format!("{}{}", prefix, "SortEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SortEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.source_field {
             params.put(&format!("{}{}", prefix, "SourceField"), &field_value);
@@ -2668,28 +2602,16 @@ impl IntArrayOptionsSerializer {
         }
 
         if let Some(ref field_value) = obj.default_value {
-            params.put(
-                &format!("{}{}", prefix, "DefaultValue"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DefaultValue"), &field_value);
         }
         if let Some(ref field_value) = obj.facet_enabled {
-            params.put(
-                &format!("{}{}", prefix, "FacetEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "FacetEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.return_enabled {
-            params.put(
-                &format!("{}{}", prefix, "ReturnEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ReturnEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.search_enabled {
-            params.put(
-                &format!("{}{}", prefix, "SearchEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SearchEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.source_fields {
             params.put(&format!("{}{}", prefix, "SourceFields"), &field_value);
@@ -2763,34 +2685,19 @@ impl IntOptionsSerializer {
         }
 
         if let Some(ref field_value) = obj.default_value {
-            params.put(
-                &format!("{}{}", prefix, "DefaultValue"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DefaultValue"), &field_value);
         }
         if let Some(ref field_value) = obj.facet_enabled {
-            params.put(
-                &format!("{}{}", prefix, "FacetEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "FacetEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.return_enabled {
-            params.put(
-                &format!("{}{}", prefix, "ReturnEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ReturnEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.search_enabled {
-            params.put(
-                &format!("{}{}", prefix, "SearchEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SearchEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.sort_enabled {
-            params.put(
-                &format!("{}{}", prefix, "SortEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SortEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.source_field {
             params.put(&format!("{}{}", prefix, "SourceField"), &field_value);
@@ -2867,28 +2774,16 @@ impl LatLonOptionsSerializer {
             params.put(&format!("{}{}", prefix, "DefaultValue"), &field_value);
         }
         if let Some(ref field_value) = obj.facet_enabled {
-            params.put(
-                &format!("{}{}", prefix, "FacetEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "FacetEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.return_enabled {
-            params.put(
-                &format!("{}{}", prefix, "ReturnEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ReturnEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.search_enabled {
-            params.put(
-                &format!("{}{}", prefix, "SearchEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SearchEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.sort_enabled {
-            params.put(
-                &format!("{}{}", prefix, "SortEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SortEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.source_field {
             params.put(&format!("{}{}", prefix, "SourceField"), &field_value);
@@ -3028,22 +2923,13 @@ impl LiteralArrayOptionsSerializer {
             params.put(&format!("{}{}", prefix, "DefaultValue"), &field_value);
         }
         if let Some(ref field_value) = obj.facet_enabled {
-            params.put(
-                &format!("{}{}", prefix, "FacetEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "FacetEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.return_enabled {
-            params.put(
-                &format!("{}{}", prefix, "ReturnEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ReturnEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.search_enabled {
-            params.put(
-                &format!("{}{}", prefix, "SearchEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SearchEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.source_fields {
             params.put(&format!("{}{}", prefix, "SourceFields"), &field_value);
@@ -3120,28 +3006,16 @@ impl LiteralOptionsSerializer {
             params.put(&format!("{}{}", prefix, "DefaultValue"), &field_value);
         }
         if let Some(ref field_value) = obj.facet_enabled {
-            params.put(
-                &format!("{}{}", prefix, "FacetEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "FacetEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.return_enabled {
-            params.put(
-                &format!("{}{}", prefix, "ReturnEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ReturnEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.search_enabled {
-            params.put(
-                &format!("{}{}", prefix, "SearchEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SearchEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.sort_enabled {
-            params.put(
-                &format!("{}{}", prefix, "SortEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SortEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.source_field {
             params.put(&format!("{}{}", prefix, "SourceField"), &field_value);
@@ -3374,13 +3248,13 @@ impl ScalingParametersSerializer {
         if let Some(ref field_value) = obj.desired_partition_count {
             params.put(
                 &format!("{}{}", prefix, "DesiredPartitionCount"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.desired_replication_count {
             params.put(
                 &format!("{}{}", prefix, "DesiredReplicationCount"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
     }
@@ -3693,16 +3567,10 @@ impl TextArrayOptionsSerializer {
             params.put(&format!("{}{}", prefix, "DefaultValue"), &field_value);
         }
         if let Some(ref field_value) = obj.highlight_enabled {
-            params.put(
-                &format!("{}{}", prefix, "HighlightEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "HighlightEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.return_enabled {
-            params.put(
-                &format!("{}{}", prefix, "ReturnEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ReturnEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.source_fields {
             params.put(&format!("{}{}", prefix, "SourceFields"), &field_value);
@@ -3782,22 +3650,13 @@ impl TextOptionsSerializer {
             params.put(&format!("{}{}", prefix, "DefaultValue"), &field_value);
         }
         if let Some(ref field_value) = obj.highlight_enabled {
-            params.put(
-                &format!("{}{}", prefix, "HighlightEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "HighlightEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.return_enabled {
-            params.put(
-                &format!("{}{}", prefix, "ReturnEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ReturnEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.sort_enabled {
-            params.put(
-                &format!("{}{}", prefix, "SortEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SortEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.source_field {
             params.put(&format!("{}{}", prefix, "SourceField"), &field_value);
@@ -3837,10 +3696,7 @@ impl UpdateAvailabilityOptionsRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
-        params.put(
-            &format!("{}{}", prefix, "MultiAZ"),
-            &obj.multi_az.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "MultiAZ"), &obj.multi_az);
     }
 }
 

--- a/rusoto/services/cloudwatch/src/generated.rs
+++ b/rusoto/services/cloudwatch/src/generated.rs
@@ -192,7 +192,7 @@ impl CountsSerializer {
     fn serialize(params: &mut Params, name: &str, obj: &Vec<f64>) {
         for (index, obj) in obj.iter().enumerate() {
             let key = format!("{}.member.{}", name, index + 1);
-            params.put(&key, &obj.to_string());
+            params.put(&key, &obj);
         }
     }
 }
@@ -635,10 +635,7 @@ impl DescribeAlarmHistoryInputSerializer {
             params.put(&format!("{}{}", prefix, "HistoryItemType"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -725,7 +722,7 @@ impl DescribeAlarmsForMetricInputSerializer {
         params.put(&format!("{}{}", prefix, "MetricName"), &obj.metric_name);
         params.put(&format!("{}{}", prefix, "Namespace"), &obj.namespace);
         if let Some(ref field_value) = obj.period {
-            params.put(&format!("{}{}", prefix, "Period"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Period"), &field_value);
         }
         if let Some(ref field_value) = obj.statistic {
             params.put(&format!("{}{}", prefix, "Statistic"), &field_value);
@@ -805,10 +802,7 @@ impl DescribeAlarmsInputSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -1180,10 +1174,7 @@ impl GetMetricDataInputSerializer {
 
         params.put(&format!("{}{}", prefix, "EndTime"), &obj.end_time);
         if let Some(ref field_value) = obj.max_datapoints {
-            params.put(
-                &format!("{}{}", prefix, "MaxDatapoints"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxDatapoints"), &field_value);
         }
         MetricDataQueriesSerializer::serialize(
             params,
@@ -1279,7 +1270,7 @@ impl GetMetricStatisticsInputSerializer {
         }
         params.put(&format!("{}{}", prefix, "MetricName"), &obj.metric_name);
         params.put(&format!("{}{}", prefix, "Namespace"), &obj.namespace);
-        params.put(&format!("{}{}", prefix, "Period"), &obj.period.to_string());
+        params.put(&format!("{}{}", prefix, "Period"), &obj.period);
         params.put(&format!("{}{}", prefix, "StartTime"), &obj.start_time);
         if let Some(ref field_value) = obj.statistics {
             StatisticsSerializer::serialize(
@@ -2038,10 +2029,7 @@ impl MetricDataQuerySerializer {
             );
         }
         if let Some(ref field_value) = obj.return_data {
-            params.put(
-                &format!("{}{}", prefix, "ReturnData"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ReturnData"), &field_value);
         }
     }
 }
@@ -2188,10 +2176,7 @@ impl MetricDatumSerializer {
             );
         }
         if let Some(ref field_value) = obj.storage_resolution {
-            params.put(
-                &format!("{}{}", prefix, "StorageResolution"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "StorageResolution"), &field_value);
         }
         if let Some(ref field_value) = obj.timestamp {
             params.put(&format!("{}{}", prefix, "Timestamp"), &field_value);
@@ -2200,7 +2185,7 @@ impl MetricDatumSerializer {
             params.put(&format!("{}{}", prefix, "Unit"), &field_value);
         }
         if let Some(ref field_value) = obj.value {
-            params.put(&format!("{}{}", prefix, "Value"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Value"), &field_value);
         }
         if let Some(ref field_value) = obj.values {
             ValuesSerializer::serialize(params, &format!("{}{}", prefix, "Values"), field_value);
@@ -2315,7 +2300,7 @@ impl MetricStatSerializer {
         }
 
         MetricSerializer::serialize(params, &format!("{}{}", prefix, "Metric"), &obj.metric);
-        params.put(&format!("{}{}", prefix, "Period"), &obj.period.to_string());
+        params.put(&format!("{}{}", prefix, "Period"), &obj.period);
         params.put(&format!("{}{}", prefix, "Stat"), &obj.stat);
         if let Some(ref field_value) = obj.unit {
             params.put(&format!("{}{}", prefix, "Unit"), &field_value);
@@ -2507,10 +2492,7 @@ impl PutMetricAlarmInputSerializer {
         }
 
         if let Some(ref field_value) = obj.actions_enabled {
-            params.put(
-                &format!("{}{}", prefix, "ActionsEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ActionsEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.alarm_actions {
             ResourceListSerializer::serialize(
@@ -2528,10 +2510,7 @@ impl PutMetricAlarmInputSerializer {
             &obj.comparison_operator,
         );
         if let Some(ref field_value) = obj.datapoints_to_alarm {
-            params.put(
-                &format!("{}{}", prefix, "DatapointsToAlarm"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DatapointsToAlarm"), &field_value);
         }
         if let Some(ref field_value) = obj.dimensions {
             DimensionsSerializer::serialize(
@@ -2548,7 +2527,7 @@ impl PutMetricAlarmInputSerializer {
         }
         params.put(
             &format!("{}{}", prefix, "EvaluationPeriods"),
-            &obj.evaluation_periods.to_string(),
+            &obj.evaluation_periods,
         );
         if let Some(ref field_value) = obj.extended_statistic {
             params.put(&format!("{}{}", prefix, "ExtendedStatistic"), &field_value);
@@ -2581,15 +2560,12 @@ impl PutMetricAlarmInputSerializer {
             );
         }
         if let Some(ref field_value) = obj.period {
-            params.put(&format!("{}{}", prefix, "Period"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Period"), &field_value);
         }
         if let Some(ref field_value) = obj.statistic {
             params.put(&format!("{}{}", prefix, "Statistic"), &field_value);
         }
-        params.put(
-            &format!("{}{}", prefix, "Threshold"),
-            &obj.threshold.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "Threshold"), &obj.threshold);
         if let Some(ref field_value) = obj.treat_missing_data {
             params.put(&format!("{}{}", prefix, "TreatMissingData"), &field_value);
         }
@@ -2832,19 +2808,10 @@ impl StatisticSetSerializer {
             prefix.push_str(".");
         }
 
-        params.put(
-            &format!("{}{}", prefix, "Maximum"),
-            &obj.maximum.to_string(),
-        );
-        params.put(
-            &format!("{}{}", prefix, "Minimum"),
-            &obj.minimum.to_string(),
-        );
-        params.put(
-            &format!("{}{}", prefix, "SampleCount"),
-            &obj.sample_count.to_string(),
-        );
-        params.put(&format!("{}{}", prefix, "Sum"), &obj.sum.to_string());
+        params.put(&format!("{}{}", prefix, "Maximum"), &obj.maximum);
+        params.put(&format!("{}{}", prefix, "Minimum"), &obj.minimum);
+        params.put(&format!("{}{}", prefix, "SampleCount"), &obj.sample_count);
+        params.put(&format!("{}{}", prefix, "Sum"), &obj.sum);
     }
 }
 
@@ -2939,7 +2906,7 @@ impl ValuesSerializer {
     fn serialize(params: &mut Params, name: &str, obj: &Vec<f64>) {
         for (index, obj) in obj.iter().enumerate() {
             let key = format!("{}.member.{}", name, index + 1);
-            params.put(&key, &obj.to_string());
+            params.put(&key, &obj);
         }
     }
 }

--- a/rusoto/services/ec2/src/generated.rs
+++ b/rusoto/services/ec2/src/generated.rs
@@ -59,7 +59,7 @@ impl AcceptReservedInstancesExchangeQuoteRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         ReservedInstanceIdSetSerializer::serialize(
             params,
@@ -124,7 +124,7 @@ impl AcceptTransitGatewayVpcAttachmentRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "TransitGatewayAttachmentId"),
@@ -185,7 +185,7 @@ impl AcceptVpcEndpointConnectionsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "ServiceId"), &obj.service_id);
         ValueStringListSerializer::serialize(
@@ -244,7 +244,7 @@ impl AcceptVpcPeeringConnectionRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.vpc_peering_connection_id {
             params.put(
@@ -593,7 +593,7 @@ impl AdvertiseByoipCidrRequestSerializer {
 
         params.put(&format!("{}{}", prefix, "Cidr"), &obj.cidr);
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }
@@ -655,7 +655,7 @@ impl AllocateAddressRequestSerializer {
             params.put(&format!("{}{}", prefix, "Domain"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.public_ipv_4_pool {
             params.put(&format!("{}{}", prefix, "PublicIpv4Pool"), &field_value);
@@ -740,10 +740,7 @@ impl AllocateHostsRequestSerializer {
             params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "InstanceType"), &obj.instance_type);
-        params.put(
-            &format!("{}{}", prefix, "Quantity"),
-            &obj.quantity.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "Quantity"), &obj.quantity);
         if let Some(ref field_value) = obj.tag_specifications {
             TagSpecificationListSerializer::serialize(
                 params,
@@ -901,7 +898,7 @@ impl ApplySecurityGroupsToClientVpnTargetNetworkRequestSerializer {
             &obj.client_vpn_endpoint_id,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         ClientVpnSecurityGroupIdSetSerializer::serialize(
             params,
@@ -979,10 +976,7 @@ impl AssignIpv6AddressesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.ipv_6_address_count {
-            params.put(
-                &format!("{}{}", prefix, "Ipv6AddressCount"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Ipv6AddressCount"), &field_value);
         }
         if let Some(ref field_value) = obj.ipv_6_addresses {
             Ipv6AddressListSerializer::serialize(
@@ -1062,10 +1056,7 @@ impl AssignPrivateIpAddressesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.allow_reassignment {
-            params.put(
-                &format!("{}{}", prefix, "AllowReassignment"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "AllowReassignment"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "NetworkInterfaceId"),
@@ -1081,7 +1072,7 @@ impl AssignPrivateIpAddressesRequestSerializer {
         if let Some(ref field_value) = obj.secondary_private_ip_address_count {
             params.put(
                 &format!("{}{}", prefix, "SecondaryPrivateIpAddressCount"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
     }
@@ -1118,13 +1109,10 @@ impl AssociateAddressRequestSerializer {
             params.put(&format!("{}{}", prefix, "AllocationId"), &field_value);
         }
         if let Some(ref field_value) = obj.allow_reassociation {
-            params.put(
-                &format!("{}{}", prefix, "AllowReassociation"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "AllowReassociation"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.instance_id {
             params.put(&format!("{}{}", prefix, "InstanceId"), &field_value);
@@ -1190,7 +1178,7 @@ impl AssociateClientVpnTargetNetworkRequestSerializer {
             &obj.client_vpn_endpoint_id,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "SubnetId"), &obj.subnet_id);
     }
@@ -1255,7 +1243,7 @@ impl AssociateDhcpOptionsRequestSerializer {
             &obj.dhcp_options_id,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
     }
@@ -1339,7 +1327,7 @@ impl AssociateRouteTableRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "RouteTableId"),
@@ -1460,7 +1448,7 @@ impl AssociateTransitGatewayRouteTableRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "TransitGatewayAttachmentId"),
@@ -1526,7 +1514,7 @@ impl AssociateVpcCidrBlockRequestSerializer {
         if let Some(ref field_value) = obj.amazon_provided_ipv_6_cidr_block {
             params.put(
                 &format!("{}{}", prefix, "AmazonProvidedIpv6CidrBlock"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.cidr_block {
@@ -1670,7 +1658,7 @@ impl AttachClassicLinkVpcRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         GroupIdStringListSerializer::serialize(
             params,
@@ -1730,7 +1718,7 @@ impl AttachInternetGatewayRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "InternetGatewayId"),
@@ -1762,12 +1750,9 @@ impl AttachNetworkInterfaceRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(
-            &format!("{}{}", prefix, "DeviceIndex"),
-            &obj.device_index.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "DeviceIndex"), &obj.device_index);
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
         params.put(
@@ -1831,7 +1816,7 @@ impl AttachVolumeRequestSerializer {
 
         params.put(&format!("{}{}", prefix, "Device"), &obj.device);
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
         params.put(&format!("{}{}", prefix, "VolumeId"), &obj.volume_id);
@@ -1859,7 +1844,7 @@ impl AttachVpnGatewayRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
         params.put(
@@ -1945,7 +1930,7 @@ impl AttributeBooleanValueSerializer {
         }
 
         if let Some(ref field_value) = obj.value {
-            params.put(&format!("{}{}", prefix, "Value"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Value"), &field_value);
         }
     }
 }
@@ -2093,10 +2078,7 @@ impl AuthorizeClientVpnIngressRequestSerializer {
             params.put(&format!("{}{}", prefix, "AccessGroupId"), &field_value);
         }
         if let Some(ref field_value) = obj.authorize_all_groups {
-            params.put(
-                &format!("{}{}", prefix, "AuthorizeAllGroups"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "AuthorizeAllGroups"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "ClientVpnEndpointId"),
@@ -2106,7 +2088,7 @@ impl AuthorizeClientVpnIngressRequestSerializer {
             params.put(&format!("{}{}", prefix, "Description"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "TargetNetworkCidr"),
@@ -2181,13 +2163,10 @@ impl AuthorizeSecurityGroupEgressRequestSerializer {
             params.put(&format!("{}{}", prefix, "CidrIp"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.from_port {
-            params.put(
-                &format!("{}{}", prefix, "FromPort"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "FromPort"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "GroupId"), &obj.group_id);
         if let Some(ref field_value) = obj.ip_permissions {
@@ -2213,7 +2192,7 @@ impl AuthorizeSecurityGroupEgressRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.to_port {
-            params.put(&format!("{}{}", prefix, "ToPort"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "ToPort"), &field_value);
         }
     }
 }
@@ -2255,13 +2234,10 @@ impl AuthorizeSecurityGroupIngressRequestSerializer {
             params.put(&format!("{}{}", prefix, "CidrIp"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.from_port {
-            params.put(
-                &format!("{}{}", prefix, "FromPort"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "FromPort"), &field_value);
         }
         if let Some(ref field_value) = obj.group_id {
             params.put(&format!("{}{}", prefix, "GroupId"), &field_value);
@@ -2292,7 +2268,7 @@ impl AuthorizeSecurityGroupIngressRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.to_port {
-            params.put(&format!("{}{}", prefix, "ToPort"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "ToPort"), &field_value);
         }
     }
 }
@@ -2726,7 +2702,7 @@ impl BundleInstanceRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
         StorageSerializer::serialize(params, &format!("{}{}", prefix, "Storage"), &obj.storage);
@@ -2989,7 +2965,7 @@ impl CancelBundleTaskRequestSerializer {
 
         params.put(&format!("{}{}", prefix, "BundleId"), &obj.bundle_id);
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }
@@ -3044,7 +3020,7 @@ impl CancelCapacityReservationRequestSerializer {
             &obj.capacity_reservation_id,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }
@@ -3102,7 +3078,7 @@ impl CancelConversionRequestSerializer {
             &obj.conversion_task_id,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.reason_message {
             params.put(&format!("{}{}", prefix, "ReasonMessage"), &field_value);
@@ -3157,7 +3133,7 @@ impl CancelImportTaskRequestSerializer {
             params.put(&format!("{}{}", prefix, "CancelReason"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.import_task_id {
             params.put(&format!("{}{}", prefix, "ImportTaskId"), &field_value);
@@ -3374,7 +3350,7 @@ impl CancelSpotFleetRequestsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         ValueStringListSerializer::serialize(
             params,
@@ -3383,7 +3359,7 @@ impl CancelSpotFleetRequestsRequestSerializer {
         );
         params.put(
             &format!("{}{}", prefix, "TerminateInstances"),
-            &obj.terminate_instances.to_string(),
+            &obj.terminate_instances,
         );
     }
 }
@@ -3534,7 +3510,7 @@ impl CancelSpotInstanceRequestsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         SpotInstanceRequestIdListSerializer::serialize(
             params,
@@ -4418,10 +4394,7 @@ impl ClientDataSerializer {
             params.put(&format!("{}{}", prefix, "UploadEnd"), &field_value);
         }
         if let Some(ref field_value) = obj.upload_size {
-            params.put(
-                &format!("{}{}", prefix, "UploadSize"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "UploadSize"), &field_value);
         }
         if let Some(ref field_value) = obj.upload_start {
             params.put(&format!("{}{}", prefix, "UploadStart"), &field_value);
@@ -5127,7 +5100,7 @@ impl ConfirmProductInstanceRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
         params.put(&format!("{}{}", prefix, "ProductCode"), &obj.product_code);
@@ -5197,10 +5170,7 @@ impl ConnectionLogOptionsSerializer {
             );
         }
         if let Some(ref field_value) = obj.enabled {
-            params.put(
-                &format!("{}{}", prefix, "Enabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Enabled"), &field_value);
         }
     }
 }
@@ -5509,7 +5479,7 @@ impl CopyFpgaImageRequestSerializer {
             params.put(&format!("{}{}", prefix, "Description"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.name {
             params.put(&format!("{}{}", prefix, "Name"), &field_value);
@@ -5584,13 +5554,10 @@ impl CopyImageRequestSerializer {
             params.put(&format!("{}{}", prefix, "Description"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.encrypted {
-            params.put(
-                &format!("{}{}", prefix, "Encrypted"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Encrypted"), &field_value);
         }
         if let Some(ref field_value) = obj.kms_key_id {
             params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
@@ -5666,13 +5633,10 @@ impl CopySnapshotRequestSerializer {
             params.put(&format!("{}{}", prefix, "DestinationRegion"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.encrypted {
-            params.put(
-                &format!("{}{}", prefix, "Encrypted"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Encrypted"), &field_value);
         }
         if let Some(ref field_value) = obj.kms_key_id {
             params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
@@ -5763,16 +5727,10 @@ impl CpuOptionsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.core_count {
-            params.put(
-                &format!("{}{}", prefix, "CoreCount"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "CoreCount"), &field_value);
         }
         if let Some(ref field_value) = obj.threads_per_core {
-            params.put(
-                &format!("{}{}", prefix, "ThreadsPerCore"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ThreadsPerCore"), &field_value);
         }
     }
 }
@@ -5824,13 +5782,10 @@ impl CreateCapacityReservationRequestSerializer {
             params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.ebs_optimized {
-            params.put(
-                &format!("{}{}", prefix, "EbsOptimized"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "EbsOptimized"), &field_value);
         }
         if let Some(ref field_value) = obj.end_date {
             params.put(&format!("{}{}", prefix, "EndDate"), &field_value);
@@ -5839,14 +5794,11 @@ impl CreateCapacityReservationRequestSerializer {
             params.put(&format!("{}{}", prefix, "EndDateType"), &field_value);
         }
         if let Some(ref field_value) = obj.ephemeral_storage {
-            params.put(
-                &format!("{}{}", prefix, "EphemeralStorage"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "EphemeralStorage"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "InstanceCount"),
-            &obj.instance_count.to_string(),
+            &obj.instance_count,
         );
         if let Some(ref field_value) = obj.instance_match_criteria {
             params.put(
@@ -5965,7 +5917,7 @@ impl CreateClientVpnEndpointRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "ServerCertificateArn"),
@@ -6062,7 +6014,7 @@ impl CreateClientVpnRouteRequestSerializer {
             &obj.destination_cidr_block,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "TargetVpcSubnetId"),
@@ -6123,9 +6075,9 @@ impl CreateCustomerGatewayRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "BgpAsn"), &obj.bgp_asn.to_string());
+        params.put(&format!("{}{}", prefix, "BgpAsn"), &obj.bgp_asn);
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "IpAddress"), &obj.public_ip);
         params.put(&format!("{}{}", prefix, "Type"), &obj.type_);
@@ -6186,7 +6138,7 @@ impl CreateDefaultSubnetRequestSerializer {
             &obj.availability_zone,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }
@@ -6235,7 +6187,7 @@ impl CreateDefaultVpcRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }
@@ -6287,7 +6239,7 @@ impl CreateDhcpOptionsRequestSerializer {
             &obj.dhcp_configurations,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }
@@ -6344,7 +6296,7 @@ impl CreateEgressOnlyInternetGatewayRequestSerializer {
             params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
     }
@@ -6571,7 +6523,7 @@ impl CreateFleetRequestSerializer {
             params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.excess_capacity_termination_policy {
             params.put(
@@ -6594,7 +6546,7 @@ impl CreateFleetRequestSerializer {
         if let Some(ref field_value) = obj.replace_unhealthy_instances {
             params.put(
                 &format!("{}{}", prefix, "ReplaceUnhealthyInstances"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.spot_options {
@@ -6619,7 +6571,7 @@ impl CreateFleetRequestSerializer {
         if let Some(ref field_value) = obj.terminate_instances_with_expiration {
             params.put(
                 &format!("{}{}", prefix, "TerminateInstancesWithExpiration"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.type_ {
@@ -6717,7 +6669,7 @@ impl CreateFlowLogsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.log_destination {
             params.put(&format!("{}{}", prefix, "LogDestination"), &field_value);
@@ -6808,7 +6760,7 @@ impl CreateFpgaImageRequestSerializer {
             params.put(&format!("{}{}", prefix, "Description"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         StorageLocationSerializer::serialize(
             params,
@@ -6896,15 +6848,12 @@ impl CreateImageRequestSerializer {
             params.put(&format!("{}{}", prefix, "Description"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
         params.put(&format!("{}{}", prefix, "Name"), &obj.name);
         if let Some(ref field_value) = obj.no_reboot {
-            params.put(
-                &format!("{}{}", prefix, "NoReboot"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "NoReboot"), &field_value);
         }
     }
 }
@@ -7019,7 +6968,7 @@ impl CreateInternetGatewayRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }
@@ -7073,7 +7022,7 @@ impl CreateKeyPairRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "KeyName"), &obj.key_name);
     }
@@ -7106,7 +7055,7 @@ impl CreateLaunchTemplateRequestSerializer {
             params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         RequestLaunchTemplateDataSerializer::serialize(
             params,
@@ -7185,7 +7134,7 @@ impl CreateLaunchTemplateVersionRequestSerializer {
             params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         RequestLaunchTemplateDataSerializer::serialize(
             params,
@@ -7333,9 +7282,9 @@ impl CreateNetworkAclEntryRequestSerializer {
             params.put(&format!("{}{}", prefix, "CidrBlock"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
-        params.put(&format!("{}{}", prefix, "Egress"), &obj.egress.to_string());
+        params.put(&format!("{}{}", prefix, "Egress"), &obj.egress);
         if let Some(ref field_value) = obj.icmp_type_code {
             IcmpTypeCodeSerializer::serialize(
                 params,
@@ -7359,10 +7308,7 @@ impl CreateNetworkAclEntryRequestSerializer {
         }
         params.put(&format!("{}{}", prefix, "Protocol"), &obj.protocol);
         params.put(&format!("{}{}", prefix, "RuleAction"), &obj.rule_action);
-        params.put(
-            &format!("{}{}", prefix, "RuleNumber"),
-            &obj.rule_number.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "RuleNumber"), &obj.rule_number);
     }
 }
 
@@ -7384,7 +7330,7 @@ impl CreateNetworkAclRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
     }
@@ -7446,7 +7392,7 @@ impl CreateNetworkInterfacePermissionRequestSerializer {
             params.put(&format!("{}{}", prefix, "AwsService"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "NetworkInterfaceId"),
@@ -7525,7 +7471,7 @@ impl CreateNetworkInterfaceRequestSerializer {
             params.put(&format!("{}{}", prefix, "Description"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.groups {
             SecurityGroupIdStringListSerializer::serialize(
@@ -7535,10 +7481,7 @@ impl CreateNetworkInterfaceRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.ipv_6_address_count {
-            params.put(
-                &format!("{}{}", prefix, "Ipv6AddressCount"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Ipv6AddressCount"), &field_value);
         }
         if let Some(ref field_value) = obj.ipv_6_addresses {
             InstanceIpv6AddressListSerializer::serialize(
@@ -7560,7 +7503,7 @@ impl CreateNetworkInterfaceRequestSerializer {
         if let Some(ref field_value) = obj.secondary_private_ip_address_count {
             params.put(
                 &format!("{}{}", prefix, "SecondaryPrivateIpAddressCount"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         params.put(&format!("{}{}", prefix, "SubnetId"), &obj.subnet_id);
@@ -7621,16 +7564,13 @@ impl CreatePlacementGroupRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.group_name {
             params.put(&format!("{}{}", prefix, "GroupName"), &field_value);
         }
         if let Some(ref field_value) = obj.partition_count {
-            params.put(
-                &format!("{}{}", prefix, "PartitionCount"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PartitionCount"), &field_value);
         }
         if let Some(ref field_value) = obj.strategy {
             params.put(&format!("{}{}", prefix, "Strategy"), &field_value);
@@ -7663,7 +7603,7 @@ impl CreateReservedInstancesListingRequestSerializer {
         params.put(&format!("{}{}", prefix, "ClientToken"), &obj.client_token);
         params.put(
             &format!("{}{}", prefix, "InstanceCount"),
-            &obj.instance_count.to_string(),
+            &obj.instance_count,
         );
         PriceScheduleSpecificationListSerializer::serialize(
             params,
@@ -7759,7 +7699,7 @@ impl CreateRouteRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.egress_only_internet_gateway_id {
             params.put(
@@ -7837,7 +7777,7 @@ impl CreateRouteTableRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
     }
@@ -7894,7 +7834,7 @@ impl CreateSecurityGroupRequestSerializer {
             &obj.description,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "GroupName"), &obj.group_name);
         if let Some(ref field_value) = obj.vpc_id {
@@ -7957,7 +7897,7 @@ impl CreateSnapshotRequestSerializer {
             params.put(&format!("{}{}", prefix, "Description"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.tag_specifications {
             TagSpecificationListSerializer::serialize(
@@ -7992,7 +7932,7 @@ impl CreateSpotDatafeedSubscriptionRequestSerializer {
 
         params.put(&format!("{}{}", prefix, "Bucket"), &obj.bucket);
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.prefix {
             params.put(&format!("{}{}", prefix, "Prefix"), &field_value);
@@ -8066,7 +8006,7 @@ impl CreateSubnetRequestSerializer {
         }
         params.put(&format!("{}{}", prefix, "CidrBlock"), &obj.cidr_block);
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.ipv_6_cidr_block {
             params.put(&format!("{}{}", prefix, "Ipv6CidrBlock"), &field_value);
@@ -8119,7 +8059,7 @@ impl CreateTagsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         ResourceIdListSerializer::serialize(
             params,
@@ -8155,7 +8095,7 @@ impl CreateTransitGatewayRequestSerializer {
             params.put(&format!("{}{}", prefix, "Description"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.options {
             TransitGatewayRequestOptionsSerializer::serialize(
@@ -8229,17 +8169,14 @@ impl CreateTransitGatewayRouteRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.blackhole {
-            params.put(
-                &format!("{}{}", prefix, "Blackhole"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Blackhole"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "DestinationCidrBlock"),
             &obj.destination_cidr_block,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.transit_gateway_attachment_id {
             params.put(
@@ -8304,7 +8241,7 @@ impl CreateTransitGatewayRouteTableRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.tag_specifications {
             TagSpecificationListSerializer::serialize(
@@ -8378,7 +8315,7 @@ impl CreateTransitGatewayVpcAttachmentRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.options {
             CreateTransitGatewayVpcAttachmentRequestOptionsSerializer::serialize(
@@ -8622,22 +8559,19 @@ impl CreateVolumeRequestSerializer {
             &obj.availability_zone,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.encrypted {
-            params.put(
-                &format!("{}{}", prefix, "Encrypted"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Encrypted"), &field_value);
         }
         if let Some(ref field_value) = obj.iops {
-            params.put(&format!("{}{}", prefix, "Iops"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Iops"), &field_value);
         }
         if let Some(ref field_value) = obj.kms_key_id {
             params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
         }
         if let Some(ref field_value) = obj.size {
-            params.put(&format!("{}{}", prefix, "Size"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Size"), &field_value);
         }
         if let Some(ref field_value) = obj.snapshot_id {
             params.put(&format!("{}{}", prefix, "SnapshotId"), &field_value);
@@ -8697,7 +8631,7 @@ impl CreateVpcEndpointConnectionNotificationRequestSerializer {
             &obj.connection_notification_arn,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.service_id {
             params.put(&format!("{}{}", prefix, "ServiceId"), &field_value);
@@ -8784,16 +8718,13 @@ impl CreateVpcEndpointRequestSerializer {
             params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.policy_document {
             params.put(&format!("{}{}", prefix, "PolicyDocument"), &field_value);
         }
         if let Some(ref field_value) = obj.private_dns_enabled {
-            params.put(
-                &format!("{}{}", prefix, "PrivateDnsEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PrivateDnsEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.route_table_ids {
             ValueStringListSerializer::serialize(
@@ -8886,16 +8817,13 @@ impl CreateVpcEndpointServiceConfigurationRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.acceptance_required {
-            params.put(
-                &format!("{}{}", prefix, "AcceptanceRequired"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "AcceptanceRequired"), &field_value);
         }
         if let Some(ref field_value) = obj.client_token {
             params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         ValueStringListSerializer::serialize(
             params,
@@ -8967,7 +8895,7 @@ impl CreateVpcPeeringConnectionRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.peer_owner_id {
             params.put(&format!("{}{}", prefix, "PeerOwnerId"), &field_value);
@@ -9040,12 +8968,12 @@ impl CreateVpcRequestSerializer {
         if let Some(ref field_value) = obj.amazon_provided_ipv_6_cidr_block {
             params.put(
                 &format!("{}{}", prefix, "AmazonProvidedIpv6CidrBlock"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         params.put(&format!("{}{}", prefix, "CidrBlock"), &obj.cidr_block);
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.instance_tenancy {
             params.put(&format!("{}{}", prefix, "InstanceTenancy"), &field_value);
@@ -9108,7 +9036,7 @@ impl CreateVpnConnectionRequestSerializer {
             &obj.customer_gateway_id,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.options {
             VpnConnectionOptionsSpecificationSerializer::serialize(
@@ -9211,16 +9139,13 @@ impl CreateVpnGatewayRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.amazon_side_asn {
-            params.put(
-                &format!("{}{}", prefix, "AmazonSideAsn"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "AmazonSideAsn"), &field_value);
         }
         if let Some(ref field_value) = obj.availability_zone {
             params.put(&format!("{}{}", prefix, "AvailabilityZone"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "Type"), &obj.type_);
     }
@@ -9485,7 +9410,7 @@ impl DeleteClientVpnEndpointRequestSerializer {
             &obj.client_vpn_endpoint_id,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }
@@ -9550,7 +9475,7 @@ impl DeleteClientVpnRouteRequestSerializer {
             &obj.destination_cidr_block,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.target_vpc_subnet_id {
             params.put(&format!("{}{}", prefix, "TargetVpcSubnetId"), &field_value);
@@ -9611,7 +9536,7 @@ impl DeleteCustomerGatewayRequestSerializer {
             &obj.customer_gateway_id,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }
@@ -9638,7 +9563,7 @@ impl DeleteDhcpOptionsRequestSerializer {
             &obj.dhcp_options_id,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }
@@ -9661,7 +9586,7 @@ impl DeleteEgressOnlyInternetGatewayRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "EgressOnlyInternetGatewayId"),
@@ -9876,7 +9801,7 @@ impl DeleteFleetsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         FleetIdSetSerializer::serialize(
             params,
@@ -9885,7 +9810,7 @@ impl DeleteFleetsRequestSerializer {
         );
         params.put(
             &format!("{}{}", prefix, "TerminateInstances"),
-            &obj.terminate_instances.to_string(),
+            &obj.terminate_instances,
         );
     }
 }
@@ -9947,7 +9872,7 @@ impl DeleteFlowLogsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         ValueStringListSerializer::serialize(
             params,
@@ -10001,7 +9926,7 @@ impl DeleteFpgaImageRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "FpgaImageId"), &obj.fpga_image_id);
     }
@@ -10049,7 +9974,7 @@ impl DeleteInternetGatewayRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "InternetGatewayId"),
@@ -10076,7 +10001,7 @@ impl DeleteKeyPairRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "KeyName"), &obj.key_name);
     }
@@ -10102,7 +10027,7 @@ impl DeleteLaunchTemplateRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.launch_template_id {
             params.put(&format!("{}{}", prefix, "LaunchTemplateId"), &field_value);
@@ -10166,7 +10091,7 @@ impl DeleteLaunchTemplateVersionsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.launch_template_id {
             params.put(&format!("{}{}", prefix, "LaunchTemplateId"), &field_value);
@@ -10428,17 +10353,14 @@ impl DeleteNetworkAclEntryRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
-        params.put(&format!("{}{}", prefix, "Egress"), &obj.egress.to_string());
+        params.put(&format!("{}{}", prefix, "Egress"), &obj.egress);
         params.put(
             &format!("{}{}", prefix, "NetworkAclId"),
             &obj.network_acl_id,
         );
-        params.put(
-            &format!("{}{}", prefix, "RuleNumber"),
-            &obj.rule_number.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "RuleNumber"), &obj.rule_number);
     }
 }
 
@@ -10460,7 +10382,7 @@ impl DeleteNetworkAclRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "NetworkAclId"),
@@ -10490,10 +10412,10 @@ impl DeleteNetworkInterfacePermissionRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.force {
-            params.put(&format!("{}{}", prefix, "Force"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Force"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "NetworkInterfacePermissionId"),
@@ -10550,7 +10472,7 @@ impl DeleteNetworkInterfaceRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "NetworkInterfaceId"),
@@ -10577,7 +10499,7 @@ impl DeletePlacementGroupRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "GroupName"), &obj.group_name);
     }
@@ -10617,7 +10539,7 @@ impl DeleteRouteRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "RouteTableId"),
@@ -10644,7 +10566,7 @@ impl DeleteRouteTableRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "RouteTableId"),
@@ -10673,7 +10595,7 @@ impl DeleteSecurityGroupRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.group_id {
             params.put(&format!("{}{}", prefix, "GroupId"), &field_value);
@@ -10703,7 +10625,7 @@ impl DeleteSnapshotRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "SnapshotId"), &obj.snapshot_id);
     }
@@ -10726,7 +10648,7 @@ impl DeleteSpotDatafeedSubscriptionRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }
@@ -10749,7 +10671,7 @@ impl DeleteSubnetRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "SubnetId"), &obj.subnet_id);
     }
@@ -10775,7 +10697,7 @@ impl DeleteTagsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         ResourceIdListSerializer::serialize(
             params,
@@ -10806,7 +10728,7 @@ impl DeleteTransitGatewayRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "TransitGatewayId"),
@@ -10870,7 +10792,7 @@ impl DeleteTransitGatewayRouteRequestSerializer {
             &obj.destination_cidr_block,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "TransitGatewayRouteTableId"),
@@ -10927,7 +10849,7 @@ impl DeleteTransitGatewayRouteTableRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "TransitGatewayRouteTableId"),
@@ -10986,7 +10908,7 @@ impl DeleteTransitGatewayVpcAttachmentRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "TransitGatewayAttachmentId"),
@@ -11046,7 +10968,7 @@ impl DeleteVolumeRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "VolumeId"), &obj.volume_id);
     }
@@ -11079,7 +11001,7 @@ impl DeleteVpcEndpointConnectionNotificationsRequestSerializer {
             &obj.connection_notification_ids,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }
@@ -11136,7 +11058,7 @@ impl DeleteVpcEndpointServiceConfigurationsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         ValueStringListSerializer::serialize(
             params,
@@ -11195,7 +11117,7 @@ impl DeleteVpcEndpointsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         ValueStringListSerializer::serialize(
             params,
@@ -11254,7 +11176,7 @@ impl DeleteVpcPeeringConnectionRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "VpcPeeringConnectionId"),
@@ -11309,7 +11231,7 @@ impl DeleteVpcRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
     }
@@ -11334,7 +11256,7 @@ impl DeleteVpnConnectionRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "VpnConnectionId"),
@@ -11391,7 +11313,7 @@ impl DeleteVpnGatewayRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "VpnGatewayId"),
@@ -11419,7 +11341,7 @@ impl DeprovisionByoipCidrRequestSerializer {
 
         params.put(&format!("{}{}", prefix, "Cidr"), &obj.cidr);
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }
@@ -11472,7 +11394,7 @@ impl DeregisterImageRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "ImageId"), &obj.image_id);
     }
@@ -11503,7 +11425,7 @@ impl DescribeAccountAttributesRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }
@@ -11570,7 +11492,7 @@ impl DescribeAddressesRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -11635,7 +11557,7 @@ impl DescribeAggregateIdFormatRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }
@@ -11700,7 +11622,7 @@ impl DescribeAvailabilityZonesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -11787,7 +11709,7 @@ impl DescribeBundleTasksRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -11853,12 +11775,9 @@ impl DescribeByoipCidrsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
-        params.put(
-            &format!("{}{}", prefix, "MaxResults"),
-            &obj.max_results.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "MaxResults"), &obj.max_results);
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
         }
@@ -11931,7 +11850,7 @@ impl DescribeCapacityReservationsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -11941,10 +11860,7 @@ impl DescribeCapacityReservationsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -12014,7 +11930,7 @@ impl DescribeClassicLinkInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -12031,10 +11947,7 @@ impl DescribeClassicLinkInstancesRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -12112,7 +12025,7 @@ impl DescribeClientVpnAuthorizationRulesRequestSerializer {
             &obj.client_vpn_endpoint_id,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -12122,10 +12035,7 @@ impl DescribeClientVpnAuthorizationRulesRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -12200,7 +12110,7 @@ impl DescribeClientVpnConnectionsRequestSerializer {
             &obj.client_vpn_endpoint_id,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -12210,10 +12120,7 @@ impl DescribeClientVpnConnectionsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -12288,7 +12195,7 @@ impl DescribeClientVpnEndpointsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -12298,10 +12205,7 @@ impl DescribeClientVpnEndpointsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -12373,7 +12277,7 @@ impl DescribeClientVpnRoutesRequestSerializer {
             &obj.client_vpn_endpoint_id,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -12383,10 +12287,7 @@ impl DescribeClientVpnRoutesRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -12467,7 +12368,7 @@ impl DescribeClientVpnTargetNetworksRequestSerializer {
             &obj.client_vpn_endpoint_id,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -12477,10 +12378,7 @@ impl DescribeClientVpnTargetNetworksRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -12570,7 +12468,7 @@ impl DescribeConversionTasksRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }
@@ -12637,7 +12535,7 @@ impl DescribeCustomerGatewaysRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -12710,7 +12608,7 @@ impl DescribeDhcpOptionsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -12774,7 +12672,7 @@ impl DescribeEgressOnlyInternetGatewaysRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.egress_only_internet_gateway_ids {
             EgressOnlyInternetGatewayIdListSerializer::serialize(
@@ -12784,10 +12682,7 @@ impl DescribeEgressOnlyInternetGatewaysRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -12857,7 +12752,7 @@ impl DescribeElasticGpusRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.elastic_gpu_ids {
             ElasticGpuIdSetSerializer::serialize(
@@ -12874,10 +12769,7 @@ impl DescribeElasticGpusRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -13057,17 +12949,14 @@ impl DescribeFleetHistoryRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.event_type {
             params.put(&format!("{}{}", prefix, "EventType"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "FleetId"), &obj.fleet_id);
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -13155,7 +13044,7 @@ impl DescribeFleetInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -13166,10 +13055,7 @@ impl DescribeFleetInstancesRequestSerializer {
         }
         params.put(&format!("{}{}", prefix, "FleetId"), &obj.fleet_id);
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -13340,7 +13226,7 @@ impl DescribeFleetsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -13357,10 +13243,7 @@ impl DescribeFleetsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -13423,7 +13306,7 @@ impl DescribeFlowLogsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filter {
             FilterListSerializer::serialize(
@@ -13440,10 +13323,7 @@ impl DescribeFlowLogsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -13503,7 +13383,7 @@ impl DescribeFpgaImageAttributeRequestSerializer {
 
         params.put(&format!("{}{}", prefix, "Attribute"), &obj.attribute);
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "FpgaImageId"), &obj.fpga_image_id);
     }
@@ -13567,7 +13447,7 @@ impl DescribeFpgaImagesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -13584,10 +13464,7 @@ impl DescribeFpgaImagesRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -13671,22 +13548,13 @@ impl DescribeHostReservationOfferingsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_duration {
-            params.put(
-                &format!("{}{}", prefix, "MaxDuration"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxDuration"), &field_value);
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.min_duration {
-            params.put(
-                &format!("{}{}", prefix, "MinDuration"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MinDuration"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -13768,10 +13636,7 @@ impl DescribeHostReservationsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -13853,10 +13718,7 @@ impl DescribeHostsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -13935,10 +13797,7 @@ impl DescribeIamInstanceProfileAssociationsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -14108,7 +13967,7 @@ impl DescribeImageAttributeRequestSerializer {
 
         params.put(&format!("{}{}", prefix, "Attribute"), &obj.attribute);
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "ImageId"), &obj.image_id);
     }
@@ -14139,7 +13998,7 @@ impl DescribeImagesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.executable_users {
             ExecutableByStringListSerializer::serialize(
@@ -14224,7 +14083,7 @@ impl DescribeImportImageTasksRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -14241,10 +14100,7 @@ impl DescribeImportImageTasksRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -14316,7 +14172,7 @@ impl DescribeImportSnapshotTasksRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -14333,10 +14189,7 @@ impl DescribeImportSnapshotTasksRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -14404,7 +14257,7 @@ impl DescribeInstanceAttributeRequestSerializer {
 
         params.put(&format!("{}{}", prefix, "Attribute"), &obj.attribute);
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
     }
@@ -14438,7 +14291,7 @@ impl DescribeInstanceCreditSpecificationsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -14455,10 +14308,7 @@ impl DescribeInstanceCreditSpecificationsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -14530,7 +14380,7 @@ impl DescribeInstanceStatusRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -14542,7 +14392,7 @@ impl DescribeInstanceStatusRequestSerializer {
         if let Some(ref field_value) = obj.include_all_instances {
             params.put(
                 &format!("{}{}", prefix, "IncludeAllInstances"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.instance_ids {
@@ -14553,10 +14403,7 @@ impl DescribeInstanceStatusRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -14626,7 +14473,7 @@ impl DescribeInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -14643,10 +14490,7 @@ impl DescribeInstancesRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -14709,7 +14553,7 @@ impl DescribeInternetGatewaysRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -14781,7 +14625,7 @@ impl DescribeKeyPairsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -14858,7 +14702,7 @@ impl DescribeLaunchTemplateVersionsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -14874,10 +14718,7 @@ impl DescribeLaunchTemplateVersionsRequestSerializer {
             params.put(&format!("{}{}", prefix, "LaunchTemplateName"), &field_value);
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.max_version {
             params.put(&format!("{}{}", prefix, "MaxVersion"), &field_value);
@@ -14962,7 +14803,7 @@ impl DescribeLaunchTemplatesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -14986,10 +14827,7 @@ impl DescribeLaunchTemplatesRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -15056,7 +14894,7 @@ impl DescribeMovingAddressesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -15066,10 +14904,7 @@ impl DescribeMovingAddressesRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -15151,10 +14986,7 @@ impl DescribeNatGatewaysRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.nat_gateway_ids {
             ValueStringListSerializer::serialize(
@@ -15224,7 +15056,7 @@ impl DescribeNetworkAclsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -15297,7 +15129,7 @@ impl DescribeNetworkInterfaceAttributeRequestSerializer {
             params.put(&format!("{}{}", prefix, "Attribute"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "NetworkInterfaceId"),
@@ -15404,10 +15236,7 @@ impl DescribeNetworkInterfacePermissionsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.network_interface_permission_ids {
             NetworkInterfacePermissionIdListSerializer::serialize(
@@ -15486,7 +15315,7 @@ impl DescribeNetworkInterfacesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -15496,10 +15325,7 @@ impl DescribeNetworkInterfacesRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.network_interface_ids {
             NetworkInterfaceIdListSerializer::serialize(
@@ -15573,7 +15399,7 @@ impl DescribePlacementGroupsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -15649,7 +15475,7 @@ impl DescribePrefixListsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -15659,10 +15485,7 @@ impl DescribePrefixListsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -15734,13 +15557,10 @@ impl DescribePrincipalIdFormatRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -15810,10 +15630,7 @@ impl DescribePublicIpv4PoolsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -15883,7 +15700,7 @@ impl DescribeRegionsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -16135,7 +15952,7 @@ impl DescribeReservedInstancesOfferingsRequestSerializer {
             params.put(&format!("{}{}", prefix, "AvailabilityZone"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -16145,10 +15962,7 @@ impl DescribeReservedInstancesOfferingsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.include_marketplace {
-            params.put(
-                &format!("{}{}", prefix, "IncludeMarketplace"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "IncludeMarketplace"), &field_value);
         }
         if let Some(ref field_value) = obj.instance_tenancy {
             params.put(&format!("{}{}", prefix, "InstanceTenancy"), &field_value);
@@ -16157,28 +15971,16 @@ impl DescribeReservedInstancesOfferingsRequestSerializer {
             params.put(&format!("{}{}", prefix, "InstanceType"), &field_value);
         }
         if let Some(ref field_value) = obj.max_duration {
-            params.put(
-                &format!("{}{}", prefix, "MaxDuration"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxDuration"), &field_value);
         }
         if let Some(ref field_value) = obj.max_instance_count {
-            params.put(
-                &format!("{}{}", prefix, "MaxInstanceCount"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxInstanceCount"), &field_value);
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.min_duration {
-            params.put(
-                &format!("{}{}", prefix, "MinDuration"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MinDuration"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -16266,7 +16068,7 @@ impl DescribeReservedInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -16349,7 +16151,7 @@ impl DescribeRouteTablesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -16359,10 +16161,7 @@ impl DescribeRouteTablesRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -16448,7 +16247,7 @@ impl DescribeScheduledInstanceAvailabilityRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -16463,21 +16262,18 @@ impl DescribeScheduledInstanceAvailabilityRequestSerializer {
             &obj.first_slot_start_time_range,
         );
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.max_slot_duration_in_hours {
             params.put(
                 &format!("{}{}", prefix, "MaxSlotDurationInHours"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.min_slot_duration_in_hours {
             params.put(
                 &format!("{}{}", prefix, "MinSlotDurationInHours"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.next_token {
@@ -16557,7 +16353,7 @@ impl DescribeScheduledInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -16567,10 +16363,7 @@ impl DescribeScheduledInstancesRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -16649,7 +16442,7 @@ impl DescribeSecurityGroupReferencesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         GroupIdsSerializer::serialize(params, &format!("{}{}", prefix, "GroupId"), &obj.group_id);
     }
@@ -16714,7 +16507,7 @@ impl DescribeSecurityGroupsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -16738,10 +16531,7 @@ impl DescribeSecurityGroupsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -16806,7 +16596,7 @@ impl DescribeSnapshotAttributeRequestSerializer {
 
         params.put(&format!("{}{}", prefix, "Attribute"), &obj.attribute);
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "SnapshotId"), &obj.snapshot_id);
     }
@@ -16888,7 +16678,7 @@ impl DescribeSnapshotsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -16898,10 +16688,7 @@ impl DescribeSnapshotsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -16983,7 +16770,7 @@ impl DescribeSpotDatafeedSubscriptionRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }
@@ -17044,13 +16831,10 @@ impl DescribeSpotFleetInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -17133,16 +16917,13 @@ impl DescribeSpotFleetRequestHistoryRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.event_type {
             params.put(&format!("{}{}", prefix, "EventType"), &field_value);
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -17236,13 +17017,10 @@ impl DescribeSpotFleetRequestsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -17321,7 +17099,7 @@ impl DescribeSpotInstanceRequestsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -17331,10 +17109,7 @@ impl DescribeSpotInstanceRequestsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -17424,7 +17199,7 @@ impl DescribeSpotPriceHistoryRequestSerializer {
             params.put(&format!("{}{}", prefix, "AvailabilityZone"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.end_time {
             params.put(&format!("{}{}", prefix, "EndTime"), &field_value);
@@ -17444,10 +17219,7 @@ impl DescribeSpotPriceHistoryRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -17526,13 +17298,10 @@ impl DescribeStaleSecurityGroupsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -17599,7 +17368,7 @@ impl DescribeSubnetsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -17666,7 +17435,7 @@ impl DescribeTagsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -17676,10 +17445,7 @@ impl DescribeTagsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -17742,7 +17508,7 @@ impl DescribeTransitGatewayAttachmentsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -17752,10 +17518,7 @@ impl DescribeTransitGatewayAttachmentsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -17832,7 +17595,7 @@ impl DescribeTransitGatewayRouteTablesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -17842,10 +17605,7 @@ impl DescribeTransitGatewayRouteTablesRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -17926,7 +17686,7 @@ impl DescribeTransitGatewayVpcAttachmentsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -17936,10 +17696,7 @@ impl DescribeTransitGatewayVpcAttachmentsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -18016,7 +17773,7 @@ impl DescribeTransitGatewaysRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -18026,10 +17783,7 @@ impl DescribeTransitGatewaysRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -18104,7 +17858,7 @@ impl DescribeVolumeAttributeRequestSerializer {
 
         params.put(&format!("{}{}", prefix, "Attribute"), &obj.attribute);
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "VolumeId"), &obj.volume_id);
     }
@@ -18179,7 +17933,7 @@ impl DescribeVolumeStatusRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -18189,10 +17943,7 @@ impl DescribeVolumeStatusRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -18267,7 +18018,7 @@ impl DescribeVolumesModificationsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -18277,10 +18028,7 @@ impl DescribeVolumesModificationsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -18358,7 +18106,7 @@ impl DescribeVolumesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -18368,10 +18116,7 @@ impl DescribeVolumesRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -18439,7 +18184,7 @@ impl DescribeVpcAttributeRequestSerializer {
 
         params.put(&format!("{}{}", prefix, "Attribute"), &obj.attribute);
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
     }
@@ -18511,10 +18256,7 @@ impl DescribeVpcClassicLinkDnsSupportRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -18585,7 +18327,7 @@ impl DescribeVpcClassicLinkRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -18668,7 +18410,7 @@ impl DescribeVpcEndpointConnectionNotificationsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -18678,10 +18420,7 @@ impl DescribeVpcEndpointConnectionNotificationsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -18749,7 +18488,7 @@ impl DescribeVpcEndpointConnectionsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -18759,10 +18498,7 @@ impl DescribeVpcEndpointConnectionsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -18836,7 +18572,7 @@ impl DescribeVpcEndpointServiceConfigurationsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -18846,10 +18582,7 @@ impl DescribeVpcEndpointServiceConfigurationsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -18930,7 +18663,7 @@ impl DescribeVpcEndpointServicePermissionsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -18940,10 +18673,7 @@ impl DescribeVpcEndpointServicePermissionsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -19015,7 +18745,7 @@ impl DescribeVpcEndpointServicesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -19025,10 +18755,7 @@ impl DescribeVpcEndpointServicesRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -19111,7 +18838,7 @@ impl DescribeVpcEndpointsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -19121,10 +18848,7 @@ impl DescribeVpcEndpointsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -19199,7 +18923,7 @@ impl DescribeVpcPeeringConnectionsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -19209,10 +18933,7 @@ impl DescribeVpcPeeringConnectionsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -19285,7 +19006,7 @@ impl DescribeVpcsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -19351,7 +19072,7 @@ impl DescribeVpnConnectionsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -19422,7 +19143,7 @@ impl DescribeVpnGatewaysRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -19492,7 +19213,7 @@ impl DetachClassicLinkVpcRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
         params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
@@ -19547,7 +19268,7 @@ impl DetachInternetGatewayRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "InternetGatewayId"),
@@ -19579,10 +19300,10 @@ impl DetachNetworkInterfaceRequestSerializer {
 
         params.put(&format!("{}{}", prefix, "AttachmentId"), &obj.attachment_id);
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.force {
-            params.put(&format!("{}{}", prefix, "Force"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Force"), &field_value);
         }
     }
 }
@@ -19615,10 +19336,10 @@ impl DetachVolumeRequestSerializer {
             params.put(&format!("{}{}", prefix, "Device"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.force {
-            params.put(&format!("{}{}", prefix, "Force"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Force"), &field_value);
         }
         if let Some(ref field_value) = obj.instance_id {
             params.put(&format!("{}{}", prefix, "InstanceId"), &field_value);
@@ -19648,7 +19369,7 @@ impl DetachVpnGatewayRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
         params.put(
@@ -19891,7 +19612,7 @@ impl DisableTransitGatewayRouteTablePropagationRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "TransitGatewayAttachmentId"),
@@ -20028,7 +19749,7 @@ impl DisableVpcClassicLinkRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
     }
@@ -20085,7 +19806,7 @@ impl DisassociateAddressRequestSerializer {
             params.put(&format!("{}{}", prefix, "AssociationId"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.public_ip {
             params.put(&format!("{}{}", prefix, "PublicIp"), &field_value);
@@ -20121,7 +19842,7 @@ impl DisassociateClientVpnTargetNetworkRequestSerializer {
             &obj.client_vpn_endpoint_id,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }
@@ -20237,7 +19958,7 @@ impl DisassociateRouteTableRequestSerializer {
             &obj.association_id,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }
@@ -20325,7 +20046,7 @@ impl DisassociateTransitGatewayRouteTableRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "TransitGatewayAttachmentId"),
@@ -20538,7 +20259,7 @@ impl DiskImageDetailSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Bytes"), &obj.bytes.to_string());
+        params.put(&format!("{}{}", prefix, "Bytes"), &obj.bytes);
         params.put(&format!("{}{}", prefix, "Format"), &obj.format);
         params.put(
             &format!("{}{}", prefix, "ImportManifestUrl"),
@@ -20681,10 +20402,7 @@ impl DnsServersOptionsModifyStructureSerializer {
             );
         }
         if let Some(ref field_value) = obj.enabled {
-            params.put(
-                &format!("{}{}", prefix, "Enabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Enabled"), &field_value);
         }
     }
 }
@@ -20803,17 +20521,14 @@ impl EbsBlockDeviceSerializer {
         if let Some(ref field_value) = obj.delete_on_termination {
             params.put(
                 &format!("{}{}", prefix, "DeleteOnTermination"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.encrypted {
-            params.put(
-                &format!("{}{}", prefix, "Encrypted"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Encrypted"), &field_value);
         }
         if let Some(ref field_value) = obj.iops {
-            params.put(&format!("{}{}", prefix, "Iops"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Iops"), &field_value);
         }
         if let Some(ref field_value) = obj.kms_key_id {
             params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
@@ -20822,10 +20537,7 @@ impl EbsBlockDeviceSerializer {
             params.put(&format!("{}{}", prefix, "SnapshotId"), &field_value);
         }
         if let Some(ref field_value) = obj.volume_size {
-            params.put(
-                &format!("{}{}", prefix, "VolumeSize"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "VolumeSize"), &field_value);
         }
         if let Some(ref field_value) = obj.volume_type {
             params.put(&format!("{}{}", prefix, "VolumeType"), &field_value);
@@ -20897,7 +20609,7 @@ impl EbsInstanceBlockDeviceSpecificationSerializer {
         if let Some(ref field_value) = obj.delete_on_termination {
             params.put(
                 &format!("{}{}", prefix, "DeleteOnTermination"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.volume_id {
@@ -21430,7 +21142,7 @@ impl EnableTransitGatewayRouteTablePropagationRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "TransitGatewayAttachmentId"),
@@ -21519,7 +21231,7 @@ impl EnableVolumeIORequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "VolumeId"), &obj.volume_id);
     }
@@ -21592,7 +21304,7 @@ impl EnableVpcClassicLinkRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "VpcId"), &obj.vpc_id);
     }
@@ -21774,7 +21486,7 @@ impl ExportClientVpnClientCertificateRevocationListRequestSerializer {
             &obj.client_vpn_endpoint_id,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }
@@ -21841,7 +21553,7 @@ impl ExportClientVpnClientConfigurationRequestSerializer {
             &obj.client_vpn_endpoint_id,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }
@@ -22096,7 +21808,7 @@ impl ExportTransitGatewayRoutesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -22669,19 +22381,13 @@ impl FleetLaunchTemplateOverridesRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.priority {
-            params.put(
-                &format!("{}{}", prefix, "Priority"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Priority"), &field_value);
         }
         if let Some(ref field_value) = obj.subnet_id {
             params.put(&format!("{}{}", prefix, "SubnetId"), &field_value);
         }
         if let Some(ref field_value) = obj.weighted_capacity {
-            params.put(
-                &format!("{}{}", prefix, "WeightedCapacity"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "WeightedCapacity"), &field_value);
         }
     }
 }
@@ -23218,11 +22924,11 @@ impl GetConsoleOutputRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
         if let Some(ref field_value) = obj.latest {
-            params.put(&format!("{}{}", prefix, "Latest"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Latest"), &field_value);
         }
     }
 }
@@ -23281,11 +22987,11 @@ impl GetConsoleScreenshotRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
         if let Some(ref field_value) = obj.wake_up {
-            params.put(&format!("{}{}", prefix, "WakeUp"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "WakeUp"), &field_value);
         }
     }
 }
@@ -23418,7 +23124,7 @@ impl GetLaunchTemplateDataRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
     }
@@ -23474,7 +23180,7 @@ impl GetPasswordDataRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
     }
@@ -23536,7 +23242,7 @@ impl GetReservedInstancesExchangeQuoteRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         ReservedInstanceIdSetSerializer::serialize(
             params,
@@ -23680,7 +23386,7 @@ impl GetTransitGatewayAttachmentPropagationsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -23690,10 +23396,7 @@ impl GetTransitGatewayAttachmentPropagationsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -23773,7 +23476,7 @@ impl GetTransitGatewayRouteTableAssociationsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -23783,10 +23486,7 @@ impl GetTransitGatewayRouteTableAssociationsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -23864,7 +23564,7 @@ impl GetTransitGatewayRouteTablePropagationsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.filters {
             FilterListSerializer::serialize(
@@ -23874,10 +23574,7 @@ impl GetTransitGatewayRouteTablePropagationsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -24120,10 +23817,7 @@ impl HibernationOptionsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.configured {
-            params.put(
-                &format!("{}{}", prefix, "Configured"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Configured"), &field_value);
         }
     }
 }
@@ -24877,10 +24571,10 @@ impl IcmpTypeCodeSerializer {
         }
 
         if let Some(ref field_value) = obj.code {
-            params.put(&format!("{}{}", prefix, "Code"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Code"), &field_value);
         }
         if let Some(ref field_value) = obj.type_ {
-            params.put(&format!("{}{}", prefix, "Type"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Type"), &field_value);
         }
     }
 }
@@ -25334,7 +25028,7 @@ impl ImportClientVpnClientCertificateRevocationListRequestSerializer {
             &obj.client_vpn_endpoint_id,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }
@@ -25429,13 +25123,10 @@ impl ImportImageRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.encrypted {
-            params.put(
-                &format!("{}{}", prefix, "Encrypted"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Encrypted"), &field_value);
         }
         if let Some(ref field_value) = obj.hypervisor {
             params.put(&format!("{}{}", prefix, "Hypervisor"), &field_value);
@@ -25718,10 +25409,7 @@ impl ImportInstanceLaunchSpecificationSerializer {
             params.put(&format!("{}{}", prefix, "InstanceType"), &field_value);
         }
         if let Some(ref field_value) = obj.monitoring {
-            params.put(
-                &format!("{}{}", prefix, "Monitoring"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Monitoring"), &field_value);
         }
         if let Some(ref field_value) = obj.placement {
             PlacementSerializer::serialize(
@@ -25781,7 +25469,7 @@ impl ImportInstanceRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.launch_specification {
             ImportInstanceLaunchSpecificationSerializer::serialize(
@@ -25979,7 +25667,7 @@ impl ImportKeyPairRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "KeyName"), &obj.key_name);
         params.put(
@@ -26070,13 +25758,10 @@ impl ImportSnapshotRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.encrypted {
-            params.put(
-                &format!("{}{}", prefix, "Encrypted"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Encrypted"), &field_value);
         }
         if let Some(ref field_value) = obj.kms_key_id {
             params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
@@ -26226,7 +25911,7 @@ impl ImportVolumeRequestSerializer {
             params.put(&format!("{}{}", prefix, "Description"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         DiskImageDetailSerializer::serialize(params, &format!("{}{}", prefix, "Image"), &obj.image);
         VolumeDetailSerializer::serialize(params, &format!("{}{}", prefix, "Volume"), &obj.volume);
@@ -27808,23 +27493,20 @@ impl InstanceNetworkInterfaceSpecificationSerializer {
         if let Some(ref field_value) = obj.associate_public_ip_address {
             params.put(
                 &format!("{}{}", prefix, "AssociatePublicIpAddress"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.delete_on_termination {
             params.put(
                 &format!("{}{}", prefix, "DeleteOnTermination"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.description {
             params.put(&format!("{}{}", prefix, "Description"), &field_value);
         }
         if let Some(ref field_value) = obj.device_index {
-            params.put(
-                &format!("{}{}", prefix, "DeviceIndex"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DeviceIndex"), &field_value);
         }
         if let Some(ref field_value) = obj.groups {
             SecurityGroupIdStringListSerializer::serialize(
@@ -27834,10 +27516,7 @@ impl InstanceNetworkInterfaceSpecificationSerializer {
             );
         }
         if let Some(ref field_value) = obj.ipv_6_address_count {
-            params.put(
-                &format!("{}{}", prefix, "Ipv6AddressCount"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Ipv6AddressCount"), &field_value);
         }
         if let Some(ref field_value) = obj.ipv_6_addresses {
             InstanceIpv6AddressListSerializer::serialize(
@@ -27862,7 +27541,7 @@ impl InstanceNetworkInterfaceSpecificationSerializer {
         if let Some(ref field_value) = obj.secondary_private_ip_address_count {
             params.put(
                 &format!("{}{}", prefix, "SecondaryPrivateIpAddressCount"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.subnet_id {
@@ -28548,10 +28227,7 @@ impl IpPermissionSerializer {
         }
 
         if let Some(ref field_value) = obj.from_port {
-            params.put(
-                &format!("{}{}", prefix, "FromPort"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "FromPort"), &field_value);
         }
         if let Some(ref field_value) = obj.ip_protocol {
             params.put(&format!("{}{}", prefix, "IpProtocol"), &field_value);
@@ -28578,7 +28254,7 @@ impl IpPermissionSerializer {
             );
         }
         if let Some(ref field_value) = obj.to_port {
-            params.put(&format!("{}{}", prefix, "ToPort"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "ToPort"), &field_value);
         }
         if let Some(ref field_value) = obj.user_id_group_pairs {
             UserIdGroupPairListSerializer::serialize(
@@ -29696,16 +29372,10 @@ impl LaunchTemplateCpuOptionsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.core_count {
-            params.put(
-                &format!("{}{}", prefix, "CoreCount"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "CoreCount"), &field_value);
         }
         if let Some(ref field_value) = obj.threads_per_core {
-            params.put(
-                &format!("{}{}", prefix, "ThreadsPerCore"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ThreadsPerCore"), &field_value);
         }
     }
 }
@@ -29806,17 +29476,14 @@ impl LaunchTemplateEbsBlockDeviceRequestSerializer {
         if let Some(ref field_value) = obj.delete_on_termination {
             params.put(
                 &format!("{}{}", prefix, "DeleteOnTermination"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.encrypted {
-            params.put(
-                &format!("{}{}", prefix, "Encrypted"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Encrypted"), &field_value);
         }
         if let Some(ref field_value) = obj.iops {
-            params.put(&format!("{}{}", prefix, "Iops"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Iops"), &field_value);
         }
         if let Some(ref field_value) = obj.kms_key_id {
             params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
@@ -29825,10 +29492,7 @@ impl LaunchTemplateEbsBlockDeviceRequestSerializer {
             params.put(&format!("{}{}", prefix, "SnapshotId"), &field_value);
         }
         if let Some(ref field_value) = obj.volume_size {
-            params.put(
-                &format!("{}{}", prefix, "VolumeSize"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "VolumeSize"), &field_value);
         }
         if let Some(ref field_value) = obj.volume_type {
             params.put(&format!("{}{}", prefix, "VolumeType"), &field_value);
@@ -29982,10 +29646,7 @@ impl LaunchTemplateHibernationOptionsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.configured {
-            params.put(
-                &format!("{}{}", prefix, "Configured"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Configured"), &field_value);
         }
     }
 }
@@ -30308,23 +29969,20 @@ impl LaunchTemplateInstanceNetworkInterfaceSpecificationRequestSerializer {
         if let Some(ref field_value) = obj.associate_public_ip_address {
             params.put(
                 &format!("{}{}", prefix, "AssociatePublicIpAddress"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.delete_on_termination {
             params.put(
                 &format!("{}{}", prefix, "DeleteOnTermination"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.description {
             params.put(&format!("{}{}", prefix, "Description"), &field_value);
         }
         if let Some(ref field_value) = obj.device_index {
-            params.put(
-                &format!("{}{}", prefix, "DeviceIndex"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DeviceIndex"), &field_value);
         }
         if let Some(ref field_value) = obj.groups {
             SecurityGroupIdStringListSerializer::serialize(
@@ -30334,10 +29992,7 @@ impl LaunchTemplateInstanceNetworkInterfaceSpecificationRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.ipv_6_address_count {
-            params.put(
-                &format!("{}{}", prefix, "Ipv6AddressCount"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Ipv6AddressCount"), &field_value);
         }
         if let Some(ref field_value) = obj.ipv_6_addresses {
             InstanceIpv6AddressListRequestSerializer::serialize(
@@ -30362,7 +30017,7 @@ impl LaunchTemplateInstanceNetworkInterfaceSpecificationRequestSerializer {
         if let Some(ref field_value) = obj.secondary_private_ip_address_count {
             params.put(
                 &format!("{}{}", prefix, "SecondaryPrivateIpAddressCount"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.subnet_id {
@@ -30582,10 +30237,7 @@ impl LaunchTemplateOverridesSerializer {
             params.put(&format!("{}{}", prefix, "InstanceType"), &field_value);
         }
         if let Some(ref field_value) = obj.priority {
-            params.put(
-                &format!("{}{}", prefix, "Priority"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Priority"), &field_value);
         }
         if let Some(ref field_value) = obj.spot_price {
             params.put(&format!("{}{}", prefix, "SpotPrice"), &field_value);
@@ -30594,10 +30246,7 @@ impl LaunchTemplateOverridesSerializer {
             params.put(&format!("{}{}", prefix, "SubnetId"), &field_value);
         }
         if let Some(ref field_value) = obj.weighted_capacity {
-            params.put(
-                &format!("{}{}", prefix, "WeightedCapacity"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "WeightedCapacity"), &field_value);
         }
     }
 }
@@ -30872,7 +30521,7 @@ impl LaunchTemplateSpotMarketOptionsRequestSerializer {
         if let Some(ref field_value) = obj.block_duration_minutes {
             params.put(
                 &format!("{}{}", prefix, "BlockDurationMinutes"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.instance_interruption_behavior {
@@ -31131,10 +30780,7 @@ impl LaunchTemplatesMonitoringRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.enabled {
-            params.put(
-                &format!("{}{}", prefix, "Enabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Enabled"), &field_value);
         }
     }
 }
@@ -31506,7 +31152,7 @@ impl ModifyCapacityReservationRequestSerializer {
             &obj.capacity_reservation_id,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.end_date {
             params.put(&format!("{}{}", prefix, "EndDate"), &field_value);
@@ -31515,10 +31161,7 @@ impl ModifyCapacityReservationRequestSerializer {
             params.put(&format!("{}{}", prefix, "EndDateType"), &field_value);
         }
         if let Some(ref field_value) = obj.instance_count {
-            params.put(
-                &format!("{}{}", prefix, "InstanceCount"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "InstanceCount"), &field_value);
         }
     }
 }
@@ -31598,7 +31241,7 @@ impl ModifyClientVpnEndpointRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.server_certificate_arn {
             params.put(
@@ -31659,7 +31302,7 @@ impl ModifyFleetRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.excess_capacity_termination_policy {
             params.put(
@@ -31740,7 +31383,7 @@ impl ModifyFpgaImageAttributeRequestSerializer {
             params.put(&format!("{}{}", prefix, "Description"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "FpgaImageId"), &obj.fpga_image_id);
         if let Some(ref field_value) = obj.load_permission {
@@ -31892,10 +31535,7 @@ impl ModifyIdFormatRequestSerializer {
         }
 
         params.put(&format!("{}{}", prefix, "Resource"), &obj.resource);
-        params.put(
-            &format!("{}{}", prefix, "UseLongIds"),
-            &obj.use_long_ids.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "UseLongIds"), &obj.use_long_ids);
     }
 }
 
@@ -31920,10 +31560,7 @@ impl ModifyIdentityIdFormatRequestSerializer {
 
         params.put(&format!("{}{}", prefix, "PrincipalArn"), &obj.principal_arn);
         params.put(&format!("{}{}", prefix, "Resource"), &obj.resource);
-        params.put(
-            &format!("{}{}", prefix, "UseLongIds"),
-            &obj.use_long_ids.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "UseLongIds"), &obj.use_long_ids);
     }
 }
 
@@ -31972,7 +31609,7 @@ impl ModifyImageAttributeRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "ImageId"), &obj.image_id);
         if let Some(ref field_value) = obj.launch_permission {
@@ -32075,7 +31712,7 @@ impl ModifyInstanceAttributeRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.ebs_optimized {
             AttributeBooleanValueSerializer::serialize(
@@ -32183,7 +31820,7 @@ impl ModifyInstanceCapacityReservationAttributesRequestSerializer {
             &obj.capacity_reservation_specification,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
     }
@@ -32240,7 +31877,7 @@ impl ModifyInstanceCreditSpecificationRequestSerializer {
             params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         InstanceCreditSpecificationListRequestSerializer::serialize(
             params,
@@ -32330,10 +31967,7 @@ impl ModifyInstancePlacementRequestSerializer {
         }
         params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
         if let Some(ref field_value) = obj.partition_number {
-            params.put(
-                &format!("{}{}", prefix, "PartitionNumber"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PartitionNumber"), &field_value);
         }
         if let Some(ref field_value) = obj.tenancy {
             params.put(&format!("{}{}", prefix, "Tenancy"), &field_value);
@@ -32399,7 +32033,7 @@ impl ModifyLaunchTemplateRequestSerializer {
             params.put(&format!("{}{}", prefix, "SetDefaultVersion"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.launch_template_id {
             params.put(&format!("{}{}", prefix, "LaunchTemplateId"), &field_value);
@@ -32482,7 +32116,7 @@ impl ModifyNetworkInterfaceAttributeRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.groups {
             SecurityGroupIdStringListSerializer::serialize(
@@ -32613,7 +32247,7 @@ impl ModifySnapshotAttributeRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.group_names {
             GroupNameStringListSerializer::serialize(
@@ -32667,10 +32301,7 @@ impl ModifySpotFleetRequestRequestSerializer {
             &obj.spot_fleet_request_id,
         );
         if let Some(ref field_value) = obj.target_capacity {
-            params.put(
-                &format!("{}{}", prefix, "TargetCapacity"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "TargetCapacity"), &field_value);
         }
     }
 }
@@ -32772,7 +32403,7 @@ impl ModifyTransitGatewayVpcAttachmentRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.options {
             ModifyTransitGatewayVpcAttachmentRequestOptionsSerializer::serialize(
@@ -32886,7 +32517,7 @@ impl ModifyVolumeAttributeRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "VolumeId"), &obj.volume_id);
     }
@@ -32916,13 +32547,13 @@ impl ModifyVolumeRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.iops {
-            params.put(&format!("{}{}", prefix, "Iops"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Iops"), &field_value);
         }
         if let Some(ref field_value) = obj.size {
-            params.put(&format!("{}{}", prefix, "Size"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Size"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "VolumeId"), &obj.volume_id);
         if let Some(ref field_value) = obj.volume_type {
@@ -33038,7 +32669,7 @@ impl ModifyVpcEndpointConnectionNotificationRequestSerializer {
             &obj.connection_notification_id,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }
@@ -33129,16 +32760,13 @@ impl ModifyVpcEndpointRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.policy_document {
             params.put(&format!("{}{}", prefix, "PolicyDocument"), &field_value);
         }
         if let Some(ref field_value) = obj.private_dns_enabled {
-            params.put(
-                &format!("{}{}", prefix, "PrivateDnsEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PrivateDnsEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.remove_route_table_ids {
             ValueStringListSerializer::serialize(
@@ -33162,10 +32790,7 @@ impl ModifyVpcEndpointRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.reset_policy {
-            params.put(
-                &format!("{}{}", prefix, "ResetPolicy"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ResetPolicy"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "VpcEndpointId"),
@@ -33230,10 +32855,7 @@ impl ModifyVpcEndpointServiceConfigurationRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.acceptance_required {
-            params.put(
-                &format!("{}{}", prefix, "AcceptanceRequired"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "AcceptanceRequired"), &field_value);
         }
         if let Some(ref field_value) = obj.add_network_load_balancer_arns {
             ValueStringListSerializer::serialize(
@@ -33243,7 +32865,7 @@ impl ModifyVpcEndpointServiceConfigurationRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.remove_network_load_balancer_arns {
             ValueStringListSerializer::serialize(
@@ -33317,7 +32939,7 @@ impl ModifyVpcEndpointServicePermissionsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.remove_allowed_principals {
             ValueStringListSerializer::serialize(
@@ -33387,7 +33009,7 @@ impl ModifyVpcPeeringConnectionOptionsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.requester_peering_connection_options {
             PeeringConnectionOptionsRequestSerializer::serialize(
@@ -33464,7 +33086,7 @@ impl ModifyVpcTenancyRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "InstanceTenancy"),
@@ -33516,7 +33138,7 @@ impl MonitorInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         InstanceIdStringListSerializer::serialize(
             params,
@@ -33609,7 +33231,7 @@ impl MoveAddressToVpcRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "PublicIp"), &obj.public_ip);
     }
@@ -34407,7 +34029,7 @@ impl NetworkInterfaceAttachmentChangesSerializer {
         if let Some(ref field_value) = obj.delete_on_termination {
             params.put(
                 &format!("{}{}", prefix, "DeleteOnTermination"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
     }
@@ -34799,7 +34421,7 @@ impl OccurrenceDayRequestSetSerializer {
     fn serialize(params: &mut Params, name: &str, obj: &Vec<i64>) {
         for (index, obj) in obj.iter().enumerate() {
             let key = format!("{}.{}", name, index + 1);
-            params.put(&key, &obj.to_string());
+            params.put(&key, &obj);
         }
     }
 }
@@ -34942,22 +34564,16 @@ impl OnDemandOptionsRequestSerializer {
             params.put(&format!("{}{}", prefix, "AllocationStrategy"), &field_value);
         }
         if let Some(ref field_value) = obj.min_target_capacity {
-            params.put(
-                &format!("{}{}", prefix, "MinTargetCapacity"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MinTargetCapacity"), &field_value);
         }
         if let Some(ref field_value) = obj.single_availability_zone {
             params.put(
                 &format!("{}{}", prefix, "SingleAvailabilityZone"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.single_instance_type {
-            params.put(
-                &format!("{}{}", prefix, "SingleInstanceType"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SingleInstanceType"), &field_value);
         }
     }
 }
@@ -35102,19 +34718,19 @@ impl PeeringConnectionOptionsRequestSerializer {
         if let Some(ref field_value) = obj.allow_dns_resolution_from_remote_vpc {
             params.put(
                 &format!("{}{}", prefix, "AllowDnsResolutionFromRemoteVpc"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.allow_egress_from_local_classic_link_to_remote_vpc {
             params.put(
                 &format!("{}{}", prefix, "AllowEgressFromLocalClassicLinkToRemoteVpc"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.allow_egress_from_local_vpc_to_remote_classic_link {
             params.put(
                 &format!("{}{}", prefix, "AllowEgressFromLocalVpcToRemoteClassicLink"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
     }
@@ -35215,10 +34831,7 @@ impl PlacementSerializer {
             params.put(&format!("{}{}", prefix, "HostId"), &field_value);
         }
         if let Some(ref field_value) = obj.partition_number {
-            params.put(
-                &format!("{}{}", prefix, "PartitionNumber"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PartitionNumber"), &field_value);
         }
         if let Some(ref field_value) = obj.spread_domain {
             params.put(&format!("{}{}", prefix, "SpreadDomain"), &field_value);
@@ -35411,10 +35024,10 @@ impl PortRangeSerializer {
         }
 
         if let Some(ref field_value) = obj.from {
-            params.put(&format!("{}{}", prefix, "From"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "From"), &field_value);
         }
         if let Some(ref field_value) = obj.to {
-            params.put(&format!("{}{}", prefix, "To"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "To"), &field_value);
         }
     }
 }
@@ -35655,10 +35268,10 @@ impl PriceScheduleSpecificationSerializer {
             params.put(&format!("{}{}", prefix, "CurrencyCode"), &field_value);
         }
         if let Some(ref field_value) = obj.price {
-            params.put(&format!("{}{}", prefix, "Price"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Price"), &field_value);
         }
         if let Some(ref field_value) = obj.term {
-            params.put(&format!("{}{}", prefix, "Term"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Term"), &field_value);
         }
     }
 }
@@ -35846,10 +35459,7 @@ impl PrivateIpAddressSpecificationSerializer {
         }
 
         if let Some(ref field_value) = obj.primary {
-            params.put(
-                &format!("{}{}", prefix, "Primary"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Primary"), &field_value);
         }
         if let Some(ref field_value) = obj.private_ip_address {
             params.put(&format!("{}{}", prefix, "PrivateIpAddress"), &field_value);
@@ -36061,7 +35671,7 @@ impl ProvisionByoipCidrRequestSerializer {
             params.put(&format!("{}{}", prefix, "Description"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }
@@ -36477,7 +36087,7 @@ impl PurchaseRequestSerializer {
 
         params.put(
             &format!("{}{}", prefix, "InstanceCount"),
-            &obj.instance_count.to_string(),
+            &obj.instance_count,
         );
         params.put(
             &format!("{}{}", prefix, "PurchaseToken"),
@@ -36520,11 +36130,11 @@ impl PurchaseReservedInstancesOfferingRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "InstanceCount"),
-            &obj.instance_count.to_string(),
+            &obj.instance_count,
         );
         if let Some(ref field_value) = obj.limit_price {
             ReservedInstanceLimitPriceSerializer::serialize(
@@ -36596,7 +36206,7 @@ impl PurchaseScheduledInstancesRequestSerializer {
             params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         PurchaseRequestSetSerializer::serialize(
             params,
@@ -36718,7 +36328,7 @@ impl RebootInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         InstanceIdStringListSerializer::serialize(
             params,
@@ -36912,13 +36522,10 @@ impl RegisterImageRequestSerializer {
             params.put(&format!("{}{}", prefix, "Description"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.ena_support {
-            params.put(
-                &format!("{}{}", prefix, "EnaSupport"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "EnaSupport"), &field_value);
         }
         if let Some(ref field_value) = obj.image_location {
             params.put(&format!("{}{}", prefix, "ImageLocation"), &field_value);
@@ -36985,7 +36592,7 @@ impl RejectTransitGatewayVpcAttachmentRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "TransitGatewayAttachmentId"),
@@ -37046,7 +36653,7 @@ impl RejectVpcEndpointConnectionsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "ServiceId"), &obj.service_id);
         ValueStringListSerializer::serialize(
@@ -37105,7 +36712,7 @@ impl RejectVpcPeeringConnectionRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "VpcPeeringConnectionId"),
@@ -37165,7 +36772,7 @@ impl ReleaseAddressRequestSerializer {
             params.put(&format!("{}{}", prefix, "AllocationId"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.public_ip {
             params.put(&format!("{}{}", prefix, "PublicIp"), &field_value);
@@ -37318,7 +36925,7 @@ impl ReplaceNetworkAclAssociationRequestSerializer {
             &obj.association_id,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "NetworkAclId"),
@@ -37393,9 +37000,9 @@ impl ReplaceNetworkAclEntryRequestSerializer {
             params.put(&format!("{}{}", prefix, "CidrBlock"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
-        params.put(&format!("{}{}", prefix, "Egress"), &obj.egress.to_string());
+        params.put(&format!("{}{}", prefix, "Egress"), &obj.egress);
         if let Some(ref field_value) = obj.icmp_type_code {
             IcmpTypeCodeSerializer::serialize(
                 params,
@@ -37419,10 +37026,7 @@ impl ReplaceNetworkAclEntryRequestSerializer {
         }
         params.put(&format!("{}{}", prefix, "Protocol"), &obj.protocol);
         params.put(&format!("{}{}", prefix, "RuleAction"), &obj.rule_action);
-        params.put(
-            &format!("{}{}", prefix, "RuleNumber"),
-            &obj.rule_number.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "RuleNumber"), &obj.rule_number);
     }
 }
 
@@ -37474,7 +37078,7 @@ impl ReplaceRouteRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.egress_only_internet_gateway_id {
             params.put(
@@ -37534,7 +37138,7 @@ impl ReplaceRouteTableAssociationRequestSerializer {
             &obj.association_id,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "RouteTableId"),
@@ -37596,17 +37200,14 @@ impl ReplaceTransitGatewayRouteRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.blackhole {
-            params.put(
-                &format!("{}{}", prefix, "Blackhole"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Blackhole"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "DestinationCidrBlock"),
             &obj.destination_cidr_block,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.transit_gateway_attachment_id {
             params.put(
@@ -37682,7 +37283,7 @@ impl ReportInstanceStatusRequestSerializer {
             params.put(&format!("{}{}", prefix, "Description"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.end_time {
             params.put(&format!("{}{}", prefix, "EndTime"), &field_value);
@@ -37822,14 +37423,11 @@ impl RequestLaunchTemplateDataSerializer {
         if let Some(ref field_value) = obj.disable_api_termination {
             params.put(
                 &format!("{}{}", prefix, "DisableApiTermination"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.ebs_optimized {
-            params.put(
-                &format!("{}{}", prefix, "EbsOptimized"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "EbsOptimized"), &field_value);
         }
         if let Some(ref field_value) = obj.elastic_gpu_specifications {
             ElasticGpuSpecificationListSerializer::serialize(
@@ -37961,7 +37559,7 @@ impl RequestSpotFleetRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         SpotFleetRequestConfigDataSerializer::serialize(
             params,
@@ -38050,20 +37648,17 @@ impl RequestSpotInstancesRequestSerializer {
         if let Some(ref field_value) = obj.block_duration_minutes {
             params.put(
                 &format!("{}{}", prefix, "BlockDurationMinutes"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.client_token {
             params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.instance_count {
-            params.put(
-                &format!("{}{}", prefix, "InstanceCount"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "InstanceCount"), &field_value);
         }
         if let Some(ref field_value) = obj.instance_interruption_behavior {
             params.put(
@@ -38187,10 +37782,7 @@ impl RequestSpotLaunchSpecificationSerializer {
             );
         }
         if let Some(ref field_value) = obj.ebs_optimized {
-            params.put(
-                &format!("{}{}", prefix, "EbsOptimized"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "EbsOptimized"), &field_value);
         }
         if let Some(ref field_value) = obj.iam_instance_profile {
             IamInstanceProfileSpecificationSerializer::serialize(
@@ -38411,7 +38003,7 @@ impl ReservedInstanceLimitPriceSerializer {
         }
 
         if let Some(ref field_value) = obj.amount {
-            params.put(&format!("{}{}", prefix, "Amount"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Amount"), &field_value);
         }
         if let Some(ref field_value) = obj.currency_code {
             params.put(&format!("{}{}", prefix, "CurrencyCode"), &field_value);
@@ -38697,10 +38289,7 @@ impl ReservedInstancesConfigurationSerializer {
             params.put(&format!("{}{}", prefix, "AvailabilityZone"), &field_value);
         }
         if let Some(ref field_value) = obj.instance_count {
-            params.put(
-                &format!("{}{}", prefix, "InstanceCount"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "InstanceCount"), &field_value);
         }
         if let Some(ref field_value) = obj.instance_type {
             params.put(&format!("{}{}", prefix, "InstanceType"), &field_value);
@@ -39274,7 +38863,7 @@ impl ResetFpgaImageAttributeRequestSerializer {
             params.put(&format!("{}{}", prefix, "Attribute"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "FpgaImageId"), &obj.fpga_image_id);
     }
@@ -39330,7 +38919,7 @@ impl ResetImageAttributeRequestSerializer {
 
         params.put(&format!("{}{}", prefix, "Attribute"), &obj.attribute);
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "ImageId"), &obj.image_id);
     }
@@ -39357,7 +38946,7 @@ impl ResetInstanceAttributeRequestSerializer {
 
         params.put(&format!("{}{}", prefix, "Attribute"), &obj.attribute);
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "InstanceId"), &obj.instance_id);
     }
@@ -39384,7 +38973,7 @@ impl ResetNetworkInterfaceAttributeRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "NetworkInterfaceId"),
@@ -39418,7 +39007,7 @@ impl ResetSnapshotAttributeRequestSerializer {
 
         params.put(&format!("{}{}", prefix, "Attribute"), &obj.attribute);
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "SnapshotId"), &obj.snapshot_id);
     }
@@ -39774,7 +39363,7 @@ impl RestoreAddressToClassicRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "PublicIp"), &obj.public_ip);
     }
@@ -39844,13 +39433,10 @@ impl RevokeClientVpnIngressRequestSerializer {
             &obj.client_vpn_endpoint_id,
         );
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.revoke_all_groups {
-            params.put(
-                &format!("{}{}", prefix, "RevokeAllGroups"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "RevokeAllGroups"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "TargetNetworkCidr"),
@@ -39925,13 +39511,10 @@ impl RevokeSecurityGroupEgressRequestSerializer {
             params.put(&format!("{}{}", prefix, "CidrIp"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.from_port {
-            params.put(
-                &format!("{}{}", prefix, "FromPort"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "FromPort"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "GroupId"), &obj.group_id);
         if let Some(ref field_value) = obj.ip_permissions {
@@ -39957,7 +39540,7 @@ impl RevokeSecurityGroupEgressRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.to_port {
-            params.put(&format!("{}{}", prefix, "ToPort"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "ToPort"), &field_value);
         }
     }
 }
@@ -39999,13 +39582,10 @@ impl RevokeSecurityGroupIngressRequestSerializer {
             params.put(&format!("{}{}", prefix, "CidrIp"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.from_port {
-            params.put(
-                &format!("{}{}", prefix, "FromPort"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "FromPort"), &field_value);
         }
         if let Some(ref field_value) = obj.group_id {
             params.put(&format!("{}{}", prefix, "GroupId"), &field_value);
@@ -40036,7 +39616,7 @@ impl RevokeSecurityGroupIngressRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.to_port {
-            params.put(&format!("{}{}", prefix, "ToPort"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "ToPort"), &field_value);
         }
     }
 }
@@ -40392,10 +39972,7 @@ impl RunInstancesMonitoringEnabledSerializer {
             prefix.push_str(".");
         }
 
-        params.put(
-            &format!("{}{}", prefix, "Enabled"),
-            &obj.enabled.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "Enabled"), &obj.enabled);
     }
 }
 
@@ -40519,17 +40096,14 @@ impl RunInstancesRequestSerializer {
         if let Some(ref field_value) = obj.disable_api_termination {
             params.put(
                 &format!("{}{}", prefix, "DisableApiTermination"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.ebs_optimized {
-            params.put(
-                &format!("{}{}", prefix, "EbsOptimized"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "EbsOptimized"), &field_value);
         }
         if let Some(ref field_value) = obj.elastic_gpu_specification {
             ElasticGpuSpecificationsSerializer::serialize(
@@ -40579,10 +40153,7 @@ impl RunInstancesRequestSerializer {
             params.put(&format!("{}{}", prefix, "InstanceType"), &field_value);
         }
         if let Some(ref field_value) = obj.ipv_6_address_count {
-            params.put(
-                &format!("{}{}", prefix, "Ipv6AddressCount"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Ipv6AddressCount"), &field_value);
         }
         if let Some(ref field_value) = obj.ipv_6_addresses {
             InstanceIpv6AddressListSerializer::serialize(
@@ -40611,14 +40182,8 @@ impl RunInstancesRequestSerializer {
                 field_value,
             );
         }
-        params.put(
-            &format!("{}{}", prefix, "MaxCount"),
-            &obj.max_count.to_string(),
-        );
-        params.put(
-            &format!("{}{}", prefix, "MinCount"),
-            &obj.min_count.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "MaxCount"), &obj.max_count);
+        params.put(&format!("{}{}", prefix, "MinCount"), &obj.min_count);
         if let Some(ref field_value) = obj.monitoring {
             RunInstancesMonitoringEnabledSerializer::serialize(
                 params,
@@ -40704,13 +40269,10 @@ impl RunScheduledInstancesRequestSerializer {
             params.put(&format!("{}{}", prefix, "ClientToken"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.instance_count {
-            params.put(
-                &format!("{}{}", prefix, "InstanceCount"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "InstanceCount"), &field_value);
         }
         ScheduledInstancesLaunchSpecificationSerializer::serialize(
             params,
@@ -41186,10 +40748,7 @@ impl ScheduledInstanceRecurrenceRequestSerializer {
             params.put(&format!("{}{}", prefix, "Frequency"), &field_value);
         }
         if let Some(ref field_value) = obj.interval {
-            params.put(
-                &format!("{}{}", prefix, "Interval"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Interval"), &field_value);
         }
         if let Some(ref field_value) = obj.occurrence_days {
             OccurrenceDayRequestSetSerializer::serialize(
@@ -41201,7 +40760,7 @@ impl ScheduledInstanceRecurrenceRequestSerializer {
         if let Some(ref field_value) = obj.occurrence_relative_to_end {
             params.put(
                 &format!("{}{}", prefix, "OccurrenceRelativeToEnd"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.occurrence_unit {
@@ -41308,26 +40867,20 @@ impl ScheduledInstancesEbsSerializer {
         if let Some(ref field_value) = obj.delete_on_termination {
             params.put(
                 &format!("{}{}", prefix, "DeleteOnTermination"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.encrypted {
-            params.put(
-                &format!("{}{}", prefix, "Encrypted"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Encrypted"), &field_value);
         }
         if let Some(ref field_value) = obj.iops {
-            params.put(&format!("{}{}", prefix, "Iops"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Iops"), &field_value);
         }
         if let Some(ref field_value) = obj.snapshot_id {
             params.put(&format!("{}{}", prefix, "SnapshotId"), &field_value);
         }
         if let Some(ref field_value) = obj.volume_size {
-            params.put(
-                &format!("{}{}", prefix, "VolumeSize"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "VolumeSize"), &field_value);
         }
         if let Some(ref field_value) = obj.volume_type {
             params.put(&format!("{}{}", prefix, "VolumeType"), &field_value);
@@ -41445,10 +40998,7 @@ impl ScheduledInstancesLaunchSpecificationSerializer {
             );
         }
         if let Some(ref field_value) = obj.ebs_optimized {
-            params.put(
-                &format!("{}{}", prefix, "EbsOptimized"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "EbsOptimized"), &field_value);
         }
         if let Some(ref field_value) = obj.iam_instance_profile {
             ScheduledInstancesIamInstanceProfileSerializer::serialize(
@@ -41524,10 +41074,7 @@ impl ScheduledInstancesMonitoringSerializer {
         }
 
         if let Some(ref field_value) = obj.enabled {
-            params.put(
-                &format!("{}{}", prefix, "Enabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Enabled"), &field_value);
         }
     }
 }
@@ -41573,23 +41120,20 @@ impl ScheduledInstancesNetworkInterfaceSerializer {
         if let Some(ref field_value) = obj.associate_public_ip_address {
             params.put(
                 &format!("{}{}", prefix, "AssociatePublicIpAddress"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.delete_on_termination {
             params.put(
                 &format!("{}{}", prefix, "DeleteOnTermination"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.description {
             params.put(&format!("{}{}", prefix, "Description"), &field_value);
         }
         if let Some(ref field_value) = obj.device_index {
-            params.put(
-                &format!("{}{}", prefix, "DeviceIndex"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DeviceIndex"), &field_value);
         }
         if let Some(ref field_value) = obj.groups {
             ScheduledInstancesSecurityGroupIdSetSerializer::serialize(
@@ -41599,10 +41143,7 @@ impl ScheduledInstancesNetworkInterfaceSerializer {
             );
         }
         if let Some(ref field_value) = obj.ipv_6_address_count {
-            params.put(
-                &format!("{}{}", prefix, "Ipv6AddressCount"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Ipv6AddressCount"), &field_value);
         }
         if let Some(ref field_value) = obj.ipv_6_addresses {
             ScheduledInstancesIpv6AddressListSerializer::serialize(
@@ -41627,7 +41168,7 @@ impl ScheduledInstancesNetworkInterfaceSerializer {
         if let Some(ref field_value) = obj.secondary_private_ip_address_count {
             params.put(
                 &format!("{}{}", prefix, "SecondaryPrivateIpAddressCount"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.subnet_id {
@@ -41693,10 +41234,7 @@ impl ScheduledInstancesPrivateIpAddressConfigSerializer {
         }
 
         if let Some(ref field_value) = obj.primary {
-            params.put(
-                &format!("{}{}", prefix, "Primary"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Primary"), &field_value);
         }
         if let Some(ref field_value) = obj.private_ip_address {
             params.put(&format!("{}{}", prefix, "PrivateIpAddress"), &field_value);
@@ -41751,14 +41289,11 @@ impl SearchTransitGatewayRoutesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         FilterListSerializer::serialize(params, &format!("{}{}", prefix, "Filter"), &obj.filters);
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "TransitGatewayRouteTableId"),
@@ -42933,10 +42468,7 @@ impl SpotFleetLaunchSpecificationSerializer {
             );
         }
         if let Some(ref field_value) = obj.ebs_optimized {
-            params.put(
-                &format!("{}{}", prefix, "EbsOptimized"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "EbsOptimized"), &field_value);
         }
         if let Some(ref field_value) = obj.iam_instance_profile {
             IamInstanceProfileSpecificationSerializer::serialize(
@@ -43005,10 +42537,7 @@ impl SpotFleetLaunchSpecificationSerializer {
             params.put(&format!("{}{}", prefix, "UserData"), &field_value);
         }
         if let Some(ref field_value) = obj.weighted_capacity {
-            params.put(
-                &format!("{}{}", prefix, "WeightedCapacity"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "WeightedCapacity"), &field_value);
         }
     }
 }
@@ -43049,10 +42578,7 @@ impl SpotFleetMonitoringSerializer {
         }
 
         if let Some(ref field_value) = obj.enabled {
-            params.put(
-                &format!("{}{}", prefix, "Enabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Enabled"), &field_value);
         }
     }
 }
@@ -43314,10 +42840,7 @@ impl SpotFleetRequestConfigDataSerializer {
             );
         }
         if let Some(ref field_value) = obj.fulfilled_capacity {
-            params.put(
-                &format!("{}{}", prefix, "FulfilledCapacity"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "FulfilledCapacity"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "IamFleetRole"),
@@ -43332,7 +42855,7 @@ impl SpotFleetRequestConfigDataSerializer {
         if let Some(ref field_value) = obj.instance_pools_to_use_count {
             params.put(
                 &format!("{}{}", prefix, "InstancePoolsToUseCount"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.launch_specifications {
@@ -43365,19 +42888,19 @@ impl SpotFleetRequestConfigDataSerializer {
         if let Some(ref field_value) = obj.on_demand_fulfilled_capacity {
             params.put(
                 &format!("{}{}", prefix, "OnDemandFulfilledCapacity"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.on_demand_target_capacity {
             params.put(
                 &format!("{}{}", prefix, "OnDemandTargetCapacity"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.replace_unhealthy_instances {
             params.put(
                 &format!("{}{}", prefix, "ReplaceUnhealthyInstances"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.spot_price {
@@ -43385,12 +42908,12 @@ impl SpotFleetRequestConfigDataSerializer {
         }
         params.put(
             &format!("{}{}", prefix, "TargetCapacity"),
-            &obj.target_capacity.to_string(),
+            &obj.target_capacity,
         );
         if let Some(ref field_value) = obj.terminate_instances_with_expiration {
             params.put(
                 &format!("{}{}", prefix, "TerminateInstancesWithExpiration"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.type_ {
@@ -43822,7 +43345,7 @@ impl SpotMarketOptionsSerializer {
         if let Some(ref field_value) = obj.block_duration_minutes {
             params.put(
                 &format!("{}{}", prefix, "BlockDurationMinutes"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.instance_interruption_behavior {
@@ -43951,26 +43474,20 @@ impl SpotOptionsRequestSerializer {
         if let Some(ref field_value) = obj.instance_pools_to_use_count {
             params.put(
                 &format!("{}{}", prefix, "InstancePoolsToUseCount"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.min_target_capacity {
-            params.put(
-                &format!("{}{}", prefix, "MinTargetCapacity"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MinTargetCapacity"), &field_value);
         }
         if let Some(ref field_value) = obj.single_availability_zone {
             params.put(
                 &format!("{}{}", prefix, "SingleAvailabilityZone"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.single_instance_type {
-            params.put(
-                &format!("{}{}", prefix, "SingleInstanceType"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SingleInstanceType"), &field_value);
         }
     }
 }
@@ -44272,7 +43789,7 @@ impl StartInstancesRequestSerializer {
             params.put(&format!("{}{}", prefix, "AdditionalInfo"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         InstanceIdStringListSerializer::serialize(
             params,
@@ -44416,16 +43933,13 @@ impl StopInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.force {
-            params.put(&format!("{}{}", prefix, "Force"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Force"), &field_value);
         }
         if let Some(ref field_value) = obj.hibernate {
-            params.put(
-                &format!("{}{}", prefix, "Hibernate"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Hibernate"), &field_value);
         }
         InstanceIdStringListSerializer::serialize(
             params,
@@ -45137,18 +44651,15 @@ impl TargetCapacitySpecificationRequestSerializer {
         if let Some(ref field_value) = obj.on_demand_target_capacity {
             params.put(
                 &format!("{}{}", prefix, "OnDemandTargetCapacity"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.spot_target_capacity {
-            params.put(
-                &format!("{}{}", prefix, "SpotTargetCapacity"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SpotTargetCapacity"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "TotalTargetCapacity"),
-            &obj.total_target_capacity.to_string(),
+            &obj.total_target_capacity,
         );
     }
 }
@@ -45203,10 +44714,7 @@ impl TargetConfigurationRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.instance_count {
-            params.put(
-                &format!("{}{}", prefix, "InstanceCount"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "InstanceCount"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "OfferingId"), &obj.offering_id);
     }
@@ -45526,7 +45034,7 @@ impl TerminateClientVpnConnectionsRequestSerializer {
             params.put(&format!("{}{}", prefix, "ConnectionId"), &field_value);
         }
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.username {
             params.put(&format!("{}{}", prefix, "Username"), &field_value);
@@ -45665,7 +45173,7 @@ impl TerminateInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         InstanceIdStringListSerializer::serialize(
             params,
@@ -46340,10 +45848,7 @@ impl TransitGatewayRequestOptionsSerializer {
         }
 
         if let Some(ref field_value) = obj.amazon_side_asn {
-            params.put(
-                &format!("{}{}", prefix, "AmazonSideAsn"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "AmazonSideAsn"), &field_value);
         }
         if let Some(ref field_value) = obj.auto_accept_shared_attachments {
             params.put(
@@ -47106,7 +46611,7 @@ impl UnmonitorInstancesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         InstanceIdStringListSerializer::serialize(
             params,
@@ -47372,7 +46877,7 @@ impl UpdateSecurityGroupRuleDescriptionsEgressRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.group_id {
             params.put(&format!("{}{}", prefix, "GroupId"), &field_value);
@@ -47442,7 +46947,7 @@ impl UpdateSecurityGroupRuleDescriptionsIngressRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.group_id {
             params.put(&format!("{}{}", prefix, "GroupId"), &field_value);
@@ -48057,7 +47562,7 @@ impl VolumeDetailSerializer {
             prefix.push_str(".");
         }
 
-        params.put(&format!("{}{}", prefix, "Size"), &obj.size.to_string());
+        params.put(&format!("{}{}", prefix, "Size"), &obj.size);
     }
 }
 
@@ -49587,10 +49092,7 @@ impl VpnConnectionOptionsSpecificationSerializer {
         }
 
         if let Some(ref field_value) = obj.static_routes_only {
-            params.put(
-                &format!("{}{}", prefix, "StaticRoutesOnly"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "StaticRoutesOnly"), &field_value);
         }
         if let Some(ref field_value) = obj.tunnel_options {
             TunnelOptionsListSerializer::serialize(
@@ -49852,7 +49354,7 @@ impl WithdrawByoipCidrRequestSerializer {
 
         params.put(&format!("{}{}", prefix, "Cidr"), &obj.cidr);
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
     }
 }

--- a/rusoto/services/elasticache/src/generated.rs
+++ b/rusoto/services/elasticache/src/generated.rs
@@ -1474,7 +1474,7 @@ impl ConfigureShardSerializer {
 
         params.put(
             &format!("{}{}", prefix, "NewReplicaCount"),
-            &obj.new_replica_count.to_string(),
+            &obj.new_replica_count,
         );
         params.put(&format!("{}{}", prefix, "NodeGroupId"), &obj.node_group_id);
         if let Some(ref field_value) = obj.preferred_availability_zones {
@@ -1613,7 +1613,7 @@ impl CreateCacheClusterMessageSerializer {
         if let Some(ref field_value) = obj.auto_minor_version_upgrade {
             params.put(
                 &format!("{}{}", prefix, "AutoMinorVersionUpgrade"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         params.put(
@@ -1655,13 +1655,10 @@ impl CreateCacheClusterMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.num_cache_nodes {
-            params.put(
-                &format!("{}{}", prefix, "NumCacheNodes"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "NumCacheNodes"), &field_value);
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"), &field_value);
         }
         if let Some(ref field_value) = obj.preferred_availability_zone {
             params.put(
@@ -1705,7 +1702,7 @@ impl CreateCacheClusterMessageSerializer {
         if let Some(ref field_value) = obj.snapshot_retention_limit {
             params.put(
                 &format!("{}{}", prefix, "SnapshotRetentionLimit"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.snapshot_window {
@@ -2006,7 +2003,7 @@ impl CreateReplicationGroupMessageSerializer {
         if let Some(ref field_value) = obj.at_rest_encryption_enabled {
             params.put(
                 &format!("{}{}", prefix, "AtRestEncryptionEnabled"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.auth_token {
@@ -2015,13 +2012,13 @@ impl CreateReplicationGroupMessageSerializer {
         if let Some(ref field_value) = obj.auto_minor_version_upgrade {
             params.put(
                 &format!("{}{}", prefix, "AutoMinorVersionUpgrade"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.automatic_failover_enabled {
             params.put(
                 &format!("{}{}", prefix, "AutomaticFailoverEnabled"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.cache_node_type {
@@ -2066,19 +2063,13 @@ impl CreateReplicationGroupMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.num_cache_clusters {
-            params.put(
-                &format!("{}{}", prefix, "NumCacheClusters"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "NumCacheClusters"), &field_value);
         }
         if let Some(ref field_value) = obj.num_node_groups {
-            params.put(
-                &format!("{}{}", prefix, "NumNodeGroups"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "NumNodeGroups"), &field_value);
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"), &field_value);
         }
         if let Some(ref field_value) = obj.preferred_cache_cluster_a_zs {
             AvailabilityZonesListSerializer::serialize(
@@ -2099,7 +2090,7 @@ impl CreateReplicationGroupMessageSerializer {
         if let Some(ref field_value) = obj.replicas_per_node_group {
             params.put(
                 &format!("{}{}", prefix, "ReplicasPerNodeGroup"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         params.put(
@@ -2130,7 +2121,7 @@ impl CreateReplicationGroupMessageSerializer {
         if let Some(ref field_value) = obj.snapshot_retention_limit {
             params.put(
                 &format!("{}{}", prefix, "SnapshotRetentionLimit"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.snapshot_window {
@@ -2142,7 +2133,7 @@ impl CreateReplicationGroupMessageSerializer {
         if let Some(ref field_value) = obj.transit_encryption_enabled {
             params.put(
                 &format!("{}{}", prefix, "TransitEncryptionEnabled"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
     }
@@ -2256,13 +2247,10 @@ impl DecreaseReplicaCountMessageSerializer {
 
         params.put(
             &format!("{}{}", prefix, "ApplyImmediately"),
-            &obj.apply_immediately.to_string(),
+            &obj.apply_immediately,
         );
         if let Some(ref field_value) = obj.new_replica_count {
-            params.put(
-                &format!("{}{}", prefix, "NewReplicaCount"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "NewReplicaCount"), &field_value);
         }
         if let Some(ref field_value) = obj.replica_configuration {
             ReplicaConfigurationListSerializer::serialize(
@@ -2478,7 +2466,7 @@ impl DeleteReplicationGroupMessageSerializer {
         if let Some(ref field_value) = obj.retain_primary_cluster {
             params.put(
                 &format!("{}{}", prefix, "RetainPrimaryCluster"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
     }
@@ -2588,22 +2576,16 @@ impl DescribeCacheClustersMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.show_cache_clusters_not_in_replication_groups {
             params.put(
                 &format!("{}{}", prefix, "ShowCacheClustersNotInReplicationGroups"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.show_cache_node_info {
-            params.put(
-                &format!("{}{}", prefix, "ShowCacheNodeInfo"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ShowCacheNodeInfo"), &field_value);
         }
     }
 }
@@ -2641,10 +2623,7 @@ impl DescribeCacheEngineVersionsMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.default_only {
-            params.put(
-                &format!("{}{}", prefix, "DefaultOnly"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DefaultOnly"), &field_value);
         }
         if let Some(ref field_value) = obj.engine {
             params.put(&format!("{}{}", prefix, "Engine"), &field_value);
@@ -2656,10 +2635,7 @@ impl DescribeCacheEngineVersionsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -2694,10 +2670,7 @@ impl DescribeCacheParameterGroupsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -2732,10 +2705,7 @@ impl DescribeCacheParametersMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.source {
             params.put(&format!("{}{}", prefix, "Source"), &field_value);
@@ -2773,10 +2743,7 @@ impl DescribeCacheSecurityGroupsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -2811,10 +2778,7 @@ impl DescribeCacheSubnetGroupsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -2847,10 +2811,7 @@ impl DescribeEngineDefaultParametersMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -2914,10 +2875,7 @@ impl DescribeEventsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.duration {
-            params.put(
-                &format!("{}{}", prefix, "Duration"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Duration"), &field_value);
         }
         if let Some(ref field_value) = obj.end_time {
             params.put(&format!("{}{}", prefix, "EndTime"), &field_value);
@@ -2926,10 +2884,7 @@ impl DescribeEventsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.source_identifier {
             params.put(&format!("{}{}", prefix, "SourceIdentifier"), &field_value);
@@ -2967,10 +2922,7 @@ impl DescribeReplicationGroupsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.replication_group_id {
             params.put(&format!("{}{}", prefix, "ReplicationGroupId"), &field_value);
@@ -3018,10 +2970,7 @@ impl DescribeReservedCacheNodesMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.offering_type {
             params.put(&format!("{}{}", prefix, "OfferingType"), &field_value);
@@ -3086,10 +3035,7 @@ impl DescribeReservedCacheNodesOfferingsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.offering_type {
             params.put(&format!("{}{}", prefix, "OfferingType"), &field_value);
@@ -3177,10 +3123,7 @@ impl DescribeSnapshotsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.replication_group_id {
             params.put(&format!("{}{}", prefix, "ReplicationGroupId"), &field_value);
@@ -3188,7 +3131,7 @@ impl DescribeSnapshotsMessageSerializer {
         if let Some(ref field_value) = obj.show_node_group_config {
             params.put(
                 &format!("{}{}", prefix, "ShowNodeGroupConfig"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.snapshot_name {
@@ -3471,13 +3414,10 @@ impl IncreaseReplicaCountMessageSerializer {
 
         params.put(
             &format!("{}{}", prefix, "ApplyImmediately"),
-            &obj.apply_immediately.to_string(),
+            &obj.apply_immediately,
         );
         if let Some(ref field_value) = obj.new_replica_count {
-            params.put(
-                &format!("{}{}", prefix, "NewReplicaCount"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "NewReplicaCount"), &field_value);
         }
         if let Some(ref field_value) = obj.replica_configuration {
             ReplicaConfigurationListSerializer::serialize(
@@ -3662,15 +3602,12 @@ impl ModifyCacheClusterMessageSerializer {
             params.put(&format!("{}{}", prefix, "AZMode"), &field_value);
         }
         if let Some(ref field_value) = obj.apply_immediately {
-            params.put(
-                &format!("{}{}", prefix, "ApplyImmediately"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ApplyImmediately"), &field_value);
         }
         if let Some(ref field_value) = obj.auto_minor_version_upgrade {
             params.put(
                 &format!("{}{}", prefix, "AutoMinorVersionUpgrade"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         params.put(
@@ -3723,10 +3660,7 @@ impl ModifyCacheClusterMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.num_cache_nodes {
-            params.put(
-                &format!("{}{}", prefix, "NumCacheNodes"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "NumCacheNodes"), &field_value);
         }
         if let Some(ref field_value) = obj.preferred_maintenance_window {
             params.put(
@@ -3744,7 +3678,7 @@ impl ModifyCacheClusterMessageSerializer {
         if let Some(ref field_value) = obj.snapshot_retention_limit {
             params.put(
                 &format!("{}{}", prefix, "SnapshotRetentionLimit"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.snapshot_window {
@@ -3932,21 +3866,18 @@ impl ModifyReplicationGroupMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.apply_immediately {
-            params.put(
-                &format!("{}{}", prefix, "ApplyImmediately"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ApplyImmediately"), &field_value);
         }
         if let Some(ref field_value) = obj.auto_minor_version_upgrade {
             params.put(
                 &format!("{}{}", prefix, "AutoMinorVersionUpgrade"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.automatic_failover_enabled {
             params.put(
                 &format!("{}{}", prefix, "AutomaticFailoverEnabled"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.cache_node_type {
@@ -4010,7 +3941,7 @@ impl ModifyReplicationGroupMessageSerializer {
         if let Some(ref field_value) = obj.snapshot_retention_limit {
             params.put(
                 &format!("{}{}", prefix, "SnapshotRetentionLimit"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.snapshot_window {
@@ -4087,11 +4018,11 @@ impl ModifyReplicationGroupShardConfigurationMessageSerializer {
 
         params.put(
             &format!("{}{}", prefix, "ApplyImmediately"),
-            &obj.apply_immediately.to_string(),
+            &obj.apply_immediately,
         );
         params.put(
             &format!("{}{}", prefix, "NodeGroupCount"),
-            &obj.node_group_count.to_string(),
+            &obj.node_group_count,
         );
         if let Some(ref field_value) = obj.node_groups_to_remove {
             NodeGroupsToRemoveListSerializer::serialize(
@@ -4286,10 +4217,7 @@ impl NodeGroupConfigurationSerializer {
             );
         }
         if let Some(ref field_value) = obj.replica_count {
-            params.put(
-                &format!("{}{}", prefix, "ReplicaCount"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ReplicaCount"), &field_value);
         }
         if let Some(ref field_value) = obj.slots {
             params.put(&format!("{}{}", prefix, "Slots"), &field_value);
@@ -4781,10 +4709,7 @@ impl PurchaseReservedCacheNodesOfferingMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.cache_node_count {
-            params.put(
-                &format!("{}{}", prefix, "CacheNodeCount"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "CacheNodeCount"), &field_value);
         }
         if let Some(ref field_value) = obj.reserved_cache_node_id {
             params.put(
@@ -5564,10 +5489,7 @@ impl ResetCacheParameterGroupMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.reset_all_parameters {
-            params.put(
-                &format!("{}{}", prefix, "ResetAllParameters"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ResetAllParameters"), &field_value);
         }
     }
 }

--- a/rusoto/services/elasticbeanstalk/src/generated.rs
+++ b/rusoto/services/elasticbeanstalk/src/generated.rs
@@ -979,10 +979,7 @@ impl BuildConfigurationSerializer {
         }
         params.put(&format!("{}{}", prefix, "Image"), &obj.image);
         if let Some(ref field_value) = obj.timeout_in_minutes {
-            params.put(
-                &format!("{}{}", prefix, "TimeoutInMinutes"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "TimeoutInMinutes"), &field_value);
         }
     }
 }
@@ -1914,7 +1911,7 @@ impl CreateApplicationVersionMessageSerializer {
         if let Some(ref field_value) = obj.auto_create_application {
             params.put(
                 &format!("{}{}", prefix, "AutoCreateApplication"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.build_configuration {
@@ -1928,10 +1925,7 @@ impl CreateApplicationVersionMessageSerializer {
             params.put(&format!("{}{}", prefix, "Description"), &field_value);
         }
         if let Some(ref field_value) = obj.process {
-            params.put(
-                &format!("{}{}", prefix, "Process"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Process"), &field_value);
         }
         if let Some(ref field_value) = obj.source_build_information {
             SourceBuildInformationSerializer::serialize(
@@ -2325,7 +2319,7 @@ impl DeleteApplicationMessageSerializer {
         if let Some(ref field_value) = obj.terminate_env_by_force {
             params.put(
                 &format!("{}{}", prefix, "TerminateEnvByForce"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
     }
@@ -2356,10 +2350,7 @@ impl DeleteApplicationVersionMessageSerializer {
             &obj.application_name,
         );
         if let Some(ref field_value) = obj.delete_source_bundle {
-            params.put(
-                &format!("{}{}", prefix, "DeleteSourceBundle"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DeleteSourceBundle"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "VersionLabel"), &obj.version_label);
     }
@@ -2590,10 +2581,7 @@ impl DescribeApplicationVersionsMessageSerializer {
             params.put(&format!("{}{}", prefix, "ApplicationName"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -2867,10 +2855,7 @@ impl DescribeEnvironmentManagedActionHistoryRequestSerializer {
             params.put(&format!("{}{}", prefix, "EnvironmentName"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -3055,10 +3040,7 @@ impl DescribeEnvironmentsMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.include_deleted {
-            params.put(
-                &format!("{}{}", prefix, "IncludeDeleted"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "IncludeDeleted"), &field_value);
         }
         if let Some(ref field_value) = obj.included_deleted_back_to {
             params.put(
@@ -3067,10 +3049,7 @@ impl DescribeEnvironmentsMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -3132,10 +3111,7 @@ impl DescribeEventsMessageSerializer {
             params.put(&format!("{}{}", prefix, "EnvironmentName"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -4629,10 +4605,7 @@ impl ListPlatformVersionsRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -5086,20 +5059,11 @@ impl MaxAgeRuleSerializer {
         }
 
         if let Some(ref field_value) = obj.delete_source_from_s3 {
-            params.put(
-                &format!("{}{}", prefix, "DeleteSourceFromS3"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DeleteSourceFromS3"), &field_value);
         }
-        params.put(
-            &format!("{}{}", prefix, "Enabled"),
-            &obj.enabled.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "Enabled"), &obj.enabled);
         if let Some(ref field_value) = obj.max_age_in_days {
-            params.put(
-                &format!("{}{}", prefix, "MaxAgeInDays"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxAgeInDays"), &field_value);
         }
     }
 }
@@ -5153,20 +5117,11 @@ impl MaxCountRuleSerializer {
         }
 
         if let Some(ref field_value) = obj.delete_source_from_s3 {
-            params.put(
-                &format!("{}{}", prefix, "DeleteSourceFromS3"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DeleteSourceFromS3"), &field_value);
         }
-        params.put(
-            &format!("{}{}", prefix, "Enabled"),
-            &obj.enabled.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "Enabled"), &obj.enabled);
         if let Some(ref field_value) = obj.max_count {
-            params.put(
-                &format!("{}{}", prefix, "MaxCount"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxCount"), &field_value);
         }
     }
 }
@@ -7064,16 +7019,10 @@ impl TerminateEnvironmentMessageSerializer {
             params.put(&format!("{}{}", prefix, "EnvironmentName"), &field_value);
         }
         if let Some(ref field_value) = obj.force_terminate {
-            params.put(
-                &format!("{}{}", prefix, "ForceTerminate"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ForceTerminate"), &field_value);
         }
         if let Some(ref field_value) = obj.terminate_resources {
-            params.put(
-                &format!("{}{}", prefix, "TerminateResources"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "TerminateResources"), &field_value);
         }
     }
 }

--- a/rusoto/services/elb/src/generated.rs
+++ b/rusoto/services/elb/src/generated.rs
@@ -94,15 +94,9 @@ impl AccessLogSerializer {
         }
 
         if let Some(ref field_value) = obj.emit_interval {
-            params.put(
-                &format!("{}{}", prefix, "EmitInterval"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "EmitInterval"), &field_value);
         }
-        params.put(
-            &format!("{}{}", prefix, "Enabled"),
-            &obj.enabled.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "Enabled"), &obj.enabled);
         if let Some(ref field_value) = obj.s3_bucket_name {
             params.put(&format!("{}{}", prefix, "S3BucketName"), &field_value);
         }
@@ -835,15 +829,9 @@ impl ConnectionDrainingSerializer {
             prefix.push_str(".");
         }
 
-        params.put(
-            &format!("{}{}", prefix, "Enabled"),
-            &obj.enabled.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "Enabled"), &obj.enabled);
         if let Some(ref field_value) = obj.timeout {
-            params.put(
-                &format!("{}{}", prefix, "Timeout"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Timeout"), &field_value);
         }
     }
 }
@@ -911,10 +899,7 @@ impl ConnectionSettingsSerializer {
             prefix.push_str(".");
         }
 
-        params.put(
-            &format!("{}{}", prefix, "IdleTimeout"),
-            &obj.idle_timeout.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "IdleTimeout"), &obj.idle_timeout);
     }
 }
 
@@ -1110,7 +1095,7 @@ impl CreateLBCookieStickinessPolicyInputSerializer {
         if let Some(ref field_value) = obj.cookie_expiration_period {
             params.put(
                 &format!("{}{}", prefix, "CookieExpirationPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         params.put(
@@ -1302,10 +1287,7 @@ impl CrossZoneLoadBalancingSerializer {
             prefix.push_str(".");
         }
 
-        params.put(
-            &format!("{}{}", prefix, "Enabled"),
-            &obj.enabled.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "Enabled"), &obj.enabled);
     }
 }
 
@@ -1582,10 +1564,7 @@ impl DescribeAccessPointsInputSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.page_size {
-            params.put(
-                &format!("{}{}", prefix, "PageSize"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PageSize"), &field_value);
         }
     }
 }
@@ -1651,10 +1630,7 @@ impl DescribeAccountLimitsInputSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.page_size {
-            params.put(
-                &format!("{}{}", prefix, "PageSize"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PageSize"), &field_value);
         }
     }
 }
@@ -2120,20 +2096,14 @@ impl HealthCheckSerializer {
 
         params.put(
             &format!("{}{}", prefix, "HealthyThreshold"),
-            &obj.healthy_threshold.to_string(),
+            &obj.healthy_threshold,
         );
-        params.put(
-            &format!("{}{}", prefix, "Interval"),
-            &obj.interval.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "Interval"), &obj.interval);
         params.put(&format!("{}{}", prefix, "Target"), &obj.target);
-        params.put(
-            &format!("{}{}", prefix, "Timeout"),
-            &obj.timeout.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "Timeout"), &obj.timeout);
         params.put(
             &format!("{}{}", prefix, "UnhealthyThreshold"),
-            &obj.unhealthy_threshold.to_string(),
+            &obj.unhealthy_threshold,
         );
     }
 }
@@ -2535,16 +2505,13 @@ impl ListenerSerializer {
             prefix.push_str(".");
         }
 
-        params.put(
-            &format!("{}{}", prefix, "InstancePort"),
-            &obj.instance_port.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "InstancePort"), &obj.instance_port);
         if let Some(ref field_value) = obj.instance_protocol {
             params.put(&format!("{}{}", prefix, "InstanceProtocol"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "LoadBalancerPort"),
-            &obj.load_balancer_port.to_string(),
+            &obj.load_balancer_port,
         );
         params.put(&format!("{}{}", prefix, "Protocol"), &obj.protocol);
         if let Some(ref field_value) = obj.ssl_certificate_id {
@@ -3455,7 +3422,7 @@ impl PortsSerializer {
     fn serialize(params: &mut Params, name: &str, obj: &Vec<i64>) {
         for (index, obj) in obj.iter().enumerate() {
             let key = format!("{}.member.{}", name, index + 1);
-            params.put(&key, &obj.to_string());
+            params.put(&key, &obj);
         }
     }
 }
@@ -3786,7 +3753,7 @@ impl SetLoadBalancerListenerSSLCertificateInputSerializer {
         );
         params.put(
             &format!("{}{}", prefix, "LoadBalancerPort"),
-            &obj.load_balancer_port.to_string(),
+            &obj.load_balancer_port,
         );
         params.put(
             &format!("{}{}", prefix, "SSLCertificateId"),
@@ -3839,10 +3806,7 @@ impl SetLoadBalancerPoliciesForBackendServerInputSerializer {
             prefix.push_str(".");
         }
 
-        params.put(
-            &format!("{}{}", prefix, "InstancePort"),
-            &obj.instance_port.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "InstancePort"), &obj.instance_port);
         params.put(
             &format!("{}{}", prefix, "LoadBalancerName"),
             &obj.load_balancer_name,
@@ -3901,7 +3865,7 @@ impl SetLoadBalancerPoliciesOfListenerInputSerializer {
         );
         params.put(
             &format!("{}{}", prefix, "LoadBalancerPort"),
-            &obj.load_balancer_port.to_string(),
+            &obj.load_balancer_port,
         );
         PolicyNamesSerializer::serialize(
             params,

--- a/rusoto/services/elbv2/src/generated.rs
+++ b/rusoto/services/elbv2/src/generated.rs
@@ -139,7 +139,7 @@ impl ActionSerializer {
             );
         }
         if let Some(ref field_value) = obj.order {
-            params.put(&format!("{}{}", prefix, "Order"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Order"), &field_value);
         }
         if let Some(ref field_value) = obj.redirect_config {
             RedirectActionConfigSerializer::serialize(
@@ -533,10 +533,7 @@ impl AuthenticateCognitoActionConfigSerializer {
             params.put(&format!("{}{}", prefix, "SessionCookieName"), &field_value);
         }
         if let Some(ref field_value) = obj.session_timeout {
-            params.put(
-                &format!("{}{}", prefix, "SessionTimeout"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SessionTimeout"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "UserPoolArn"), &obj.user_pool_arn);
         params.put(
@@ -916,10 +913,7 @@ impl AuthenticateOidcActionConfigSerializer {
             params.put(&format!("{}{}", prefix, "SessionCookieName"), &field_value);
         }
         if let Some(ref field_value) = obj.session_timeout {
-            params.put(
-                &format!("{}{}", prefix, "SessionTimeout"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SessionTimeout"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "TokenEndpoint"),
@@ -1134,10 +1128,7 @@ impl CertificateSerializer {
             params.put(&format!("{}{}", prefix, "CertificateArn"), &field_value);
         }
         if let Some(ref field_value) = obj.is_default {
-            params.put(
-                &format!("{}{}", prefix, "IsDefault"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "IsDefault"), &field_value);
         }
     }
 }
@@ -1316,7 +1307,7 @@ impl CreateListenerInputSerializer {
             &format!("{}{}", prefix, "LoadBalancerArn"),
             &obj.load_balancer_arn,
         );
-        params.put(&format!("{}{}", prefix, "Port"), &obj.port.to_string());
+        params.put(&format!("{}{}", prefix, "Port"), &obj.port);
         params.put(&format!("{}{}", prefix, "Protocol"), &obj.protocol);
         if let Some(ref field_value) = obj.ssl_policy {
             params.put(&format!("{}{}", prefix, "SslPolicy"), &field_value);
@@ -1470,10 +1461,7 @@ impl CreateRuleInputSerializer {
             &obj.conditions,
         );
         params.put(&format!("{}{}", prefix, "ListenerArn"), &obj.listener_arn);
-        params.put(
-            &format!("{}{}", prefix, "Priority"),
-            &obj.priority.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "Priority"), &obj.priority);
     }
 }
 
@@ -1545,15 +1533,12 @@ impl CreateTargetGroupInputSerializer {
         }
 
         if let Some(ref field_value) = obj.health_check_enabled {
-            params.put(
-                &format!("{}{}", prefix, "HealthCheckEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "HealthCheckEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.health_check_interval_seconds {
             params.put(
                 &format!("{}{}", prefix, "HealthCheckIntervalSeconds"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.health_check_path {
@@ -1571,13 +1556,13 @@ impl CreateTargetGroupInputSerializer {
         if let Some(ref field_value) = obj.health_check_timeout_seconds {
             params.put(
                 &format!("{}{}", prefix, "HealthCheckTimeoutSeconds"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.healthy_threshold_count {
             params.put(
                 &format!("{}{}", prefix, "HealthyThresholdCount"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.matcher {
@@ -1585,7 +1570,7 @@ impl CreateTargetGroupInputSerializer {
         }
         params.put(&format!("{}{}", prefix, "Name"), &obj.name);
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"), &field_value);
         }
         if let Some(ref field_value) = obj.protocol {
             params.put(&format!("{}{}", prefix, "Protocol"), &field_value);
@@ -1596,7 +1581,7 @@ impl CreateTargetGroupInputSerializer {
         if let Some(ref field_value) = obj.unhealthy_threshold_count {
             params.put(
                 &format!("{}{}", prefix, "UnhealthyThresholdCount"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.vpc_id {
@@ -1904,10 +1889,7 @@ impl DescribeAccountLimitsInputSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.page_size {
-            params.put(
-                &format!("{}{}", prefix, "PageSize"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PageSize"), &field_value);
         }
     }
 }
@@ -1972,10 +1954,7 @@ impl DescribeListenerCertificatesInputSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.page_size {
-            params.put(
-                &format!("{}{}", prefix, "PageSize"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PageSize"), &field_value);
         }
     }
 }
@@ -2051,10 +2030,7 @@ impl DescribeListenersInputSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.page_size {
-            params.put(
-                &format!("{}{}", prefix, "PageSize"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PageSize"), &field_value);
         }
     }
 }
@@ -2186,10 +2162,7 @@ impl DescribeLoadBalancersInputSerializer {
             );
         }
         if let Some(ref field_value) = obj.page_size {
-            params.put(
-                &format!("{}{}", prefix, "PageSize"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PageSize"), &field_value);
         }
     }
 }
@@ -2258,10 +2231,7 @@ impl DescribeRulesInputSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.page_size {
-            params.put(
-                &format!("{}{}", prefix, "PageSize"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PageSize"), &field_value);
         }
         if let Some(ref field_value) = obj.rule_arns {
             RuleArnsSerializer::serialize(
@@ -2334,10 +2304,7 @@ impl DescribeSSLPoliciesInputSerializer {
             );
         }
         if let Some(ref field_value) = obj.page_size {
-            params.put(
-                &format!("{}{}", prefix, "PageSize"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PageSize"), &field_value);
         }
     }
 }
@@ -2516,10 +2483,7 @@ impl DescribeTargetGroupsInputSerializer {
             );
         }
         if let Some(ref field_value) = obj.page_size {
-            params.put(
-                &format!("{}{}", prefix, "PageSize"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PageSize"), &field_value);
         }
         if let Some(ref field_value) = obj.target_group_arns {
             TargetGroupArnsSerializer::serialize(
@@ -3600,7 +3564,7 @@ impl ModifyListenerInputSerializer {
         }
         params.put(&format!("{}{}", prefix, "ListenerArn"), &obj.listener_arn);
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"), &field_value);
         }
         if let Some(ref field_value) = obj.protocol {
             params.put(&format!("{}{}", prefix, "Protocol"), &field_value);
@@ -3848,15 +3812,12 @@ impl ModifyTargetGroupInputSerializer {
         }
 
         if let Some(ref field_value) = obj.health_check_enabled {
-            params.put(
-                &format!("{}{}", prefix, "HealthCheckEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "HealthCheckEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.health_check_interval_seconds {
             params.put(
                 &format!("{}{}", prefix, "HealthCheckIntervalSeconds"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.health_check_path {
@@ -3874,13 +3835,13 @@ impl ModifyTargetGroupInputSerializer {
         if let Some(ref field_value) = obj.health_check_timeout_seconds {
             params.put(
                 &format!("{}{}", prefix, "HealthCheckTimeoutSeconds"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.healthy_threshold_count {
             params.put(
                 &format!("{}{}", prefix, "HealthyThresholdCount"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.matcher {
@@ -3893,7 +3854,7 @@ impl ModifyTargetGroupInputSerializer {
         if let Some(ref field_value) = obj.unhealthy_threshold_count {
             params.put(
                 &format!("{}{}", prefix, "UnhealthyThresholdCount"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
     }
@@ -4506,10 +4467,7 @@ impl RulePriorityPairSerializer {
         }
 
         if let Some(ref field_value) = obj.priority {
-            params.put(
-                &format!("{}{}", prefix, "Priority"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Priority"), &field_value);
         }
         if let Some(ref field_value) = obj.rule_arn {
             params.put(&format!("{}{}", prefix, "RuleArn"), &field_value);
@@ -5243,7 +5201,7 @@ impl TargetDescriptionSerializer {
         }
         params.put(&format!("{}{}", prefix, "Id"), &obj.id);
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"), &field_value);
         }
     }
 }

--- a/rusoto/services/iam/src/generated.rs
+++ b/rusoto/services/iam/src/generated.rs
@@ -1006,7 +1006,7 @@ impl CreateLoginProfileRequestSerializer {
         if let Some(ref field_value) = obj.password_reset_required {
             params.put(
                 &format!("{}{}", prefix, "PasswordResetRequired"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
@@ -1195,10 +1195,7 @@ impl CreatePolicyVersionRequestSerializer {
             &obj.policy_document,
         );
         if let Some(ref field_value) = obj.set_as_default {
-            params.put(
-                &format!("{}{}", prefix, "SetAsDefault"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SetAsDefault"), &field_value);
         }
     }
 }
@@ -1270,10 +1267,7 @@ impl CreateRoleRequestSerializer {
             params.put(&format!("{}{}", prefix, "Description"), &field_value);
         }
         if let Some(ref field_value) = obj.max_session_duration {
-            params.put(
-                &format!("{}{}", prefix, "MaxSessionDuration"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxSessionDuration"), &field_value);
         }
         if let Some(ref field_value) = obj.path {
             params.put(&format!("{}{}", prefix, "Path"), &field_value);
@@ -2779,10 +2773,7 @@ impl GetAccountAuthorizationDetailsRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
     }
 }
@@ -3129,10 +3120,7 @@ impl GetGroupRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
     }
 }
@@ -3756,10 +3744,7 @@ impl GetServiceLastAccessedDetailsRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
     }
 }
@@ -3861,10 +3846,7 @@ impl GetServiceLastAccessedDetailsWithEntitiesRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "ServiceNamespace"),
@@ -4454,10 +4436,7 @@ impl ListAccessKeysRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         if let Some(ref field_value) = obj.user_name {
             params.put(&format!("{}{}", prefix, "UserName"), &field_value);
@@ -4527,10 +4506,7 @@ impl ListAccountAliasesRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
     }
 }
@@ -4605,10 +4581,7 @@ impl ListAttachedGroupPoliciesRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         if let Some(ref field_value) = obj.path_prefix {
             params.put(&format!("{}{}", prefix, "PathPrefix"), &field_value);
@@ -4686,10 +4659,7 @@ impl ListAttachedRolePoliciesRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         if let Some(ref field_value) = obj.path_prefix {
             params.put(&format!("{}{}", prefix, "PathPrefix"), &field_value);
@@ -4768,10 +4738,7 @@ impl ListAttachedUserPoliciesRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         if let Some(ref field_value) = obj.path_prefix {
             params.put(&format!("{}{}", prefix, "PathPrefix"), &field_value);
@@ -4857,10 +4824,7 @@ impl ListEntitiesForPolicyRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         if let Some(ref field_value) = obj.path_prefix {
             params.put(&format!("{}{}", prefix, "PathPrefix"), &field_value);
@@ -4952,10 +4916,7 @@ impl ListGroupPoliciesRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
     }
 }
@@ -5027,10 +4988,7 @@ impl ListGroupsForUserRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
     }
@@ -5100,10 +5058,7 @@ impl ListGroupsRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         if let Some(ref field_value) = obj.path_prefix {
             params.put(&format!("{}{}", prefix, "PathPrefix"), &field_value);
@@ -5171,10 +5126,7 @@ impl ListInstanceProfilesForRoleRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "RoleName"), &obj.role_name);
     }
@@ -5248,10 +5200,7 @@ impl ListInstanceProfilesRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         if let Some(ref field_value) = obj.path_prefix {
             params.put(&format!("{}{}", prefix, "PathPrefix"), &field_value);
@@ -5327,10 +5276,7 @@ impl ListMFADevicesRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         if let Some(ref field_value) = obj.user_name {
             params.put(&format!("{}{}", prefix, "UserName"), &field_value);
@@ -5567,16 +5513,10 @@ impl ListPoliciesRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         if let Some(ref field_value) = obj.only_attached {
-            params.put(
-                &format!("{}{}", prefix, "OnlyAttached"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "OnlyAttached"), &field_value);
         }
         if let Some(ref field_value) = obj.path_prefix {
             params.put(&format!("{}{}", prefix, "PathPrefix"), &field_value);
@@ -5672,10 +5612,7 @@ impl ListPolicyVersionsRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "PolicyArn"), &obj.policy_arn);
     }
@@ -5748,10 +5685,7 @@ impl ListRolePoliciesRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "RoleName"), &obj.role_name);
     }
@@ -5824,10 +5758,7 @@ impl ListRoleTagsRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "RoleName"), &obj.role_name);
     }
@@ -5892,10 +5823,7 @@ impl ListRolesRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         if let Some(ref field_value) = obj.path_prefix {
             params.put(&format!("{}{}", prefix, "PathPrefix"), &field_value);
@@ -6011,10 +5939,7 @@ impl ListSSHPublicKeysRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         if let Some(ref field_value) = obj.user_name {
             params.put(&format!("{}{}", prefix, "UserName"), &field_value);
@@ -6087,10 +6012,7 @@ impl ListServerCertificatesRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         if let Some(ref field_value) = obj.path_prefix {
             params.put(&format!("{}{}", prefix, "PathPrefix"), &field_value);
@@ -6225,10 +6147,7 @@ impl ListSigningCertificatesRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         if let Some(ref field_value) = obj.user_name {
             params.put(&format!("{}{}", prefix, "UserName"), &field_value);
@@ -6303,10 +6222,7 @@ impl ListUserPoliciesRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
     }
@@ -6379,10 +6295,7 @@ impl ListUserTagsRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
     }
@@ -6447,10 +6360,7 @@ impl ListUsersRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         if let Some(ref field_value) = obj.path_prefix {
             params.put(&format!("{}{}", prefix, "PathPrefix"), &field_value);
@@ -6521,10 +6431,7 @@ impl ListVirtualMFADevicesRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
     }
 }
@@ -9305,10 +9212,7 @@ impl SimulateCustomPolicyRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         SimulationPolicyListTypeSerializer::serialize(
             params,
@@ -9432,10 +9336,7 @@ impl SimulatePrincipalPolicyRequestSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         if let Some(ref field_value) = obj.policy_input_list {
             SimulationPolicyListTypeSerializer::serialize(
@@ -9938,55 +9839,43 @@ impl UpdateAccountPasswordPolicyRequestSerializer {
         if let Some(ref field_value) = obj.allow_users_to_change_password {
             params.put(
                 &format!("{}{}", prefix, "AllowUsersToChangePassword"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.hard_expiry {
-            params.put(
-                &format!("{}{}", prefix, "HardExpiry"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "HardExpiry"), &field_value);
         }
         if let Some(ref field_value) = obj.max_password_age {
-            params.put(
-                &format!("{}{}", prefix, "MaxPasswordAge"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxPasswordAge"), &field_value);
         }
         if let Some(ref field_value) = obj.minimum_password_length {
             params.put(
                 &format!("{}{}", prefix, "MinimumPasswordLength"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.password_reuse_prevention {
             params.put(
                 &format!("{}{}", prefix, "PasswordReusePrevention"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.require_lowercase_characters {
             params.put(
                 &format!("{}{}", prefix, "RequireLowercaseCharacters"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.require_numbers {
-            params.put(
-                &format!("{}{}", prefix, "RequireNumbers"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "RequireNumbers"), &field_value);
         }
         if let Some(ref field_value) = obj.require_symbols {
-            params.put(
-                &format!("{}{}", prefix, "RequireSymbols"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "RequireSymbols"), &field_value);
         }
         if let Some(ref field_value) = obj.require_uppercase_characters {
             params.put(
                 &format!("{}{}", prefix, "RequireUppercaseCharacters"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
     }
@@ -10071,7 +9960,7 @@ impl UpdateLoginProfileRequestSerializer {
         if let Some(ref field_value) = obj.password_reset_required {
             params.put(
                 &format!("{}{}", prefix, "PasswordResetRequired"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         params.put(&format!("{}{}", prefix, "UserName"), &obj.user_name);
@@ -10184,10 +10073,7 @@ impl UpdateRoleRequestSerializer {
             params.put(&format!("{}{}", prefix, "Description"), &field_value);
         }
         if let Some(ref field_value) = obj.max_session_duration {
-            params.put(
-                &format!("{}{}", prefix, "MaxSessionDuration"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxSessionDuration"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "RoleName"), &obj.role_name);
     }

--- a/rusoto/services/importexport/src/generated.rs
+++ b/rusoto/services/importexport/src/generated.rs
@@ -168,10 +168,7 @@ impl CreateJobInputSerializer {
         if let Some(ref field_value) = obj.manifest_addendum {
             params.put(&format!("{}{}", prefix, "ManifestAddendum"), &field_value);
         }
-        params.put(
-            &format!("{}{}", prefix, "ValidateOnly"),
-            &obj.validate_only.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "ValidateOnly"), &obj.validate_only);
     }
 }
 
@@ -673,10 +670,7 @@ impl ListJobsInputSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_jobs {
-            params.put(
-                &format!("{}{}", prefix, "MaxJobs"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxJobs"), &field_value);
         }
     }
 }
@@ -891,10 +885,7 @@ impl UpdateJobInputSerializer {
         params.put(&format!("{}{}", prefix, "JobId"), &obj.job_id);
         params.put(&format!("{}{}", prefix, "JobType"), &obj.job_type);
         params.put(&format!("{}{}", prefix, "Manifest"), &obj.manifest);
-        params.put(
-            &format!("{}{}", prefix, "ValidateOnly"),
-            &obj.validate_only.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "ValidateOnly"), &obj.validate_only);
     }
 }
 

--- a/rusoto/services/neptune/src/generated.rs
+++ b/rusoto/services/neptune/src/generated.rs
@@ -510,10 +510,7 @@ impl CopyDBClusterSnapshotMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.copy_tags {
-            params.put(
-                &format!("{}{}", prefix, "CopyTags"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "CopyTags"), &field_value);
         }
         if let Some(ref field_value) = obj.kms_key_id {
             params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
@@ -701,7 +698,7 @@ impl CreateDBClusterMessageSerializer {
         if let Some(ref field_value) = obj.backup_retention_period {
             params.put(
                 &format!("{}{}", prefix, "BackupRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.character_set_name {
@@ -726,7 +723,7 @@ impl CreateDBClusterMessageSerializer {
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(
                 &format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         params.put(&format!("{}{}", prefix, "Engine"), &obj.engine);
@@ -746,7 +743,7 @@ impl CreateDBClusterMessageSerializer {
             params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"), &field_value);
         }
         if let Some(ref field_value) = obj.pre_signed_url {
             params.put(&format!("{}{}", prefix, "PreSignedUrl"), &field_value);
@@ -770,10 +767,7 @@ impl CreateDBClusterMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.storage_encrypted {
-            params.put(
-                &format!("{}{}", prefix, "StorageEncrypted"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "StorageEncrypted"), &field_value);
         }
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tag"), field_value);
@@ -1038,15 +1032,12 @@ impl CreateDBInstanceMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.allocated_storage {
-            params.put(
-                &format!("{}{}", prefix, "AllocatedStorage"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "AllocatedStorage"), &field_value);
         }
         if let Some(ref field_value) = obj.auto_minor_version_upgrade {
             params.put(
                 &format!("{}{}", prefix, "AutoMinorVersionUpgrade"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.availability_zone {
@@ -1055,17 +1046,14 @@ impl CreateDBInstanceMessageSerializer {
         if let Some(ref field_value) = obj.backup_retention_period {
             params.put(
                 &format!("{}{}", prefix, "BackupRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.character_set_name {
             params.put(&format!("{}{}", prefix, "CharacterSetName"), &field_value);
         }
         if let Some(ref field_value) = obj.copy_tags_to_snapshot {
-            params.put(
-                &format!("{}{}", prefix, "CopyTagsToSnapshot"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "CopyTagsToSnapshot"), &field_value);
         }
         if let Some(ref field_value) = obj.db_cluster_identifier {
             params.put(
@@ -1116,13 +1104,13 @@ impl CreateDBInstanceMessageSerializer {
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(
                 &format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.enable_performance_insights {
             params.put(
                 &format!("{}{}", prefix, "EnablePerformanceInsights"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         params.put(&format!("{}{}", prefix, "Engine"), &obj.engine);
@@ -1130,7 +1118,7 @@ impl CreateDBInstanceMessageSerializer {
             params.put(&format!("{}{}", prefix, "EngineVersion"), &field_value);
         }
         if let Some(ref field_value) = obj.iops {
-            params.put(&format!("{}{}", prefix, "Iops"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Iops"), &field_value);
         }
         if let Some(ref field_value) = obj.kms_key_id {
             params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
@@ -1145,19 +1133,13 @@ impl CreateDBInstanceMessageSerializer {
             params.put(&format!("{}{}", prefix, "MasterUsername"), &field_value);
         }
         if let Some(ref field_value) = obj.monitoring_interval {
-            params.put(
-                &format!("{}{}", prefix, "MonitoringInterval"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MonitoringInterval"), &field_value);
         }
         if let Some(ref field_value) = obj.monitoring_role_arn {
             params.put(&format!("{}{}", prefix, "MonitoringRoleArn"), &field_value);
         }
         if let Some(ref field_value) = obj.multi_az {
-            params.put(
-                &format!("{}{}", prefix, "MultiAZ"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MultiAZ"), &field_value);
         }
         if let Some(ref field_value) = obj.option_group_name {
             params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
@@ -1169,7 +1151,7 @@ impl CreateDBInstanceMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"), &field_value);
         }
         if let Some(ref field_value) = obj.preferred_backup_window {
             params.put(
@@ -1184,17 +1166,11 @@ impl CreateDBInstanceMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.promotion_tier {
-            params.put(
-                &format!("{}{}", prefix, "PromotionTier"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PromotionTier"), &field_value);
         }
 
         if let Some(ref field_value) = obj.storage_encrypted {
-            params.put(
-                &format!("{}{}", prefix, "StorageEncrypted"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "StorageEncrypted"), &field_value);
         }
         if let Some(ref field_value) = obj.storage_type {
             params.put(&format!("{}{}", prefix, "StorageType"), &field_value);
@@ -1412,10 +1388,7 @@ impl CreateEventSubscriptionMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.enabled {
-            params.put(
-                &format!("{}{}", prefix, "Enabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Enabled"), &field_value);
         }
         if let Some(ref field_value) = obj.event_categories {
             EventCategoriesListSerializer::serialize(
@@ -3563,10 +3536,7 @@ impl DeleteDBClusterMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.skip_final_snapshot {
-            params.put(
-                &format!("{}{}", prefix, "SkipFinalSnapshot"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SkipFinalSnapshot"), &field_value);
         }
     }
 }
@@ -3701,10 +3671,7 @@ impl DeleteDBInstanceMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.skip_final_snapshot {
-            params.put(
-                &format!("{}{}", prefix, "SkipFinalSnapshot"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SkipFinalSnapshot"), &field_value);
         }
     }
 }
@@ -3871,10 +3838,7 @@ impl DescribeDBClusterParameterGroupsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -3918,10 +3882,7 @@ impl DescribeDBClusterParametersMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.source {
             params.put(&format!("{}{}", prefix, "Source"), &field_value);
@@ -4037,25 +3998,16 @@ impl DescribeDBClusterSnapshotsMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.include_public {
-            params.put(
-                &format!("{}{}", prefix, "IncludePublic"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "IncludePublic"), &field_value);
         }
         if let Some(ref field_value) = obj.include_shared {
-            params.put(
-                &format!("{}{}", prefix, "IncludeShared"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "IncludeShared"), &field_value);
         }
         if let Some(ref field_value) = obj.marker {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.snapshot_type {
             params.put(&format!("{}{}", prefix, "SnapshotType"), &field_value);
@@ -4102,10 +4054,7 @@ impl DescribeDBClustersMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -4148,10 +4097,7 @@ impl DescribeDBEngineVersionsMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.default_only {
-            params.put(
-                &format!("{}{}", prefix, "DefaultOnly"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DefaultOnly"), &field_value);
         }
         if let Some(ref field_value) = obj.engine {
             params.put(&format!("{}{}", prefix, "Engine"), &field_value);
@@ -4169,23 +4115,20 @@ impl DescribeDBEngineVersionsMessageSerializer {
         if let Some(ref field_value) = obj.list_supported_character_sets {
             params.put(
                 &format!("{}{}", prefix, "ListSupportedCharacterSets"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.list_supported_timezones {
             params.put(
                 &format!("{}{}", prefix, "ListSupportedTimezones"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.marker {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -4229,10 +4172,7 @@ impl DescribeDBInstancesMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -4276,10 +4216,7 @@ impl DescribeDBParameterGroupsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -4322,10 +4259,7 @@ impl DescribeDBParametersMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.source {
             params.put(&format!("{}{}", prefix, "Source"), &field_value);
@@ -4369,10 +4303,7 @@ impl DescribeDBSubnetGroupsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -4418,10 +4349,7 @@ impl DescribeEngineDefaultClusterParametersMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -4493,10 +4421,7 @@ impl DescribeEngineDefaultParametersMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -4595,10 +4520,7 @@ impl DescribeEventSubscriptionsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.subscription_name {
             params.put(&format!("{}{}", prefix, "SubscriptionName"), &field_value);
@@ -4639,10 +4561,7 @@ impl DescribeEventsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.duration {
-            params.put(
-                &format!("{}{}", prefix, "Duration"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Duration"), &field_value);
         }
         if let Some(ref field_value) = obj.end_time {
             params.put(&format!("{}{}", prefix, "EndTime"), &field_value);
@@ -4665,10 +4584,7 @@ impl DescribeEventsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.source_identifier {
             params.put(&format!("{}{}", prefix, "SourceIdentifier"), &field_value);
@@ -4733,13 +4649,10 @@ impl DescribeOrderableDBInstanceOptionsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.vpc {
-            params.put(&format!("{}{}", prefix, "Vpc"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Vpc"), &field_value);
         }
     }
 }
@@ -4777,10 +4690,7 @@ impl DescribePendingMaintenanceActionsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.resource_identifier {
             params.put(&format!("{}{}", prefix, "ResourceIdentifier"), &field_value);
@@ -5666,15 +5576,12 @@ impl ModifyDBClusterMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.apply_immediately {
-            params.put(
-                &format!("{}{}", prefix, "ApplyImmediately"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ApplyImmediately"), &field_value);
         }
         if let Some(ref field_value) = obj.backup_retention_period {
             params.put(
                 &format!("{}{}", prefix, "BackupRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         params.put(
@@ -5690,7 +5597,7 @@ impl ModifyDBClusterMessageSerializer {
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(
                 &format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.engine_version {
@@ -5709,7 +5616,7 @@ impl ModifyDBClusterMessageSerializer {
             params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"), &field_value);
         }
         if let Some(ref field_value) = obj.preferred_backup_window {
             params.put(
@@ -5949,33 +5856,27 @@ impl ModifyDBInstanceMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.allocated_storage {
-            params.put(
-                &format!("{}{}", prefix, "AllocatedStorage"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "AllocatedStorage"), &field_value);
         }
         if let Some(ref field_value) = obj.allow_major_version_upgrade {
             params.put(
                 &format!("{}{}", prefix, "AllowMajorVersionUpgrade"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.apply_immediately {
-            params.put(
-                &format!("{}{}", prefix, "ApplyImmediately"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ApplyImmediately"), &field_value);
         }
         if let Some(ref field_value) = obj.auto_minor_version_upgrade {
             params.put(
                 &format!("{}{}", prefix, "AutoMinorVersionUpgrade"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.backup_retention_period {
             params.put(
                 &format!("{}{}", prefix, "BackupRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.ca_certificate_identifier {
@@ -5992,10 +5893,7 @@ impl ModifyDBInstanceMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.copy_tags_to_snapshot {
-            params.put(
-                &format!("{}{}", prefix, "CopyTagsToSnapshot"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "CopyTagsToSnapshot"), &field_value);
         }
         if let Some(ref field_value) = obj.db_instance_class {
             params.put(&format!("{}{}", prefix, "DBInstanceClass"), &field_value);
@@ -6011,10 +5909,7 @@ impl ModifyDBInstanceMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.db_port_number {
-            params.put(
-                &format!("{}{}", prefix, "DBPortNumber"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DBPortNumber"), &field_value);
         }
         if let Some(ref field_value) = obj.db_security_groups {
             DBSecurityGroupNameListSerializer::serialize(
@@ -6035,20 +5930,20 @@ impl ModifyDBInstanceMessageSerializer {
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(
                 &format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.enable_performance_insights {
             params.put(
                 &format!("{}{}", prefix, "EnablePerformanceInsights"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.engine_version {
             params.put(&format!("{}{}", prefix, "EngineVersion"), &field_value);
         }
         if let Some(ref field_value) = obj.iops {
-            params.put(&format!("{}{}", prefix, "Iops"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Iops"), &field_value);
         }
         if let Some(ref field_value) = obj.license_model {
             params.put(&format!("{}{}", prefix, "LicenseModel"), &field_value);
@@ -6057,19 +5952,13 @@ impl ModifyDBInstanceMessageSerializer {
             params.put(&format!("{}{}", prefix, "MasterUserPassword"), &field_value);
         }
         if let Some(ref field_value) = obj.monitoring_interval {
-            params.put(
-                &format!("{}{}", prefix, "MonitoringInterval"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MonitoringInterval"), &field_value);
         }
         if let Some(ref field_value) = obj.monitoring_role_arn {
             params.put(&format!("{}{}", prefix, "MonitoringRoleArn"), &field_value);
         }
         if let Some(ref field_value) = obj.multi_az {
-            params.put(
-                &format!("{}{}", prefix, "MultiAZ"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MultiAZ"), &field_value);
         }
         if let Some(ref field_value) = obj.new_db_instance_identifier {
             params.put(
@@ -6099,10 +5988,7 @@ impl ModifyDBInstanceMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.promotion_tier {
-            params.put(
-                &format!("{}{}", prefix, "PromotionTier"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PromotionTier"), &field_value);
         }
 
         if let Some(ref field_value) = obj.storage_type {
@@ -6274,10 +6160,7 @@ impl ModifyEventSubscriptionMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.enabled {
-            params.put(
-                &format!("{}{}", prefix, "Enabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Enabled"), &field_value);
         }
         if let Some(ref field_value) = obj.event_categories {
             EventCategoriesListSerializer::serialize(
@@ -6714,10 +6597,7 @@ impl ParameterSerializer {
             params.put(&format!("{}{}", prefix, "Description"), &field_value);
         }
         if let Some(ref field_value) = obj.is_modifiable {
-            params.put(
-                &format!("{}{}", prefix, "IsModifiable"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "IsModifiable"), &field_value);
         }
         if let Some(ref field_value) = obj.minimum_engine_version {
             params.put(
@@ -7243,10 +7123,7 @@ impl RebootDBInstanceMessageSerializer {
             &obj.db_instance_identifier,
         );
         if let Some(ref field_value) = obj.force_failover {
-            params.put(
-                &format!("{}{}", prefix, "ForceFailover"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ForceFailover"), &field_value);
         }
     }
 }
@@ -7418,10 +7295,7 @@ impl ResetDBClusterParameterGroupMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.reset_all_parameters {
-            params.put(
-                &format!("{}{}", prefix, "ResetAllParameters"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ResetAllParameters"), &field_value);
         }
     }
 }
@@ -7458,10 +7332,7 @@ impl ResetDBParameterGroupMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.reset_all_parameters {
-            params.put(
-                &format!("{}{}", prefix, "ResetAllParameters"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ResetAllParameters"), &field_value);
         }
     }
 }
@@ -7568,7 +7439,7 @@ impl RestoreDBClusterFromSnapshotMessageSerializer {
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(
                 &format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         params.put(&format!("{}{}", prefix, "Engine"), &obj.engine);
@@ -7582,7 +7453,7 @@ impl RestoreDBClusterFromSnapshotMessageSerializer {
             params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "SnapshotIdentifier"),
@@ -7676,7 +7547,7 @@ impl RestoreDBClusterToPointInTimeMessageSerializer {
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(
                 &format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.kms_key_id {
@@ -7686,7 +7557,7 @@ impl RestoreDBClusterToPointInTimeMessageSerializer {
             params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"), &field_value);
         }
         if let Some(ref field_value) = obj.restore_to_time {
             params.put(&format!("{}{}", prefix, "RestoreToTime"), &field_value);
@@ -7704,7 +7575,7 @@ impl RestoreDBClusterToPointInTimeMessageSerializer {
         if let Some(ref field_value) = obj.use_latest_restorable_time {
             params.put(
                 &format!("{}{}", prefix, "UseLatestRestorableTime"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.vpc_security_group_ids {

--- a/rusoto/services/rds/src/generated.rs
+++ b/rusoto/services/rds/src/generated.rs
@@ -601,12 +601,12 @@ impl BacktrackDBClusterMessageSerializer {
             &obj.db_cluster_identifier,
         );
         if let Some(ref field_value) = obj.force {
-            params.put(&format!("{}{}", prefix, "Force"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Force"), &field_value);
         }
         if let Some(ref field_value) = obj.use_earliest_time_on_point_in_time_unavailable {
             params.put(
                 &format!("{}{}", prefix, "UseEarliestTimeOnPointInTimeUnavailable"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
     }
@@ -908,10 +908,7 @@ impl CopyDBClusterSnapshotMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.copy_tags {
-            params.put(
-                &format!("{}{}", prefix, "CopyTags"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "CopyTags"), &field_value);
         }
         if let Some(ref field_value) = obj.kms_key_id {
             params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
@@ -1060,10 +1057,7 @@ impl CopyDBSnapshotMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.copy_tags {
-            params.put(
-                &format!("{}{}", prefix, "CopyTags"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "CopyTags"), &field_value);
         }
         if let Some(ref field_value) = obj.kms_key_id {
             params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
@@ -1301,15 +1295,12 @@ impl CreateDBClusterMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.backtrack_window {
-            params.put(
-                &format!("{}{}", prefix, "BacktrackWindow"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "BacktrackWindow"), &field_value);
         }
         if let Some(ref field_value) = obj.backup_retention_period {
             params.put(
                 &format!("{}{}", prefix, "BackupRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.character_set_name {
@@ -1332,10 +1323,7 @@ impl CreateDBClusterMessageSerializer {
             params.put(&format!("{}{}", prefix, "DatabaseName"), &field_value);
         }
         if let Some(ref field_value) = obj.deletion_protection {
-            params.put(
-                &format!("{}{}", prefix, "DeletionProtection"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DeletionProtection"), &field_value);
         }
         if let Some(ref field_value) = obj.enable_cloudwatch_logs_exports {
             LogTypeListSerializer::serialize(
@@ -1347,7 +1335,7 @@ impl CreateDBClusterMessageSerializer {
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(
                 &format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         params.put(&format!("{}{}", prefix, "Engine"), &obj.engine);
@@ -1376,7 +1364,7 @@ impl CreateDBClusterMessageSerializer {
             params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"), &field_value);
         }
         if let Some(ref field_value) = obj.pre_signed_url {
             params.put(&format!("{}{}", prefix, "PreSignedUrl"), &field_value);
@@ -1407,10 +1395,7 @@ impl CreateDBClusterMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.storage_encrypted {
-            params.put(
-                &format!("{}{}", prefix, "StorageEncrypted"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "StorageEncrypted"), &field_value);
         }
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tag"), field_value);
@@ -1683,15 +1668,12 @@ impl CreateDBInstanceMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.allocated_storage {
-            params.put(
-                &format!("{}{}", prefix, "AllocatedStorage"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "AllocatedStorage"), &field_value);
         }
         if let Some(ref field_value) = obj.auto_minor_version_upgrade {
             params.put(
                 &format!("{}{}", prefix, "AutoMinorVersionUpgrade"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.availability_zone {
@@ -1700,17 +1682,14 @@ impl CreateDBInstanceMessageSerializer {
         if let Some(ref field_value) = obj.backup_retention_period {
             params.put(
                 &format!("{}{}", prefix, "BackupRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.character_set_name {
             params.put(&format!("{}{}", prefix, "CharacterSetName"), &field_value);
         }
         if let Some(ref field_value) = obj.copy_tags_to_snapshot {
-            params.put(
-                &format!("{}{}", prefix, "CopyTagsToSnapshot"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "CopyTagsToSnapshot"), &field_value);
         }
         if let Some(ref field_value) = obj.db_cluster_identifier {
             params.put(
@@ -1746,10 +1725,7 @@ impl CreateDBInstanceMessageSerializer {
             params.put(&format!("{}{}", prefix, "DBSubnetGroupName"), &field_value);
         }
         if let Some(ref field_value) = obj.deletion_protection {
-            params.put(
-                &format!("{}{}", prefix, "DeletionProtection"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DeletionProtection"), &field_value);
         }
         if let Some(ref field_value) = obj.domain {
             params.put(&format!("{}{}", prefix, "Domain"), &field_value);
@@ -1767,13 +1743,13 @@ impl CreateDBInstanceMessageSerializer {
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(
                 &format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.enable_performance_insights {
             params.put(
                 &format!("{}{}", prefix, "EnablePerformanceInsights"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         params.put(&format!("{}{}", prefix, "Engine"), &obj.engine);
@@ -1781,7 +1757,7 @@ impl CreateDBInstanceMessageSerializer {
             params.put(&format!("{}{}", prefix, "EngineVersion"), &field_value);
         }
         if let Some(ref field_value) = obj.iops {
-            params.put(&format!("{}{}", prefix, "Iops"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Iops"), &field_value);
         }
         if let Some(ref field_value) = obj.kms_key_id {
             params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
@@ -1796,19 +1772,13 @@ impl CreateDBInstanceMessageSerializer {
             params.put(&format!("{}{}", prefix, "MasterUsername"), &field_value);
         }
         if let Some(ref field_value) = obj.monitoring_interval {
-            params.put(
-                &format!("{}{}", prefix, "MonitoringInterval"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MonitoringInterval"), &field_value);
         }
         if let Some(ref field_value) = obj.monitoring_role_arn {
             params.put(&format!("{}{}", prefix, "MonitoringRoleArn"), &field_value);
         }
         if let Some(ref field_value) = obj.multi_az {
-            params.put(
-                &format!("{}{}", prefix, "MultiAZ"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MultiAZ"), &field_value);
         }
         if let Some(ref field_value) = obj.option_group_name {
             params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
@@ -1822,11 +1792,11 @@ impl CreateDBInstanceMessageSerializer {
         if let Some(ref field_value) = obj.performance_insights_retention_period {
             params.put(
                 &format!("{}{}", prefix, "PerformanceInsightsRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"), &field_value);
         }
         if let Some(ref field_value) = obj.preferred_backup_window {
             params.put(
@@ -1848,22 +1818,13 @@ impl CreateDBInstanceMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.promotion_tier {
-            params.put(
-                &format!("{}{}", prefix, "PromotionTier"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PromotionTier"), &field_value);
         }
         if let Some(ref field_value) = obj.publicly_accessible {
-            params.put(
-                &format!("{}{}", prefix, "PubliclyAccessible"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PubliclyAccessible"), &field_value);
         }
         if let Some(ref field_value) = obj.storage_encrypted {
-            params.put(
-                &format!("{}{}", prefix, "StorageEncrypted"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "StorageEncrypted"), &field_value);
         }
         if let Some(ref field_value) = obj.storage_type {
             params.put(&format!("{}{}", prefix, "StorageType"), &field_value);
@@ -1962,17 +1923,14 @@ impl CreateDBInstanceReadReplicaMessageSerializer {
         if let Some(ref field_value) = obj.auto_minor_version_upgrade {
             params.put(
                 &format!("{}{}", prefix, "AutoMinorVersionUpgrade"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.availability_zone {
             params.put(&format!("{}{}", prefix, "AvailabilityZone"), &field_value);
         }
         if let Some(ref field_value) = obj.copy_tags_to_snapshot {
-            params.put(
-                &format!("{}{}", prefix, "CopyTagsToSnapshot"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "CopyTagsToSnapshot"), &field_value);
         }
         if let Some(ref field_value) = obj.db_instance_class {
             params.put(&format!("{}{}", prefix, "DBInstanceClass"), &field_value);
@@ -1985,10 +1943,7 @@ impl CreateDBInstanceReadReplicaMessageSerializer {
             params.put(&format!("{}{}", prefix, "DBSubnetGroupName"), &field_value);
         }
         if let Some(ref field_value) = obj.deletion_protection {
-            params.put(
-                &format!("{}{}", prefix, "DeletionProtection"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DeletionProtection"), &field_value);
         }
         if let Some(ref field_value) = obj.enable_cloudwatch_logs_exports {
             LogTypeListSerializer::serialize(
@@ -2000,35 +1955,29 @@ impl CreateDBInstanceReadReplicaMessageSerializer {
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(
                 &format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.enable_performance_insights {
             params.put(
                 &format!("{}{}", prefix, "EnablePerformanceInsights"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.iops {
-            params.put(&format!("{}{}", prefix, "Iops"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Iops"), &field_value);
         }
         if let Some(ref field_value) = obj.kms_key_id {
             params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
         }
         if let Some(ref field_value) = obj.monitoring_interval {
-            params.put(
-                &format!("{}{}", prefix, "MonitoringInterval"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MonitoringInterval"), &field_value);
         }
         if let Some(ref field_value) = obj.monitoring_role_arn {
             params.put(&format!("{}{}", prefix, "MonitoringRoleArn"), &field_value);
         }
         if let Some(ref field_value) = obj.multi_az {
-            params.put(
-                &format!("{}{}", prefix, "MultiAZ"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MultiAZ"), &field_value);
         }
         if let Some(ref field_value) = obj.option_group_name {
             params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
@@ -2042,11 +1991,11 @@ impl CreateDBInstanceReadReplicaMessageSerializer {
         if let Some(ref field_value) = obj.performance_insights_retention_period {
             params.put(
                 &format!("{}{}", prefix, "PerformanceInsightsRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"), &field_value);
         }
         if let Some(ref field_value) = obj.pre_signed_url {
             params.put(&format!("{}{}", prefix, "PreSignedUrl"), &field_value);
@@ -2059,10 +2008,7 @@ impl CreateDBInstanceReadReplicaMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.publicly_accessible {
-            params.put(
-                &format!("{}{}", prefix, "PubliclyAccessible"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PubliclyAccessible"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "SourceDBInstanceIdentifier"),
@@ -2077,7 +2023,7 @@ impl CreateDBInstanceReadReplicaMessageSerializer {
         if let Some(ref field_value) = obj.use_default_processor_features {
             params.put(
                 &format!("{}{}", prefix, "UseDefaultProcessorFeatures"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.vpc_security_group_ids {
@@ -2426,10 +2372,7 @@ impl CreateEventSubscriptionMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.enabled {
-            params.put(
-                &format!("{}{}", prefix, "Enabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Enabled"), &field_value);
         }
         if let Some(ref field_value) = obj.event_categories {
             EventCategoriesListSerializer::serialize(
@@ -2520,10 +2463,7 @@ impl CreateGlobalClusterMessageSerializer {
             params.put(&format!("{}{}", prefix, "DatabaseName"), &field_value);
         }
         if let Some(ref field_value) = obj.deletion_protection {
-            params.put(
-                &format!("{}{}", prefix, "DeletionProtection"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DeletionProtection"), &field_value);
         }
         if let Some(ref field_value) = obj.engine {
             params.put(&format!("{}{}", prefix, "Engine"), &field_value);
@@ -2544,10 +2484,7 @@ impl CreateGlobalClusterMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.storage_encrypted {
-            params.put(
-                &format!("{}{}", prefix, "StorageEncrypted"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "StorageEncrypted"), &field_value);
         }
     }
 }
@@ -5962,10 +5899,7 @@ impl DeleteDBClusterMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.skip_final_snapshot {
-            params.put(
-                &format!("{}{}", prefix, "SkipFinalSnapshot"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SkipFinalSnapshot"), &field_value);
         }
     }
 }
@@ -6152,7 +6086,7 @@ impl DeleteDBInstanceMessageSerializer {
         if let Some(ref field_value) = obj.delete_automated_backups {
             params.put(
                 &format!("{}{}", prefix, "DeleteAutomatedBackups"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.final_db_snapshot_identifier {
@@ -6162,10 +6096,7 @@ impl DeleteDBInstanceMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.skip_final_snapshot {
-            params.put(
-                &format!("{}{}", prefix, "SkipFinalSnapshot"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "SkipFinalSnapshot"), &field_value);
         }
     }
 }
@@ -6492,10 +6423,7 @@ impl DescribeCertificatesMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -6545,10 +6473,7 @@ impl DescribeDBClusterBacktracksMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -6599,10 +6524,7 @@ impl DescribeDBClusterEndpointsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -6646,10 +6568,7 @@ impl DescribeDBClusterParameterGroupsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -6693,10 +6612,7 @@ impl DescribeDBClusterParametersMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.source {
             params.put(&format!("{}{}", prefix, "Source"), &field_value);
@@ -6812,25 +6728,16 @@ impl DescribeDBClusterSnapshotsMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.include_public {
-            params.put(
-                &format!("{}{}", prefix, "IncludePublic"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "IncludePublic"), &field_value);
         }
         if let Some(ref field_value) = obj.include_shared {
-            params.put(
-                &format!("{}{}", prefix, "IncludeShared"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "IncludeShared"), &field_value);
         }
         if let Some(ref field_value) = obj.marker {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.snapshot_type {
             params.put(&format!("{}{}", prefix, "SnapshotType"), &field_value);
@@ -6877,10 +6784,7 @@ impl DescribeDBClustersMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -6923,10 +6827,7 @@ impl DescribeDBEngineVersionsMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.default_only {
-            params.put(
-                &format!("{}{}", prefix, "DefaultOnly"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DefaultOnly"), &field_value);
         }
         if let Some(ref field_value) = obj.engine {
             params.put(&format!("{}{}", prefix, "Engine"), &field_value);
@@ -6944,23 +6845,20 @@ impl DescribeDBEngineVersionsMessageSerializer {
         if let Some(ref field_value) = obj.list_supported_character_sets {
             params.put(
                 &format!("{}{}", prefix, "ListSupportedCharacterSets"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.list_supported_timezones {
             params.put(
                 &format!("{}{}", prefix, "ListSupportedTimezones"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.marker {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -7009,10 +6907,7 @@ impl DescribeDBInstanceAutomatedBackupsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -7056,10 +6951,7 @@ impl DescribeDBInstancesMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -7158,16 +7050,10 @@ impl DescribeDBLogFilesMessageSerializer {
             &obj.db_instance_identifier,
         );
         if let Some(ref field_value) = obj.file_last_written {
-            params.put(
-                &format!("{}{}", prefix, "FileLastWritten"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "FileLastWritten"), &field_value);
         }
         if let Some(ref field_value) = obj.file_size {
-            params.put(
-                &format!("{}{}", prefix, "FileSize"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "FileSize"), &field_value);
         }
         if let Some(ref field_value) = obj.filename_contains {
             params.put(&format!("{}{}", prefix, "FilenameContains"), &field_value);
@@ -7183,10 +7069,7 @@ impl DescribeDBLogFilesMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -7269,10 +7152,7 @@ impl DescribeDBParameterGroupsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -7315,10 +7195,7 @@ impl DescribeDBParametersMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.source {
             params.put(&format!("{}{}", prefix, "Source"), &field_value);
@@ -7365,10 +7242,7 @@ impl DescribeDBSecurityGroupsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -7482,25 +7356,16 @@ impl DescribeDBSnapshotsMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.include_public {
-            params.put(
-                &format!("{}{}", prefix, "IncludePublic"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "IncludePublic"), &field_value);
         }
         if let Some(ref field_value) = obj.include_shared {
-            params.put(
-                &format!("{}{}", prefix, "IncludeShared"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "IncludeShared"), &field_value);
         }
         if let Some(ref field_value) = obj.marker {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.snapshot_type {
             params.put(&format!("{}{}", prefix, "SnapshotType"), &field_value);
@@ -7544,10 +7409,7 @@ impl DescribeDBSubnetGroupsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -7593,10 +7455,7 @@ impl DescribeEngineDefaultClusterParametersMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -7668,10 +7527,7 @@ impl DescribeEngineDefaultParametersMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -7770,10 +7626,7 @@ impl DescribeEventSubscriptionsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.subscription_name {
             params.put(&format!("{}{}", prefix, "SubscriptionName"), &field_value);
@@ -7814,10 +7667,7 @@ impl DescribeEventsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.duration {
-            params.put(
-                &format!("{}{}", prefix, "Duration"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Duration"), &field_value);
         }
         if let Some(ref field_value) = obj.end_time {
             params.put(&format!("{}{}", prefix, "EndTime"), &field_value);
@@ -7840,10 +7690,7 @@ impl DescribeEventsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.source_identifier {
             params.put(&format!("{}{}", prefix, "SourceIdentifier"), &field_value);
@@ -7895,10 +7742,7 @@ impl DescribeGlobalClustersMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -7942,10 +7786,7 @@ impl DescribeOptionGroupOptionsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -7993,10 +7834,7 @@ impl DescribeOptionGroupsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.option_group_name {
             params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
@@ -8055,13 +7893,10 @@ impl DescribeOrderableDBInstanceOptionsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.vpc {
-            params.put(&format!("{}{}", prefix, "Vpc"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Vpc"), &field_value);
         }
     }
 }
@@ -8099,10 +7934,7 @@ impl DescribePendingMaintenanceActionsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.resource_identifier {
             params.put(&format!("{}{}", prefix, "ResourceIdentifier"), &field_value);
@@ -8161,16 +7993,10 @@ impl DescribeReservedDBInstancesMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.multi_az {
-            params.put(
-                &format!("{}{}", prefix, "MultiAZ"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MultiAZ"), &field_value);
         }
         if let Some(ref field_value) = obj.offering_type {
             params.put(&format!("{}{}", prefix, "OfferingType"), &field_value);
@@ -8246,16 +8072,10 @@ impl DescribeReservedDBInstancesOfferingsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.multi_az {
-            params.put(
-                &format!("{}{}", prefix, "MultiAZ"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MultiAZ"), &field_value);
         }
         if let Some(ref field_value) = obj.offering_type {
             params.put(&format!("{}{}", prefix, "OfferingType"), &field_value);
@@ -8305,10 +8125,7 @@ impl DescribeSourceRegionsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.region_name {
             params.put(&format!("{}{}", prefix, "RegionName"), &field_value);
@@ -8585,10 +8402,7 @@ impl DownloadDBLogFilePortionMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.number_of_lines {
-            params.put(
-                &format!("{}{}", prefix, "NumberOfLines"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "NumberOfLines"), &field_value);
         }
     }
 }
@@ -9704,10 +9518,7 @@ impl ModifyCurrentDBClusterCapacityMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.capacity {
-            params.put(
-                &format!("{}{}", prefix, "Capacity"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Capacity"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "DBClusterIdentifier"),
@@ -9716,7 +9527,7 @@ impl ModifyCurrentDBClusterCapacityMessageSerializer {
         if let Some(ref field_value) = obj.seconds_before_timeout {
             params.put(
                 &format!("{}{}", prefix, "SecondsBeforeTimeout"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.timeout_action {
@@ -9821,21 +9632,15 @@ impl ModifyDBClusterMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.apply_immediately {
-            params.put(
-                &format!("{}{}", prefix, "ApplyImmediately"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ApplyImmediately"), &field_value);
         }
         if let Some(ref field_value) = obj.backtrack_window {
-            params.put(
-                &format!("{}{}", prefix, "BacktrackWindow"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "BacktrackWindow"), &field_value);
         }
         if let Some(ref field_value) = obj.backup_retention_period {
             params.put(
                 &format!("{}{}", prefix, "BackupRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.cloudwatch_logs_export_configuration {
@@ -9856,21 +9661,15 @@ impl ModifyDBClusterMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.deletion_protection {
-            params.put(
-                &format!("{}{}", prefix, "DeletionProtection"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DeletionProtection"), &field_value);
         }
         if let Some(ref field_value) = obj.enable_http_endpoint {
-            params.put(
-                &format!("{}{}", prefix, "EnableHttpEndpoint"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "EnableHttpEndpoint"), &field_value);
         }
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(
                 &format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.engine_version {
@@ -9889,7 +9688,7 @@ impl ModifyDBClusterMessageSerializer {
             params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"), &field_value);
         }
         if let Some(ref field_value) = obj.preferred_backup_window {
             params.put(
@@ -10146,33 +9945,27 @@ impl ModifyDBInstanceMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.allocated_storage {
-            params.put(
-                &format!("{}{}", prefix, "AllocatedStorage"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "AllocatedStorage"), &field_value);
         }
         if let Some(ref field_value) = obj.allow_major_version_upgrade {
             params.put(
                 &format!("{}{}", prefix, "AllowMajorVersionUpgrade"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.apply_immediately {
-            params.put(
-                &format!("{}{}", prefix, "ApplyImmediately"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ApplyImmediately"), &field_value);
         }
         if let Some(ref field_value) = obj.auto_minor_version_upgrade {
             params.put(
                 &format!("{}{}", prefix, "AutoMinorVersionUpgrade"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.backup_retention_period {
             params.put(
                 &format!("{}{}", prefix, "BackupRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.ca_certificate_identifier {
@@ -10189,10 +9982,7 @@ impl ModifyDBInstanceMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.copy_tags_to_snapshot {
-            params.put(
-                &format!("{}{}", prefix, "CopyTagsToSnapshot"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "CopyTagsToSnapshot"), &field_value);
         }
         if let Some(ref field_value) = obj.db_instance_class {
             params.put(&format!("{}{}", prefix, "DBInstanceClass"), &field_value);
@@ -10208,10 +9998,7 @@ impl ModifyDBInstanceMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.db_port_number {
-            params.put(
-                &format!("{}{}", prefix, "DBPortNumber"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DBPortNumber"), &field_value);
         }
         if let Some(ref field_value) = obj.db_security_groups {
             DBSecurityGroupNameListSerializer::serialize(
@@ -10224,10 +10011,7 @@ impl ModifyDBInstanceMessageSerializer {
             params.put(&format!("{}{}", prefix, "DBSubnetGroupName"), &field_value);
         }
         if let Some(ref field_value) = obj.deletion_protection {
-            params.put(
-                &format!("{}{}", prefix, "DeletionProtection"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DeletionProtection"), &field_value);
         }
         if let Some(ref field_value) = obj.domain {
             params.put(&format!("{}{}", prefix, "Domain"), &field_value);
@@ -10238,20 +10022,20 @@ impl ModifyDBInstanceMessageSerializer {
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(
                 &format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.enable_performance_insights {
             params.put(
                 &format!("{}{}", prefix, "EnablePerformanceInsights"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.engine_version {
             params.put(&format!("{}{}", prefix, "EngineVersion"), &field_value);
         }
         if let Some(ref field_value) = obj.iops {
-            params.put(&format!("{}{}", prefix, "Iops"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Iops"), &field_value);
         }
         if let Some(ref field_value) = obj.license_model {
             params.put(&format!("{}{}", prefix, "LicenseModel"), &field_value);
@@ -10260,19 +10044,13 @@ impl ModifyDBInstanceMessageSerializer {
             params.put(&format!("{}{}", prefix, "MasterUserPassword"), &field_value);
         }
         if let Some(ref field_value) = obj.monitoring_interval {
-            params.put(
-                &format!("{}{}", prefix, "MonitoringInterval"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MonitoringInterval"), &field_value);
         }
         if let Some(ref field_value) = obj.monitoring_role_arn {
             params.put(&format!("{}{}", prefix, "MonitoringRoleArn"), &field_value);
         }
         if let Some(ref field_value) = obj.multi_az {
-            params.put(
-                &format!("{}{}", prefix, "MultiAZ"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MultiAZ"), &field_value);
         }
         if let Some(ref field_value) = obj.new_db_instance_identifier {
             params.put(
@@ -10292,7 +10070,7 @@ impl ModifyDBInstanceMessageSerializer {
         if let Some(ref field_value) = obj.performance_insights_retention_period {
             params.put(
                 &format!("{}{}", prefix, "PerformanceInsightsRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.preferred_backup_window {
@@ -10315,16 +10093,10 @@ impl ModifyDBInstanceMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.promotion_tier {
-            params.put(
-                &format!("{}{}", prefix, "PromotionTier"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PromotionTier"), &field_value);
         }
         if let Some(ref field_value) = obj.publicly_accessible {
-            params.put(
-                &format!("{}{}", prefix, "PubliclyAccessible"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PubliclyAccessible"), &field_value);
         }
         if let Some(ref field_value) = obj.storage_type {
             params.put(&format!("{}{}", prefix, "StorageType"), &field_value);
@@ -10341,7 +10113,7 @@ impl ModifyDBInstanceMessageSerializer {
         if let Some(ref field_value) = obj.use_default_processor_features {
             params.put(
                 &format!("{}{}", prefix, "UseDefaultProcessorFeatures"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.vpc_security_group_ids {
@@ -10635,10 +10407,7 @@ impl ModifyEventSubscriptionMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.enabled {
-            params.put(
-                &format!("{}{}", prefix, "Enabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Enabled"), &field_value);
         }
         if let Some(ref field_value) = obj.event_categories {
             EventCategoriesListSerializer::serialize(
@@ -10710,10 +10479,7 @@ impl ModifyGlobalClusterMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.deletion_protection {
-            params.put(
-                &format!("{}{}", prefix, "DeletionProtection"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DeletionProtection"), &field_value);
         }
         if let Some(ref field_value) = obj.global_cluster_identifier {
             params.put(
@@ -10783,10 +10549,7 @@ impl ModifyOptionGroupMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.apply_immediately {
-            params.put(
-                &format!("{}{}", prefix, "ApplyImmediately"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ApplyImmediately"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "OptionGroupName"),
@@ -10964,7 +10727,7 @@ impl OptionConfigurationSerializer {
             params.put(&format!("{}{}", prefix, "OptionVersion"), &field_value);
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"), &field_value);
         }
         if let Some(ref field_value) = obj.vpc_security_group_memberships {
             VpcSecurityGroupIdListSerializer::serialize(
@@ -11581,16 +11344,10 @@ impl OptionSettingSerializer {
             params.put(&format!("{}{}", prefix, "Description"), &field_value);
         }
         if let Some(ref field_value) = obj.is_collection {
-            params.put(
-                &format!("{}{}", prefix, "IsCollection"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "IsCollection"), &field_value);
         }
         if let Some(ref field_value) = obj.is_modifiable {
-            params.put(
-                &format!("{}{}", prefix, "IsModifiable"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "IsModifiable"), &field_value);
         }
         if let Some(ref field_value) = obj.name {
             params.put(&format!("{}{}", prefix, "Name"), &field_value);
@@ -12075,10 +11832,7 @@ impl ParameterSerializer {
             params.put(&format!("{}{}", prefix, "Description"), &field_value);
         }
         if let Some(ref field_value) = obj.is_modifiable {
-            params.put(
-                &format!("{}{}", prefix, "IsModifiable"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "IsModifiable"), &field_value);
         }
         if let Some(ref field_value) = obj.minimum_engine_version {
             params.put(
@@ -12587,7 +12341,7 @@ impl PromoteReadReplicaMessageSerializer {
         if let Some(ref field_value) = obj.backup_retention_period {
             params.put(
                 &format!("{}{}", prefix, "BackupRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         params.put(
@@ -12657,10 +12411,7 @@ impl PurchaseReservedDBInstancesOfferingMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.db_instance_count {
-            params.put(
-                &format!("{}{}", prefix, "DBInstanceCount"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DBInstanceCount"), &field_value);
         }
         if let Some(ref field_value) = obj.reserved_db_instance_id {
             params.put(
@@ -12861,10 +12612,7 @@ impl RebootDBInstanceMessageSerializer {
             &obj.db_instance_identifier,
         );
         if let Some(ref field_value) = obj.force_failover {
-            params.put(
-                &format!("{}{}", prefix, "ForceFailover"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ForceFailover"), &field_value);
         }
     }
 }
@@ -13504,10 +13252,7 @@ impl ResetDBClusterParameterGroupMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.reset_all_parameters {
-            params.put(
-                &format!("{}{}", prefix, "ResetAllParameters"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ResetAllParameters"), &field_value);
         }
     }
 }
@@ -13544,10 +13289,7 @@ impl ResetDBParameterGroupMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.reset_all_parameters {
-            params.put(
-                &format!("{}{}", prefix, "ResetAllParameters"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ResetAllParameters"), &field_value);
         }
     }
 }
@@ -13670,15 +13412,12 @@ impl RestoreDBClusterFromS3MessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.backtrack_window {
-            params.put(
-                &format!("{}{}", prefix, "BacktrackWindow"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "BacktrackWindow"), &field_value);
         }
         if let Some(ref field_value) = obj.backup_retention_period {
             params.put(
                 &format!("{}{}", prefix, "BackupRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.character_set_name {
@@ -13701,10 +13440,7 @@ impl RestoreDBClusterFromS3MessageSerializer {
             params.put(&format!("{}{}", prefix, "DatabaseName"), &field_value);
         }
         if let Some(ref field_value) = obj.deletion_protection {
-            params.put(
-                &format!("{}{}", prefix, "DeletionProtection"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DeletionProtection"), &field_value);
         }
         if let Some(ref field_value) = obj.enable_cloudwatch_logs_exports {
             LogTypeListSerializer::serialize(
@@ -13716,7 +13452,7 @@ impl RestoreDBClusterFromS3MessageSerializer {
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(
                 &format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         params.put(&format!("{}{}", prefix, "Engine"), &obj.engine);
@@ -13738,7 +13474,7 @@ impl RestoreDBClusterFromS3MessageSerializer {
             params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"), &field_value);
         }
         if let Some(ref field_value) = obj.preferred_backup_window {
             params.put(
@@ -13769,10 +13505,7 @@ impl RestoreDBClusterFromS3MessageSerializer {
             &obj.source_engine_version,
         );
         if let Some(ref field_value) = obj.storage_encrypted {
-            params.put(
-                &format!("{}{}", prefix, "StorageEncrypted"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "StorageEncrypted"), &field_value);
         }
         if let Some(ref field_value) = obj.tags {
             TagListSerializer::serialize(params, &format!("{}{}", prefix, "Tag"), field_value);
@@ -13875,10 +13608,7 @@ impl RestoreDBClusterFromSnapshotMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.backtrack_window {
-            params.put(
-                &format!("{}{}", prefix, "BacktrackWindow"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "BacktrackWindow"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "DBClusterIdentifier"),
@@ -13897,10 +13627,7 @@ impl RestoreDBClusterFromSnapshotMessageSerializer {
             params.put(&format!("{}{}", prefix, "DatabaseName"), &field_value);
         }
         if let Some(ref field_value) = obj.deletion_protection {
-            params.put(
-                &format!("{}{}", prefix, "DeletionProtection"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DeletionProtection"), &field_value);
         }
         if let Some(ref field_value) = obj.enable_cloudwatch_logs_exports {
             LogTypeListSerializer::serialize(
@@ -13912,7 +13639,7 @@ impl RestoreDBClusterFromSnapshotMessageSerializer {
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(
                 &format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         params.put(&format!("{}{}", prefix, "Engine"), &obj.engine);
@@ -13929,7 +13656,7 @@ impl RestoreDBClusterFromSnapshotMessageSerializer {
             params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"), &field_value);
         }
         if let Some(ref field_value) = obj.scaling_configuration {
             ScalingConfigurationSerializer::serialize(
@@ -14029,10 +13756,7 @@ impl RestoreDBClusterToPointInTimeMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.backtrack_window {
-            params.put(
-                &format!("{}{}", prefix, "BacktrackWindow"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "BacktrackWindow"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "DBClusterIdentifier"),
@@ -14048,10 +13772,7 @@ impl RestoreDBClusterToPointInTimeMessageSerializer {
             params.put(&format!("{}{}", prefix, "DBSubnetGroupName"), &field_value);
         }
         if let Some(ref field_value) = obj.deletion_protection {
-            params.put(
-                &format!("{}{}", prefix, "DeletionProtection"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DeletionProtection"), &field_value);
         }
         if let Some(ref field_value) = obj.enable_cloudwatch_logs_exports {
             LogTypeListSerializer::serialize(
@@ -14063,7 +13784,7 @@ impl RestoreDBClusterToPointInTimeMessageSerializer {
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(
                 &format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.kms_key_id {
@@ -14073,7 +13794,7 @@ impl RestoreDBClusterToPointInTimeMessageSerializer {
             params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"), &field_value);
         }
         if let Some(ref field_value) = obj.restore_to_time {
             params.put(&format!("{}{}", prefix, "RestoreToTime"), &field_value);
@@ -14091,7 +13812,7 @@ impl RestoreDBClusterToPointInTimeMessageSerializer {
         if let Some(ref field_value) = obj.use_latest_restorable_time {
             params.put(
                 &format!("{}{}", prefix, "UseLatestRestorableTime"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.vpc_security_group_ids {
@@ -14204,17 +13925,14 @@ impl RestoreDBInstanceFromDBSnapshotMessageSerializer {
         if let Some(ref field_value) = obj.auto_minor_version_upgrade {
             params.put(
                 &format!("{}{}", prefix, "AutoMinorVersionUpgrade"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.availability_zone {
             params.put(&format!("{}{}", prefix, "AvailabilityZone"), &field_value);
         }
         if let Some(ref field_value) = obj.copy_tags_to_snapshot {
-            params.put(
-                &format!("{}{}", prefix, "CopyTagsToSnapshot"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "CopyTagsToSnapshot"), &field_value);
         }
         if let Some(ref field_value) = obj.db_instance_class {
             params.put(&format!("{}{}", prefix, "DBInstanceClass"), &field_value);
@@ -14240,10 +13958,7 @@ impl RestoreDBInstanceFromDBSnapshotMessageSerializer {
             params.put(&format!("{}{}", prefix, "DBSubnetGroupName"), &field_value);
         }
         if let Some(ref field_value) = obj.deletion_protection {
-            params.put(
-                &format!("{}{}", prefix, "DeletionProtection"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DeletionProtection"), &field_value);
         }
         if let Some(ref field_value) = obj.domain {
             params.put(&format!("{}{}", prefix, "Domain"), &field_value);
@@ -14261,29 +13976,26 @@ impl RestoreDBInstanceFromDBSnapshotMessageSerializer {
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(
                 &format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.engine {
             params.put(&format!("{}{}", prefix, "Engine"), &field_value);
         }
         if let Some(ref field_value) = obj.iops {
-            params.put(&format!("{}{}", prefix, "Iops"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Iops"), &field_value);
         }
         if let Some(ref field_value) = obj.license_model {
             params.put(&format!("{}{}", prefix, "LicenseModel"), &field_value);
         }
         if let Some(ref field_value) = obj.multi_az {
-            params.put(
-                &format!("{}{}", prefix, "MultiAZ"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MultiAZ"), &field_value);
         }
         if let Some(ref field_value) = obj.option_group_name {
             params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"), &field_value);
         }
         if let Some(ref field_value) = obj.processor_features {
             ProcessorFeatureListSerializer::serialize(
@@ -14293,10 +14005,7 @@ impl RestoreDBInstanceFromDBSnapshotMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.publicly_accessible {
-            params.put(
-                &format!("{}{}", prefix, "PubliclyAccessible"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PubliclyAccessible"), &field_value);
         }
         if let Some(ref field_value) = obj.storage_type {
             params.put(&format!("{}{}", prefix, "StorageType"), &field_value);
@@ -14316,7 +14025,7 @@ impl RestoreDBInstanceFromDBSnapshotMessageSerializer {
         if let Some(ref field_value) = obj.use_default_processor_features {
             params.put(
                 &format!("{}{}", prefix, "UseDefaultProcessorFeatures"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.vpc_security_group_ids {
@@ -14457,15 +14166,12 @@ impl RestoreDBInstanceFromS3MessageSerializer {
         }
 
         if let Some(ref field_value) = obj.allocated_storage {
-            params.put(
-                &format!("{}{}", prefix, "AllocatedStorage"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "AllocatedStorage"), &field_value);
         }
         if let Some(ref field_value) = obj.auto_minor_version_upgrade {
             params.put(
                 &format!("{}{}", prefix, "AutoMinorVersionUpgrade"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.availability_zone {
@@ -14474,14 +14180,11 @@ impl RestoreDBInstanceFromS3MessageSerializer {
         if let Some(ref field_value) = obj.backup_retention_period {
             params.put(
                 &format!("{}{}", prefix, "BackupRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.copy_tags_to_snapshot {
-            params.put(
-                &format!("{}{}", prefix, "CopyTagsToSnapshot"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "CopyTagsToSnapshot"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "DBInstanceClass"),
@@ -14511,10 +14214,7 @@ impl RestoreDBInstanceFromS3MessageSerializer {
             params.put(&format!("{}{}", prefix, "DBSubnetGroupName"), &field_value);
         }
         if let Some(ref field_value) = obj.deletion_protection {
-            params.put(
-                &format!("{}{}", prefix, "DeletionProtection"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DeletionProtection"), &field_value);
         }
         if let Some(ref field_value) = obj.enable_cloudwatch_logs_exports {
             LogTypeListSerializer::serialize(
@@ -14526,13 +14226,13 @@ impl RestoreDBInstanceFromS3MessageSerializer {
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(
                 &format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.enable_performance_insights {
             params.put(
                 &format!("{}{}", prefix, "EnablePerformanceInsights"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         params.put(&format!("{}{}", prefix, "Engine"), &obj.engine);
@@ -14540,7 +14240,7 @@ impl RestoreDBInstanceFromS3MessageSerializer {
             params.put(&format!("{}{}", prefix, "EngineVersion"), &field_value);
         }
         if let Some(ref field_value) = obj.iops {
-            params.put(&format!("{}{}", prefix, "Iops"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Iops"), &field_value);
         }
         if let Some(ref field_value) = obj.kms_key_id {
             params.put(&format!("{}{}", prefix, "KmsKeyId"), &field_value);
@@ -14555,19 +14255,13 @@ impl RestoreDBInstanceFromS3MessageSerializer {
             params.put(&format!("{}{}", prefix, "MasterUsername"), &field_value);
         }
         if let Some(ref field_value) = obj.monitoring_interval {
-            params.put(
-                &format!("{}{}", prefix, "MonitoringInterval"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MonitoringInterval"), &field_value);
         }
         if let Some(ref field_value) = obj.monitoring_role_arn {
             params.put(&format!("{}{}", prefix, "MonitoringRoleArn"), &field_value);
         }
         if let Some(ref field_value) = obj.multi_az {
-            params.put(
-                &format!("{}{}", prefix, "MultiAZ"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MultiAZ"), &field_value);
         }
         if let Some(ref field_value) = obj.option_group_name {
             params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
@@ -14581,11 +14275,11 @@ impl RestoreDBInstanceFromS3MessageSerializer {
         if let Some(ref field_value) = obj.performance_insights_retention_period {
             params.put(
                 &format!("{}{}", prefix, "PerformanceInsightsRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"), &field_value);
         }
         if let Some(ref field_value) = obj.preferred_backup_window {
             params.put(
@@ -14607,10 +14301,7 @@ impl RestoreDBInstanceFromS3MessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.publicly_accessible {
-            params.put(
-                &format!("{}{}", prefix, "PubliclyAccessible"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PubliclyAccessible"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "S3BucketName"),
@@ -14629,10 +14320,7 @@ impl RestoreDBInstanceFromS3MessageSerializer {
             &obj.source_engine_version,
         );
         if let Some(ref field_value) = obj.storage_encrypted {
-            params.put(
-                &format!("{}{}", prefix, "StorageEncrypted"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "StorageEncrypted"), &field_value);
         }
         if let Some(ref field_value) = obj.storage_type {
             params.put(&format!("{}{}", prefix, "StorageType"), &field_value);
@@ -14643,7 +14331,7 @@ impl RestoreDBInstanceFromS3MessageSerializer {
         if let Some(ref field_value) = obj.use_default_processor_features {
             params.put(
                 &format!("{}{}", prefix, "UseDefaultProcessorFeatures"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.vpc_security_group_ids {
@@ -14762,17 +14450,14 @@ impl RestoreDBInstanceToPointInTimeMessageSerializer {
         if let Some(ref field_value) = obj.auto_minor_version_upgrade {
             params.put(
                 &format!("{}{}", prefix, "AutoMinorVersionUpgrade"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.availability_zone {
             params.put(&format!("{}{}", prefix, "AvailabilityZone"), &field_value);
         }
         if let Some(ref field_value) = obj.copy_tags_to_snapshot {
-            params.put(
-                &format!("{}{}", prefix, "CopyTagsToSnapshot"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "CopyTagsToSnapshot"), &field_value);
         }
         if let Some(ref field_value) = obj.db_instance_class {
             params.put(&format!("{}{}", prefix, "DBInstanceClass"), &field_value);
@@ -14790,10 +14475,7 @@ impl RestoreDBInstanceToPointInTimeMessageSerializer {
             params.put(&format!("{}{}", prefix, "DBSubnetGroupName"), &field_value);
         }
         if let Some(ref field_value) = obj.deletion_protection {
-            params.put(
-                &format!("{}{}", prefix, "DeletionProtection"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DeletionProtection"), &field_value);
         }
         if let Some(ref field_value) = obj.domain {
             params.put(&format!("{}{}", prefix, "Domain"), &field_value);
@@ -14811,29 +14493,26 @@ impl RestoreDBInstanceToPointInTimeMessageSerializer {
         if let Some(ref field_value) = obj.enable_iam_database_authentication {
             params.put(
                 &format!("{}{}", prefix, "EnableIAMDatabaseAuthentication"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.engine {
             params.put(&format!("{}{}", prefix, "Engine"), &field_value);
         }
         if let Some(ref field_value) = obj.iops {
-            params.put(&format!("{}{}", prefix, "Iops"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Iops"), &field_value);
         }
         if let Some(ref field_value) = obj.license_model {
             params.put(&format!("{}{}", prefix, "LicenseModel"), &field_value);
         }
         if let Some(ref field_value) = obj.multi_az {
-            params.put(
-                &format!("{}{}", prefix, "MultiAZ"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MultiAZ"), &field_value);
         }
         if let Some(ref field_value) = obj.option_group_name {
             params.put(&format!("{}{}", prefix, "OptionGroupName"), &field_value);
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"), &field_value);
         }
         if let Some(ref field_value) = obj.processor_features {
             ProcessorFeatureListSerializer::serialize(
@@ -14843,10 +14522,7 @@ impl RestoreDBInstanceToPointInTimeMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.publicly_accessible {
-            params.put(
-                &format!("{}{}", prefix, "PubliclyAccessible"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PubliclyAccessible"), &field_value);
         }
         if let Some(ref field_value) = obj.restore_time {
             params.put(&format!("{}{}", prefix, "RestoreTime"), &field_value);
@@ -14885,13 +14561,13 @@ impl RestoreDBInstanceToPointInTimeMessageSerializer {
         if let Some(ref field_value) = obj.use_default_processor_features {
             params.put(
                 &format!("{}{}", prefix, "UseDefaultProcessorFeatures"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.use_latest_restorable_time {
             params.put(
                 &format!("{}{}", prefix, "UseLatestRestorableTime"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.vpc_security_group_ids {
@@ -15065,27 +14741,18 @@ impl ScalingConfigurationSerializer {
         }
 
         if let Some(ref field_value) = obj.auto_pause {
-            params.put(
-                &format!("{}{}", prefix, "AutoPause"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "AutoPause"), &field_value);
         }
         if let Some(ref field_value) = obj.max_capacity {
-            params.put(
-                &format!("{}{}", prefix, "MaxCapacity"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxCapacity"), &field_value);
         }
         if let Some(ref field_value) = obj.min_capacity {
-            params.put(
-                &format!("{}{}", prefix, "MinCapacity"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MinCapacity"), &field_value);
         }
         if let Some(ref field_value) = obj.seconds_until_auto_pause {
             params.put(
                 &format!("{}{}", prefix, "SecondsUntilAutoPause"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
     }

--- a/rusoto/services/redshift/src/generated.rs
+++ b/rusoto/services/redshift/src/generated.rs
@@ -583,12 +583,12 @@ impl BatchModifyClusterSnapshotsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.force {
-            params.put(&format!("{}{}", prefix, "Force"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Force"), &field_value);
         }
         if let Some(ref field_value) = obj.manual_snapshot_retention_period {
             params.put(
                 &format!("{}{}", prefix, "ManualSnapshotRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         SnapshotIdentifierListSerializer::serialize(
@@ -2140,7 +2140,7 @@ impl CopyClusterSnapshotMessageSerializer {
         if let Some(ref field_value) = obj.manual_snapshot_retention_period {
             params.put(
                 &format!("{}{}", prefix, "ManualSnapshotRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.source_snapshot_cluster_identifier {
@@ -2267,13 +2267,13 @@ impl CreateClusterMessageSerializer {
         if let Some(ref field_value) = obj.allow_version_upgrade {
             params.put(
                 &format!("{}{}", prefix, "AllowVersionUpgrade"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.automated_snapshot_retention_period {
             params.put(
                 &format!("{}{}", prefix, "AutomatedSnapshotRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.availability_zone {
@@ -2315,16 +2315,10 @@ impl CreateClusterMessageSerializer {
             params.put(&format!("{}{}", prefix, "ElasticIp"), &field_value);
         }
         if let Some(ref field_value) = obj.encrypted {
-            params.put(
-                &format!("{}{}", prefix, "Encrypted"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Encrypted"), &field_value);
         }
         if let Some(ref field_value) = obj.enhanced_vpc_routing {
-            params.put(
-                &format!("{}{}", prefix, "EnhancedVpcRouting"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "EnhancedVpcRouting"), &field_value);
         }
         if let Some(ref field_value) = obj.hsm_client_certificate_identifier {
             params.put(
@@ -2357,7 +2351,7 @@ impl CreateClusterMessageSerializer {
         if let Some(ref field_value) = obj.manual_snapshot_retention_period {
             params.put(
                 &format!("{}{}", prefix, "ManualSnapshotRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         params.put(
@@ -2370,13 +2364,10 @@ impl CreateClusterMessageSerializer {
         );
         params.put(&format!("{}{}", prefix, "NodeType"), &obj.node_type);
         if let Some(ref field_value) = obj.number_of_nodes {
-            params.put(
-                &format!("{}{}", prefix, "NumberOfNodes"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "NumberOfNodes"), &field_value);
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"), &field_value);
         }
         if let Some(ref field_value) = obj.preferred_maintenance_window {
             params.put(
@@ -2385,10 +2376,7 @@ impl CreateClusterMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.publicly_accessible {
-            params.put(
-                &format!("{}{}", prefix, "PubliclyAccessible"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PubliclyAccessible"), &field_value);
         }
         if let Some(ref field_value) = obj.snapshot_schedule_identifier {
             params.put(
@@ -2591,7 +2579,7 @@ impl CreateClusterSnapshotMessageSerializer {
         if let Some(ref field_value) = obj.manual_snapshot_retention_period {
             params.put(
                 &format!("{}{}", prefix, "ManualSnapshotRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         params.put(
@@ -2731,10 +2719,7 @@ impl CreateEventSubscriptionMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.enabled {
-            params.put(
-                &format!("{}{}", prefix, "Enabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Enabled"), &field_value);
         }
         if let Some(ref field_value) = obj.event_categories {
             EventCategoriesListSerializer::serialize(
@@ -3027,13 +3012,10 @@ impl CreateSnapshotScheduleMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.dry_run {
-            params.put(&format!("{}{}", prefix, "DryRun"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "DryRun"), &field_value);
         }
         if let Some(ref field_value) = obj.next_invocations {
-            params.put(
-                &format!("{}{}", prefix, "NextInvocations"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "NextInvocations"), &field_value);
         }
         if let Some(ref field_value) = obj.schedule_definitions {
             ScheduleDefinitionListSerializer::serialize(
@@ -3342,13 +3324,13 @@ impl DeleteClusterMessageSerializer {
         if let Some(ref field_value) = obj.final_cluster_snapshot_retention_period {
             params.put(
                 &format!("{}{}", prefix, "FinalClusterSnapshotRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.skip_final_cluster_snapshot {
             params.put(
                 &format!("{}{}", prefix, "SkipFinalClusterSnapshot"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
     }
@@ -3703,10 +3685,7 @@ impl DescribeClusterDbRevisionsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -3739,10 +3718,7 @@ impl DescribeClusterParameterGroupsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.parameter_group_name {
             params.put(&format!("{}{}", prefix, "ParameterGroupName"), &field_value);
@@ -3790,10 +3766,7 @@ impl DescribeClusterParametersMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "ParameterGroupName"),
@@ -3839,10 +3812,7 @@ impl DescribeClusterSecurityGroupsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.tag_keys {
             TagKeyListSerializer::serialize(
@@ -3899,10 +3869,7 @@ impl DescribeClusterSnapshotsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.cluster_exists {
-            params.put(
-                &format!("{}{}", prefix, "ClusterExists"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ClusterExists"), &field_value);
         }
         if let Some(ref field_value) = obj.cluster_identifier {
             params.put(&format!("{}{}", prefix, "ClusterIdentifier"), &field_value);
@@ -3914,10 +3881,7 @@ impl DescribeClusterSnapshotsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.owner_account {
             params.put(&format!("{}{}", prefix, "OwnerAccount"), &field_value);
@@ -3989,10 +3953,7 @@ impl DescribeClusterSubnetGroupsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.tag_keys {
             TagKeyListSerializer::serialize(
@@ -4040,10 +4001,7 @@ impl DescribeClusterTracksMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -4083,10 +4041,7 @@ impl DescribeClusterVersionsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
     }
 }
@@ -4122,10 +4077,7 @@ impl DescribeClustersMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.tag_keys {
             TagKeyListSerializer::serialize(
@@ -4168,10 +4120,7 @@ impl DescribeDefaultClusterParametersMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "ParameterGroupFamily"),
@@ -4261,10 +4210,7 @@ impl DescribeEventSubscriptionsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.subscription_name {
             params.put(&format!("{}{}", prefix, "SubscriptionName"), &field_value);
@@ -4315,10 +4261,7 @@ impl DescribeEventsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.duration {
-            params.put(
-                &format!("{}{}", prefix, "Duration"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Duration"), &field_value);
         }
         if let Some(ref field_value) = obj.end_time {
             params.put(&format!("{}{}", prefix, "EndTime"), &field_value);
@@ -4327,10 +4270,7 @@ impl DescribeEventsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.source_identifier {
             params.put(&format!("{}{}", prefix, "SourceIdentifier"), &field_value);
@@ -4378,10 +4318,7 @@ impl DescribeHsmClientCertificatesMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.tag_keys {
             TagKeyListSerializer::serialize(
@@ -4434,10 +4371,7 @@ impl DescribeHsmConfigurationsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.tag_keys {
             TagKeyListSerializer::serialize(
@@ -4508,10 +4442,7 @@ impl DescribeOrderableClusterOptionsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.node_type {
             params.put(&format!("{}{}", prefix, "NodeType"), &field_value);
@@ -4543,10 +4474,7 @@ impl DescribeReservedNodeOfferingsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.reserved_node_offering_id {
             params.put(
@@ -4581,10 +4509,7 @@ impl DescribeReservedNodesMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.reserved_node_id {
             params.put(&format!("{}{}", prefix, "ReservedNodeId"), &field_value);
@@ -4643,10 +4568,7 @@ impl DescribeSnapshotCopyGrantsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.snapshot_copy_grant_name {
             params.put(
@@ -4703,10 +4625,7 @@ impl DescribeSnapshotSchedulesMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.schedule_identifier {
             params.put(&format!("{}{}", prefix, "ScheduleIdentifier"), &field_value);
@@ -4795,10 +4714,7 @@ impl DescribeTableRestoreStatusMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.table_restore_request_id {
             params.put(
@@ -4839,10 +4755,7 @@ impl DescribeTagsMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         if let Some(ref field_value) = obj.resource_name {
             params.put(&format!("{}{}", prefix, "ResourceName"), &field_value);
@@ -5152,14 +5065,11 @@ impl EnableSnapshotCopyMessageSerializer {
         if let Some(ref field_value) = obj.manual_snapshot_retention_period {
             params.put(
                 &format!("{}{}", prefix, "ManualSnapshotRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.retention_period {
-            params.put(
-                &format!("{}{}", prefix, "RetentionPeriod"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "RetentionPeriod"), &field_value);
         }
         if let Some(ref field_value) = obj.snapshot_copy_grant_name {
             params.put(
@@ -5684,10 +5594,7 @@ impl GetClusterCredentialsMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.auto_create {
-            params.put(
-                &format!("{}{}", prefix, "AutoCreate"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "AutoCreate"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "ClusterIdentifier"),
@@ -5705,10 +5612,7 @@ impl GetClusterCredentialsMessageSerializer {
         }
         params.put(&format!("{}{}", prefix, "DbUser"), &obj.db_user);
         if let Some(ref field_value) = obj.duration_seconds {
-            params.put(
-                &format!("{}{}", prefix, "DurationSeconds"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DurationSeconds"), &field_value);
         }
     }
 }
@@ -5741,10 +5645,7 @@ impl GetReservedNodeExchangeOfferingsInputMessageSerializer {
             params.put(&format!("{}{}", prefix, "Marker"), &field_value);
         }
         if let Some(ref field_value) = obj.max_records {
-            params.put(
-                &format!("{}{}", prefix, "MaxRecords"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxRecords"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "ReservedNodeId"),
@@ -6474,15 +6375,12 @@ impl ModifyClusterMaintenanceMessageSerializer {
             &obj.cluster_identifier,
         );
         if let Some(ref field_value) = obj.defer_maintenance {
-            params.put(
-                &format!("{}{}", prefix, "DeferMaintenance"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DeferMaintenance"), &field_value);
         }
         if let Some(ref field_value) = obj.defer_maintenance_duration {
             params.put(
                 &format!("{}{}", prefix, "DeferMaintenanceDuration"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.defer_maintenance_end_time {
@@ -6594,13 +6492,13 @@ impl ModifyClusterMessageSerializer {
         if let Some(ref field_value) = obj.allow_version_upgrade {
             params.put(
                 &format!("{}{}", prefix, "AllowVersionUpgrade"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.automated_snapshot_retention_period {
             params.put(
                 &format!("{}{}", prefix, "AutomatedSnapshotRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         params.put(
@@ -6630,16 +6528,10 @@ impl ModifyClusterMessageSerializer {
             params.put(&format!("{}{}", prefix, "ElasticIp"), &field_value);
         }
         if let Some(ref field_value) = obj.encrypted {
-            params.put(
-                &format!("{}{}", prefix, "Encrypted"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Encrypted"), &field_value);
         }
         if let Some(ref field_value) = obj.enhanced_vpc_routing {
-            params.put(
-                &format!("{}{}", prefix, "EnhancedVpcRouting"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "EnhancedVpcRouting"), &field_value);
         }
         if let Some(ref field_value) = obj.hsm_client_certificate_identifier {
             params.put(
@@ -6665,7 +6557,7 @@ impl ModifyClusterMessageSerializer {
         if let Some(ref field_value) = obj.manual_snapshot_retention_period {
             params.put(
                 &format!("{}{}", prefix, "ManualSnapshotRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.master_user_password {
@@ -6681,10 +6573,7 @@ impl ModifyClusterMessageSerializer {
             params.put(&format!("{}{}", prefix, "NodeType"), &field_value);
         }
         if let Some(ref field_value) = obj.number_of_nodes {
-            params.put(
-                &format!("{}{}", prefix, "NumberOfNodes"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "NumberOfNodes"), &field_value);
         }
         if let Some(ref field_value) = obj.preferred_maintenance_window {
             params.put(
@@ -6693,10 +6582,7 @@ impl ModifyClusterMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.publicly_accessible {
-            params.put(
-                &format!("{}{}", prefix, "PubliclyAccessible"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PubliclyAccessible"), &field_value);
         }
         if let Some(ref field_value) = obj.vpc_security_group_ids {
             VpcSecurityGroupIdListSerializer::serialize(
@@ -6781,12 +6667,12 @@ impl ModifyClusterSnapshotMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.force {
-            params.put(&format!("{}{}", prefix, "Force"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Force"), &field_value);
         }
         if let Some(ref field_value) = obj.manual_snapshot_retention_period {
             params.put(
                 &format!("{}{}", prefix, "ManualSnapshotRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         params.put(
@@ -6849,7 +6735,7 @@ impl ModifyClusterSnapshotScheduleMessageSerializer {
         if let Some(ref field_value) = obj.disassociate_schedule {
             params.put(
                 &format!("{}{}", prefix, "DisassociateSchedule"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.schedule_identifier {
@@ -6953,10 +6839,7 @@ impl ModifyEventSubscriptionMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.enabled {
-            params.put(
-                &format!("{}{}", prefix, "Enabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Enabled"), &field_value);
         }
         if let Some(ref field_value) = obj.event_categories {
             EventCategoriesListSerializer::serialize(
@@ -7043,11 +6926,11 @@ impl ModifySnapshotCopyRetentionPeriodMessageSerializer {
             &obj.cluster_identifier,
         );
         if let Some(ref field_value) = obj.manual {
-            params.put(&format!("{}{}", prefix, "Manual"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Manual"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "RetentionPeriod"),
-            &obj.retention_period.to_string(),
+            &obj.retention_period,
         );
     }
 }
@@ -7308,10 +7191,7 @@ impl ParameterSerializer {
             params.put(&format!("{}{}", prefix, "Description"), &field_value);
         }
         if let Some(ref field_value) = obj.is_modifiable {
-            params.put(
-                &format!("{}{}", prefix, "IsModifiable"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "IsModifiable"), &field_value);
         }
         if let Some(ref field_value) = obj.minimum_engine_version {
             params.put(
@@ -7527,10 +7407,7 @@ impl PurchaseReservedNodeOfferingMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.node_count {
-            params.put(
-                &format!("{}{}", prefix, "NodeCount"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "NodeCount"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "ReservedNodeOfferingId"),
@@ -7999,10 +7876,7 @@ impl ResetClusterParameterGroupMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.reset_all_parameters {
-            params.put(
-                &format!("{}{}", prefix, "ResetAllParameters"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ResetAllParameters"), &field_value);
         }
     }
 }
@@ -8031,10 +7905,7 @@ impl ResizeClusterMessageSerializer {
         }
 
         if let Some(ref field_value) = obj.classic {
-            params.put(
-                &format!("{}{}", prefix, "Classic"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Classic"), &field_value);
         }
         params.put(
             &format!("{}{}", prefix, "ClusterIdentifier"),
@@ -8048,7 +7919,7 @@ impl ResizeClusterMessageSerializer {
         }
         params.put(
             &format!("{}{}", prefix, "NumberOfNodes"),
-            &obj.number_of_nodes.to_string(),
+            &obj.number_of_nodes,
         );
     }
 }
@@ -8329,13 +8200,13 @@ impl RestoreFromClusterSnapshotMessageSerializer {
         if let Some(ref field_value) = obj.allow_version_upgrade {
             params.put(
                 &format!("{}{}", prefix, "AllowVersionUpgrade"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.automated_snapshot_retention_period {
             params.put(
                 &format!("{}{}", prefix, "AutomatedSnapshotRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.availability_zone {
@@ -8368,10 +8239,7 @@ impl RestoreFromClusterSnapshotMessageSerializer {
             params.put(&format!("{}{}", prefix, "ElasticIp"), &field_value);
         }
         if let Some(ref field_value) = obj.enhanced_vpc_routing {
-            params.put(
-                &format!("{}{}", prefix, "EnhancedVpcRouting"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "EnhancedVpcRouting"), &field_value);
         }
         if let Some(ref field_value) = obj.hsm_client_certificate_identifier {
             params.put(
@@ -8404,7 +8272,7 @@ impl RestoreFromClusterSnapshotMessageSerializer {
         if let Some(ref field_value) = obj.manual_snapshot_retention_period {
             params.put(
                 &format!("{}{}", prefix, "ManualSnapshotRetentionPeriod"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.node_type {
@@ -8414,7 +8282,7 @@ impl RestoreFromClusterSnapshotMessageSerializer {
             params.put(&format!("{}{}", prefix, "OwnerAccount"), &field_value);
         }
         if let Some(ref field_value) = obj.port {
-            params.put(&format!("{}{}", prefix, "Port"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Port"), &field_value);
         }
         if let Some(ref field_value) = obj.preferred_maintenance_window {
             params.put(
@@ -8423,10 +8291,7 @@ impl RestoreFromClusterSnapshotMessageSerializer {
             );
         }
         if let Some(ref field_value) = obj.publicly_accessible {
-            params.put(
-                &format!("{}{}", prefix, "PubliclyAccessible"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "PubliclyAccessible"), &field_value);
         }
         if let Some(ref field_value) = obj.snapshot_cluster_identifier {
             params.put(

--- a/rusoto/services/sdb/src/generated.rs
+++ b/rusoto/services/sdb/src/generated.rs
@@ -466,10 +466,7 @@ impl GetAttributesRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.consistent_read {
-            params.put(
-                &format!("{}{}", prefix, "ConsistentRead"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ConsistentRead"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "DomainName"), &obj.domain_name);
         params.put(&format!("{}{}", prefix, "ItemName"), &obj.item_name);
@@ -600,10 +597,7 @@ impl ListDomainsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.max_number_of_domains {
-            params.put(
-                &format!("{}{}", prefix, "MaxNumberOfDomains"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxNumberOfDomains"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -716,10 +710,7 @@ impl ReplaceableAttributeSerializer {
 
         params.put(&format!("{}{}", prefix, "Name"), &obj.name);
         if let Some(ref field_value) = obj.replace {
-            params.put(
-                &format!("{}{}", prefix, "Replace"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Replace"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "Value"), &obj.value);
     }
@@ -794,10 +785,7 @@ impl SelectRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.consistent_read {
-            params.put(
-                &format!("{}{}", prefix, "ConsistentRead"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ConsistentRead"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -875,7 +863,7 @@ impl UpdateConditionSerializer {
         }
 
         if let Some(ref field_value) = obj.exists {
-            params.put(&format!("{}{}", prefix, "Exists"), &field_value.to_string());
+            params.put(&format!("{}{}", prefix, "Exists"), &field_value);
         }
         if let Some(ref field_value) = obj.name {
             params.put(&format!("{}{}", prefix, "Name"), &field_value);

--- a/rusoto/services/ses/src/generated.rs
+++ b/rusoto/services/ses/src/generated.rs
@@ -2186,10 +2186,7 @@ impl EventDestinationSerializer {
             );
         }
         if let Some(ref field_value) = obj.enabled {
-            params.put(
-                &format!("{}{}", prefix, "Enabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Enabled"), &field_value);
         }
         if let Some(ref field_value) = obj.kinesis_firehose_destination {
             KinesisFirehoseDestinationSerializer::serialize(
@@ -3325,10 +3322,7 @@ impl ListConfigurationSetsRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -3396,10 +3390,7 @@ impl ListCustomVerificationEmailTemplatesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.max_results {
-            params.put(
-                &format!("{}{}", prefix, "MaxResults"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxResults"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -3471,10 +3462,7 @@ impl ListIdentitiesRequestSerializer {
             params.put(&format!("{}{}", prefix, "IdentityType"), &field_value);
         }
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -3689,10 +3677,7 @@ impl ListTemplatesRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.max_items {
-            params.put(
-                &format!("{}{}", prefix, "MaxItems"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "MaxItems"), &field_value);
         }
         if let Some(ref field_value) = obj.next_token {
             params.put(&format!("{}{}", prefix, "NextToken"), &field_value);
@@ -4505,10 +4490,7 @@ impl ReceiptRuleSerializer {
             );
         }
         if let Some(ref field_value) = obj.enabled {
-            params.put(
-                &format!("{}{}", prefix, "Enabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Enabled"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "Name"), &obj.name);
         if let Some(ref field_value) = obj.recipients {
@@ -4519,10 +4501,7 @@ impl ReceiptRuleSerializer {
             );
         }
         if let Some(ref field_value) = obj.scan_enabled {
-            params.put(
-                &format!("{}{}", prefix, "ScanEnabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "ScanEnabled"), &field_value);
         }
         if let Some(ref field_value) = obj.tls_policy {
             params.put(&format!("{}{}", prefix, "TlsPolicy"), &field_value);
@@ -5726,10 +5705,7 @@ impl SetIdentityDkimEnabledRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(
-            &format!("{}{}", prefix, "DkimEnabled"),
-            &obj.dkim_enabled.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "DkimEnabled"), &obj.dkim_enabled);
         params.put(&format!("{}{}", prefix, "Identity"), &obj.identity);
     }
 }
@@ -5778,7 +5754,7 @@ impl SetIdentityFeedbackForwardingEnabledRequestSerializer {
 
         params.put(
             &format!("{}{}", prefix, "ForwardingEnabled"),
-            &obj.forwarding_enabled.to_string(),
+            &obj.forwarding_enabled,
         );
         params.put(&format!("{}{}", prefix, "Identity"), &obj.identity);
     }
@@ -5828,10 +5804,7 @@ impl SetIdentityHeadersInNotificationsEnabledRequestSerializer {
             prefix.push_str(".");
         }
 
-        params.put(
-            &format!("{}{}", prefix, "Enabled"),
-            &obj.enabled.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "Enabled"), &obj.enabled);
         params.put(&format!("{}{}", prefix, "Identity"), &obj.identity);
         params.put(
             &format!("{}{}", prefix, "NotificationType"),
@@ -6420,10 +6393,7 @@ impl UpdateAccountSendingEnabledRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.enabled {
-            params.put(
-                &format!("{}{}", prefix, "Enabled"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "Enabled"), &field_value);
         }
     }
 }
@@ -6508,10 +6478,7 @@ impl UpdateConfigurationSetReputationMetricsEnabledRequestSerializer {
             &format!("{}{}", prefix, "ConfigurationSetName"),
             &obj.configuration_set_name,
         );
-        params.put(
-            &format!("{}{}", prefix, "Enabled"),
-            &obj.enabled.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "Enabled"), &obj.enabled);
     }
 }
 
@@ -6541,10 +6508,7 @@ impl UpdateConfigurationSetSendingEnabledRequestSerializer {
             &format!("{}{}", prefix, "ConfigurationSetName"),
             &obj.configuration_set_name,
         );
-        params.put(
-            &format!("{}{}", prefix, "Enabled"),
-            &obj.enabled.to_string(),
-        );
+        params.put(&format!("{}{}", prefix, "Enabled"), &obj.enabled);
     }
 }
 

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -1759,7 +1759,7 @@ impl SubscribeInputSerializer {
         if let Some(ref field_value) = obj.return_subscription_arn {
             params.put(
                 &format!("{}{}", prefix, "ReturnSubscriptionArn"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         params.put(&format!("{}{}", prefix, "TopicArn"), &obj.topic_arn);

--- a/rusoto/services/sqs/src/generated.rs
+++ b/rusoto/services/sqs/src/generated.rs
@@ -283,10 +283,7 @@ impl ChangeMessageVisibilityBatchRequestEntrySerializer {
             &obj.receipt_handle,
         );
         if let Some(ref field_value) = obj.visibility_timeout {
-            params.put(
-                &format!("{}{}", prefix, "VisibilityTimeout"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "VisibilityTimeout"), &field_value);
         }
     }
 }
@@ -435,7 +432,7 @@ impl ChangeMessageVisibilityRequestSerializer {
         );
         params.put(
             &format!("{}{}", prefix, "VisibilityTimeout"),
-            &obj.visibility_timeout.to_string(),
+            &obj.visibility_timeout,
         );
     }
 }
@@ -1363,7 +1360,7 @@ impl ReceiveMessageRequestSerializer {
         if let Some(ref field_value) = obj.max_number_of_messages {
             params.put(
                 &format!("{}{}", prefix, "MaxNumberOfMessages"),
-                &field_value.to_string(),
+                &field_value,
             );
         }
         if let Some(ref field_value) = obj.message_attribute_names {
@@ -1381,16 +1378,10 @@ impl ReceiveMessageRequestSerializer {
             );
         }
         if let Some(ref field_value) = obj.visibility_timeout {
-            params.put(
-                &format!("{}{}", prefix, "VisibilityTimeout"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "VisibilityTimeout"), &field_value);
         }
         if let Some(ref field_value) = obj.wait_time_seconds {
-            params.put(
-                &format!("{}{}", prefix, "WaitTimeSeconds"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "WaitTimeSeconds"), &field_value);
         }
     }
 }
@@ -1499,10 +1490,7 @@ impl SendMessageBatchRequestEntrySerializer {
         }
 
         if let Some(ref field_value) = obj.delay_seconds {
-            params.put(
-                &format!("{}{}", prefix, "DelaySeconds"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DelaySeconds"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "Id"), &obj.id);
         if let Some(ref field_value) = obj.message_attributes {
@@ -1685,10 +1673,7 @@ impl SendMessageRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.delay_seconds {
-            params.put(
-                &format!("{}{}", prefix, "DelaySeconds"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DelaySeconds"), &field_value);
         }
         if let Some(ref field_value) = obj.message_attributes {
             MessageBodyAttributeMapSerializer::serialize(

--- a/rusoto/services/sts/src/generated.rs
+++ b/rusoto/services/sts/src/generated.rs
@@ -118,10 +118,7 @@ impl AssumeRoleRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.duration_seconds {
-            params.put(
-                &format!("{}{}", prefix, "DurationSeconds"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DurationSeconds"), &field_value);
         }
         if let Some(ref field_value) = obj.external_id {
             params.put(&format!("{}{}", prefix, "ExternalId"), &field_value);
@@ -209,10 +206,7 @@ impl AssumeRoleWithSAMLRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.duration_seconds {
-            params.put(
-                &format!("{}{}", prefix, "DurationSeconds"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DurationSeconds"), &field_value);
         }
         if let Some(ref field_value) = obj.policy {
             params.put(&format!("{}{}", prefix, "Policy"), &field_value);
@@ -328,10 +322,7 @@ impl AssumeRoleWithWebIdentityRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.duration_seconds {
-            params.put(
-                &format!("{}{}", prefix, "DurationSeconds"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DurationSeconds"), &field_value);
         }
         if let Some(ref field_value) = obj.policy {
             params.put(&format!("{}{}", prefix, "Policy"), &field_value);
@@ -718,10 +709,7 @@ impl GetFederationTokenRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.duration_seconds {
-            params.put(
-                &format!("{}{}", prefix, "DurationSeconds"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DurationSeconds"), &field_value);
         }
         params.put(&format!("{}{}", prefix, "Name"), &obj.name);
         if let Some(ref field_value) = obj.policy {
@@ -797,10 +785,7 @@ impl GetSessionTokenRequestSerializer {
         }
 
         if let Some(ref field_value) = obj.duration_seconds {
-            params.put(
-                &format!("{}{}", prefix, "DurationSeconds"),
-                &field_value.to_string(),
-            );
+            params.put(&format!("{}{}", prefix, "DurationSeconds"), &field_value);
         }
         if let Some(ref field_value) = obj.serial_number {
             params.put(&format!("{}{}", prefix, "SerialNumber"), &field_value);

--- a/service_crategen/src/commands/generate/codegen/query.rs
+++ b/service_crategen/src/commands/generate/codegen/query.rs
@@ -389,10 +389,12 @@ fn required_primitive_field_serializer(
 
 fn serialize_primitive_expression(shape_type: &ShapeType, var_name: &str) -> String {
     match *shape_type {
-        ShapeType::String | ShapeType::Timestamp => format!("&{}", var_name),
-        ShapeType::Integer | ShapeType::Double | ShapeType::Long | ShapeType::Boolean => {
-            format!("&{}.to_string()", var_name)
-        }
+        ShapeType::String |
+        ShapeType::Timestamp |
+        ShapeType::Integer |
+        ShapeType::Double |
+        ShapeType::Long |
+        ShapeType::Boolean => format!("&{}", var_name),
         ShapeType::Blob => format!("::std::str::from_utf8(&{}).unwrap()", var_name),
         shape_type => panic!("Unknown primitive shape type: {:?}", shape_type),
     }


### PR DESCRIPTION
This is a rather small change that simply takes advantage of the `ToParam` impls on `u8`, `bool`, `f32`, `f64` and `i64`, rather than forcing the use of the `String` impl everywhere.

Shaves off ~2000 LOC across all services.