### PR TITLE
Convert all service crates to Rust 2018 edition.

### DIFF
--- a/rusoto/services/acm-pca/Cargo.toml
+++ b/rusoto/services/acm-pca/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/acm-pca/src/lib.rs
+++ b/rusoto/services/acm-pca/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/acm/Cargo.toml
+++ b/rusoto/services/acm/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/acm/src/lib.rs
+++ b/rusoto/services/acm/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/alexaforbusiness/Cargo.toml
+++ b/rusoto/services/alexaforbusiness/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/alexaforbusiness/src/lib.rs
+++ b/rusoto/services/alexaforbusiness/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/amplify/Cargo.toml
+++ b/rusoto/services/amplify/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/amplify/src/lib.rs
+++ b/rusoto/services/amplify/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/apigateway/Cargo.toml
+++ b/rusoto/services/apigateway/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/apigateway/src/lib.rs
+++ b/rusoto/services/apigateway/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/apigatewaymanagementapi/Cargo.toml
+++ b/rusoto/services/apigatewaymanagementapi/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/apigatewaymanagementapi/src/lib.rs
+++ b/rusoto/services/apigatewaymanagementapi/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/apigatewayv2/Cargo.toml
+++ b/rusoto/services/apigatewayv2/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/apigatewayv2/src/lib.rs
+++ b/rusoto/services/apigatewayv2/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/application-autoscaling/Cargo.toml
+++ b/rusoto/services/application-autoscaling/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/application-autoscaling/src/custom/custom_tests.rs
+++ b/rusoto/services/application-autoscaling/src/custom/custom_tests.rs
@@ -1,6 +1,6 @@
 extern crate rusoto_mock;
 
-use ::*;
+use crate::generated::*;
 
 use rusoto_core::Region;
 use self::rusoto_mock::*;

--- a/rusoto/services/application-autoscaling/src/lib.rs
+++ b/rusoto/services/application-autoscaling/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/appstream/Cargo.toml
+++ b/rusoto/services/appstream/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/appstream/src/lib.rs
+++ b/rusoto/services/appstream/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/appsync/Cargo.toml
+++ b/rusoto/services/appsync/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/appsync/src/lib.rs
+++ b/rusoto/services/appsync/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/athena/Cargo.toml
+++ b/rusoto/services/athena/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/athena/src/lib.rs
+++ b/rusoto/services/athena/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/autoscaling-plans/Cargo.toml
+++ b/rusoto/services/autoscaling-plans/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/autoscaling-plans/src/lib.rs
+++ b/rusoto/services/autoscaling-plans/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/autoscaling/Cargo.toml
+++ b/rusoto/services/autoscaling/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/autoscaling/src/lib.rs
+++ b/rusoto/services/autoscaling/src/lib.rs
@@ -25,6 +25,6 @@ extern crate xml;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/batch/Cargo.toml
+++ b/rusoto/services/batch/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/batch/src/lib.rs
+++ b/rusoto/services/batch/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/budgets/Cargo.toml
+++ b/rusoto/services/budgets/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/budgets/src/lib.rs
+++ b/rusoto/services/budgets/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/ce/Cargo.toml
+++ b/rusoto/services/ce/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/ce/src/lib.rs
+++ b/rusoto/services/ce/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/chime/Cargo.toml
+++ b/rusoto/services/chime/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/chime/src/lib.rs
+++ b/rusoto/services/chime/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/cloud9/Cargo.toml
+++ b/rusoto/services/cloud9/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/cloud9/src/lib.rs
+++ b/rusoto/services/cloud9/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/clouddirectory/Cargo.toml
+++ b/rusoto/services/clouddirectory/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/clouddirectory/src/lib.rs
+++ b/rusoto/services/clouddirectory/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/cloudformation/Cargo.toml
+++ b/rusoto/services/cloudformation/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/cloudformation/src/custom/custom_tests.rs
+++ b/rusoto/services/cloudformation/src/custom/custom_tests.rs
@@ -1,6 +1,6 @@
 extern crate rusoto_mock;
 
-use ::{CloudFormation, CloudFormationClient, ListStacksInput};
+use crate::generated::{CloudFormation, CloudFormationClient, ListStacksInput};
 
 use rusoto_core::Region;
 use rusoto_core::signature::SignedRequest;

