### PR TITLE
Prep for 0.39.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 (Please put notes here)
 
+## [0.39.0] - 2019-05-19
+
 - Add Worklink service
 - Add FSX service
 - Fix de/serialization of DynamoDB binary set attribute values
@@ -15,6 +17,9 @@
 - Add ComprehendMedical service
 - Add Ap-East-1 Region
 - Remove log crate dependency from services
+- Remove decoding of the uri path before encoding it
+- Use http::HeaderMap instead of our custom implementation
+- Update all public crates to Rust 2018 edition
 
 ## [0.38.0] - 2019-04-17
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ For example, to include only S3 and SQS:
 
 ```toml
 [dependencies]
-rusoto_core = "0.38.0"
-rusoto_sqs = "0.38.0"
-rusoto_s3 = "0.38.0"
+rusoto_core = "0.39.0"
+rusoto_sqs = "0.39.0"
+rusoto_s3 = "0.39.0"
 ```
 
 ## Migration notes

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["AWS", "Amazon", "mock", "testing"]
 license = "MIT"
 name = "rusoto_mock"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.31.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 categories = [
   "development-tools::testing"

--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 name = "rusoto_core"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 exclude = ["test_resources/*"]
 edition = "2018"
@@ -50,7 +50,7 @@ xml-rs = "0.7"
 
 [dependencies.rusoto_credential]
 path = "../credential"
-version = "0.17"
+version = "0.39"
 
 [dependencies.clippy]
 optional = true

--- a/rusoto/core/README.md
+++ b/rusoto/core/README.md
@@ -38,9 +38,9 @@ For example, to include only S3 and SQS:
 
 ``` toml
 [dependencies]
-rusoto_core = "0.38.0"
-rusoto_sqs = "0.38.0"
-rusoto_s3 = "0.38.0"
+rusoto_core = "0.39.0"
+rusoto_sqs = "0.39.0"
+rusoto_s3 = "0.39.0"
 ```
 
 ## Migration notes
@@ -93,9 +93,9 @@ If you do not want to use OpenSSL, you can replace it with rustls by editing you
 
 ``` toml
 [dependencies]
-rusoto_core = { version="0.38.0", default_features=false, features=["rustls"] }
-rusoto_sqs = { version="0.38.0", default_features=false, features=["rustls"] }
-rusoto_s3 = { version="0.38.0", default_features=false, features=["rustls"] }
+rusoto_core = { version="0.39.0", default_features=false, features=["rustls"] }
+rusoto_sqs = { version="0.39.0", default_features=false, features=["rustls"] }
+rusoto_s3 = { version="0.39.0", default_features=false, features=["rustls"] }
 ```
 
 ### Credentials

--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -10,7 +10,7 @@ description = "AWS credential tooling"
 name = "rusoto_credential"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.17.0"
+version = "0.39.0"
 exclude = ["tests/sample-data/*"]
 edition = "2018"
 

--- a/rusoto/services/acm-pca/Cargo.toml
+++ b/rusoto/services/acm-pca/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_acm_pca"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/acm-pca/Cargo.toml
+++ b/rusoto/services/acm-pca/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/acm-pca/README.md
+++ b/rusoto/services/acm-pca/README.md
@@ -23,7 +23,7 @@ To use `rusoto_acm_pca` in your application, add it as a dependency in your `Car
 
 ```toml
 [dependencies]
-rusoto_acm_pca = "0.38.0"
+rusoto_acm_pca = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/acm/Cargo.toml
+++ b/rusoto/services/acm/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_acm"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/acm/Cargo.toml
+++ b/rusoto/services/acm/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/acm/README.md
+++ b/rusoto/services/acm/README.md
@@ -23,7 +23,7 @@ To use `rusoto_acm` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_acm = "0.38.0"
+rusoto_acm = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/alexaforbusiness/Cargo.toml
+++ b/rusoto/services/alexaforbusiness/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_alexaforbusiness"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/alexaforbusiness/Cargo.toml
+++ b/rusoto/services/alexaforbusiness/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/alexaforbusiness/README.md
+++ b/rusoto/services/alexaforbusiness/README.md
@@ -23,7 +23,7 @@ To use `rusoto_alexaforbusiness` in your application, add it as a dependency in 
 
 ```toml
 [dependencies]
-rusoto_alexaforbusiness = "0.38.0"
+rusoto_alexaforbusiness = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/amplify/Cargo.toml
+++ b/rusoto/services/amplify/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_amplify"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/amplify/Cargo.toml
+++ b/rusoto/services/amplify/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/amplify/README.md
+++ b/rusoto/services/amplify/README.md
@@ -23,7 +23,7 @@ To use `rusoto_amplify` in your application, add it as a dependency in your `Car
 
 ```toml
 [dependencies]
-rusoto_amplify = "0.38.0"
+rusoto_amplify = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/apigateway/Cargo.toml
+++ b/rusoto/services/apigateway/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_apigateway"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/apigateway/Cargo.toml
+++ b/rusoto/services/apigateway/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/apigateway/README.md
+++ b/rusoto/services/apigateway/README.md
@@ -23,7 +23,7 @@ To use `rusoto_apigateway` in your application, add it as a dependency in your `
 
 ```toml
 [dependencies]
-rusoto_apigateway = "0.38.0"
+rusoto_apigateway = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/apigatewaymanagementapi/Cargo.toml
+++ b/rusoto/services/apigatewaymanagementapi/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_apigatewaymanagementapi"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/apigatewaymanagementapi/Cargo.toml
+++ b/rusoto/services/apigatewaymanagementapi/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/apigatewaymanagementapi/README.md
+++ b/rusoto/services/apigatewaymanagementapi/README.md
@@ -23,7 +23,7 @@ To use `rusoto_apigatewaymanagementapi` in your application, add it as a depende
 
 ```toml
 [dependencies]
-rusoto_apigatewaymanagementapi = "0.38.0"
+rusoto_apigatewaymanagementapi = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/apigatewayv2/Cargo.toml
+++ b/rusoto/services/apigatewayv2/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_apigatewayv2"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/apigatewayv2/Cargo.toml
+++ b/rusoto/services/apigatewayv2/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/apigatewayv2/README.md
+++ b/rusoto/services/apigatewayv2/README.md
@@ -23,7 +23,7 @@ To use `rusoto_apigatewayv2` in your application, add it as a dependency in your
 
 ```toml
 [dependencies]
-rusoto_apigatewayv2 = "0.38.0"
+rusoto_apigatewayv2 = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/application-autoscaling/Cargo.toml
+++ b/rusoto/services/application-autoscaling/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_application_autoscaling"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/application-autoscaling/Cargo.toml
+++ b/rusoto/services/application-autoscaling/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/application-autoscaling/README.md
+++ b/rusoto/services/application-autoscaling/README.md
@@ -23,7 +23,7 @@ To use `rusoto_application_autoscaling` in your application, add it as a depende
 
 ```toml
 [dependencies]
-rusoto_application_autoscaling = "0.38.0"
+rusoto_application_autoscaling = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/appstream/Cargo.toml
+++ b/rusoto/services/appstream/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_appstream"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/appstream/Cargo.toml
+++ b/rusoto/services/appstream/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/appstream/README.md
+++ b/rusoto/services/appstream/README.md
@@ -23,7 +23,7 @@ To use `rusoto_appstream` in your application, add it as a dependency in your `C
 
 ```toml
 [dependencies]
-rusoto_appstream = "0.38.0"
+rusoto_appstream = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/appsync/Cargo.toml
+++ b/rusoto/services/appsync/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_appsync"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/appsync/Cargo.toml
+++ b/rusoto/services/appsync/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/appsync/README.md
+++ b/rusoto/services/appsync/README.md
@@ -23,7 +23,7 @@ To use `rusoto_appsync` in your application, add it as a dependency in your `Car
 
 ```toml
 [dependencies]
-rusoto_appsync = "0.38.0"
+rusoto_appsync = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/athena/Cargo.toml
+++ b/rusoto/services/athena/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_athena"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/athena/Cargo.toml
+++ b/rusoto/services/athena/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/athena/README.md
+++ b/rusoto/services/athena/README.md
@@ -23,7 +23,7 @@ To use `rusoto_athena` in your application, add it as a dependency in your `Carg
 
 ```toml
 [dependencies]
-rusoto_athena = "0.38.0"
+rusoto_athena = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/autoscaling-plans/Cargo.toml
+++ b/rusoto/services/autoscaling-plans/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_autoscaling_plans"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/autoscaling-plans/Cargo.toml
+++ b/rusoto/services/autoscaling-plans/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/autoscaling-plans/README.md
+++ b/rusoto/services/autoscaling-plans/README.md
@@ -23,7 +23,7 @@ To use `rusoto_autoscaling_plans` in your application, add it as a dependency in
 
 ```toml
 [dependencies]
-rusoto_autoscaling_plans = "0.38.0"
+rusoto_autoscaling_plans = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/autoscaling/Cargo.toml
+++ b/rusoto/services/autoscaling/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/autoscaling/Cargo.toml
+++ b/rusoto/services/autoscaling/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_autoscaling"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -20,7 +20,7 @@ serde_urlencoded = "0.5"
 xml-rs = "0.7"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/autoscaling/README.md
+++ b/rusoto/services/autoscaling/README.md
@@ -23,7 +23,7 @@ To use `rusoto_autoscaling` in your application, add it as a dependency in your 
 
 ```toml
 [dependencies]
-rusoto_autoscaling = "0.38.0"
+rusoto_autoscaling = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/batch/Cargo.toml
+++ b/rusoto/services/batch/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_batch"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/batch/Cargo.toml
+++ b/rusoto/services/batch/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/batch/README.md
+++ b/rusoto/services/batch/README.md
@@ -23,7 +23,7 @@ To use `rusoto_batch` in your application, add it as a dependency in your `Cargo
 
 ```toml
 [dependencies]
-rusoto_batch = "0.38.0"
+rusoto_batch = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/budgets/Cargo.toml
+++ b/rusoto/services/budgets/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_budgets"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/budgets/Cargo.toml
+++ b/rusoto/services/budgets/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/budgets/README.md
+++ b/rusoto/services/budgets/README.md
@@ -23,7 +23,7 @@ To use `rusoto_budgets` in your application, add it as a dependency in your `Car
 
 ```toml
 [dependencies]
-rusoto_budgets = "0.38.0"
+rusoto_budgets = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/ce/Cargo.toml
+++ b/rusoto/services/ce/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_ce"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/ce/Cargo.toml
+++ b/rusoto/services/ce/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/ce/README.md
+++ b/rusoto/services/ce/README.md
@@ -23,7 +23,7 @@ To use `rusoto_ce` in your application, add it as a dependency in your `Cargo.to
 
 ```toml
 [dependencies]
-rusoto_ce = "0.38.0"
+rusoto_ce = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/chime/Cargo.toml
+++ b/rusoto/services/chime/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_chime"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/chime/Cargo.toml
+++ b/rusoto/services/chime/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/chime/README.md
+++ b/rusoto/services/chime/README.md
@@ -23,7 +23,7 @@ To use `rusoto_chime` in your application, add it as a dependency in your `Cargo
 
 ```toml
 [dependencies]
-rusoto_chime = "0.38.0"
+rusoto_chime = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/cloud9/Cargo.toml
+++ b/rusoto/services/cloud9/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_cloud9"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/cloud9/Cargo.toml
+++ b/rusoto/services/cloud9/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/cloud9/README.md
+++ b/rusoto/services/cloud9/README.md
@@ -23,7 +23,7 @@ To use `rusoto_cloud9` in your application, add it as a dependency in your `Carg
 
 ```toml
 [dependencies]
-rusoto_cloud9 = "0.38.0"
+rusoto_cloud9 = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/clouddirectory/Cargo.toml
+++ b/rusoto/services/clouddirectory/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_clouddirectory"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/clouddirectory/Cargo.toml
+++ b/rusoto/services/clouddirectory/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/clouddirectory/README.md
+++ b/rusoto/services/clouddirectory/README.md
@@ -23,7 +23,7 @@ To use `rusoto_clouddirectory` in your application, add it as a dependency in yo
 
 ```toml
 [dependencies]
-rusoto_clouddirectory = "0.38.0"
+rusoto_clouddirectory = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/cloudformation/Cargo.toml
+++ b/rusoto/services/cloudformation/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/cloudformation/Cargo.toml
+++ b/rusoto/services/cloudformation/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_cloudformation"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -20,7 +20,7 @@ serde_urlencoded = "0.5"
 xml-rs = "0.7"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/cloudformation/README.md
+++ b/rusoto/services/cloudformation/README.md
@@ -23,7 +23,7 @@ To use `rusoto_cloudformation` in your application, add it as a dependency in yo
 
 ```toml
 [dependencies]
-rusoto_cloudformation = "0.38.0"
+rusoto_cloudformation = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/cloudfront/Cargo.toml
+++ b/rusoto/services/cloudfront/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_cloudfront"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -19,7 +19,7 @@ futures = "0.1.16"
 xml-rs = "0.7"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/cloudfront/Cargo.toml
+++ b/rusoto/services/cloudfront/Cargo.toml
@@ -23,7 +23,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/cloudfront/README.md
+++ b/rusoto/services/cloudfront/README.md
@@ -23,7 +23,7 @@ To use `rusoto_cloudfront` in your application, add it as a dependency in your `
 
 ```toml
 [dependencies]
-rusoto_cloudfront = "0.38.0"
+rusoto_cloudfront = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/cloudhsm/Cargo.toml
+++ b/rusoto/services/cloudhsm/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_cloudhsm"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/cloudhsm/Cargo.toml
+++ b/rusoto/services/cloudhsm/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/cloudhsm/README.md
+++ b/rusoto/services/cloudhsm/README.md
@@ -23,7 +23,7 @@ To use `rusoto_cloudhsm` in your application, add it as a dependency in your `Ca
 
 ```toml
 [dependencies]
-rusoto_cloudhsm = "0.38.0"
+rusoto_cloudhsm = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/cloudhsmv2/Cargo.toml
+++ b/rusoto/services/cloudhsmv2/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_cloudhsmv2"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/cloudhsmv2/Cargo.toml
+++ b/rusoto/services/cloudhsmv2/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/cloudhsmv2/README.md
+++ b/rusoto/services/cloudhsmv2/README.md
@@ -23,7 +23,7 @@ To use `rusoto_cloudhsmv2` in your application, add it as a dependency in your `
 
 ```toml
 [dependencies]
-rusoto_cloudhsmv2 = "0.38.0"
+rusoto_cloudhsmv2 = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/cloudsearch/Cargo.toml
+++ b/rusoto/services/cloudsearch/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/cloudsearch/Cargo.toml
+++ b/rusoto/services/cloudsearch/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_cloudsearch"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -20,7 +20,7 @@ serde_urlencoded = "0.5"
 xml-rs = "0.7"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/cloudsearch/README.md
+++ b/rusoto/services/cloudsearch/README.md
@@ -23,7 +23,7 @@ To use `rusoto_cloudsearch` in your application, add it as a dependency in your 
 
 ```toml
 [dependencies]
-rusoto_cloudsearch = "0.38.0"
+rusoto_cloudsearch = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/cloudsearchdomain/Cargo.toml
+++ b/rusoto/services/cloudsearchdomain/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_cloudsearchdomain"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/cloudsearchdomain/Cargo.toml
+++ b/rusoto/services/cloudsearchdomain/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/cloudsearchdomain/README.md
+++ b/rusoto/services/cloudsearchdomain/README.md
@@ -23,7 +23,7 @@ To use `rusoto_cloudsearchdomain` in your application, add it as a dependency in
 
 ```toml
 [dependencies]
-rusoto_cloudsearchdomain = "0.38.0"
+rusoto_cloudsearchdomain = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/cloudtrail/Cargo.toml
+++ b/rusoto/services/cloudtrail/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_cloudtrail"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/cloudtrail/Cargo.toml
+++ b/rusoto/services/cloudtrail/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/cloudtrail/README.md
+++ b/rusoto/services/cloudtrail/README.md
@@ -23,7 +23,7 @@ To use `rusoto_cloudtrail` in your application, add it as a dependency in your `
 
 ```toml
 [dependencies]
-rusoto_cloudtrail = "0.38.0"
+rusoto_cloudtrail = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/cloudwatch/Cargo.toml
+++ b/rusoto/services/cloudwatch/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/cloudwatch/Cargo.toml
+++ b/rusoto/services/cloudwatch/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_cloudwatch"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -20,7 +20,7 @@ serde_urlencoded = "0.5"
 xml-rs = "0.7"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/cloudwatch/README.md
+++ b/rusoto/services/cloudwatch/README.md
@@ -23,7 +23,7 @@ To use `rusoto_cloudwatch` in your application, add it as a dependency in your `
 
 ```toml
 [dependencies]
-rusoto_cloudwatch = "0.38.0"
+rusoto_cloudwatch = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/codebuild/Cargo.toml
+++ b/rusoto/services/codebuild/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_codebuild"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/codebuild/Cargo.toml
+++ b/rusoto/services/codebuild/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/codebuild/README.md
+++ b/rusoto/services/codebuild/README.md
@@ -23,7 +23,7 @@ To use `rusoto_codebuild` in your application, add it as a dependency in your `C
 
 ```toml
 [dependencies]
-rusoto_codebuild = "0.38.0"
+rusoto_codebuild = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/codecommit/Cargo.toml
+++ b/rusoto/services/codecommit/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_codecommit"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/codecommit/Cargo.toml
+++ b/rusoto/services/codecommit/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/codecommit/README.md
+++ b/rusoto/services/codecommit/README.md
@@ -23,7 +23,7 @@ To use `rusoto_codecommit` in your application, add it as a dependency in your `
 
 ```toml
 [dependencies]
-rusoto_codecommit = "0.38.0"
+rusoto_codecommit = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/codedeploy/Cargo.toml
+++ b/rusoto/services/codedeploy/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_codedeploy"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/codedeploy/Cargo.toml
+++ b/rusoto/services/codedeploy/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/codedeploy/README.md
+++ b/rusoto/services/codedeploy/README.md
@@ -23,7 +23,7 @@ To use `rusoto_codedeploy` in your application, add it as a dependency in your `
 
 ```toml
 [dependencies]
-rusoto_codedeploy = "0.38.0"
+rusoto_codedeploy = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/codepipeline/Cargo.toml
+++ b/rusoto/services/codepipeline/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_codepipeline"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/codepipeline/Cargo.toml
+++ b/rusoto/services/codepipeline/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/codepipeline/README.md
+++ b/rusoto/services/codepipeline/README.md
@@ -23,7 +23,7 @@ To use `rusoto_codepipeline` in your application, add it as a dependency in your
 
 ```toml
 [dependencies]
-rusoto_codepipeline = "0.38.0"
+rusoto_codepipeline = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/codestar/Cargo.toml
+++ b/rusoto/services/codestar/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_codestar"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/codestar/Cargo.toml
+++ b/rusoto/services/codestar/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/codestar/README.md
+++ b/rusoto/services/codestar/README.md
@@ -23,7 +23,7 @@ To use `rusoto_codestar` in your application, add it as a dependency in your `Ca
 
 ```toml
 [dependencies]
-rusoto_codestar = "0.38.0"
+rusoto_codestar = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/cognito-identity/Cargo.toml
+++ b/rusoto/services/cognito-identity/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_cognito_identity"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/cognito-identity/Cargo.toml
+++ b/rusoto/services/cognito-identity/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/cognito-identity/README.md
+++ b/rusoto/services/cognito-identity/README.md
@@ -23,7 +23,7 @@ To use `rusoto_cognito_identity` in your application, add it as a dependency in 
 
 ```toml
 [dependencies]
-rusoto_cognito_identity = "0.38.0"
+rusoto_cognito_identity = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/cognito-idp/Cargo.toml
+++ b/rusoto/services/cognito-idp/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_cognito_idp"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/cognito-idp/Cargo.toml
+++ b/rusoto/services/cognito-idp/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/cognito-idp/README.md
+++ b/rusoto/services/cognito-idp/README.md
@@ -23,7 +23,7 @@ To use `rusoto_cognito_idp` in your application, add it as a dependency in your 
 
 ```toml
 [dependencies]
-rusoto_cognito_idp = "0.38.0"
+rusoto_cognito_idp = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/cognito-sync/Cargo.toml
+++ b/rusoto/services/cognito-sync/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_cognito_sync"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/cognito-sync/Cargo.toml
+++ b/rusoto/services/cognito-sync/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/cognito-sync/README.md
+++ b/rusoto/services/cognito-sync/README.md
@@ -23,7 +23,7 @@ To use `rusoto_cognito_sync` in your application, add it as a dependency in your
 
 ```toml
 [dependencies]
-rusoto_cognito_sync = "0.38.0"
+rusoto_cognito_sync = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/comprehend/Cargo.toml
+++ b/rusoto/services/comprehend/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_comprehend"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/comprehend/Cargo.toml
+++ b/rusoto/services/comprehend/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/comprehend/README.md
+++ b/rusoto/services/comprehend/README.md
@@ -23,7 +23,7 @@ To use `rusoto_comprehend` in your application, add it as a dependency in your `
 
 ```toml
 [dependencies]
-rusoto_comprehend = "0.38.0"
+rusoto_comprehend = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/comprehendmedical/Cargo.toml
+++ b/rusoto/services/comprehendmedical/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_comprehendmedical"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/comprehendmedical/Cargo.toml
+++ b/rusoto/services/comprehendmedical/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/comprehendmedical/README.md
+++ b/rusoto/services/comprehendmedical/README.md
@@ -23,7 +23,7 @@ To use `rusoto_comprehendmedical` in your application, add it as a dependency in
 
 ```toml
 [dependencies]
-rusoto_comprehendmedical = "0.38.0"
+rusoto_comprehendmedical = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/config/Cargo.toml
+++ b/rusoto/services/config/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_config"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/config/Cargo.toml
+++ b/rusoto/services/config/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/config/README.md
+++ b/rusoto/services/config/README.md
@@ -23,7 +23,7 @@ To use `rusoto_config` in your application, add it as a dependency in your `Carg
 
 ```toml
 [dependencies]
-rusoto_config = "0.38.0"
+rusoto_config = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/connect/Cargo.toml
+++ b/rusoto/services/connect/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_connect"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/connect/Cargo.toml
+++ b/rusoto/services/connect/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/connect/README.md
+++ b/rusoto/services/connect/README.md
@@ -23,7 +23,7 @@ To use `rusoto_connect` in your application, add it as a dependency in your `Car
 
 ```toml
 [dependencies]
-rusoto_connect = "0.38.0"
+rusoto_connect = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/cur/Cargo.toml
+++ b/rusoto/services/cur/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/cur/Cargo.toml
+++ b/rusoto/services/cur/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_cur"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/cur/README.md
+++ b/rusoto/services/cur/README.md
@@ -23,7 +23,7 @@ To use `rusoto_cur` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_cur = "0.38.0"
+rusoto_cur = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/datapipeline/Cargo.toml
+++ b/rusoto/services/datapipeline/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_datapipeline"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/datapipeline/Cargo.toml
+++ b/rusoto/services/datapipeline/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/datapipeline/README.md
+++ b/rusoto/services/datapipeline/README.md
@@ -23,7 +23,7 @@ To use `rusoto_datapipeline` in your application, add it as a dependency in your
 
 ```toml
 [dependencies]
-rusoto_datapipeline = "0.38.0"
+rusoto_datapipeline = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/dax/Cargo.toml
+++ b/rusoto/services/dax/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_dax"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/dax/Cargo.toml
+++ b/rusoto/services/dax/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/dax/README.md
+++ b/rusoto/services/dax/README.md
@@ -23,7 +23,7 @@ To use `rusoto_dax` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_dax = "0.38.0"
+rusoto_dax = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/devicefarm/Cargo.toml
+++ b/rusoto/services/devicefarm/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_devicefarm"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/devicefarm/Cargo.toml
+++ b/rusoto/services/devicefarm/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/devicefarm/README.md
+++ b/rusoto/services/devicefarm/README.md
@@ -23,7 +23,7 @@ To use `rusoto_devicefarm` in your application, add it as a dependency in your `
 
 ```toml
 [dependencies]
-rusoto_devicefarm = "0.38.0"
+rusoto_devicefarm = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/directconnect/Cargo.toml
+++ b/rusoto/services/directconnect/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_directconnect"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/directconnect/Cargo.toml
+++ b/rusoto/services/directconnect/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/directconnect/README.md
+++ b/rusoto/services/directconnect/README.md
@@ -23,7 +23,7 @@ To use `rusoto_directconnect` in your application, add it as a dependency in you
 
 ```toml
 [dependencies]
-rusoto_directconnect = "0.38.0"
+rusoto_directconnect = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/discovery/Cargo.toml
+++ b/rusoto/services/discovery/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_discovery"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/discovery/Cargo.toml
+++ b/rusoto/services/discovery/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/discovery/README.md
+++ b/rusoto/services/discovery/README.md
@@ -23,7 +23,7 @@ To use `rusoto_discovery` in your application, add it as a dependency in your `C
 
 ```toml
 [dependencies]
-rusoto_discovery = "0.38.0"
+rusoto_discovery = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/dms/Cargo.toml
+++ b/rusoto/services/dms/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_dms"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/dms/Cargo.toml
+++ b/rusoto/services/dms/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/dms/README.md
+++ b/rusoto/services/dms/README.md
@@ -23,7 +23,7 @@ To use `rusoto_dms` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_dms = "0.38.0"
+rusoto_dms = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/docdb/Cargo.toml
+++ b/rusoto/services/docdb/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_docdb"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -20,7 +20,7 @@ serde_urlencoded = "0.5"
 xml-rs = "0.7"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/docdb/Cargo.toml
+++ b/rusoto/services/docdb/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/docdb/README.md
+++ b/rusoto/services/docdb/README.md
@@ -23,7 +23,7 @@ To use `rusoto_docdb` in your application, add it as a dependency in your `Cargo
 
 ```toml
 [dependencies]
-rusoto_docdb = "0.38.0"
+rusoto_docdb = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/ds/Cargo.toml
+++ b/rusoto/services/ds/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_ds"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/ds/Cargo.toml
+++ b/rusoto/services/ds/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/ds/README.md
+++ b/rusoto/services/ds/README.md
@@ -23,7 +23,7 @@ To use `rusoto_ds` in your application, add it as a dependency in your `Cargo.to
 
 ```toml
 [dependencies]
-rusoto_ds = "0.38.0"
+rusoto_ds = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/dynamodb/Cargo.toml
+++ b/rusoto/services/dynamodb/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_dynamodb"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/dynamodb/Cargo.toml
+++ b/rusoto/services/dynamodb/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/dynamodb/README.md
+++ b/rusoto/services/dynamodb/README.md
@@ -23,7 +23,7 @@ To use `rusoto_dynamodb` in your application, add it as a dependency in your `Ca
 
 ```toml
 [dependencies]
-rusoto_dynamodb = "0.38.0"
+rusoto_dynamodb = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/dynamodbstreams/Cargo.toml
+++ b/rusoto/services/dynamodbstreams/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_dynamodbstreams"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/dynamodbstreams/Cargo.toml
+++ b/rusoto/services/dynamodbstreams/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/dynamodbstreams/README.md
+++ b/rusoto/services/dynamodbstreams/README.md
@@ -23,7 +23,7 @@ To use `rusoto_dynamodbstreams` in your application, add it as a dependency in y
 
 ```toml
 [dependencies]
-rusoto_dynamodbstreams = "0.38.0"
+rusoto_dynamodbstreams = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/ec2/Cargo.toml
+++ b/rusoto/services/ec2/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_ec2"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -20,7 +20,7 @@ serde_urlencoded = "0.5"
 xml-rs = "0.7"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/ec2/Cargo.toml
+++ b/rusoto/services/ec2/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/ec2/README.md
+++ b/rusoto/services/ec2/README.md
@@ -23,7 +23,7 @@ To use `rusoto_ec2` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_ec2 = "0.38.0"
+rusoto_ec2 = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/ecr/Cargo.toml
+++ b/rusoto/services/ecr/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_ecr"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/ecr/Cargo.toml
+++ b/rusoto/services/ecr/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/ecr/README.md
+++ b/rusoto/services/ecr/README.md
@@ -23,7 +23,7 @@ To use `rusoto_ecr` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_ecr = "0.38.0"
+rusoto_ecr = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/ecs/Cargo.toml
+++ b/rusoto/services/ecs/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_ecs"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/ecs/Cargo.toml
+++ b/rusoto/services/ecs/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/ecs/README.md
+++ b/rusoto/services/ecs/README.md
@@ -23,7 +23,7 @@ To use `rusoto_ecs` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_ecs = "0.38.0"
+rusoto_ecs = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/efs/Cargo.toml
+++ b/rusoto/services/efs/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_efs"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/efs/Cargo.toml
+++ b/rusoto/services/efs/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/efs/README.md
+++ b/rusoto/services/efs/README.md
@@ -23,7 +23,7 @@ To use `rusoto_efs` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_efs = "0.38.0"
+rusoto_efs = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/eks/Cargo.toml
+++ b/rusoto/services/eks/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_eks"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/eks/Cargo.toml
+++ b/rusoto/services/eks/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/eks/README.md
+++ b/rusoto/services/eks/README.md
@@ -23,7 +23,7 @@ To use `rusoto_eks` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_eks = "0.38.0"
+rusoto_eks = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/elasticache/Cargo.toml
+++ b/rusoto/services/elasticache/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_elasticache"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -20,7 +20,7 @@ serde_urlencoded = "0.5"
 xml-rs = "0.7"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/elasticache/Cargo.toml
+++ b/rusoto/services/elasticache/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/elasticache/README.md
+++ b/rusoto/services/elasticache/README.md
@@ -23,7 +23,7 @@ To use `rusoto_elasticache` in your application, add it as a dependency in your 
 
 ```toml
 [dependencies]
-rusoto_elasticache = "0.38.0"
+rusoto_elasticache = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/elasticbeanstalk/Cargo.toml
+++ b/rusoto/services/elasticbeanstalk/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/elasticbeanstalk/Cargo.toml
+++ b/rusoto/services/elasticbeanstalk/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_elasticbeanstalk"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -20,7 +20,7 @@ serde_urlencoded = "0.5"
 xml-rs = "0.7"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/elasticbeanstalk/README.md
+++ b/rusoto/services/elasticbeanstalk/README.md
@@ -23,7 +23,7 @@ To use `rusoto_elasticbeanstalk` in your application, add it as a dependency in 
 
 ```toml
 [dependencies]
-rusoto_elasticbeanstalk = "0.38.0"
+rusoto_elasticbeanstalk = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/elastictranscoder/Cargo.toml
+++ b/rusoto/services/elastictranscoder/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_elastictranscoder"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/elastictranscoder/Cargo.toml
+++ b/rusoto/services/elastictranscoder/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/elastictranscoder/README.md
+++ b/rusoto/services/elastictranscoder/README.md
@@ -23,7 +23,7 @@ To use `rusoto_elastictranscoder` in your application, add it as a dependency in
 
 ```toml
 [dependencies]
-rusoto_elastictranscoder = "0.38.0"
+rusoto_elastictranscoder = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/elb/Cargo.toml
+++ b/rusoto/services/elb/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_elb"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -20,7 +20,7 @@ serde_urlencoded = "0.5"
 xml-rs = "0.7"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/elb/Cargo.toml
+++ b/rusoto/services/elb/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/elb/README.md
+++ b/rusoto/services/elb/README.md
@@ -23,7 +23,7 @@ To use `rusoto_elb` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_elb = "0.38.0"
+rusoto_elb = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/elbv2/Cargo.toml
+++ b/rusoto/services/elbv2/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/elbv2/Cargo.toml
+++ b/rusoto/services/elbv2/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_elbv2"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -20,7 +20,7 @@ serde_urlencoded = "0.5"
 xml-rs = "0.7"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/elbv2/README.md
+++ b/rusoto/services/elbv2/README.md
@@ -23,7 +23,7 @@ To use `rusoto_elbv2` in your application, add it as a dependency in your `Cargo
 
 ```toml
 [dependencies]
-rusoto_elbv2 = "0.38.0"
+rusoto_elbv2 = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/emr/Cargo.toml
+++ b/rusoto/services/emr/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_emr"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/emr/Cargo.toml
+++ b/rusoto/services/emr/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/emr/README.md
+++ b/rusoto/services/emr/README.md
@@ -23,7 +23,7 @@ To use `rusoto_emr` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_emr = "0.38.0"
+rusoto_emr = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/events/Cargo.toml
+++ b/rusoto/services/events/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_events"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/events/Cargo.toml
+++ b/rusoto/services/events/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/events/README.md
+++ b/rusoto/services/events/README.md
@@ -23,7 +23,7 @@ To use `rusoto_events` in your application, add it as a dependency in your `Carg
 
 ```toml
 [dependencies]
-rusoto_events = "0.38.0"
+rusoto_events = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/firehose/Cargo.toml
+++ b/rusoto/services/firehose/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_firehose"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/firehose/Cargo.toml
+++ b/rusoto/services/firehose/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/firehose/README.md
+++ b/rusoto/services/firehose/README.md
@@ -23,7 +23,7 @@ To use `rusoto_firehose` in your application, add it as a dependency in your `Ca
 
 ```toml
 [dependencies]
-rusoto_firehose = "0.38.0"
+rusoto_firehose = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/fms/Cargo.toml
+++ b/rusoto/services/fms/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_fms"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/fms/Cargo.toml
+++ b/rusoto/services/fms/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/fms/README.md
+++ b/rusoto/services/fms/README.md
@@ -23,7 +23,7 @@ To use `rusoto_fms` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_fms = "0.38.0"
+rusoto_fms = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/fsx/Cargo.toml
+++ b/rusoto/services/fsx/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_fsx"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/fsx/Cargo.toml
+++ b/rusoto/services/fsx/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/fsx/README.md
+++ b/rusoto/services/fsx/README.md
@@ -23,7 +23,7 @@ To use `rusoto_fsx` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_fsx = "0.38.0"
+rusoto_fsx = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/gamelift/Cargo.toml
+++ b/rusoto/services/gamelift/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_gamelift"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/gamelift/Cargo.toml
+++ b/rusoto/services/gamelift/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/gamelift/README.md
+++ b/rusoto/services/gamelift/README.md
@@ -23,7 +23,7 @@ To use `rusoto_gamelift` in your application, add it as a dependency in your `Ca
 
 ```toml
 [dependencies]
-rusoto_gamelift = "0.38.0"
+rusoto_gamelift = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/glacier/Cargo.toml
+++ b/rusoto/services/glacier/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_glacier"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/glacier/Cargo.toml
+++ b/rusoto/services/glacier/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/glacier/README.md
+++ b/rusoto/services/glacier/README.md
@@ -23,7 +23,7 @@ To use `rusoto_glacier` in your application, add it as a dependency in your `Car
 
 ```toml
 [dependencies]
-rusoto_glacier = "0.38.0"
+rusoto_glacier = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/glue/Cargo.toml
+++ b/rusoto/services/glue/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_glue"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/glue/Cargo.toml
+++ b/rusoto/services/glue/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/glue/README.md
+++ b/rusoto/services/glue/README.md
@@ -23,7 +23,7 @@ To use `rusoto_glue` in your application, add it as a dependency in your `Cargo.
 
 ```toml
 [dependencies]
-rusoto_glue = "0.38.0"
+rusoto_glue = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/greengrass/Cargo.toml
+++ b/rusoto/services/greengrass/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_greengrass"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/greengrass/Cargo.toml
+++ b/rusoto/services/greengrass/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/greengrass/README.md
+++ b/rusoto/services/greengrass/README.md
@@ -23,7 +23,7 @@ To use `rusoto_greengrass` in your application, add it as a dependency in your `
 
 ```toml
 [dependencies]
-rusoto_greengrass = "0.38.0"
+rusoto_greengrass = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/guardduty/Cargo.toml
+++ b/rusoto/services/guardduty/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_guardduty"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/guardduty/Cargo.toml
+++ b/rusoto/services/guardduty/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/guardduty/README.md
+++ b/rusoto/services/guardduty/README.md
@@ -23,7 +23,7 @@ To use `rusoto_guardduty` in your application, add it as a dependency in your `C
 
 ```toml
 [dependencies]
-rusoto_guardduty = "0.38.0"
+rusoto_guardduty = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/health/Cargo.toml
+++ b/rusoto/services/health/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_health"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/health/Cargo.toml
+++ b/rusoto/services/health/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/health/README.md
+++ b/rusoto/services/health/README.md
@@ -23,7 +23,7 @@ To use `rusoto_health` in your application, add it as a dependency in your `Carg
 
 ```toml
 [dependencies]
-rusoto_health = "0.38.0"
+rusoto_health = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/iam/Cargo.toml
+++ b/rusoto/services/iam/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/iam/Cargo.toml
+++ b/rusoto/services/iam/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_iam"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -20,7 +20,7 @@ serde_urlencoded = "0.5"
 xml-rs = "0.7"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/iam/README.md
+++ b/rusoto/services/iam/README.md
@@ -23,7 +23,7 @@ To use `rusoto_iam` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_iam = "0.38.0"
+rusoto_iam = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/importexport/Cargo.toml
+++ b/rusoto/services/importexport/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/importexport/Cargo.toml
+++ b/rusoto/services/importexport/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_importexport"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -20,7 +20,7 @@ serde_urlencoded = "0.5"
 xml-rs = "0.7"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/importexport/README.md
+++ b/rusoto/services/importexport/README.md
@@ -23,7 +23,7 @@ To use `rusoto_importexport` in your application, add it as a dependency in your
 
 ```toml
 [dependencies]
-rusoto_importexport = "0.38.0"
+rusoto_importexport = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/inspector/Cargo.toml
+++ b/rusoto/services/inspector/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_inspector"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/inspector/Cargo.toml
+++ b/rusoto/services/inspector/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/inspector/README.md
+++ b/rusoto/services/inspector/README.md
@@ -23,7 +23,7 @@ To use `rusoto_inspector` in your application, add it as a dependency in your `C
 
 ```toml
 [dependencies]
-rusoto_inspector = "0.38.0"
+rusoto_inspector = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/iot-data/Cargo.toml
+++ b/rusoto/services/iot-data/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_iot_data"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/iot-data/Cargo.toml
+++ b/rusoto/services/iot-data/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/iot-data/README.md
+++ b/rusoto/services/iot-data/README.md
@@ -23,7 +23,7 @@ To use `rusoto_iot_data` in your application, add it as a dependency in your `Ca
 
 ```toml
 [dependencies]
-rusoto_iot_data = "0.38.0"
+rusoto_iot_data = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/iot-jobs-data/Cargo.toml
+++ b/rusoto/services/iot-jobs-data/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_iot_jobs_data"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/iot-jobs-data/Cargo.toml
+++ b/rusoto/services/iot-jobs-data/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/iot-jobs-data/README.md
+++ b/rusoto/services/iot-jobs-data/README.md
@@ -23,7 +23,7 @@ To use `rusoto_iot_jobs_data` in your application, add it as a dependency in you
 
 ```toml
 [dependencies]
-rusoto_iot_jobs_data = "0.38.0"
+rusoto_iot_jobs_data = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/iot/Cargo.toml
+++ b/rusoto/services/iot/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_iot"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/iot/Cargo.toml
+++ b/rusoto/services/iot/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/iot/README.md
+++ b/rusoto/services/iot/README.md
@@ -23,7 +23,7 @@ To use `rusoto_iot` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_iot = "0.38.0"
+rusoto_iot = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/iot1click-devices/Cargo.toml
+++ b/rusoto/services/iot1click-devices/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_iot1click_devices"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/iot1click-devices/Cargo.toml
+++ b/rusoto/services/iot1click-devices/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/iot1click-devices/README.md
+++ b/rusoto/services/iot1click-devices/README.md
@@ -23,7 +23,7 @@ To use `rusoto_iot1click_devices` in your application, add it as a dependency in
 
 ```toml
 [dependencies]
-rusoto_iot1click_devices = "0.38.0"
+rusoto_iot1click_devices = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/iot1click-projects/Cargo.toml
+++ b/rusoto/services/iot1click-projects/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_iot1click_projects"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/iot1click-projects/Cargo.toml
+++ b/rusoto/services/iot1click-projects/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/iot1click-projects/README.md
+++ b/rusoto/services/iot1click-projects/README.md
@@ -23,7 +23,7 @@ To use `rusoto_iot1click_projects` in your application, add it as a dependency i
 
 ```toml
 [dependencies]
-rusoto_iot1click_projects = "0.38.0"
+rusoto_iot1click_projects = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/iotanalytics/Cargo.toml
+++ b/rusoto/services/iotanalytics/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_iotanalytics"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/iotanalytics/Cargo.toml
+++ b/rusoto/services/iotanalytics/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/iotanalytics/README.md
+++ b/rusoto/services/iotanalytics/README.md
@@ -23,7 +23,7 @@ To use `rusoto_iotanalytics` in your application, add it as a dependency in your
 
 ```toml
 [dependencies]
-rusoto_iotanalytics = "0.38.0"
+rusoto_iotanalytics = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/kafka/Cargo.toml
+++ b/rusoto/services/kafka/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_kafka"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/kafka/Cargo.toml
+++ b/rusoto/services/kafka/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/kafka/README.md
+++ b/rusoto/services/kafka/README.md
@@ -23,7 +23,7 @@ To use `rusoto_kafka` in your application, add it as a dependency in your `Cargo
 
 ```toml
 [dependencies]
-rusoto_kafka = "0.38.0"
+rusoto_kafka = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/kinesis-video-archived-media/Cargo.toml
+++ b/rusoto/services/kinesis-video-archived-media/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_kinesis_video_archived_media"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/kinesis-video-archived-media/Cargo.toml
+++ b/rusoto/services/kinesis-video-archived-media/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/kinesis-video-archived-media/README.md
+++ b/rusoto/services/kinesis-video-archived-media/README.md
@@ -23,7 +23,7 @@ To use `rusoto_kinesis_video_archived_media` in your application, add it as a de
 
 ```toml
 [dependencies]
-rusoto_kinesis_video_archived_media = "0.38.0"
+rusoto_kinesis_video_archived_media = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/kinesis-video-media/Cargo.toml
+++ b/rusoto/services/kinesis-video-media/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_kinesis_video_media"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/kinesis-video-media/Cargo.toml
+++ b/rusoto/services/kinesis-video-media/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/kinesis-video-media/README.md
+++ b/rusoto/services/kinesis-video-media/README.md
@@ -23,7 +23,7 @@ To use `rusoto_kinesis_video_media` in your application, add it as a dependency 
 
 ```toml
 [dependencies]
-rusoto_kinesis_video_media = "0.38.0"
+rusoto_kinesis_video_media = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/kinesis/Cargo.toml
+++ b/rusoto/services/kinesis/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_kinesis"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/kinesis/Cargo.toml
+++ b/rusoto/services/kinesis/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/kinesis/README.md
+++ b/rusoto/services/kinesis/README.md
@@ -23,7 +23,7 @@ To use `rusoto_kinesis` in your application, add it as a dependency in your `Car
 
 ```toml
 [dependencies]
-rusoto_kinesis = "0.38.0"
+rusoto_kinesis = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/kinesisanalytics/Cargo.toml
+++ b/rusoto/services/kinesisanalytics/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_kinesisanalytics"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/kinesisanalytics/Cargo.toml
+++ b/rusoto/services/kinesisanalytics/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/kinesisanalytics/README.md
+++ b/rusoto/services/kinesisanalytics/README.md
@@ -23,7 +23,7 @@ To use `rusoto_kinesisanalytics` in your application, add it as a dependency in 
 
 ```toml
 [dependencies]
-rusoto_kinesisanalytics = "0.38.0"
+rusoto_kinesisanalytics = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/kinesisvideo/Cargo.toml
+++ b/rusoto/services/kinesisvideo/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_kinesisvideo"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/kinesisvideo/Cargo.toml
+++ b/rusoto/services/kinesisvideo/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/kinesisvideo/README.md
+++ b/rusoto/services/kinesisvideo/README.md
@@ -23,7 +23,7 @@ To use `rusoto_kinesisvideo` in your application, add it as a dependency in your
 
 ```toml
 [dependencies]
-rusoto_kinesisvideo = "0.38.0"
+rusoto_kinesisvideo = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/kms/Cargo.toml
+++ b/rusoto/services/kms/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_kms"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/kms/Cargo.toml
+++ b/rusoto/services/kms/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/kms/README.md
+++ b/rusoto/services/kms/README.md
@@ -23,7 +23,7 @@ To use `rusoto_kms` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_kms = "0.38.0"
+rusoto_kms = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/lambda/Cargo.toml
+++ b/rusoto/services/lambda/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_lambda"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/lambda/Cargo.toml
+++ b/rusoto/services/lambda/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/lambda/README.md
+++ b/rusoto/services/lambda/README.md
@@ -23,7 +23,7 @@ To use `rusoto_lambda` in your application, add it as a dependency in your `Carg
 
 ```toml
 [dependencies]
-rusoto_lambda = "0.38.0"
+rusoto_lambda = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/lex-models/Cargo.toml
+++ b/rusoto/services/lex-models/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_lex_models"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/lex-models/Cargo.toml
+++ b/rusoto/services/lex-models/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/lex-models/README.md
+++ b/rusoto/services/lex-models/README.md
@@ -23,7 +23,7 @@ To use `rusoto_lex_models` in your application, add it as a dependency in your `
 
 ```toml
 [dependencies]
-rusoto_lex_models = "0.38.0"
+rusoto_lex_models = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/lex-runtime/Cargo.toml
+++ b/rusoto/services/lex-runtime/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_lex_runtime"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/lex-runtime/Cargo.toml
+++ b/rusoto/services/lex-runtime/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/lex-runtime/README.md
+++ b/rusoto/services/lex-runtime/README.md
@@ -23,7 +23,7 @@ To use `rusoto_lex_runtime` in your application, add it as a dependency in your 
 
 ```toml
 [dependencies]
-rusoto_lex_runtime = "0.38.0"
+rusoto_lex_runtime = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/license-manager/Cargo.toml
+++ b/rusoto/services/license-manager/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_license_manager"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/license-manager/Cargo.toml
+++ b/rusoto/services/license-manager/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/license-manager/README.md
+++ b/rusoto/services/license-manager/README.md
@@ -23,7 +23,7 @@ To use `rusoto_license_manager` in your application, add it as a dependency in y
 
 ```toml
 [dependencies]
-rusoto_license_manager = "0.38.0"
+rusoto_license_manager = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/lightsail/Cargo.toml
+++ b/rusoto/services/lightsail/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_lightsail"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/lightsail/Cargo.toml
+++ b/rusoto/services/lightsail/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/lightsail/README.md
+++ b/rusoto/services/lightsail/README.md
@@ -23,7 +23,7 @@ To use `rusoto_lightsail` in your application, add it as a dependency in your `C
 
 ```toml
 [dependencies]
-rusoto_lightsail = "0.38.0"
+rusoto_lightsail = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/logs/Cargo.toml
+++ b/rusoto/services/logs/Cargo.toml
@@ -29,7 +29,7 @@ default-features = false
 chrono = "0.4"
 
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/logs/Cargo.toml
+++ b/rusoto/services/logs/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_logs"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 

--- a/rusoto/services/logs/README.md
+++ b/rusoto/services/logs/README.md
@@ -23,7 +23,7 @@ To use `rusoto_logs` in your application, add it as a dependency in your `Cargo.
 
 ```toml
 [dependencies]
-rusoto_logs = "0.38.0"
+rusoto_logs = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/machinelearning/Cargo.toml
+++ b/rusoto/services/machinelearning/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_machinelearning"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/machinelearning/Cargo.toml
+++ b/rusoto/services/machinelearning/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/machinelearning/README.md
+++ b/rusoto/services/machinelearning/README.md
@@ -23,7 +23,7 @@ To use `rusoto_machinelearning` in your application, add it as a dependency in y
 
 ```toml
 [dependencies]
-rusoto_machinelearning = "0.38.0"
+rusoto_machinelearning = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/macie/Cargo.toml
+++ b/rusoto/services/macie/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_macie"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/macie/Cargo.toml
+++ b/rusoto/services/macie/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/macie/README.md
+++ b/rusoto/services/macie/README.md
@@ -23,7 +23,7 @@ To use `rusoto_macie` in your application, add it as a dependency in your `Cargo
 
 ```toml
 [dependencies]
-rusoto_macie = "0.38.0"
+rusoto_macie = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/marketplace-entitlement/Cargo.toml
+++ b/rusoto/services/marketplace-entitlement/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_marketplace_entitlement"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/marketplace-entitlement/Cargo.toml
+++ b/rusoto/services/marketplace-entitlement/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/marketplace-entitlement/README.md
+++ b/rusoto/services/marketplace-entitlement/README.md
@@ -23,7 +23,7 @@ To use `rusoto_marketplace_entitlement` in your application, add it as a depende
 
 ```toml
 [dependencies]
-rusoto_marketplace_entitlement = "0.38.0"
+rusoto_marketplace_entitlement = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/marketplacecommerceanalytics/Cargo.toml
+++ b/rusoto/services/marketplacecommerceanalytics/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_marketplacecommerceanalytics"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/marketplacecommerceanalytics/Cargo.toml
+++ b/rusoto/services/marketplacecommerceanalytics/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/marketplacecommerceanalytics/README.md
+++ b/rusoto/services/marketplacecommerceanalytics/README.md
@@ -23,7 +23,7 @@ To use `rusoto_marketplacecommerceanalytics` in your application, add it as a de
 
 ```toml
 [dependencies]
-rusoto_marketplacecommerceanalytics = "0.38.0"
+rusoto_marketplacecommerceanalytics = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/mediaconvert/Cargo.toml
+++ b/rusoto/services/mediaconvert/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_mediaconvert"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/mediaconvert/Cargo.toml
+++ b/rusoto/services/mediaconvert/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/mediaconvert/README.md
+++ b/rusoto/services/mediaconvert/README.md
@@ -23,7 +23,7 @@ To use `rusoto_mediaconvert` in your application, add it as a dependency in your
 
 ```toml
 [dependencies]
-rusoto_mediaconvert = "0.38.0"
+rusoto_mediaconvert = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/medialive/Cargo.toml
+++ b/rusoto/services/medialive/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_medialive"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/medialive/Cargo.toml
+++ b/rusoto/services/medialive/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/medialive/README.md
+++ b/rusoto/services/medialive/README.md
@@ -23,7 +23,7 @@ To use `rusoto_medialive` in your application, add it as a dependency in your `C
 
 ```toml
 [dependencies]
-rusoto_medialive = "0.38.0"
+rusoto_medialive = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/mediapackage/Cargo.toml
+++ b/rusoto/services/mediapackage/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_mediapackage"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/mediapackage/Cargo.toml
+++ b/rusoto/services/mediapackage/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/mediapackage/README.md
+++ b/rusoto/services/mediapackage/README.md
@@ -23,7 +23,7 @@ To use `rusoto_mediapackage` in your application, add it as a dependency in your
 
 ```toml
 [dependencies]
-rusoto_mediapackage = "0.38.0"
+rusoto_mediapackage = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/mediastore/Cargo.toml
+++ b/rusoto/services/mediastore/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_mediastore"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/mediastore/Cargo.toml
+++ b/rusoto/services/mediastore/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/mediastore/README.md
+++ b/rusoto/services/mediastore/README.md
@@ -23,7 +23,7 @@ To use `rusoto_mediastore` in your application, add it as a dependency in your `
 
 ```toml
 [dependencies]
-rusoto_mediastore = "0.38.0"
+rusoto_mediastore = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/mediatailor/Cargo.toml
+++ b/rusoto/services/mediatailor/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_mediatailor"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/mediatailor/Cargo.toml
+++ b/rusoto/services/mediatailor/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/mediatailor/README.md
+++ b/rusoto/services/mediatailor/README.md
@@ -23,7 +23,7 @@ To use `rusoto_mediatailor` in your application, add it as a dependency in your 
 
 ```toml
 [dependencies]
-rusoto_mediatailor = "0.38.0"
+rusoto_mediatailor = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/meteringmarketplace/Cargo.toml
+++ b/rusoto/services/meteringmarketplace/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_meteringmarketplace"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/meteringmarketplace/Cargo.toml
+++ b/rusoto/services/meteringmarketplace/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/meteringmarketplace/README.md
+++ b/rusoto/services/meteringmarketplace/README.md
@@ -23,7 +23,7 @@ To use `rusoto_meteringmarketplace` in your application, add it as a dependency 
 
 ```toml
 [dependencies]
-rusoto_meteringmarketplace = "0.38.0"
+rusoto_meteringmarketplace = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/mgh/Cargo.toml
+++ b/rusoto/services/mgh/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_mgh"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/mgh/Cargo.toml
+++ b/rusoto/services/mgh/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/mgh/README.md
+++ b/rusoto/services/mgh/README.md
@@ -23,7 +23,7 @@ To use `rusoto_mgh` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_mgh = "0.38.0"
+rusoto_mgh = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/mobile/Cargo.toml
+++ b/rusoto/services/mobile/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_mobile"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/mobile/Cargo.toml
+++ b/rusoto/services/mobile/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/mobile/README.md
+++ b/rusoto/services/mobile/README.md
@@ -23,7 +23,7 @@ To use `rusoto_mobile` in your application, add it as a dependency in your `Carg
 
 ```toml
 [dependencies]
-rusoto_mobile = "0.38.0"
+rusoto_mobile = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/mq/Cargo.toml
+++ b/rusoto/services/mq/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_mq"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/mq/Cargo.toml
+++ b/rusoto/services/mq/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/mq/README.md
+++ b/rusoto/services/mq/README.md
@@ -23,7 +23,7 @@ To use `rusoto_mq` in your application, add it as a dependency in your `Cargo.to
 
 ```toml
 [dependencies]
-rusoto_mq = "0.38.0"
+rusoto_mq = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/mturk/Cargo.toml
+++ b/rusoto/services/mturk/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_mturk"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/mturk/Cargo.toml
+++ b/rusoto/services/mturk/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/mturk/README.md
+++ b/rusoto/services/mturk/README.md
@@ -23,7 +23,7 @@ To use `rusoto_mturk` in your application, add it as a dependency in your `Cargo
 
 ```toml
 [dependencies]
-rusoto_mturk = "0.38.0"
+rusoto_mturk = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/neptune/Cargo.toml
+++ b/rusoto/services/neptune/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/neptune/Cargo.toml
+++ b/rusoto/services/neptune/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_neptune"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -20,7 +20,7 @@ serde_urlencoded = "0.5"
 xml-rs = "0.7"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/neptune/README.md
+++ b/rusoto/services/neptune/README.md
@@ -23,7 +23,7 @@ To use `rusoto_neptune` in your application, add it as a dependency in your `Car
 
 ```toml
 [dependencies]
-rusoto_neptune = "0.38.0"
+rusoto_neptune = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/opsworks/Cargo.toml
+++ b/rusoto/services/opsworks/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_opsworks"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/opsworks/Cargo.toml
+++ b/rusoto/services/opsworks/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/opsworks/README.md
+++ b/rusoto/services/opsworks/README.md
@@ -23,7 +23,7 @@ To use `rusoto_opsworks` in your application, add it as a dependency in your `Ca
 
 ```toml
 [dependencies]
-rusoto_opsworks = "0.38.0"
+rusoto_opsworks = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/opsworkscm/Cargo.toml
+++ b/rusoto/services/opsworkscm/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_opsworkscm"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/opsworkscm/Cargo.toml
+++ b/rusoto/services/opsworkscm/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/opsworkscm/README.md
+++ b/rusoto/services/opsworkscm/README.md
@@ -23,7 +23,7 @@ To use `rusoto_opsworkscm` in your application, add it as a dependency in your `
 
 ```toml
 [dependencies]
-rusoto_opsworkscm = "0.38.0"
+rusoto_opsworkscm = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/organizations/Cargo.toml
+++ b/rusoto/services/organizations/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_organizations"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/organizations/Cargo.toml
+++ b/rusoto/services/organizations/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/organizations/README.md
+++ b/rusoto/services/organizations/README.md
@@ -23,7 +23,7 @@ To use `rusoto_organizations` in your application, add it as a dependency in you
 
 ```toml
 [dependencies]
-rusoto_organizations = "0.38.0"
+rusoto_organizations = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/pi/Cargo.toml
+++ b/rusoto/services/pi/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_pi"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/pi/Cargo.toml
+++ b/rusoto/services/pi/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/pi/README.md
+++ b/rusoto/services/pi/README.md
@@ -23,7 +23,7 @@ To use `rusoto_pi` in your application, add it as a dependency in your `Cargo.to
 
 ```toml
 [dependencies]
-rusoto_pi = "0.38.0"
+rusoto_pi = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/polly/Cargo.toml
+++ b/rusoto/services/polly/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_polly"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/polly/Cargo.toml
+++ b/rusoto/services/polly/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/polly/README.md
+++ b/rusoto/services/polly/README.md
@@ -23,7 +23,7 @@ To use `rusoto_polly` in your application, add it as a dependency in your `Cargo
 
 ```toml
 [dependencies]
-rusoto_polly = "0.38.0"
+rusoto_polly = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/pricing/Cargo.toml
+++ b/rusoto/services/pricing/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_pricing"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/pricing/Cargo.toml
+++ b/rusoto/services/pricing/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/pricing/README.md
+++ b/rusoto/services/pricing/README.md
@@ -23,7 +23,7 @@ To use `rusoto_pricing` in your application, add it as a dependency in your `Car
 
 ```toml
 [dependencies]
-rusoto_pricing = "0.38.0"
+rusoto_pricing = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/ram/Cargo.toml
+++ b/rusoto/services/ram/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_ram"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/ram/Cargo.toml
+++ b/rusoto/services/ram/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/ram/README.md
+++ b/rusoto/services/ram/README.md
@@ -23,7 +23,7 @@ To use `rusoto_ram` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_ram = "0.38.0"
+rusoto_ram = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/rds-data/Cargo.toml
+++ b/rusoto/services/rds-data/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_rds_data"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/rds-data/Cargo.toml
+++ b/rusoto/services/rds-data/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/rds-data/README.md
+++ b/rusoto/services/rds-data/README.md
@@ -23,7 +23,7 @@ To use `rusoto_rds_data` in your application, add it as a dependency in your `Ca
 
 ```toml
 [dependencies]
-rusoto_rds_data = "0.38.0"
+rusoto_rds_data = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/rds/Cargo.toml
+++ b/rusoto/services/rds/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_rds"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -20,7 +20,7 @@ serde_urlencoded = "0.5"
 xml-rs = "0.7"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/rds/Cargo.toml
+++ b/rusoto/services/rds/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/rds/README.md
+++ b/rusoto/services/rds/README.md
@@ -23,7 +23,7 @@ To use `rusoto_rds` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_rds = "0.38.0"
+rusoto_rds = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/redshift/Cargo.toml
+++ b/rusoto/services/redshift/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/redshift/Cargo.toml
+++ b/rusoto/services/redshift/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_redshift"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -20,7 +20,7 @@ serde_urlencoded = "0.5"
 xml-rs = "0.7"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/redshift/README.md
+++ b/rusoto/services/redshift/README.md
@@ -23,7 +23,7 @@ To use `rusoto_redshift` in your application, add it as a dependency in your `Ca
 
 ```toml
 [dependencies]
-rusoto_redshift = "0.38.0"
+rusoto_redshift = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/rekognition/Cargo.toml
+++ b/rusoto/services/rekognition/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/rekognition/Cargo.toml
+++ b/rusoto/services/rekognition/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_rekognition"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/rekognition/README.md
+++ b/rusoto/services/rekognition/README.md
@@ -23,7 +23,7 @@ To use `rusoto_rekognition` in your application, add it as a dependency in your 
 
 ```toml
 [dependencies]
-rusoto_rekognition = "0.38.0"
+rusoto_rekognition = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/resource-groups/Cargo.toml
+++ b/rusoto/services/resource-groups/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_resource_groups"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/resource-groups/Cargo.toml
+++ b/rusoto/services/resource-groups/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/resource-groups/README.md
+++ b/rusoto/services/resource-groups/README.md
@@ -23,7 +23,7 @@ To use `rusoto_resource_groups` in your application, add it as a dependency in y
 
 ```toml
 [dependencies]
-rusoto_resource_groups = "0.38.0"
+rusoto_resource_groups = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/resourcegroupstaggingapi/Cargo.toml
+++ b/rusoto/services/resourcegroupstaggingapi/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_resourcegroupstaggingapi"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/resourcegroupstaggingapi/Cargo.toml
+++ b/rusoto/services/resourcegroupstaggingapi/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/resourcegroupstaggingapi/README.md
+++ b/rusoto/services/resourcegroupstaggingapi/README.md
@@ -23,7 +23,7 @@ To use `rusoto_resourcegroupstaggingapi` in your application, add it as a depend
 
 ```toml
 [dependencies]
-rusoto_resourcegroupstaggingapi = "0.38.0"
+rusoto_resourcegroupstaggingapi = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/route53/Cargo.toml
+++ b/rusoto/services/route53/Cargo.toml
@@ -23,7 +23,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/route53/Cargo.toml
+++ b/rusoto/services/route53/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_route53"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -19,7 +19,7 @@ futures = "0.1.16"
 xml-rs = "0.7"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/route53/README.md
+++ b/rusoto/services/route53/README.md
@@ -23,7 +23,7 @@ To use `rusoto_route53` in your application, add it as a dependency in your `Car
 
 ```toml
 [dependencies]
-rusoto_route53 = "0.38.0"
+rusoto_route53 = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/route53domains/Cargo.toml
+++ b/rusoto/services/route53domains/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_route53domains"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/route53domains/Cargo.toml
+++ b/rusoto/services/route53domains/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/route53domains/README.md
+++ b/rusoto/services/route53domains/README.md
@@ -23,7 +23,7 @@ To use `rusoto_route53domains` in your application, add it as a dependency in yo
 
 ```toml
 [dependencies]
-rusoto_route53domains = "0.38.0"
+rusoto_route53domains = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/s3/Cargo.toml
+++ b/rusoto/services/s3/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_s3"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -19,7 +19,7 @@ futures = "0.1.16"
 xml-rs = "0.7"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/s3/Cargo.toml
+++ b/rusoto/services/s3/Cargo.toml
@@ -23,7 +23,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/s3/README.md
+++ b/rusoto/services/s3/README.md
@@ -23,7 +23,7 @@ To use `rusoto_s3` in your application, add it as a dependency in your `Cargo.to
 
 ```toml
 [dependencies]
-rusoto_s3 = "0.38.0"
+rusoto_s3 = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/sagemaker-runtime/Cargo.toml
+++ b/rusoto/services/sagemaker-runtime/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_sagemaker_runtime"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/sagemaker-runtime/Cargo.toml
+++ b/rusoto/services/sagemaker-runtime/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/sagemaker-runtime/README.md
+++ b/rusoto/services/sagemaker-runtime/README.md
@@ -23,7 +23,7 @@ To use `rusoto_sagemaker_runtime` in your application, add it as a dependency in
 
 ```toml
 [dependencies]
-rusoto_sagemaker_runtime = "0.38.0"
+rusoto_sagemaker_runtime = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/sagemaker/Cargo.toml
+++ b/rusoto/services/sagemaker/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_sagemaker"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/sagemaker/Cargo.toml
+++ b/rusoto/services/sagemaker/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/sagemaker/README.md
+++ b/rusoto/services/sagemaker/README.md
@@ -23,7 +23,7 @@ To use `rusoto_sagemaker` in your application, add it as a dependency in your `C
 
 ```toml
 [dependencies]
-rusoto_sagemaker = "0.38.0"
+rusoto_sagemaker = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/sdb/Cargo.toml
+++ b/rusoto/services/sdb/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_sdb"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -20,7 +20,7 @@ serde_urlencoded = "0.5"
 xml-rs = "0.7"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/sdb/Cargo.toml
+++ b/rusoto/services/sdb/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/sdb/README.md
+++ b/rusoto/services/sdb/README.md
@@ -23,7 +23,7 @@ To use `rusoto_sdb` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_sdb = "0.38.0"
+rusoto_sdb = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/secretsmanager/Cargo.toml
+++ b/rusoto/services/secretsmanager/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_secretsmanager"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/secretsmanager/Cargo.toml
+++ b/rusoto/services/secretsmanager/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/secretsmanager/README.md
+++ b/rusoto/services/secretsmanager/README.md
@@ -23,7 +23,7 @@ To use `rusoto_secretsmanager` in your application, add it as a dependency in yo
 
 ```toml
 [dependencies]
-rusoto_secretsmanager = "0.38.0"
+rusoto_secretsmanager = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/serverlessrepo/Cargo.toml
+++ b/rusoto/services/serverlessrepo/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_serverlessrepo"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/serverlessrepo/Cargo.toml
+++ b/rusoto/services/serverlessrepo/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/serverlessrepo/README.md
+++ b/rusoto/services/serverlessrepo/README.md
@@ -23,7 +23,7 @@ To use `rusoto_serverlessrepo` in your application, add it as a dependency in yo
 
 ```toml
 [dependencies]
-rusoto_serverlessrepo = "0.38.0"
+rusoto_serverlessrepo = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/servicecatalog/Cargo.toml
+++ b/rusoto/services/servicecatalog/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_servicecatalog"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/servicecatalog/Cargo.toml
+++ b/rusoto/services/servicecatalog/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/servicecatalog/README.md
+++ b/rusoto/services/servicecatalog/README.md
@@ -23,7 +23,7 @@ To use `rusoto_servicecatalog` in your application, add it as a dependency in yo
 
 ```toml
 [dependencies]
-rusoto_servicecatalog = "0.38.0"
+rusoto_servicecatalog = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/servicediscovery/Cargo.toml
+++ b/rusoto/services/servicediscovery/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_servicediscovery"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/servicediscovery/Cargo.toml
+++ b/rusoto/services/servicediscovery/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/servicediscovery/README.md
+++ b/rusoto/services/servicediscovery/README.md
@@ -23,7 +23,7 @@ To use `rusoto_servicediscovery` in your application, add it as a dependency in 
 
 ```toml
 [dependencies]
-rusoto_servicediscovery = "0.38.0"
+rusoto_servicediscovery = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/ses/Cargo.toml
+++ b/rusoto/services/ses/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_ses"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -20,7 +20,7 @@ serde_urlencoded = "0.5"
 xml-rs = "0.7"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/ses/Cargo.toml
+++ b/rusoto/services/ses/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/ses/README.md
+++ b/rusoto/services/ses/README.md
@@ -23,7 +23,7 @@ To use `rusoto_ses` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_ses = "0.38.0"
+rusoto_ses = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/shield/Cargo.toml
+++ b/rusoto/services/shield/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_shield"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/shield/Cargo.toml
+++ b/rusoto/services/shield/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/shield/README.md
+++ b/rusoto/services/shield/README.md
@@ -23,7 +23,7 @@ To use `rusoto_shield` in your application, add it as a dependency in your `Carg
 
 ```toml
 [dependencies]
-rusoto_shield = "0.38.0"
+rusoto_shield = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/sms/Cargo.toml
+++ b/rusoto/services/sms/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_sms"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/sms/Cargo.toml
+++ b/rusoto/services/sms/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/sms/README.md
+++ b/rusoto/services/sms/README.md
@@ -23,7 +23,7 @@ To use `rusoto_sms` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_sms = "0.38.0"
+rusoto_sms = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/snowball/Cargo.toml
+++ b/rusoto/services/snowball/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_snowball"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/snowball/Cargo.toml
+++ b/rusoto/services/snowball/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/snowball/README.md
+++ b/rusoto/services/snowball/README.md
@@ -23,7 +23,7 @@ To use `rusoto_snowball` in your application, add it as a dependency in your `Ca
 
 ```toml
 [dependencies]
-rusoto_snowball = "0.38.0"
+rusoto_snowball = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/sns/Cargo.toml
+++ b/rusoto/services/sns/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_sns"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -20,7 +20,7 @@ serde_urlencoded = "0.5"
 xml-rs = "0.7"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/sns/Cargo.toml
+++ b/rusoto/services/sns/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/sns/README.md
+++ b/rusoto/services/sns/README.md
@@ -23,7 +23,7 @@ To use `rusoto_sns` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_sns = "0.38.0"
+rusoto_sns = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/sqs/Cargo.toml
+++ b/rusoto/services/sqs/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_sqs"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -20,7 +20,7 @@ serde_urlencoded = "0.5"
 xml-rs = "0.7"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/sqs/Cargo.toml
+++ b/rusoto/services/sqs/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/sqs/README.md
+++ b/rusoto/services/sqs/README.md
@@ -23,7 +23,7 @@ To use `rusoto_sqs` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_sqs = "0.38.0"
+rusoto_sqs = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/ssm/Cargo.toml
+++ b/rusoto/services/ssm/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_ssm"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/ssm/Cargo.toml
+++ b/rusoto/services/ssm/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/ssm/README.md
+++ b/rusoto/services/ssm/README.md
@@ -23,7 +23,7 @@ To use `rusoto_ssm` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_ssm = "0.38.0"
+rusoto_ssm = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/stepfunctions/Cargo.toml
+++ b/rusoto/services/stepfunctions/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_stepfunctions"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/stepfunctions/Cargo.toml
+++ b/rusoto/services/stepfunctions/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/stepfunctions/README.md
+++ b/rusoto/services/stepfunctions/README.md
@@ -23,7 +23,7 @@ To use `rusoto_stepfunctions` in your application, add it as a dependency in you
 
 ```toml
 [dependencies]
-rusoto_stepfunctions = "0.38.0"
+rusoto_stepfunctions = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/storagegateway/Cargo.toml
+++ b/rusoto/services/storagegateway/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_storagegateway"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/storagegateway/Cargo.toml
+++ b/rusoto/services/storagegateway/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/storagegateway/README.md
+++ b/rusoto/services/storagegateway/README.md
@@ -23,7 +23,7 @@ To use `rusoto_storagegateway` in your application, add it as a dependency in yo
 
 ```toml
 [dependencies]
-rusoto_storagegateway = "0.38.0"
+rusoto_storagegateway = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/sts/Cargo.toml
+++ b/rusoto/services/sts/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_sts"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_urlencoded = "0.5"
 xml-rs = "0.7"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/sts/Cargo.toml
+++ b/rusoto/services/sts/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/sts/README.md
+++ b/rusoto/services/sts/README.md
@@ -23,7 +23,7 @@ To use `rusoto_sts` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_sts = "0.38.0"
+rusoto_sts = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/support/Cargo.toml
+++ b/rusoto/services/support/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_support"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/support/Cargo.toml
+++ b/rusoto/services/support/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/support/README.md
+++ b/rusoto/services/support/README.md
@@ -23,7 +23,7 @@ To use `rusoto_support` in your application, add it as a dependency in your `Car
 
 ```toml
 [dependencies]
-rusoto_support = "0.38.0"
+rusoto_support = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/swf/Cargo.toml
+++ b/rusoto/services/swf/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_swf"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/swf/Cargo.toml
+++ b/rusoto/services/swf/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/swf/README.md
+++ b/rusoto/services/swf/README.md
@@ -23,7 +23,7 @@ To use `rusoto_swf` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_swf = "0.38.0"
+rusoto_swf = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/transcribe/Cargo.toml
+++ b/rusoto/services/transcribe/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_transcribe"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/transcribe/Cargo.toml
+++ b/rusoto/services/transcribe/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/transcribe/README.md
+++ b/rusoto/services/transcribe/README.md
@@ -23,7 +23,7 @@ To use `rusoto_transcribe` in your application, add it as a dependency in your `
 
 ```toml
 [dependencies]
-rusoto_transcribe = "0.38.0"
+rusoto_transcribe = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/translate/Cargo.toml
+++ b/rusoto/services/translate/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_translate"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/translate/Cargo.toml
+++ b/rusoto/services/translate/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/translate/README.md
+++ b/rusoto/services/translate/README.md
@@ -23,7 +23,7 @@ To use `rusoto_translate` in your application, add it as a dependency in your `C
 
 ```toml
 [dependencies]
-rusoto_translate = "0.38.0"
+rusoto_translate = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/waf-regional/Cargo.toml
+++ b/rusoto/services/waf-regional/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_waf_regional"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/waf-regional/Cargo.toml
+++ b/rusoto/services/waf-regional/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/waf-regional/README.md
+++ b/rusoto/services/waf-regional/README.md
@@ -23,7 +23,7 @@ To use `rusoto_waf_regional` in your application, add it as a dependency in your
 
 ```toml
 [dependencies]
-rusoto_waf_regional = "0.38.0"
+rusoto_waf_regional = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/waf/Cargo.toml
+++ b/rusoto/services/waf/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_waf"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/waf/Cargo.toml
+++ b/rusoto/services/waf/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/waf/README.md
+++ b/rusoto/services/waf/README.md
@@ -23,7 +23,7 @@ To use `rusoto_waf` in your application, add it as a dependency in your `Cargo.t
 
 ```toml
 [dependencies]
-rusoto_waf = "0.38.0"
+rusoto_waf = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/workdocs/Cargo.toml
+++ b/rusoto/services/workdocs/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_workdocs"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/workdocs/Cargo.toml
+++ b/rusoto/services/workdocs/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/workdocs/README.md
+++ b/rusoto/services/workdocs/README.md
@@ -23,7 +23,7 @@ To use `rusoto_workdocs` in your application, add it as a dependency in your `Ca
 
 ```toml
 [dependencies]
-rusoto_workdocs = "0.38.0"
+rusoto_workdocs = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/worklink/Cargo.toml
+++ b/rusoto/services/worklink/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_worklink"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/worklink/Cargo.toml
+++ b/rusoto/services/worklink/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/worklink/README.md
+++ b/rusoto/services/worklink/README.md
@@ -23,7 +23,7 @@ To use `rusoto_worklink` in your application, add it as a dependency in your `Ca
 
 ```toml
 [dependencies]
-rusoto_worklink = "0.38.0"
+rusoto_worklink = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/workmail/Cargo.toml
+++ b/rusoto/services/workmail/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_workmail"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/workmail/Cargo.toml
+++ b/rusoto/services/workmail/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/workmail/README.md
+++ b/rusoto/services/workmail/README.md
@@ -23,7 +23,7 @@ To use `rusoto_workmail` in your application, add it as a dependency in your `Ca
 
 ```toml
 [dependencies]
-rusoto_workmail = "0.38.0"
+rusoto_workmail = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/workspaces/Cargo.toml
+++ b/rusoto/services/workspaces/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_workspaces"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/workspaces/Cargo.toml
+++ b/rusoto/services/workspaces/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/workspaces/README.md
+++ b/rusoto/services/workspaces/README.md
@@ -23,7 +23,7 @@ To use `rusoto_workspaces` in your application, add it as a dependency in your `
 
 ```toml
 [dependencies]
-rusoto_workspaces = "0.38.0"
+rusoto_workspaces = "0.39.0"
 ```
 
 ## Contributing

--- a/rusoto/services/xray/Cargo.toml
+++ b/rusoto/services/xray/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]
-version = "0.31.0"
+version = "0.39.0"
 path = "../../../mock"
 
 [features]

--- a/rusoto/services/xray/Cargo.toml
+++ b/rusoto/services/xray/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "rusoto_xray"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.38.0"
+version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
 
@@ -21,7 +21,7 @@ serde_derive = "1.0.2"
 serde_json = "1.0.1"
 
 [dependencies.rusoto_core]
-version = "0.38.0"
+version = "0.39.0"
 path = "../../core"
 default-features = false
 [dev-dependencies.rusoto_mock]

--- a/rusoto/services/xray/README.md
+++ b/rusoto/services/xray/README.md
@@ -23,7 +23,7 @@ To use `rusoto_xray` in your application, add it as a dependency in your `Cargo.
 
 ```toml
 [dependencies]
-rusoto_xray = "0.38.0"
+rusoto_xray = "0.39.0"
 ```
 
 ## Contributing

--- a/service_crategen/services.json
+++ b/service_crategen/services.json
@@ -1,559 +1,559 @@
 {
   "acm": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2015-12-08",
     "baseTypeName": "Acm"
   },
   "acm-pca": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-08-22",
     "baseTypeName": "AcmPca"
   },
   "alexaforbusiness": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-11-09",
     "baseTypeName": "AlexaForBusiness"
   },
   "amplify": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-07-25",
     "baseTypeName": "Amplify"
   },
   "apigateway": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2015-07-09",
     "baseTypeName": "ApiGateway"
   },
   "apigatewaymanagementapi": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2018-11-29",
     "baseTypeName": "ApiGatewayManagementApi"
   },
   "apigatewayv2": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2018-11-29",
     "baseTypeName": "ApiGatewayV2"
   },
   "application-autoscaling": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-02-06",
     "baseTypeName": "ApplicationAutoScaling"
   },
   "appstream": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-12-01",
     "baseTypeName": "AppStream"
   },
   "appsync": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-07-25",
     "baseTypeName": "AppSync"
   },
   "athena": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-05-18",
     "baseTypeName": "Athena"
   },
   "autoscaling": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2011-01-01",
     "baseTypeName": "Autoscaling"
   },
   "autoscaling-plans": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2018-01-06",
     "baseTypeName": "AutoscalingPlans"
   },
   "batch": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-08-10",
     "baseTypeName": "Batch"
   },
   "budgets": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-10-20",
     "baseTypeName": "Budgets"
   },
   "ce": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-10-25",
     "baseTypeName": "CostExplorer"
   },
   "chime": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2018-05-01",
     "baseTypeName": "Chime"
   },
   "cloud9": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-09-23",
     "baseTypeName": "Cloud9"
   },
   "clouddirectory": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-05-10",
     "baseTypeName": "CloudDirectory"
   },
   "cloudformation": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2010-05-15",
     "baseTypeName": "CloudFormation"
   },
   "cloudfront": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-03-25",
     "baseTypeName": "CloudFront"
   },
   "cloudhsm": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2014-05-30",
     "baseTypeName": "CloudHsm"
   },
   "cloudhsmv2": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-04-28",
     "baseTypeName": "CloudHsmv2"
   },
   "cloudsearch": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2013-01-01",
     "baseTypeName": "CloudSearch"
   },
   "cloudsearchdomain": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2013-01-01",
     "baseTypeName": "CloudSearchDomain"
   },
   "cloudtrail": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2013-11-01",
     "baseTypeName": "CloudTrail"
   },
   "cloudwatch": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2010-08-01",
     "baseTypeName": "CloudWatch"
   },
   "codebuild": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-10-06",
     "baseTypeName": "CodeBuild"
   },
   "codecommit": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2015-04-13",
     "baseTypeName": "CodeCommit"
   },
   "codedeploy": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2014-10-06",
     "baseTypeName": "CodeDeploy"
   },
   "codepipeline": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2015-07-09",
     "baseTypeName": "CodePipeline"
   },
   "codestar": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-04-19",
     "baseTypeName": "CodeStar"
   },
   "cognito-identity": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2014-06-30",
     "baseTypeName": "CognitoIdentity"
   },
   "cognito-idp": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-04-18",
     "baseTypeName": "CognitoIdentityProvider"
   },
   "cognito-sync": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2014-06-30",
     "baseTypeName": "CognitoSync"
   },
   "comprehend": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-11-27",
     "baseTypeName": "Comprehend"
   },
   "comprehendmedical": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2018-10-30",
     "baseTypeName": "ComprehendMedical"
   },
   "config": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2014-11-12",
     "baseTypeName": "ConfigService"
   },
   "connect": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-08-08",
     "baseTypeName": "Connect"
   },
   "cur": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-01-06",
     "baseTypeName": "CostAndUsageReport"
   },
   "datapipeline": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2012-10-29",
     "baseTypeName": "DataPipeline"
   },
   "dax": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-04-19",
     "baseTypeName": "DynamodbAccelerator"
   },
   "devicefarm": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2015-06-23",
     "baseTypeName": "DeviceFarm"
   },
   "directconnect": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2012-10-25",
     "baseTypeName": "DirectConnect"
   },
   "discovery": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2015-11-01",
     "baseTypeName": "Discovery"
   },
   "dms": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-01-01",
     "baseTypeName": "DatabaseMigrationService"
   },
   "docdb": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2014-10-31",
     "baseTypeName": "Docdb"
   },
   "ds": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2015-04-16",
     "baseTypeName": "DirectoryService"
   },
   "dynamodb": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2012-08-10",
     "baseTypeName": "DynamoDb"
   },
   "dynamodbstreams": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2012-08-10",
     "baseTypeName": "DynamoDbStreams"
   },
   "ec2": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-11-15",
     "baseTypeName": "Ec2"
   },
   "ecr": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2015-09-21",
     "baseTypeName": "Ecr"
   },
   "ecs": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2014-11-13",
     "baseTypeName": "Ecs"
   },
   "elasticache": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2015-02-02",
     "baseTypeName": "ElastiCache"
   },
   "elasticbeanstalk": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2010-12-01",
     "baseTypeName": "ElasticBeanstalk"
   },
   "efs": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2015-02-01",
     "baseTypeName": "Efs"
   },
   "eks": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-11-01",
     "baseTypeName": "Eks"
   },
   "elastictranscoder": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2012-09-25",
     "baseTypeName": "Ets"
   },
   "elb": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2012-06-01",
     "baseTypeName": "Elb"
   },
   "elbv2": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2015-12-01",
     "baseTypeName": "Elb"
   },
   "emr": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2009-03-31",
     "baseTypeName": "Emr"
   },
   "events": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2015-10-07",
     "baseTypeName": "CloudWatchEvents"
   },
   "firehose": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2015-08-04",
     "baseTypeName": "KinesisFirehose"
   },
   "fms": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2018-01-01",
     "baseTypeName": "Fms"
   },
   "fsx": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2018-03-01",
     "baseTypeName": "Fsx"
   },
   "gamelift": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2015-10-01",
     "baseTypeName": "GameLift"
   },
   "glacier": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2012-06-01",
     "baseTypeName": "Glacier"
   },
   "glue": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-03-31",
     "baseTypeName": "Glue"
   },
   "greengrass": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-06-07",
     "baseTypeName": "GreenGrass"
   },
   "guardduty": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-11-28",
     "baseTypeName": "GuardDuty"
   },
   "health": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-08-04",
     "baseTypeName": "AWSHealth"
   },
   "iam": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2010-05-08",
     "baseTypeName": "Iam"
   },
   "importexport": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2010-06-01",
     "baseTypeName": "ImportExport"
   },
   "inspector": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-02-16",
     "baseTypeName": "Inspector"
   },
   "iot": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2015-05-28",
     "baseTypeName": "Iot"
   },
   "iotanalytics": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-11-27",
     "baseTypeName": "IotAnalytics"
   },
   "iot-data": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2015-05-28",
     "baseTypeName": "IotData"
   },
   "iot-jobs-data": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-09-29",
     "baseTypeName": "IotJobsData"
   },
   "iot1click-devices": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2018-05-14",
     "baseTypeName": "Iot1ClickDevices"
   },
   "iot1click-projects": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2018-05-14",
     "baseTypeName": "Iot1ClickProjects"
   },
   "kafka": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2018-11-14",
     "baseTypeName": "Kafka"
   },
   "kinesis": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2013-12-02",
     "baseTypeName": "Kinesis"
   },
   "kinesisanalytics": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2015-08-14",
     "baseTypeName": "KinesisAnalytics"
   },
   "kinesisvideo": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-09-30",
     "baseTypeName": "KinesisVideo"
   },
   "kinesis-video-media": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-09-30",
     "baseTypeName": "KinesisVideoMedia"
   },
   "kinesis-video-archived-media": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-09-30",
     "baseTypeName": "KinesisVideoArchivedMedia"
   },
   "kms": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2014-11-01",
     "baseTypeName": "Kms"
   },
   "lambda": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2015-03-31",
     "baseTypeName": "Lambda"
   },
   "lex-models": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-04-19",
     "baseTypeName": "LexModels"
   },
   "lex-runtime": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-11-28",
     "baseTypeName": "LexRuntime"
   },
   "license-manager": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2018-08-01",
     "baseTypeName": "LicenseManager"
   },
   "lightsail": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-11-28",
     "baseTypeName": "Lightsail"
   },
   "logs": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2014-03-28",
     "baseTypeName": "CloudWatchLogs",
     "customDevDependencies": {
@@ -561,290 +561,290 @@
     }
   },
   "machinelearning": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2014-12-12",
     "baseTypeName": "MachineLearning"
   },
   "macie": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-12-19",
     "baseTypeName": "Macie"
   },
   "marketplacecommerceanalytics": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2015-07-01",
     "baseTypeName": "MarketplaceCommerceAnalytics"
   },
   "marketplace-entitlement": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-01-11",
     "baseTypeName": "MarketplaceEntitlement"
   },
   "mediaconvert": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-08-29",
     "baseTypeName": "MediaConvert"
   },
   "medialive": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-10-14",
     "baseTypeName": "MediaLive"
   },
   "mediapackage": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-10-12",
     "baseTypeName": "MediaPackage"
   },
   "mediastore": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-09-01",
     "baseTypeName": "MediaStore"
   },
   "mediatailor": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2018-04-23",
     "baseTypeName": "MediaTailor"
   },
   "meteringmarketplace": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-01-14",
     "baseTypeName": "MarketplaceMetering"
   },
   "mgh": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-05-31",
     "baseTypeName": "MigrationHub"
   },
   "mobile": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-07-01",
     "baseTypeName": "Mobile"
   },
   "mq": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-11-27",
     "baseTypeName": "MQ"
   },
   "mturk": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-01-17",
     "baseTypeName": "MechanicalTurk"
   },
   "neptune": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2014-10-31",
     "baseTypeName": "Neptune"
   },
   "opsworks": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2013-02-18",
     "baseTypeName": "OpsWorks"
   },
   "opsworkscm": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-11-01",
     "baseTypeName": "OpsWorksCM"
   },
   "organizations": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-11-28",
     "baseTypeName": "Organizations"
   },
   "pi": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2018-02-27",
     "baseTypeName": "PerformanceInsights"
   },
   "polly": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-06-10",
     "baseTypeName": "Polly"
   },
   "pricing": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-10-15",
     "baseTypeName": "Pricing"
   },
   "ram": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2018-01-04",
     "baseTypeName": "Ram"
   },
   "rds": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2014-10-31",
     "baseTypeName": "Rds"
   },
   "rds-data": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2018-08-01",
     "baseTypeName": "RdsData"
   },
   "redshift": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2012-12-01",
     "baseTypeName": "Redshift"
   },
   "rekognition": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-06-27",
     "baseTypeName": "Rekognition"
   },
   "resource-groups": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-11-27",
     "baseTypeName": "ResourceGroups"
   },
   "resourcegroupstaggingapi": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-01-26",
     "baseTypeName": "ResourceGroupsTaggingApi"
   },
   "route53": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2013-04-01",
     "baseTypeName": "Route53"
   },
   "route53domains": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2014-05-15",
     "baseTypeName": "Route53Domains"
   },
   "s3": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2006-03-01",
     "baseTypeName": "S3"
   },
   "sagemaker": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-07-24",
     "baseTypeName": "SageMaker"
   },
   "sagemaker-runtime": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-05-13",
     "baseTypeName": "SageMakerRuntime"
   },
   "sdb": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2009-04-15",
     "baseTypeName": "SimpleDb"
   },
   "secretsmanager": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-10-17",
     "baseTypeName": "SecretsManager"
   },
   "serverlessrepo": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-09-08",
     "baseTypeName": "ServerlessRepo"
   },
   "servicecatalog": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2015-12-10",
     "baseTypeName": "ServiceCatalog"
   },
   "servicediscovery": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-03-14",
     "baseTypeName": "ServiceDiscovery"
   },
   "ses": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2010-12-01",
     "baseTypeName": "Ses"
   },
   "shield": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-06-02",
     "baseTypeName": "Shield"
   },
   "sms": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-10-24",
     "baseTypeName": "ServerMigrationService"
   },
   "snowball": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-06-30",
     "baseTypeName": "Snowball"
   },
   "sns": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2010-03-31",
     "baseTypeName": "Sns"
   },
   "sqs": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2012-11-05",
     "baseTypeName": "Sqs"
   },
   "ssm": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2014-11-06",
     "baseTypeName": "Ssm"
   },
   "stepfunctions": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-11-23",
     "baseTypeName": "StepFunctions"
   },
   "storagegateway": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2013-06-30",
     "baseTypeName": "StorageGateway"
   },
   "sts": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2011-06-15",
     "customDependencies": {
       "chrono": "0.4.0"
@@ -852,68 +852,68 @@
     "baseTypeName": "Sts"
   },
   "support": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2013-04-15",
     "baseTypeName": "AWSSupport"
   },
   "swf": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2012-01-25",
     "baseTypeName": "Swf"
   },
   "transcribe": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-10-26",
     "baseTypeName": "Transcribe"
   },
   "translate": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-07-01",
     "baseTypeName": "Translate"
   },
   "waf": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2015-08-24",
     "baseTypeName": "Waf"
   },
   "waf-regional": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-11-28",
     "baseTypeName": "WAFRegional"
   },
   "workdocs": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-05-01",
     "baseTypeName": "Workdocs"
   },
   "worklink": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2018-09-25",
     "baseTypeName": "Worklink"
   },
   "workmail": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2017-10-01",
     "baseTypeName": "Workmail"
   },
   "workspaces": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2015-04-08",
     "baseTypeName": "Workspaces"
   },
   "xray": {
-    "version": "0.38.0",
-    "coreVersion": "0.38.0",
+    "version": "0.39.0",
+    "coreVersion": "0.39.0",
     "protocolVersion": "2016-04-12",
     "baseTypeName": "XRay"
   }

--- a/service_crategen/src/service.rs
+++ b/service_crategen/src/service.rs
@@ -181,7 +181,7 @@ impl<'b> Service<'b> {
             "rusoto_mock".to_owned(),
             cargo::Dependency::Extended {
                 path: Some("../../../mock".into()),
-                version: Some("0.31.0".into()),
+                version: Some("0.39.0".into()),
                 optional: None,
                 default_features: None,
                 features: None,


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Release 0.39.0! 🎉 

I've taken the liberty to fix https://github.com/rusoto/rusoto/issues/1356 in here as well: all crates will be updated in lockstep so it's easier to know what versions to use. `rusoto_core` 0.39.0 will use `rusoto_credential` 0.39.0. 👍 