### PR TITLE
use http::HeaderMap in HttpResponse

### DIFF
--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -29,6 +29,7 @@ rustc_version = "0.2.1"
 bytes = "0.4.12"
 futures = "0.1.16"
 hmac = "0.5.0"
+http = "0.1.17"
 hyper = "0.12"
 hyper-tls = { version = "0.3.0", optional = true }
 hyper-rustls = { version = "0.16.0", optional = true }

--- a/rusoto/core/src/proto/json/error.rs
+++ b/rusoto/core/src/proto/json/error.rs
@@ -71,15 +71,14 @@ impl Error {
 
 #[test]
 fn deserialize_dynamodb_error() {
-    use super::super::super::request::Headers;
-    use hyper::StatusCode;
+    use http::StatusCode;
 
     let payload = r#"{"__type":"com.amazonaws.dynamodb.v20120810#ResourceNotFoundException",
 "message":"Requested resource not found: Table: tablename not found"}"#;
     let response = BufferedHttpResponse {
         status: StatusCode::OK,
         body: payload.into(),
-        headers: Headers::default(),
+        headers: Default::default(),
     };
 
     let error = Error::parse(&response).unwrap();

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -21204,8 +21204,11 @@ impl S3 for S3Client {
             };
             let mut values = ::std::collections::HashMap::new();
             for (key, value) in response.headers.iter() {
-                if key.starts_with("x-amz-meta-") {
-                    values.insert(key["x-amz-meta-".len()..].to_owned(), value.to_owned());
+                if key.as_str().starts_with("x-amz-meta-") {
+                    values.insert(
+                        key.as_str()["x-amz-meta-".len()..].to_owned(),
+                        value.to_owned(),
+                    );
                 }
             }
             result.metadata = Some(values);
@@ -21800,8 +21803,11 @@ impl S3 for S3Client {
                 };
                 let mut values = ::std::collections::HashMap::new();
                 for (key, value) in response.headers.iter() {
-                    if key.starts_with("x-amz-meta-") {
-                        values.insert(key["x-amz-meta-".len()..].to_owned(), value.to_owned());
+                    if key.as_str().starts_with("x-amz-meta-") {
+                        values.insert(
+                            key.as_str()["x-amz-meta-".len()..].to_owned(),
+                            value.to_owned(),
+                        );
                     }
                 }
                 result.metadata = Some(values);

--- a/service_crategen/src/commands/generate/codegen/rest_response_parser.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_response_parser.rs
@@ -89,8 +89,8 @@ fn parse_headers_map(member_name: &str, member: &Member, required: bool) -> Stri
     format!(
         "let mut values = ::std::collections::HashMap::new();
     for (key, value) in response.headers.iter() {{
-        if key.starts_with(\"{location_name}\") {{
-            values.insert(key[\"{location_name}\".len()..].to_owned(), value.to_owned());
+        if key.as_str().starts_with(\"{location_name}\") {{
+            values.insert(key.as_str()[\"{location_name}\".len()..].to_owned(), value.to_owned());
         }}
     }}
     {set_statement}",


### PR DESCRIPTION
Getting rid of our custom header implementation in favour of `http::HeaderMap`. Header names will be normalized to lowercase, as is the case with the current implementation.