### PR TITLE
Fix rustls/native-tls features conflict

### DIFF
--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -31,8 +31,6 @@ version = "0.0"
 [dependencies.rusoto_core]
 version = "> 0.25.0"
 path = "../rusoto/core"
-default_features = false
-features = ["native-tls"]
 
 [features]
 nightly-testing = ["clippy", "rusoto_core/nightly-testing"]

--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -63,8 +63,7 @@ serde_json = "1.0.1"
 serde_test = "1.0.1"
 
 [features]
-default = ["native-tls"]
+default = ["hyper-tls"]
 nightly-testing = ["clippy", "rusoto_credential/nightly-testing"]
-native-tls = ["hyper-tls"]
 rustls = ["hyper-rustls"]
 unstable = []

--- a/rusoto/core/src/lib.rs
+++ b/rusoto/core/src/lib.rs
@@ -25,7 +25,7 @@ extern crate futures;
 extern crate hyper;
 #[cfg(feature = "rustls")]
 extern crate hyper_rustls as tls;
-#[cfg(feature = "native-tls")]
+#[cfg(not(feature = "rustls"))]
 extern crate hyper_tls as tls;
 #[macro_use]
 extern crate lazy_static;

--- a/rusoto/core/src/request.rs
+++ b/rusoto/core/src/request.rs
@@ -313,7 +313,7 @@ pub struct HttpClient<C = HttpsConnector<HttpConnector>> {
 impl HttpClient {
     /// Create a tls-enabled http client.
     pub fn new() -> Result<Self, TlsError> {
-        #[cfg(feature = "native-tls")]
+        #[cfg(not(feature = "rustls"))]
         let connector = match HttpsConnector::new(4) {
             Ok(connector) => connector,
             Err(tls_error) => {
@@ -331,7 +331,7 @@ impl HttpClient {
 
     /// Create a tls-enabled http client.
     pub fn new_with_config(config: HttpConfig) -> Result<Self, TlsError> {
-        #[cfg(feature = "native-tls")]
+        #[cfg(not(feature = "rustls"))]
         let connector = match HttpsConnector::new(4) {
             Ok(connector) => connector,
             Err(tls_error) => {

--- a/rusoto/services/acm-pca/Cargo.toml
+++ b/rusoto/services/acm-pca/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/acm/Cargo.toml
+++ b/rusoto/services/acm/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/alexaforbusiness/Cargo.toml
+++ b/rusoto/services/alexaforbusiness/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/amplify/Cargo.toml
+++ b/rusoto/services/amplify/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/apigateway/Cargo.toml
+++ b/rusoto/services/apigateway/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/apigatewaymanagementapi/Cargo.toml
+++ b/rusoto/services/apigatewaymanagementapi/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/apigatewayv2/Cargo.toml
+++ b/rusoto/services/apigatewayv2/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/application-autoscaling/Cargo.toml
+++ b/rusoto/services/application-autoscaling/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/appstream/Cargo.toml
+++ b/rusoto/services/appstream/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/appsync/Cargo.toml
+++ b/rusoto/services/appsync/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/athena/Cargo.toml
+++ b/rusoto/services/athena/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/autoscaling-plans/Cargo.toml
+++ b/rusoto/services/autoscaling-plans/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/autoscaling/Cargo.toml
+++ b/rusoto/services/autoscaling/Cargo.toml
@@ -28,6 +28,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/batch/Cargo.toml
+++ b/rusoto/services/batch/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/budgets/Cargo.toml
+++ b/rusoto/services/budgets/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/ce/Cargo.toml
+++ b/rusoto/services/ce/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/chime/Cargo.toml
+++ b/rusoto/services/chime/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cloud9/Cargo.toml
+++ b/rusoto/services/cloud9/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/clouddirectory/Cargo.toml
+++ b/rusoto/services/clouddirectory/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cloudformation/Cargo.toml
+++ b/rusoto/services/cloudformation/Cargo.toml
@@ -28,6 +28,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cloudfront/Cargo.toml
+++ b/rusoto/services/cloudfront/Cargo.toml
@@ -27,6 +27,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cloudhsm/Cargo.toml
+++ b/rusoto/services/cloudhsm/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cloudhsmv2/Cargo.toml
+++ b/rusoto/services/cloudhsmv2/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cloudsearch/Cargo.toml
+++ b/rusoto/services/cloudsearch/Cargo.toml
@@ -28,6 +28,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cloudsearchdomain/Cargo.toml
+++ b/rusoto/services/cloudsearchdomain/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cloudtrail/Cargo.toml
+++ b/rusoto/services/cloudtrail/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cloudwatch/Cargo.toml
+++ b/rusoto/services/cloudwatch/Cargo.toml
@@ -28,6 +28,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/codebuild/Cargo.toml
+++ b/rusoto/services/codebuild/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/codecommit/Cargo.toml
+++ b/rusoto/services/codecommit/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/codedeploy/Cargo.toml
+++ b/rusoto/services/codedeploy/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/codepipeline/Cargo.toml
+++ b/rusoto/services/codepipeline/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/codestar/Cargo.toml
+++ b/rusoto/services/codestar/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cognito-identity/Cargo.toml
+++ b/rusoto/services/cognito-identity/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cognito-idp/Cargo.toml
+++ b/rusoto/services/cognito-idp/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cognito-sync/Cargo.toml
+++ b/rusoto/services/cognito-sync/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/comprehend/Cargo.toml
+++ b/rusoto/services/comprehend/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/comprehendmedical/Cargo.toml
+++ b/rusoto/services/comprehendmedical/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/config/Cargo.toml
+++ b/rusoto/services/config/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/connect/Cargo.toml
+++ b/rusoto/services/connect/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/cur/Cargo.toml
+++ b/rusoto/services/cur/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/datapipeline/Cargo.toml
+++ b/rusoto/services/datapipeline/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/dax/Cargo.toml
+++ b/rusoto/services/dax/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/devicefarm/Cargo.toml
+++ b/rusoto/services/devicefarm/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/directconnect/Cargo.toml
+++ b/rusoto/services/directconnect/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/discovery/Cargo.toml
+++ b/rusoto/services/discovery/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/dms/Cargo.toml
+++ b/rusoto/services/dms/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/docdb/Cargo.toml
+++ b/rusoto/services/docdb/Cargo.toml
@@ -28,6 +28,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/ds/Cargo.toml
+++ b/rusoto/services/ds/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/dynamodb/Cargo.toml
+++ b/rusoto/services/dynamodb/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/dynamodbstreams/Cargo.toml
+++ b/rusoto/services/dynamodbstreams/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/ec2/Cargo.toml
+++ b/rusoto/services/ec2/Cargo.toml
@@ -28,6 +28,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/ecr/Cargo.toml
+++ b/rusoto/services/ecr/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/ecs/Cargo.toml
+++ b/rusoto/services/ecs/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/efs/Cargo.toml
+++ b/rusoto/services/efs/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/eks/Cargo.toml
+++ b/rusoto/services/eks/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/elasticache/Cargo.toml
+++ b/rusoto/services/elasticache/Cargo.toml
@@ -28,6 +28,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/elasticbeanstalk/Cargo.toml
+++ b/rusoto/services/elasticbeanstalk/Cargo.toml
@@ -28,6 +28,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/elastictranscoder/Cargo.toml
+++ b/rusoto/services/elastictranscoder/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/elb/Cargo.toml
+++ b/rusoto/services/elb/Cargo.toml
@@ -28,6 +28,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/elbv2/Cargo.toml
+++ b/rusoto/services/elbv2/Cargo.toml
@@ -28,6 +28,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/emr/Cargo.toml
+++ b/rusoto/services/emr/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/events/Cargo.toml
+++ b/rusoto/services/events/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/firehose/Cargo.toml
+++ b/rusoto/services/firehose/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/fms/Cargo.toml
+++ b/rusoto/services/fms/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/fsx/Cargo.toml
+++ b/rusoto/services/fsx/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/gamelift/Cargo.toml
+++ b/rusoto/services/gamelift/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/glacier/Cargo.toml
+++ b/rusoto/services/glacier/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/glue/Cargo.toml
+++ b/rusoto/services/glue/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/greengrass/Cargo.toml
+++ b/rusoto/services/greengrass/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/guardduty/Cargo.toml
+++ b/rusoto/services/guardduty/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/health/Cargo.toml
+++ b/rusoto/services/health/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/iam/Cargo.toml
+++ b/rusoto/services/iam/Cargo.toml
@@ -28,6 +28,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/importexport/Cargo.toml
+++ b/rusoto/services/importexport/Cargo.toml
@@ -28,6 +28,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/inspector/Cargo.toml
+++ b/rusoto/services/inspector/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/iot-data/Cargo.toml
+++ b/rusoto/services/iot-data/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/iot-jobs-data/Cargo.toml
+++ b/rusoto/services/iot-jobs-data/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/iot/Cargo.toml
+++ b/rusoto/services/iot/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/iot1click-devices/Cargo.toml
+++ b/rusoto/services/iot1click-devices/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/iot1click-projects/Cargo.toml
+++ b/rusoto/services/iot1click-projects/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/iotanalytics/Cargo.toml
+++ b/rusoto/services/iotanalytics/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/kafka/Cargo.toml
+++ b/rusoto/services/kafka/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/kinesis-video-archived-media/Cargo.toml
+++ b/rusoto/services/kinesis-video-archived-media/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/kinesis-video-media/Cargo.toml
+++ b/rusoto/services/kinesis-video-media/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/kinesis/Cargo.toml
+++ b/rusoto/services/kinesis/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/kinesisanalytics/Cargo.toml
+++ b/rusoto/services/kinesisanalytics/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/kinesisvideo/Cargo.toml
+++ b/rusoto/services/kinesisvideo/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/kms/Cargo.toml
+++ b/rusoto/services/kms/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/lambda/Cargo.toml
+++ b/rusoto/services/lambda/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/lex-models/Cargo.toml
+++ b/rusoto/services/lex-models/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/lex-runtime/Cargo.toml
+++ b/rusoto/services/lex-runtime/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/license-manager/Cargo.toml
+++ b/rusoto/services/license-manager/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/lightsail/Cargo.toml
+++ b/rusoto/services/lightsail/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/logs/Cargo.toml
+++ b/rusoto/services/logs/Cargo.toml
@@ -33,6 +33,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/machinelearning/Cargo.toml
+++ b/rusoto/services/machinelearning/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/macie/Cargo.toml
+++ b/rusoto/services/macie/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/marketplace-entitlement/Cargo.toml
+++ b/rusoto/services/marketplace-entitlement/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/marketplacecommerceanalytics/Cargo.toml
+++ b/rusoto/services/marketplacecommerceanalytics/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/mediaconvert/Cargo.toml
+++ b/rusoto/services/mediaconvert/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/medialive/Cargo.toml
+++ b/rusoto/services/medialive/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/mediapackage/Cargo.toml
+++ b/rusoto/services/mediapackage/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/mediastore/Cargo.toml
+++ b/rusoto/services/mediastore/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/mediatailor/Cargo.toml
+++ b/rusoto/services/mediatailor/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/meteringmarketplace/Cargo.toml
+++ b/rusoto/services/meteringmarketplace/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/mgh/Cargo.toml
+++ b/rusoto/services/mgh/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/mobile/Cargo.toml
+++ b/rusoto/services/mobile/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/mq/Cargo.toml
+++ b/rusoto/services/mq/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/mturk/Cargo.toml
+++ b/rusoto/services/mturk/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/neptune/Cargo.toml
+++ b/rusoto/services/neptune/Cargo.toml
@@ -28,6 +28,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/opsworks/Cargo.toml
+++ b/rusoto/services/opsworks/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/opsworkscm/Cargo.toml
+++ b/rusoto/services/opsworkscm/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/organizations/Cargo.toml
+++ b/rusoto/services/organizations/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/pi/Cargo.toml
+++ b/rusoto/services/pi/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/polly/Cargo.toml
+++ b/rusoto/services/polly/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/pricing/Cargo.toml
+++ b/rusoto/services/pricing/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/ram/Cargo.toml
+++ b/rusoto/services/ram/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/rds-data/Cargo.toml
+++ b/rusoto/services/rds-data/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/rds/Cargo.toml
+++ b/rusoto/services/rds/Cargo.toml
@@ -28,6 +28,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/redshift/Cargo.toml
+++ b/rusoto/services/redshift/Cargo.toml
@@ -28,6 +28,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/rekognition/Cargo.toml
+++ b/rusoto/services/rekognition/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/resource-groups/Cargo.toml
+++ b/rusoto/services/resource-groups/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/resourcegroupstaggingapi/Cargo.toml
+++ b/rusoto/services/resourcegroupstaggingapi/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/route53/Cargo.toml
+++ b/rusoto/services/route53/Cargo.toml
@@ -27,6 +27,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/route53domains/Cargo.toml
+++ b/rusoto/services/route53domains/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/s3/Cargo.toml
+++ b/rusoto/services/s3/Cargo.toml
@@ -27,6 +27,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/sagemaker-runtime/Cargo.toml
+++ b/rusoto/services/sagemaker-runtime/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/sagemaker/Cargo.toml
+++ b/rusoto/services/sagemaker/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/sdb/Cargo.toml
+++ b/rusoto/services/sdb/Cargo.toml
@@ -28,6 +28,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/secretsmanager/Cargo.toml
+++ b/rusoto/services/secretsmanager/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/serverlessrepo/Cargo.toml
+++ b/rusoto/services/serverlessrepo/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/servicecatalog/Cargo.toml
+++ b/rusoto/services/servicecatalog/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/servicediscovery/Cargo.toml
+++ b/rusoto/services/servicediscovery/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/ses/Cargo.toml
+++ b/rusoto/services/ses/Cargo.toml
@@ -28,6 +28,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/shield/Cargo.toml
+++ b/rusoto/services/shield/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/sms/Cargo.toml
+++ b/rusoto/services/sms/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/snowball/Cargo.toml
+++ b/rusoto/services/snowball/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/sns/Cargo.toml
+++ b/rusoto/services/sns/Cargo.toml
@@ -28,6 +28,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/sqs/Cargo.toml
+++ b/rusoto/services/sqs/Cargo.toml
@@ -28,6 +28,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/ssm/Cargo.toml
+++ b/rusoto/services/ssm/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/stepfunctions/Cargo.toml
+++ b/rusoto/services/stepfunctions/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/storagegateway/Cargo.toml
+++ b/rusoto/services/storagegateway/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/sts/Cargo.toml
+++ b/rusoto/services/sts/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/support/Cargo.toml
+++ b/rusoto/services/support/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/swf/Cargo.toml
+++ b/rusoto/services/swf/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/transcribe/Cargo.toml
+++ b/rusoto/services/transcribe/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/translate/Cargo.toml
+++ b/rusoto/services/translate/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/waf-regional/Cargo.toml
+++ b/rusoto/services/waf-regional/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/waf/Cargo.toml
+++ b/rusoto/services/waf/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/workdocs/Cargo.toml
+++ b/rusoto/services/workdocs/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/worklink/Cargo.toml
+++ b/rusoto/services/worklink/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/workmail/Cargo.toml
+++ b/rusoto/services/workmail/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/workspaces/Cargo.toml
+++ b/rusoto/services/workspaces/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/rusoto/services/xray/Cargo.toml
+++ b/rusoto/services/xray/Cargo.toml
@@ -29,6 +29,5 @@ version = "0.39.0"
 path = "../../../mock"
 
 [features]
-default = ["native-tls"]
-native-tls = ["rusoto_core/native-tls"]
+default = ["rusoto_core/default"]
 rustls = ["rusoto_core/rustls"]

--- a/service_crategen/src/commands/generate/mod.rs
+++ b/service_crategen/src/commands/generate/mod.rs
@@ -89,8 +89,7 @@ pub fn generate_services(
         }
 
         let mut features = BTreeMap::new();
-        features.insert("default".into(), vec!["native-tls".into()]);
-        features.insert("native-tls".into(), vec!["rusoto_core/native-tls".into()]);
+        features.insert("default".into(), vec!["rusoto_core/default".into()]);
         features.insert("rustls".into(), vec!["rusoto_core/rustls".into()]);
 
         let service_dependencies = service.get_dependencies();


### PR DESCRIPTION
This change allows the use of `rusoto_mock` with the `rustls` feature to fix the issue encountered in #1374