### PR TITLE
Update rusoto_core to Rust 2018.

### DIFF
--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -16,6 +16,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
 exclude = ["test_resources/*"]
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "rusoto/rusoto", branch = "master" }

--- a/rusoto/core/src/client.rs
+++ b/rusoto/core/src/client.rs
@@ -3,11 +3,11 @@ use std::time::Duration;
 
 use futures::{Async, Future, Poll};
 
-use credential::{CredentialsError, DefaultCredentialsProvider, ProvideAwsCredentials};
-use error::RusotoError;
-use future::{self, RusotoFuture};
-use request::{DispatchSignedRequest, HttpClient, HttpDispatchError, HttpResponse};
-use signature::SignedRequest;
+use crate::credential::{CredentialsError, DefaultCredentialsProvider, ProvideAwsCredentials};
+use crate::error::RusotoError;
+use crate::future::{self, RusotoFuture};
+use crate::request::{DispatchSignedRequest, HttpClient, HttpDispatchError, HttpResponse};
+use crate::signature::SignedRequest;
 
 lazy_static! {
     static ref SHARED_CLIENT: Mutex<Weak<ClientInner<DefaultCredentialsProvider, HttpClient>>> =

--- a/rusoto/core/src/error.rs
+++ b/rusoto/core/src/error.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::fmt;
 use std::io;
 
-use credential::CredentialsError;
+use crate::credential::CredentialsError;
 
 use super::request::{BufferedHttpResponse, HttpDispatchError};
 use super::proto::xml::util::XmlParseError;

--- a/rusoto/core/src/lib.rs
+++ b/rusoto/core/src/lib.rs
@@ -58,15 +58,15 @@ pub mod request;
 pub mod signature;
 
 #[doc(hidden)]
-pub use client::Client;
+pub use crate::client::Client;
 #[doc(hidden)]
 pub mod serialization;
 #[doc(hidden)]
 pub mod proto;
 
-pub use credential::{CredentialsError, DefaultCredentialsProvider, ProvideAwsCredentials};
-pub use error::{RusotoError, RusotoResult};
-pub use future::RusotoFuture;
-pub use region::Region;
-pub use request::{DispatchSignedRequest, HttpClient, HttpConfig, HttpDispatchError};
-pub use stream::ByteStream;
+pub use crate::credential::{CredentialsError, DefaultCredentialsProvider, ProvideAwsCredentials};
+pub use crate::error::{RusotoError, RusotoResult};
+pub use crate::future::RusotoFuture;
+pub use crate::region::Region;
+pub use crate::request::{DispatchSignedRequest, HttpClient, HttpConfig, HttpDispatchError};
+pub use crate::stream::ByteStream;

--- a/rusoto/core/src/region.rs
+++ b/rusoto/core/src/region.rs
@@ -4,7 +4,7 @@
 //!
 //! For example: `UsEast1` to "us-east-1"
 
-use credential::ProfileProvider;
+use crate::credential::ProfileProvider;
 use serde::ser::SerializeTuple;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std;

--- a/rusoto/core/src/request.rs
+++ b/rusoto/core/src/request.rs
@@ -28,13 +28,13 @@ use hyper::Error as HyperError;
 use hyper::Method;
 use hyper::StatusCode;
 use hyper::{Body, Client as HyperClient, Request as HyperRequest, Response as HyperResponse};
-use tls::HttpsConnector;
+use crate::tls::HttpsConnector;
 use tokio_timer::Timeout;
 
 use log::Level::Debug;
 
-use signature::{SignedRequest, SignedRequestPayload};
-use stream::ByteStream;
+use crate::signature::{SignedRequest, SignedRequestPayload};
+use crate::stream::ByteStream;
 
 // Pulls in the statically generated rustc version.
 include!(concat!(env!("OUT_DIR"), "/user_agent_vars.rs"));
@@ -153,8 +153,8 @@ impl Future for BufferedHttpResponseFuture {
     type Error = HttpDispatchError;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.future.poll().map_err(|err| err.into()).map(|async| {
-            async.map(|body| BufferedHttpResponse {
+        self.future.poll().map_err(|err| err.into()).map(|r#async| {
+            r#async.map(|body| BufferedHttpResponse {
                 status: self.status,
                 headers: Headers(mem::replace(&mut self.headers, HashMap::new())),
                 body: body,
@@ -567,8 +567,8 @@ impl fmt::Display for TlsError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use signature::SignedRequest;
-    use Region;
+    use crate::signature::SignedRequest;
+    use crate::Region;
 
     #[test]
     fn http_client_is_send_and_sync() {

--- a/rusoto/core/src/signature.rs
+++ b/rusoto/core/src/signature.rs
@@ -22,10 +22,10 @@ use time::now_utc;
 use time::Tm;
 use url::percent_encoding::{percent_decode, utf8_percent_encode, EncodeSet};
 
-use credential::AwsCredentials;
-use param::{Params, ServiceParams};
-use region::Region;
-use stream::ByteStream;
+use crate::credential::AwsCredentials;
+use crate::param::{Params, ServiceParams};
+use crate::region::Region;
+use crate::stream::ByteStream;
 
 /// Possible payloads included in a `SignedRequest`.
 pub enum SignedRequestPayload {
@@ -779,9 +779,9 @@ mod tests {
     use std::collections::BTreeMap;
     use time::empty_tm;
 
-    use credential::{ProfileProvider, ProvideAwsCredentials};
-    use param::Params;
-    use Region;
+    use crate::credential::{ProfileProvider, ProvideAwsCredentials};
+    use crate::param::Params;
+    use crate::Region;
 
     use super::{build_canonical_query_string, SignedRequest};
 


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Update rusoto_core to use Rust 2018 edition.