--- a/rusoto/services/cloudformation/src/lib.rs
+++ b/rusoto/services/cloudformation/src/lib.rs
@@ -25,6 +25,6 @@ extern crate xml;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/cloudfront/Cargo.toml
+++ b/rusoto/services/cloudfront/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/cloudfront/src/custom/custom_tests.rs
+++ b/rusoto/services/cloudfront/src/custom/custom_tests.rs
@@ -1,6 +1,6 @@
 extern crate rusoto_mock;
 
-use ::{CloudFront, CloudFrontClient, ListDistributionsRequest};
+use crate::generated::{CloudFront, CloudFrontClient, ListDistributionsRequest};
 
 use rusoto_core::Region;
 use self::rusoto_mock::*;

--- a/rusoto/services/cloudfront/src/lib.rs
+++ b/rusoto/services/cloudfront/src/lib.rs
@@ -24,6 +24,6 @@ extern crate xml;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/cloudhsm/Cargo.toml
+++ b/rusoto/services/cloudhsm/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/cloudhsm/src/lib.rs
+++ b/rusoto/services/cloudhsm/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/cloudhsmv2/Cargo.toml
+++ b/rusoto/services/cloudhsmv2/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/cloudhsmv2/src/lib.rs
+++ b/rusoto/services/cloudhsmv2/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/cloudsearch/Cargo.toml
+++ b/rusoto/services/cloudsearch/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/cloudsearch/src/lib.rs
+++ b/rusoto/services/cloudsearch/src/lib.rs
@@ -25,6 +25,6 @@ extern crate xml;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/cloudsearchdomain/Cargo.toml
+++ b/rusoto/services/cloudsearchdomain/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/cloudsearchdomain/src/lib.rs
+++ b/rusoto/services/cloudsearchdomain/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/cloudtrail/Cargo.toml
+++ b/rusoto/services/cloudtrail/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/cloudtrail/src/lib.rs
+++ b/rusoto/services/cloudtrail/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/cloudwatch/Cargo.toml
+++ b/rusoto/services/cloudwatch/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/cloudwatch/src/custom/custom_tests.rs
+++ b/rusoto/services/cloudwatch/src/custom/custom_tests.rs
@@ -1,6 +1,6 @@
 extern crate rusoto_mock;
 
-use ::{CloudWatch, CloudWatchClient, PutMetricDataInput, Dimension, MetricDatum};
+use crate::generated::{CloudWatch, CloudWatchClient, PutMetricDataInput, Dimension, MetricDatum};
 
 use rusoto_core::Region;
 use rusoto_core::signature::SignedRequest;

