### PR TITLE
Remove log crate dependency from services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add RDS Data service
 - Add ComprehendMedical service
 - Add Ap-East-1 Region
+- Remove log crate dependency from services
 
 ## [0.38.0] - 2019-04-17
 

--- a/rusoto/services/amplify/Cargo.toml
+++ b/rusoto/services/amplify/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/amplify/src/lib.rs
+++ b/rusoto/services/amplify/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/apigateway/Cargo.toml
+++ b/rusoto/services/apigateway/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/apigateway/src/lib.rs
+++ b/rusoto/services/apigateway/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/apigatewaymanagementapi/Cargo.toml
+++ b/rusoto/services/apigatewaymanagementapi/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/apigatewaymanagementapi/src/lib.rs
+++ b/rusoto/services/apigatewaymanagementapi/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/apigatewayv2/Cargo.toml
+++ b/rusoto/services/apigatewayv2/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/apigatewayv2/src/lib.rs
+++ b/rusoto/services/apigatewayv2/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/appsync/Cargo.toml
+++ b/rusoto/services/appsync/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/appsync/src/lib.rs
+++ b/rusoto/services/appsync/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/batch/Cargo.toml
+++ b/rusoto/services/batch/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/batch/src/lib.rs
+++ b/rusoto/services/batch/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/chime/Cargo.toml
+++ b/rusoto/services/chime/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/chime/src/lib.rs
+++ b/rusoto/services/chime/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/clouddirectory/Cargo.toml
+++ b/rusoto/services/clouddirectory/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/clouddirectory/src/lib.rs
+++ b/rusoto/services/clouddirectory/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/cloudsearchdomain/Cargo.toml
+++ b/rusoto/services/cloudsearchdomain/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/cloudsearchdomain/src/lib.rs
+++ b/rusoto/services/cloudsearchdomain/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/cognito-sync/Cargo.toml
+++ b/rusoto/services/cognito-sync/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/cognito-sync/src/lib.rs
+++ b/rusoto/services/cognito-sync/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/connect/Cargo.toml
+++ b/rusoto/services/connect/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/connect/src/lib.rs
+++ b/rusoto/services/connect/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/efs/Cargo.toml
+++ b/rusoto/services/efs/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/efs/src/lib.rs
+++ b/rusoto/services/efs/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/eks/Cargo.toml
+++ b/rusoto/services/eks/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/eks/src/lib.rs
+++ b/rusoto/services/eks/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/elastictranscoder/Cargo.toml
+++ b/rusoto/services/elastictranscoder/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/elastictranscoder/src/lib.rs
+++ b/rusoto/services/elastictranscoder/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/glacier/Cargo.toml
+++ b/rusoto/services/glacier/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/glacier/src/lib.rs
+++ b/rusoto/services/glacier/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/greengrass/Cargo.toml
+++ b/rusoto/services/greengrass/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/greengrass/src/lib.rs
+++ b/rusoto/services/greengrass/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/guardduty/Cargo.toml
+++ b/rusoto/services/guardduty/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/guardduty/src/lib.rs
+++ b/rusoto/services/guardduty/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/iot-data/Cargo.toml
+++ b/rusoto/services/iot-data/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/iot-data/src/lib.rs
+++ b/rusoto/services/iot-data/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/iot-jobs-data/Cargo.toml
+++ b/rusoto/services/iot-jobs-data/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/iot-jobs-data/src/lib.rs
+++ b/rusoto/services/iot-jobs-data/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/iot/Cargo.toml
+++ b/rusoto/services/iot/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/iot/src/lib.rs
+++ b/rusoto/services/iot/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/iot1click-devices/Cargo.toml
+++ b/rusoto/services/iot1click-devices/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/iot1click-devices/src/lib.rs
+++ b/rusoto/services/iot1click-devices/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/iot1click-projects/Cargo.toml
+++ b/rusoto/services/iot1click-projects/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/iot1click-projects/src/lib.rs
+++ b/rusoto/services/iot1click-projects/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/iotanalytics/Cargo.toml
+++ b/rusoto/services/iotanalytics/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/iotanalytics/src/lib.rs
+++ b/rusoto/services/iotanalytics/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/kafka/Cargo.toml
+++ b/rusoto/services/kafka/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/kafka/src/lib.rs
+++ b/rusoto/services/kafka/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/kinesis-video-archived-media/Cargo.toml
+++ b/rusoto/services/kinesis-video-archived-media/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/kinesis-video-archived-media/src/lib.rs
+++ b/rusoto/services/kinesis-video-archived-media/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/kinesis-video-media/Cargo.toml
+++ b/rusoto/services/kinesis-video-media/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/kinesis-video-media/src/lib.rs
+++ b/rusoto/services/kinesis-video-media/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/kinesisvideo/Cargo.toml
+++ b/rusoto/services/kinesisvideo/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/kinesisvideo/src/lib.rs
+++ b/rusoto/services/kinesisvideo/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/lambda/Cargo.toml
+++ b/rusoto/services/lambda/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/lambda/src/lib.rs
+++ b/rusoto/services/lambda/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/lex-models/Cargo.toml
+++ b/rusoto/services/lex-models/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/lex-models/src/lib.rs
+++ b/rusoto/services/lex-models/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/lex-runtime/Cargo.toml
+++ b/rusoto/services/lex-runtime/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/lex-runtime/src/lib.rs
+++ b/rusoto/services/lex-runtime/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/mediaconvert/Cargo.toml
+++ b/rusoto/services/mediaconvert/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/mediaconvert/src/lib.rs
+++ b/rusoto/services/mediaconvert/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/medialive/Cargo.toml
+++ b/rusoto/services/medialive/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/medialive/src/lib.rs
+++ b/rusoto/services/medialive/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/mediapackage/Cargo.toml
+++ b/rusoto/services/mediapackage/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/mediapackage/src/lib.rs
+++ b/rusoto/services/mediapackage/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/mediatailor/Cargo.toml
+++ b/rusoto/services/mediatailor/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/mediatailor/src/lib.rs
+++ b/rusoto/services/mediatailor/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/mobile/Cargo.toml
+++ b/rusoto/services/mobile/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/mobile/src/lib.rs
+++ b/rusoto/services/mobile/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/mq/Cargo.toml
+++ b/rusoto/services/mq/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/mq/src/lib.rs
+++ b/rusoto/services/mq/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/polly/Cargo.toml
+++ b/rusoto/services/polly/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/polly/src/lib.rs
+++ b/rusoto/services/polly/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/ram/Cargo.toml
+++ b/rusoto/services/ram/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/ram/src/lib.rs
+++ b/rusoto/services/ram/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/rds-data/Cargo.toml
+++ b/rusoto/services/rds-data/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/rds-data/src/lib.rs
+++ b/rusoto/services/rds-data/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/resource-groups/Cargo.toml
+++ b/rusoto/services/resource-groups/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/resource-groups/src/lib.rs
+++ b/rusoto/services/resource-groups/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/sagemaker-runtime/Cargo.toml
+++ b/rusoto/services/sagemaker-runtime/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/sagemaker-runtime/src/lib.rs
+++ b/rusoto/services/sagemaker-runtime/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/serverlessrepo/Cargo.toml
+++ b/rusoto/services/serverlessrepo/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/serverlessrepo/src/lib.rs
+++ b/rusoto/services/serverlessrepo/src/lib.rs
@@ -38,8 +38,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/workdocs/Cargo.toml
+++ b/rusoto/services/workdocs/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/workdocs/src/lib.rs
+++ b/rusoto/services/workdocs/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/worklink/Cargo.toml
+++ b/rusoto/services/worklink/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/worklink/src/lib.rs
+++ b/rusoto/services/worklink/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/rusoto/services/xray/Cargo.toml
+++ b/rusoto/services/xray/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://www.rusoto.org/"
 [dependencies]
 bytes = "0.4.12"
 futures = "0.1.16"
