### PR TITLE
Removed xml serialization from S3 PutBucketPolicy method

### DIFF
--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -10312,26 +10312,6 @@ impl PermissionSerializer {
     }
 }
 
-pub struct PolicySerializer;
-impl PolicySerializer {
-    #[allow(unused_variables, warnings)]
-    pub fn serialize<W>(
-        mut writer: &mut EventWriter<W>,
-        name: &str,
-        obj: &String,
-    ) -> Result<(), xml::writer::Error>
-    where
-        W: Write,
-    {
-        writer.write(xml::writer::XmlEvent::start_element(name))?;
-        writer.write(xml::writer::XmlEvent::characters(&format!(
-            "{value}",
-            value = obj.to_string()
-        )))?;
-        writer.write(xml::writer::XmlEvent::end_element())
-    }
-}
-
 /// <p>The container element for a bucket's policy status.</p>
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct PolicyStatus {
@@ -22892,9 +22872,7 @@ impl S3 for S3Client {
         let mut params = Params::new();
         params.put_key("policy");
         request.set_params(params);
-        let mut writer = EventWriter::new(Vec::new());
-        PolicySerializer::serialize(&mut writer, "Policy", &input.policy);
-        request.set_payload(Some(writer.into_inner()));
+        request.set_payload(Some(input.policy.into_bytes()));
 
         self.client.sign_and_dispatch(request, |response| {
             if !response.status.is_success() {

--- a/service_crategen/src/commands/generate/codegen/rest_xml.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_xml.rs
@@ -109,6 +109,12 @@ impl GenerateProtocol for RestXmlGenerator {
             }
         }
 
+        // S3 has special cases where the payload is not meant to be xml serialized and passed
+        // as a string literal (Policy as an example). Making an exception based on service and shape.
+        if service.service_type_name().eq("S3") && name.eq("Policy") {
+            return None;
+        }
+
         let ty = get_rust_type(service, name, shape, false, self.timestamp_type());
         Some(format!(
             "
@@ -175,7 +181,7 @@ fn generate_payload_serialization(service: &Service, operation: &Operation) -> O
 
     // the payload field determines which member of the input shape is sent as the request body (if any)
     if input_shape.payload.is_some() {
-        parts.push(generate_payload_member_serialization(input_shape));
+        parts.push(generate_payload_member_serialization(service,input_shape));
         parts.push(
             generate_service_specific_code(service, operation).unwrap_or_else(|| "".to_owned()),
         );
@@ -216,7 +222,7 @@ fn generate_service_specific_code(service: &Service, operation: &Operation) -> O
     }
 }
 
-fn generate_payload_member_serialization(shape: &Shape) -> String {
+fn generate_payload_member_serialization(service: &Service,shape: &Shape) -> String {
     let payload_field = shape.payload.as_ref().unwrap();
     let payload_member = shape.members.as_ref().unwrap().get(payload_field).unwrap();
 
@@ -228,6 +234,12 @@ fn generate_payload_member_serialization(shape: &Shape) -> String {
                  }}",
             payload_field.to_snake_case()
         )
+    }
+    // s3 is a special case where the policy member should not be xml serialized but rather passed
+    // as a string literal
+    else if service.service_type_name().eq("S3") && payload_field.eq("Policy") {
+        format!("request.set_payload(Some(input.{payload_field}.into_bytes()));",
+                payload_field = payload_field.to_snake_case())
     }
     // otherwise serialize the object to XML and use that as the payload
     else if shape.required(payload_field) {


### PR DESCRIPTION
Currently, the S3 Client XML serializes the policy payload during the PutBucketPolicy request execution. service_crategen has been modified to pass the policy payload as a normal string request. 