--- a/rusoto/services/cloudwatch/src/lib.rs
+++ b/rusoto/services/cloudwatch/src/lib.rs
@@ -25,6 +25,6 @@ extern crate xml;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/codebuild/Cargo.toml
+++ b/rusoto/services/codebuild/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/codebuild/src/lib.rs
+++ b/rusoto/services/codebuild/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/codecommit/Cargo.toml
+++ b/rusoto/services/codecommit/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/codecommit/src/lib.rs
+++ b/rusoto/services/codecommit/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/codedeploy/Cargo.toml
+++ b/rusoto/services/codedeploy/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/codedeploy/src/lib.rs
+++ b/rusoto/services/codedeploy/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/codepipeline/Cargo.toml
+++ b/rusoto/services/codepipeline/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/codepipeline/src/lib.rs
+++ b/rusoto/services/codepipeline/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/codestar/Cargo.toml
+++ b/rusoto/services/codestar/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/codestar/src/lib.rs
+++ b/rusoto/services/codestar/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/cognito-identity/Cargo.toml
+++ b/rusoto/services/cognito-identity/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/cognito-identity/src/lib.rs
+++ b/rusoto/services/cognito-identity/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/cognito-idp/Cargo.toml
+++ b/rusoto/services/cognito-idp/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/cognito-idp/src/lib.rs
+++ b/rusoto/services/cognito-idp/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/cognito-sync/Cargo.toml
+++ b/rusoto/services/cognito-sync/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/cognito-sync/src/lib.rs
+++ b/rusoto/services/cognito-sync/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/comprehend/Cargo.toml
+++ b/rusoto/services/comprehend/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/comprehend/src/lib.rs
+++ b/rusoto/services/comprehend/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/comprehendmedical/Cargo.toml
+++ b/rusoto/services/comprehendmedical/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/comprehendmedical/src/lib.rs
+++ b/rusoto/services/comprehendmedical/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/config/Cargo.toml
+++ b/rusoto/services/config/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/config/src/lib.rs
+++ b/rusoto/services/config/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/connect/Cargo.toml
+++ b/rusoto/services/connect/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/connect/src/lib.rs
+++ b/rusoto/services/connect/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/cur/Cargo.toml
+++ b/rusoto/services/cur/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/cur/src/lib.rs
+++ b/rusoto/services/cur/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/datapipeline/Cargo.toml
+++ b/rusoto/services/datapipeline/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/datapipeline/src/lib.rs
+++ b/rusoto/services/datapipeline/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/dax/Cargo.toml
+++ b/rusoto/services/dax/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/dax/src/lib.rs
+++ b/rusoto/services/dax/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/devicefarm/Cargo.toml
+++ b/rusoto/services/devicefarm/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/devicefarm/src/lib.rs
+++ b/rusoto/services/devicefarm/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/directconnect/Cargo.toml
+++ b/rusoto/services/directconnect/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/directconnect/src/lib.rs
+++ b/rusoto/services/directconnect/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/discovery/Cargo.toml
+++ b/rusoto/services/discovery/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/discovery/src/lib.rs
+++ b/rusoto/services/discovery/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/dms/Cargo.toml
+++ b/rusoto/services/dms/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/dms/src/lib.rs
+++ b/rusoto/services/dms/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/docdb/Cargo.toml
+++ b/rusoto/services/docdb/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/docdb/src/lib.rs
+++ b/rusoto/services/docdb/src/lib.rs
@@ -25,6 +25,6 @@ extern crate xml;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/ds/Cargo.toml
+++ b/rusoto/services/ds/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/ds/src/lib.rs
+++ b/rusoto/services/ds/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/dynamodb/Cargo.toml
+++ b/rusoto/services/dynamodb/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/dynamodb/src/custom/custom_tests.rs
+++ b/rusoto/services/dynamodb/src/custom/custom_tests.rs
@@ -1,4 +1,4 @@
-use ::{AttributeValue};
+use crate::generated::{AttributeValue};
 
 #[test]
 fn attribute_value_default_is_empty() {

--- a/rusoto/services/dynamodb/src/lib.rs
+++ b/rusoto/services/dynamodb/src/lib.rs
@@ -65,6 +65,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/dynamodbstreams/Cargo.toml
+++ b/rusoto/services/dynamodbstreams/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/dynamodbstreams/src/lib.rs
+++ b/rusoto/services/dynamodbstreams/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/ec2/Cargo.toml
+++ b/rusoto/services/ec2/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/ec2/src/lib.rs
+++ b/rusoto/services/ec2/src/lib.rs
@@ -25,6 +25,6 @@ extern crate xml;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/ecr/Cargo.toml
+++ b/rusoto/services/ecr/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/ecr/src/lib.rs
+++ b/rusoto/services/ecr/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/ecs/Cargo.toml
+++ b/rusoto/services/ecs/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/ecs/src/lib.rs
+++ b/rusoto/services/ecs/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/efs/Cargo.toml
+++ b/rusoto/services/efs/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/efs/src/lib.rs
+++ b/rusoto/services/efs/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/eks/Cargo.toml
+++ b/rusoto/services/eks/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/eks/src/lib.rs
+++ b/rusoto/services/eks/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/elasticache/Cargo.toml
+++ b/rusoto/services/elasticache/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/elasticache/src/lib.rs
+++ b/rusoto/services/elasticache/src/lib.rs
@@ -25,6 +25,6 @@ extern crate xml;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/elasticbeanstalk/Cargo.toml
+++ b/rusoto/services/elasticbeanstalk/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/elasticbeanstalk/src/lib.rs
+++ b/rusoto/services/elasticbeanstalk/src/lib.rs
@@ -25,6 +25,6 @@ extern crate xml;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/elastictranscoder/Cargo.toml
+++ b/rusoto/services/elastictranscoder/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/elastictranscoder/src/lib.rs
+++ b/rusoto/services/elastictranscoder/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/elb/Cargo.toml
+++ b/rusoto/services/elb/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/elb/src/lib.rs
+++ b/rusoto/services/elb/src/lib.rs
@@ -25,6 +25,6 @@ extern crate xml;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/elbv2/Cargo.toml
+++ b/rusoto/services/elbv2/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/elbv2/src/lib.rs
+++ b/rusoto/services/elbv2/src/lib.rs
@@ -25,6 +25,6 @@ extern crate xml;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/emr/Cargo.toml
+++ b/rusoto/services/emr/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/emr/src/lib.rs
+++ b/rusoto/services/emr/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/events/Cargo.toml
+++ b/rusoto/services/events/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/events/src/lib.rs
+++ b/rusoto/services/events/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/firehose/Cargo.toml
+++ b/rusoto/services/firehose/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/firehose/src/lib.rs
+++ b/rusoto/services/firehose/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/fms/Cargo.toml
+++ b/rusoto/services/fms/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/fms/src/lib.rs
+++ b/rusoto/services/fms/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/fsx/Cargo.toml
+++ b/rusoto/services/fsx/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/fsx/src/lib.rs
+++ b/rusoto/services/fsx/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/gamelift/Cargo.toml
+++ b/rusoto/services/gamelift/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/gamelift/src/lib.rs
+++ b/rusoto/services/gamelift/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/glacier/Cargo.toml
+++ b/rusoto/services/glacier/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/glacier/src/custom/custom_tests.rs
+++ b/rusoto/services/glacier/src/custom/custom_tests.rs
@@ -1,6 +1,6 @@
 extern crate rusoto_mock;
 
-use ::*;
+use crate::generated::*;
 
 use rusoto_core::Region;
 use self::rusoto_mock::*;

--- a/rusoto/services/glacier/src/lib.rs
+++ b/rusoto/services/glacier/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/glue/Cargo.toml
+++ b/rusoto/services/glue/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/glue/src/lib.rs
+++ b/rusoto/services/glue/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/greengrass/Cargo.toml
+++ b/rusoto/services/greengrass/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/greengrass/src/lib.rs
+++ b/rusoto/services/greengrass/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/guardduty/Cargo.toml
+++ b/rusoto/services/guardduty/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/guardduty/src/lib.rs
+++ b/rusoto/services/guardduty/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/health/Cargo.toml
+++ b/rusoto/services/health/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/health/src/lib.rs
+++ b/rusoto/services/health/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/iam/Cargo.toml
+++ b/rusoto/services/iam/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/iam/src/lib.rs
+++ b/rusoto/services/iam/src/lib.rs
@@ -25,6 +25,6 @@ extern crate xml;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/importexport/Cargo.toml
+++ b/rusoto/services/importexport/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/importexport/src/lib.rs
+++ b/rusoto/services/importexport/src/lib.rs
@@ -25,6 +25,6 @@ extern crate xml;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/inspector/Cargo.toml
+++ b/rusoto/services/inspector/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/inspector/src/lib.rs
+++ b/rusoto/services/inspector/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/iot-data/Cargo.toml
+++ b/rusoto/services/iot-data/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/iot-data/src/lib.rs
+++ b/rusoto/services/iot-data/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/iot-jobs-data/Cargo.toml
+++ b/rusoto/services/iot-jobs-data/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/iot-jobs-data/src/lib.rs
+++ b/rusoto/services/iot-jobs-data/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/iot/Cargo.toml
+++ b/rusoto/services/iot/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/iot/src/lib.rs
+++ b/rusoto/services/iot/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/iot1click-devices/Cargo.toml
+++ b/rusoto/services/iot1click-devices/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/iot1click-devices/src/lib.rs
+++ b/rusoto/services/iot1click-devices/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/iot1click-projects/Cargo.toml
+++ b/rusoto/services/iot1click-projects/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/iot1click-projects/src/lib.rs
+++ b/rusoto/services/iot1click-projects/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/iotanalytics/Cargo.toml
+++ b/rusoto/services/iotanalytics/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/iotanalytics/src/lib.rs
+++ b/rusoto/services/iotanalytics/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/kafka/Cargo.toml
+++ b/rusoto/services/kafka/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/kafka/src/lib.rs
+++ b/rusoto/services/kafka/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/kinesis-video-archived-media/Cargo.toml
+++ b/rusoto/services/kinesis-video-archived-media/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/kinesis-video-archived-media/src/lib.rs
+++ b/rusoto/services/kinesis-video-archived-media/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/kinesis-video-media/Cargo.toml
+++ b/rusoto/services/kinesis-video-media/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/kinesis-video-media/src/lib.rs
+++ b/rusoto/services/kinesis-video-media/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/kinesis/Cargo.toml
+++ b/rusoto/services/kinesis/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/kinesis/src/lib.rs
+++ b/rusoto/services/kinesis/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/kinesisanalytics/Cargo.toml
+++ b/rusoto/services/kinesisanalytics/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/kinesisanalytics/src/lib.rs
+++ b/rusoto/services/kinesisanalytics/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/kinesisvideo/Cargo.toml
+++ b/rusoto/services/kinesisvideo/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/kinesisvideo/src/lib.rs
+++ b/rusoto/services/kinesisvideo/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/kms/Cargo.toml
+++ b/rusoto/services/kms/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/kms/src/lib.rs
+++ b/rusoto/services/kms/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/lambda/Cargo.toml
+++ b/rusoto/services/lambda/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/lambda/src/custom/custom_tests.rs
+++ b/rusoto/services/lambda/src/custom/custom_tests.rs
@@ -2,7 +2,7 @@ extern crate rusoto_mock;
 
 use bytes::Bytes;
 
-use ::{GetPolicyRequest, GetPolicyResponse, Lambda, LambdaClient, InvocationRequest};
+use crate::generated::{GetPolicyRequest, GetPolicyResponse, Lambda, LambdaClient, InvocationRequest};
 
 use rusoto_core::Region;
 use rusoto_core::signature::{SignedRequest,SignedRequestPayload};

--- a/rusoto/services/lambda/src/lib.rs
+++ b/rusoto/services/lambda/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/lex-models/Cargo.toml
+++ b/rusoto/services/lex-models/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/lex-models/src/lib.rs
+++ b/rusoto/services/lex-models/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/lex-runtime/Cargo.toml
+++ b/rusoto/services/lex-runtime/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/lex-runtime/src/lib.rs
+++ b/rusoto/services/lex-runtime/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/license-manager/Cargo.toml
+++ b/rusoto/services/license-manager/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/license-manager/src/lib.rs
+++ b/rusoto/services/license-manager/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/lightsail/Cargo.toml
+++ b/rusoto/services/lightsail/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/lightsail/src/lib.rs
+++ b/rusoto/services/lightsail/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/logs/Cargo.toml
+++ b/rusoto/services/logs/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/logs/src/lib.rs
+++ b/rusoto/services/logs/src/lib.rs
@@ -85,6 +85,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/machinelearning/Cargo.toml
+++ b/rusoto/services/machinelearning/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/machinelearning/src/lib.rs
+++ b/rusoto/services/machinelearning/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/macie/Cargo.toml
+++ b/rusoto/services/macie/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/macie/src/lib.rs
+++ b/rusoto/services/macie/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/marketplace-entitlement/Cargo.toml
+++ b/rusoto/services/marketplace-entitlement/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/marketplace-entitlement/src/lib.rs
+++ b/rusoto/services/marketplace-entitlement/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/marketplacecommerceanalytics/Cargo.toml
+++ b/rusoto/services/marketplacecommerceanalytics/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/marketplacecommerceanalytics/src/lib.rs
+++ b/rusoto/services/marketplacecommerceanalytics/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/mediaconvert/Cargo.toml
+++ b/rusoto/services/mediaconvert/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/mediaconvert/src/lib.rs
+++ b/rusoto/services/mediaconvert/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/medialive/Cargo.toml
+++ b/rusoto/services/medialive/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/medialive/src/lib.rs
+++ b/rusoto/services/medialive/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/mediapackage/Cargo.toml
+++ b/rusoto/services/mediapackage/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/mediapackage/src/lib.rs
+++ b/rusoto/services/mediapackage/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/mediastore/Cargo.toml
+++ b/rusoto/services/mediastore/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/mediastore/src/lib.rs
+++ b/rusoto/services/mediastore/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/mediatailor/Cargo.toml
+++ b/rusoto/services/mediatailor/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/mediatailor/src/lib.rs
+++ b/rusoto/services/mediatailor/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/meteringmarketplace/Cargo.toml
+++ b/rusoto/services/meteringmarketplace/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/meteringmarketplace/src/lib.rs
+++ b/rusoto/services/meteringmarketplace/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/mgh/Cargo.toml
+++ b/rusoto/services/mgh/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/mgh/src/lib.rs
+++ b/rusoto/services/mgh/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/mobile/Cargo.toml
+++ b/rusoto/services/mobile/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/mobile/src/lib.rs
+++ b/rusoto/services/mobile/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/mq/Cargo.toml
+++ b/rusoto/services/mq/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/mq/src/lib.rs
+++ b/rusoto/services/mq/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/mturk/Cargo.toml
+++ b/rusoto/services/mturk/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/mturk/src/lib.rs
+++ b/rusoto/services/mturk/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/neptune/Cargo.toml
+++ b/rusoto/services/neptune/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/neptune/src/lib.rs
+++ b/rusoto/services/neptune/src/lib.rs
@@ -25,6 +25,6 @@ extern crate xml;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/opsworks/Cargo.toml
+++ b/rusoto/services/opsworks/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/opsworks/src/lib.rs
+++ b/rusoto/services/opsworks/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/opsworkscm/Cargo.toml
+++ b/rusoto/services/opsworkscm/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/opsworkscm/src/lib.rs
+++ b/rusoto/services/opsworkscm/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/organizations/Cargo.toml
+++ b/rusoto/services/organizations/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/organizations/src/lib.rs
+++ b/rusoto/services/organizations/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/pi/Cargo.toml
+++ b/rusoto/services/pi/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/pi/src/lib.rs
+++ b/rusoto/services/pi/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/polly/Cargo.toml
+++ b/rusoto/services/polly/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/polly/src/lib.rs
+++ b/rusoto/services/polly/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/pricing/Cargo.toml
+++ b/rusoto/services/pricing/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/pricing/src/lib.rs
+++ b/rusoto/services/pricing/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/ram/Cargo.toml
+++ b/rusoto/services/ram/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/ram/src/lib.rs
+++ b/rusoto/services/ram/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/rds-data/Cargo.toml
+++ b/rusoto/services/rds-data/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/rds-data/src/lib.rs
+++ b/rusoto/services/rds-data/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/rds/Cargo.toml
+++ b/rusoto/services/rds/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/rds/src/lib.rs
+++ b/rusoto/services/rds/src/lib.rs
@@ -25,6 +25,6 @@ extern crate xml;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/redshift/Cargo.toml
+++ b/rusoto/services/redshift/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/redshift/src/lib.rs
+++ b/rusoto/services/redshift/src/lib.rs
@@ -25,6 +25,6 @@ extern crate xml;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/rekognition/Cargo.toml
+++ b/rusoto/services/rekognition/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/rekognition/src/lib.rs
+++ b/rusoto/services/rekognition/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/resource-groups/Cargo.toml
+++ b/rusoto/services/resource-groups/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/resource-groups/src/lib.rs
+++ b/rusoto/services/resource-groups/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/resourcegroupstaggingapi/Cargo.toml
+++ b/rusoto/services/resourcegroupstaggingapi/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/resourcegroupstaggingapi/src/lib.rs
+++ b/rusoto/services/resourcegroupstaggingapi/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/route53/Cargo.toml
+++ b/rusoto/services/route53/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/route53/src/custom/custom_tests.rs
+++ b/rusoto/services/route53/src/custom/custom_tests.rs
@@ -1,8 +1,8 @@
 extern crate rusoto_mock;
 
-use custom::util::quote_txt_record;
 use rusoto_core::{Region, RusotoError};
-use {ListResourceRecordSetsError, ListResourceRecordSetsRequest, Route53, Route53Client};
+use crate::generated::{ListResourceRecordSetsError, ListResourceRecordSetsRequest, Route53, Route53Client};
+use crate::custom::util::quote_txt_record;
 
 use self::rusoto_mock::*;
 

--- a/rusoto/services/route53/src/lib.rs
+++ b/rusoto/services/route53/src/lib.rs
@@ -24,6 +24,6 @@ extern crate xml;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/route53domains/Cargo.toml
+++ b/rusoto/services/route53domains/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/route53domains/src/lib.rs
+++ b/rusoto/services/route53domains/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/s3/Cargo.toml
+++ b/rusoto/services/s3/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/s3/src/custom/custom_tests.rs
+++ b/rusoto/services/s3/src/custom/custom_tests.rs
@@ -1,6 +1,6 @@
 extern crate rusoto_mock;
 
-use ::*;
+use crate::generated::*;
 
 use bytes::Bytes;
 use futures::{Future, Stream};

--- a/rusoto/services/s3/src/custom/util.rs
+++ b/rusoto/services/s3/src/custom/util.rs
@@ -3,7 +3,7 @@ use rusoto_core::signature::SignedRequest;
 use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::region::Region;
 use rusoto_core::credential::AwsCredentials;
-use generated::{GetObjectRequest, PutObjectRequest, DeleteObjectRequest, UploadPartRequest};
+use crate::generated::{GetObjectRequest, PutObjectRequest, DeleteObjectRequest, UploadPartRequest};
 use std::time::Duration;
 /// URL encodes an S3 object key. This is necessary for `copy_object` and `upload_part_copy`,
 /// which require the `copy_source` field to be URL encoded.

--- a/rusoto/services/s3/src/lib.rs
+++ b/rusoto/services/s3/src/lib.rs
@@ -24,6 +24,6 @@ extern crate xml;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/sagemaker-runtime/Cargo.toml
+++ b/rusoto/services/sagemaker-runtime/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/sagemaker-runtime/src/lib.rs
+++ b/rusoto/services/sagemaker-runtime/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/sagemaker/Cargo.toml
+++ b/rusoto/services/sagemaker/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/sagemaker/src/lib.rs
+++ b/rusoto/services/sagemaker/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/sdb/Cargo.toml
+++ b/rusoto/services/sdb/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/sdb/src/lib.rs
+++ b/rusoto/services/sdb/src/lib.rs
@@ -25,6 +25,6 @@ extern crate xml;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/secretsmanager/Cargo.toml
+++ b/rusoto/services/secretsmanager/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/secretsmanager/src/lib.rs
+++ b/rusoto/services/secretsmanager/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/serverlessrepo/Cargo.toml
+++ b/rusoto/services/serverlessrepo/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/serverlessrepo/src/lib.rs
+++ b/rusoto/services/serverlessrepo/src/lib.rs
@@ -49,6 +49,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/servicecatalog/Cargo.toml
+++ b/rusoto/services/servicecatalog/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/servicecatalog/src/lib.rs
+++ b/rusoto/services/servicecatalog/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/servicediscovery/Cargo.toml
+++ b/rusoto/services/servicediscovery/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/servicediscovery/src/lib.rs
+++ b/rusoto/services/servicediscovery/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/ses/Cargo.toml
+++ b/rusoto/services/ses/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/ses/src/lib.rs
+++ b/rusoto/services/ses/src/lib.rs
@@ -25,6 +25,6 @@ extern crate xml;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/shield/Cargo.toml
+++ b/rusoto/services/shield/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/shield/src/lib.rs
+++ b/rusoto/services/shield/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/sms/Cargo.toml
+++ b/rusoto/services/sms/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/sms/src/lib.rs
+++ b/rusoto/services/sms/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/snowball/Cargo.toml
+++ b/rusoto/services/snowball/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/snowball/src/lib.rs
+++ b/rusoto/services/snowball/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/sns/Cargo.toml
+++ b/rusoto/services/sns/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/sns/src/lib.rs
+++ b/rusoto/services/sns/src/lib.rs
@@ -25,6 +25,6 @@ extern crate xml;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/sqs/Cargo.toml
+++ b/rusoto/services/sqs/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/sqs/src/custom/custom_tests.rs
+++ b/rusoto/services/sqs/src/custom/custom_tests.rs
@@ -1,7 +1,7 @@
 extern crate rusoto_mock;
 
 use std::collections::HashMap;
-use ::{Sqs, SqsClient, SendMessageRequest, ReceiveMessageRequest, MessageAttributeValue, GetQueueUrlRequest, GetQueueUrlError};
+use crate::generated::{Sqs, SqsClient, SendMessageRequest, ReceiveMessageRequest, MessageAttributeValue, GetQueueUrlRequest, GetQueueUrlError};
 
 use rusoto_core::{Region, RusotoError};
 use rusoto_core::signature::SignedRequest;

--- a/rusoto/services/sqs/src/lib.rs
+++ b/rusoto/services/sqs/src/lib.rs
@@ -25,6 +25,6 @@ extern crate xml;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/ssm/Cargo.toml
+++ b/rusoto/services/ssm/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/ssm/src/lib.rs
+++ b/rusoto/services/ssm/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/stepfunctions/Cargo.toml
+++ b/rusoto/services/stepfunctions/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/stepfunctions/src/lib.rs
+++ b/rusoto/services/stepfunctions/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/storagegateway/Cargo.toml
+++ b/rusoto/services/storagegateway/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/storagegateway/src/lib.rs
+++ b/rusoto/services/storagegateway/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/sts/Cargo.toml
+++ b/rusoto/services/sts/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/sts/src/lib.rs
+++ b/rusoto/services/sts/src/lib.rs
@@ -26,6 +26,6 @@ extern crate xml;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/support/Cargo.toml
+++ b/rusoto/services/support/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/support/src/lib.rs
+++ b/rusoto/services/support/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/swf/Cargo.toml
+++ b/rusoto/services/swf/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/swf/src/lib.rs
+++ b/rusoto/services/swf/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/transcribe/Cargo.toml
+++ b/rusoto/services/transcribe/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/transcribe/src/lib.rs
+++ b/rusoto/services/transcribe/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/translate/Cargo.toml
+++ b/rusoto/services/translate/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/translate/src/lib.rs
+++ b/rusoto/services/translate/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/waf-regional/Cargo.toml
+++ b/rusoto/services/waf-regional/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/waf-regional/src/lib.rs
+++ b/rusoto/services/waf-regional/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/waf/Cargo.toml
+++ b/rusoto/services/waf/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/waf/src/lib.rs
+++ b/rusoto/services/waf/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/workdocs/Cargo.toml
+++ b/rusoto/services/workdocs/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/workdocs/src/lib.rs
+++ b/rusoto/services/workdocs/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/worklink/Cargo.toml
+++ b/rusoto/services/worklink/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/worklink/src/lib.rs
+++ b/rusoto/services/worklink/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/workmail/Cargo.toml
+++ b/rusoto/services/workmail/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/workmail/src/lib.rs
+++ b/rusoto/services/workmail/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/workspaces/Cargo.toml
+++ b/rusoto/services/workspaces/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/workspaces/src/lib.rs
+++ b/rusoto/services/workspaces/src/lib.rs
@@ -27,6 +27,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/rusoto/services/xray/Cargo.toml
+++ b/rusoto/services/xray/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
 version = "0.38.0"
 homepage = "https://www.rusoto.org/"
+edition = "2018"
 
 [build-dependencies]
 

--- a/rusoto/services/xray/src/lib.rs
+++ b/rusoto/services/xray/src/lib.rs
@@ -29,6 +29,6 @@ extern crate serde_json;
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             

--- a/service_crategen/src/cargo.rs
+++ b/service_crategen/src/cargo.rs
@@ -29,6 +29,7 @@ pub struct Metadata {
     pub repository: Option<String>,
     pub version: String,
     pub homepage: Option<String>,
+    pub edition: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/service_crategen/src/commands/generate/mod.rs
+++ b/service_crategen/src/commands/generate/mod.rs
@@ -138,7 +138,8 @@ pub fn generate_services(
                 readme: Some("README.md".into()),
                 repository: Some("https://github.com/rusoto/rusoto".into()),
                 version: service_config.version.clone(),
-                homepage: Some("https://www.rusoto.org/".into())
+                homepage: Some("https://www.rusoto.org/".into()),
+                edition: "2018".into()
             },
             features: Some(features),
             dependencies: service_dependencies,
@@ -249,8 +250,8 @@ See [LICENSE][license] for details.
 mod generated;
 mod custom;
 
-pub use generated::*;
-pub use custom::*;
+pub use crate::generated::*;
+pub use crate::custom::*;
             "#,
             service_docs = ::doco::Module(service.documentation().unwrap_or(&service.full_name().to_owned())),
             client_name = service.client_type_name(),


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Convert all crates to Rust 2018 edition.

Fixes the last bit of https://github.com/rusoto/rusoto/issues/1206 ! 🎉 

I haven't run all integration tests to ensure they work. The STS crate should get special attention as there was some migrating from `try!` to `?`.