-log = "0.4.1"
 serde = "1.0.2"
 serde_derive = "1.0.2"
 serde_json = "1.0.1"

--- a/rusoto/services/xray/src/lib.rs
+++ b/rusoto/services/xray/src/lib.rs
@@ -18,8 +18,6 @@
 
 extern crate bytes;
 extern crate futures;
-#[macro_use]
-extern crate log;
 extern crate rusoto_core;
 extern crate serde;
 #[macro_use]

--- a/service_crategen/src/commands/generate/mod.rs
+++ b/service_crategen/src/commands/generate/mod.rs
@@ -101,7 +101,7 @@ pub fn generate_services(
                 return "extern crate xml;".into();
             }
             let safe_name = k.replace("-", "_");
-            let use_macro = k == "serde_derive" || k == "log" || k == "lazy_static";
+            let use_macro = k == "serde_derive" || k == "lazy_static";
             if use_macro {
                 return format!("#[macro_use]\nextern crate {};", safe_name);
             }

--- a/service_crategen/src/service.rs
+++ b/service_crategen/src/service.rs
@@ -151,7 +151,6 @@ impl<'b> Service<'b> {
                 dependencies.insert("xml-rs".to_owned(), cargo::Dependency::Simple("0.7".into()));
             }
             "rest-json" => {
-                dependencies.insert("log".to_owned(), cargo::Dependency::Simple("0.4.1".into()));
                 dependencies.insert(
                     "serde".to_owned(),
                     cargo::Dependency::Simple("1.0.2".into()),


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

_Remove log crate dependency from services_

Resolves #1387 by removing the log crate inside the generated code for services. 
