### PR TITLE
Rusoto Mock to 2018 edition.

### DIFF
--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -16,6 +16,7 @@ homepage = "https://www.rusoto.org/"
 categories = [
   "development-tools::testing"
 ]
+edition = "2018"
 
 [dependencies]
 chrono = "0.4.0"


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Update `rusoto_mock` to Rust 2018 edition.