### PR TITLE
Add new constructor to SignedRequest and use that in services.

### DIFF
--- a/rusoto/core/src/signature.rs
+++ b/rusoto/core/src/signature.rs
@@ -96,6 +96,14 @@ impl SignedRequest {
         }
     }
 
+    /// Create a SignedRequest with specified content type
+    pub fn new_with_content_type(method: &str, service: &str, region: &Region, path: &str, content_type: &str) -> SignedRequest {
+        let mut s = SignedRequest::new(method, service, region, path);
+
+        s.set_content_type(content_type.to_owned());
+        s
+    }
+
     /// Sets the value of the "content-type" header.
     pub fn set_content_type(&mut self, content_type: String) {
         self.add_header("content-type", &content_type);

--- a/rusoto/services/acm-pca/src/generated.rs
+++ b/rusoto/services/acm-pca/src/generated.rs
@@ -1733,9 +1733,14 @@ impl AcmPca for AcmPcaClient {
         &self,
         input: CreateCertificateAuthorityRequest,
     ) -> RusotoFuture<CreateCertificateAuthorityResponse, CreateCertificateAuthorityError> {
-        let mut request = SignedRequest::new("POST", "acm-pca", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm-pca",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ACMPrivateCA.CreateCertificateAuthority");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1762,9 +1767,14 @@ impl AcmPca for AcmPcaClient {
         CreateCertificateAuthorityAuditReportResponse,
         CreateCertificateAuthorityAuditReportError,
     > {
-        let mut request = SignedRequest::new("POST", "acm-pca", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm-pca",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "ACMPrivateCA.CreateCertificateAuthorityAuditReport",
@@ -1793,9 +1803,14 @@ impl AcmPca for AcmPcaClient {
         &self,
         input: DeleteCertificateAuthorityRequest,
     ) -> RusotoFuture<(), DeleteCertificateAuthorityError> {
-        let mut request = SignedRequest::new("POST", "acm-pca", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm-pca",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ACMPrivateCA.DeleteCertificateAuthority");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1816,9 +1831,14 @@ impl AcmPca for AcmPcaClient {
         &self,
         input: DescribeCertificateAuthorityRequest,
     ) -> RusotoFuture<DescribeCertificateAuthorityResponse, DescribeCertificateAuthorityError> {
-        let mut request = SignedRequest::new("POST", "acm-pca", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm-pca",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ACMPrivateCA.DescribeCertificateAuthority");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1845,9 +1865,14 @@ impl AcmPca for AcmPcaClient {
         DescribeCertificateAuthorityAuditReportResponse,
         DescribeCertificateAuthorityAuditReportError,
     > {
-        let mut request = SignedRequest::new("POST", "acm-pca", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm-pca",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "ACMPrivateCA.DescribeCertificateAuthorityAuditReport",
@@ -1876,9 +1901,14 @@ impl AcmPca for AcmPcaClient {
         &self,
         input: GetCertificateRequest,
     ) -> RusotoFuture<GetCertificateResponse, GetCertificateError> {
-        let mut request = SignedRequest::new("POST", "acm-pca", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm-pca",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ACMPrivateCA.GetCertificate");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1908,9 +1938,14 @@ impl AcmPca for AcmPcaClient {
         GetCertificateAuthorityCertificateResponse,
         GetCertificateAuthorityCertificateError,
     > {
-        let mut request = SignedRequest::new("POST", "acm-pca", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm-pca",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "ACMPrivateCA.GetCertificateAuthorityCertificate",
@@ -1939,9 +1974,14 @@ impl AcmPca for AcmPcaClient {
         &self,
         input: GetCertificateAuthorityCsrRequest,
     ) -> RusotoFuture<GetCertificateAuthorityCsrResponse, GetCertificateAuthorityCsrError> {
-        let mut request = SignedRequest::new("POST", "acm-pca", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm-pca",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ACMPrivateCA.GetCertificateAuthorityCsr");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1965,9 +2005,14 @@ impl AcmPca for AcmPcaClient {
         &self,
         input: ImportCertificateAuthorityCertificateRequest,
     ) -> RusotoFuture<(), ImportCertificateAuthorityCertificateError> {
-        let mut request = SignedRequest::new("POST", "acm-pca", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm-pca",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "ACMPrivateCA.ImportCertificateAuthorityCertificate",
@@ -1993,9 +2038,14 @@ impl AcmPca for AcmPcaClient {
         &self,
         input: IssueCertificateRequest,
     ) -> RusotoFuture<IssueCertificateResponse, IssueCertificateError> {
-        let mut request = SignedRequest::new("POST", "acm-pca", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm-pca",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ACMPrivateCA.IssueCertificate");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2022,9 +2072,14 @@ impl AcmPca for AcmPcaClient {
         &self,
         input: ListCertificateAuthoritiesRequest,
     ) -> RusotoFuture<ListCertificateAuthoritiesResponse, ListCertificateAuthoritiesError> {
-        let mut request = SignedRequest::new("POST", "acm-pca", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm-pca",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ACMPrivateCA.ListCertificateAuthorities");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2045,9 +2100,14 @@ impl AcmPca for AcmPcaClient {
 
     /// <p>Lists the tags, if any, that are associated with your private CA. Tags are labels that you can use to identify and organize your CAs. Each tag consists of a key and an optional value. Call the <a>TagCertificateAuthority</a> operation to add one or more tags to your CA. Call the <a>UntagCertificateAuthority</a> operation to remove tags. </p>
     fn list_tags(&self, input: ListTagsRequest) -> RusotoFuture<ListTagsResponse, ListTagsError> {
-        let mut request = SignedRequest::new("POST", "acm-pca", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm-pca",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ACMPrivateCA.ListTags");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2074,9 +2134,14 @@ impl AcmPca for AcmPcaClient {
         &self,
         input: RestoreCertificateAuthorityRequest,
     ) -> RusotoFuture<(), RestoreCertificateAuthorityError> {
-        let mut request = SignedRequest::new("POST", "acm-pca", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm-pca",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ACMPrivateCA.RestoreCertificateAuthority");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2097,9 +2162,14 @@ impl AcmPca for AcmPcaClient {
         &self,
         input: RevokeCertificateRequest,
     ) -> RusotoFuture<(), RevokeCertificateError> {
-        let mut request = SignedRequest::new("POST", "acm-pca", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm-pca",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ACMPrivateCA.RevokeCertificate");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2123,9 +2193,14 @@ impl AcmPca for AcmPcaClient {
         &self,
         input: TagCertificateAuthorityRequest,
     ) -> RusotoFuture<(), TagCertificateAuthorityError> {
-        let mut request = SignedRequest::new("POST", "acm-pca", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm-pca",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ACMPrivateCA.TagCertificateAuthority");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2146,9 +2221,14 @@ impl AcmPca for AcmPcaClient {
         &self,
         input: UntagCertificateAuthorityRequest,
     ) -> RusotoFuture<(), UntagCertificateAuthorityError> {
-        let mut request = SignedRequest::new("POST", "acm-pca", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm-pca",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ACMPrivateCA.UntagCertificateAuthority");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2169,9 +2249,14 @@ impl AcmPca for AcmPcaClient {
         &self,
         input: UpdateCertificateAuthorityRequest,
     ) -> RusotoFuture<(), UpdateCertificateAuthorityError> {
-        let mut request = SignedRequest::new("POST", "acm-pca", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm-pca",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ACMPrivateCA.UpdateCertificateAuthority");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/acm/src/generated.rs
+++ b/rusoto/services/acm/src/generated.rs
@@ -1186,9 +1186,14 @@ impl Acm for AcmClient {
         &self,
         input: AddTagsToCertificateRequest,
     ) -> RusotoFuture<(), AddTagsToCertificateError> {
-        let mut request = SignedRequest::new("POST", "acm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CertificateManager.AddTagsToCertificate");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1211,9 +1216,14 @@ impl Acm for AcmClient {
         &self,
         input: DeleteCertificateRequest,
     ) -> RusotoFuture<(), DeleteCertificateError> {
-        let mut request = SignedRequest::new("POST", "acm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CertificateManager.DeleteCertificate");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1237,9 +1247,14 @@ impl Acm for AcmClient {
         &self,
         input: DescribeCertificateRequest,
     ) -> RusotoFuture<DescribeCertificateResponse, DescribeCertificateError> {
-        let mut request = SignedRequest::new("POST", "acm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CertificateManager.DescribeCertificate");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1265,9 +1280,14 @@ impl Acm for AcmClient {
         &self,
         input: ExportCertificateRequest,
     ) -> RusotoFuture<ExportCertificateResponse, ExportCertificateError> {
-        let mut request = SignedRequest::new("POST", "acm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CertificateManager.ExportCertificate");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1294,9 +1314,14 @@ impl Acm for AcmClient {
         &self,
         input: GetCertificateRequest,
     ) -> RusotoFuture<GetCertificateResponse, GetCertificateError> {
-        let mut request = SignedRequest::new("POST", "acm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CertificateManager.GetCertificate");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1323,9 +1348,14 @@ impl Acm for AcmClient {
         &self,
         input: ImportCertificateRequest,
     ) -> RusotoFuture<ImportCertificateResponse, ImportCertificateError> {
-        let mut request = SignedRequest::new("POST", "acm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CertificateManager.ImportCertificate");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1352,9 +1382,14 @@ impl Acm for AcmClient {
         &self,
         input: ListCertificatesRequest,
     ) -> RusotoFuture<ListCertificatesResponse, ListCertificatesError> {
-        let mut request = SignedRequest::new("POST", "acm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CertificateManager.ListCertificates");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1381,9 +1416,14 @@ impl Acm for AcmClient {
         &self,
         input: ListTagsForCertificateRequest,
     ) -> RusotoFuture<ListTagsForCertificateResponse, ListTagsForCertificateError> {
-        let mut request = SignedRequest::new("POST", "acm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CertificateManager.ListTagsForCertificate");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1409,9 +1449,14 @@ impl Acm for AcmClient {
         &self,
         input: RemoveTagsFromCertificateRequest,
     ) -> RusotoFuture<(), RemoveTagsFromCertificateError> {
-        let mut request = SignedRequest::new("POST", "acm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CertificateManager.RemoveTagsFromCertificate",
@@ -1435,9 +1480,14 @@ impl Acm for AcmClient {
         &self,
         input: RequestCertificateRequest,
     ) -> RusotoFuture<RequestCertificateResponse, RequestCertificateError> {
-        let mut request = SignedRequest::new("POST", "acm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CertificateManager.RequestCertificate");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1464,9 +1514,14 @@ impl Acm for AcmClient {
         &self,
         input: ResendValidationEmailRequest,
     ) -> RusotoFuture<(), ResendValidationEmailError> {
-        let mut request = SignedRequest::new("POST", "acm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CertificateManager.ResendValidationEmail");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1489,9 +1544,14 @@ impl Acm for AcmClient {
         &self,
         input: UpdateCertificateOptionsRequest,
     ) -> RusotoFuture<(), UpdateCertificateOptionsError> {
-        let mut request = SignedRequest::new("POST", "acm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "acm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CertificateManager.UpdateCertificateOptions",

--- a/rusoto/services/alexaforbusiness/src/generated.rs
+++ b/rusoto/services/alexaforbusiness/src/generated.rs
@@ -5706,9 +5706,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: ApproveSkillRequest,
     ) -> RusotoFuture<ApproveSkillResponse, ApproveSkillError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.ApproveSkill");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5736,9 +5741,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         input: AssociateContactWithAddressBookRequest,
     ) -> RusotoFuture<AssociateContactWithAddressBookResponse, AssociateContactWithAddressBookError>
     {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AlexaForBusiness.AssociateContactWithAddressBook",
@@ -5767,9 +5777,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: AssociateDeviceWithRoomRequest,
     ) -> RusotoFuture<AssociateDeviceWithRoomResponse, AssociateDeviceWithRoomError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.AssociateDeviceWithRoom");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5793,9 +5808,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: AssociateSkillGroupWithRoomRequest,
     ) -> RusotoFuture<AssociateSkillGroupWithRoomResponse, AssociateSkillGroupWithRoomError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AlexaForBusiness.AssociateSkillGroupWithRoom",
@@ -5822,9 +5842,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: AssociateSkillWithSkillGroupRequest,
     ) -> RusotoFuture<AssociateSkillWithSkillGroupResponse, AssociateSkillWithSkillGroupError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AlexaForBusiness.AssociateSkillWithSkillGroup",
@@ -5851,9 +5876,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: AssociateSkillWithUsersRequest,
     ) -> RusotoFuture<AssociateSkillWithUsersResponse, AssociateSkillWithUsersError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.AssociateSkillWithUsers");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5877,9 +5907,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: CreateAddressBookRequest,
     ) -> RusotoFuture<CreateAddressBookResponse, CreateAddressBookError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.CreateAddressBook");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5906,9 +5941,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: CreateBusinessReportScheduleRequest,
     ) -> RusotoFuture<CreateBusinessReportScheduleResponse, CreateBusinessReportScheduleError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AlexaForBusiness.CreateBusinessReportSchedule",
@@ -5935,9 +5975,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: CreateConferenceProviderRequest,
     ) -> RusotoFuture<CreateConferenceProviderResponse, CreateConferenceProviderError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.CreateConferenceProvider");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5961,9 +6006,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: CreateContactRequest,
     ) -> RusotoFuture<CreateContactResponse, CreateContactError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.CreateContact");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5990,9 +6040,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: CreateProfileRequest,
     ) -> RusotoFuture<CreateProfileResponse, CreateProfileError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.CreateProfile");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6019,9 +6074,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: CreateRoomRequest,
     ) -> RusotoFuture<CreateRoomResponse, CreateRoomError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.CreateRoom");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6048,9 +6108,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: CreateSkillGroupRequest,
     ) -> RusotoFuture<CreateSkillGroupResponse, CreateSkillGroupError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.CreateSkillGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6077,9 +6142,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: CreateUserRequest,
     ) -> RusotoFuture<CreateUserResponse, CreateUserError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.CreateUser");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6106,9 +6176,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: DeleteAddressBookRequest,
     ) -> RusotoFuture<DeleteAddressBookResponse, DeleteAddressBookError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.DeleteAddressBook");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6135,9 +6210,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: DeleteBusinessReportScheduleRequest,
     ) -> RusotoFuture<DeleteBusinessReportScheduleResponse, DeleteBusinessReportScheduleError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AlexaForBusiness.DeleteBusinessReportSchedule",
@@ -6164,9 +6244,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: DeleteConferenceProviderRequest,
     ) -> RusotoFuture<DeleteConferenceProviderResponse, DeleteConferenceProviderError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.DeleteConferenceProvider");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6190,9 +6275,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: DeleteContactRequest,
     ) -> RusotoFuture<DeleteContactResponse, DeleteContactError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.DeleteContact");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6219,9 +6309,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: DeleteDeviceRequest,
     ) -> RusotoFuture<DeleteDeviceResponse, DeleteDeviceError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.DeleteDevice");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6248,9 +6343,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: DeleteProfileRequest,
     ) -> RusotoFuture<DeleteProfileResponse, DeleteProfileError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.DeleteProfile");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6277,9 +6377,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: DeleteRoomRequest,
     ) -> RusotoFuture<DeleteRoomResponse, DeleteRoomError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.DeleteRoom");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6306,9 +6411,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: DeleteRoomSkillParameterRequest,
     ) -> RusotoFuture<DeleteRoomSkillParameterResponse, DeleteRoomSkillParameterError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.DeleteRoomSkillParameter");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6332,9 +6442,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: DeleteSkillAuthorizationRequest,
     ) -> RusotoFuture<DeleteSkillAuthorizationResponse, DeleteSkillAuthorizationError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.DeleteSkillAuthorization");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6358,9 +6473,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: DeleteSkillGroupRequest,
     ) -> RusotoFuture<DeleteSkillGroupResponse, DeleteSkillGroupError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.DeleteSkillGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6387,9 +6507,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: DeleteUserRequest,
     ) -> RusotoFuture<DeleteUserResponse, DeleteUserError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.DeleteUser");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6419,9 +6544,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         DisassociateContactFromAddressBookResponse,
         DisassociateContactFromAddressBookError,
     > {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AlexaForBusiness.DisassociateContactFromAddressBook",
@@ -6450,9 +6580,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: DisassociateDeviceFromRoomRequest,
     ) -> RusotoFuture<DisassociateDeviceFromRoomResponse, DisassociateDeviceFromRoomError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AlexaForBusiness.DisassociateDeviceFromRoom",
@@ -6480,9 +6615,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         input: DisassociateSkillFromSkillGroupRequest,
     ) -> RusotoFuture<DisassociateSkillFromSkillGroupResponse, DisassociateSkillFromSkillGroupError>
     {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AlexaForBusiness.DisassociateSkillFromSkillGroup",
@@ -6511,9 +6651,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: DisassociateSkillFromUsersRequest,
     ) -> RusotoFuture<DisassociateSkillFromUsersResponse, DisassociateSkillFromUsersError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AlexaForBusiness.DisassociateSkillFromUsers",
@@ -6541,9 +6686,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         input: DisassociateSkillGroupFromRoomRequest,
     ) -> RusotoFuture<DisassociateSkillGroupFromRoomResponse, DisassociateSkillGroupFromRoomError>
     {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AlexaForBusiness.DisassociateSkillGroupFromRoom",
@@ -6570,9 +6720,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: ForgetSmartHomeAppliancesRequest,
     ) -> RusotoFuture<ForgetSmartHomeAppliancesResponse, ForgetSmartHomeAppliancesError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.ForgetSmartHomeAppliances");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6596,9 +6751,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: GetAddressBookRequest,
     ) -> RusotoFuture<GetAddressBookResponse, GetAddressBookError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.GetAddressBook");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6624,9 +6784,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
     fn get_conference_preference(
         &self,
     ) -> RusotoFuture<GetConferencePreferenceResponse, GetConferencePreferenceError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.GetConferencePreference");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -6649,9 +6814,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: GetConferenceProviderRequest,
     ) -> RusotoFuture<GetConferenceProviderResponse, GetConferenceProviderError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.GetConferenceProvider");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6677,9 +6847,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: GetContactRequest,
     ) -> RusotoFuture<GetContactResponse, GetContactError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.GetContact");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6706,9 +6881,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: GetDeviceRequest,
     ) -> RusotoFuture<GetDeviceResponse, GetDeviceError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.GetDevice");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6735,9 +6915,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: GetProfileRequest,
     ) -> RusotoFuture<GetProfileResponse, GetProfileError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.GetProfile");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6761,9 +6946,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
 
     /// <p>Gets room details by room ARN.</p>
     fn get_room(&self, input: GetRoomRequest) -> RusotoFuture<GetRoomResponse, GetRoomError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.GetRoom");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6789,9 +6979,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: GetRoomSkillParameterRequest,
     ) -> RusotoFuture<GetRoomSkillParameterResponse, GetRoomSkillParameterError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.GetRoomSkillParameter");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6817,9 +7012,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: GetSkillGroupRequest,
     ) -> RusotoFuture<GetSkillGroupResponse, GetSkillGroupError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.GetSkillGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6846,9 +7046,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: ListBusinessReportSchedulesRequest,
     ) -> RusotoFuture<ListBusinessReportSchedulesResponse, ListBusinessReportSchedulesError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AlexaForBusiness.ListBusinessReportSchedules",
@@ -6875,9 +7080,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: ListConferenceProvidersRequest,
     ) -> RusotoFuture<ListConferenceProvidersResponse, ListConferenceProvidersError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.ListConferenceProviders");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6901,9 +7111,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: ListDeviceEventsRequest,
     ) -> RusotoFuture<ListDeviceEventsResponse, ListDeviceEventsError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.ListDeviceEvents");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6930,9 +7145,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: ListSkillsRequest,
     ) -> RusotoFuture<ListSkillsResponse, ListSkillsError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.ListSkills");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6959,9 +7179,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: ListSkillsStoreCategoriesRequest,
     ) -> RusotoFuture<ListSkillsStoreCategoriesResponse, ListSkillsStoreCategoriesError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.ListSkillsStoreCategories");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6986,9 +7211,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         input: ListSkillsStoreSkillsByCategoryRequest,
     ) -> RusotoFuture<ListSkillsStoreSkillsByCategoryResponse, ListSkillsStoreSkillsByCategoryError>
     {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AlexaForBusiness.ListSkillsStoreSkillsByCategory",
@@ -7017,9 +7247,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: ListSmartHomeAppliancesRequest,
     ) -> RusotoFuture<ListSmartHomeAppliancesResponse, ListSmartHomeAppliancesError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.ListSmartHomeAppliances");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7040,9 +7275,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
 
     /// <p>Lists all tags for the specified resource.</p>
     fn list_tags(&self, input: ListTagsRequest) -> RusotoFuture<ListTagsResponse, ListTagsError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.ListTags");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7069,9 +7309,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: PutConferencePreferenceRequest,
     ) -> RusotoFuture<PutConferencePreferenceResponse, PutConferencePreferenceError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.PutConferencePreference");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7095,9 +7340,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: PutRoomSkillParameterRequest,
     ) -> RusotoFuture<PutRoomSkillParameterResponse, PutRoomSkillParameterError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.PutRoomSkillParameter");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7123,9 +7373,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: PutSkillAuthorizationRequest,
     ) -> RusotoFuture<PutSkillAuthorizationResponse, PutSkillAuthorizationError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.PutSkillAuthorization");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7151,9 +7406,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: RegisterAVSDeviceRequest,
     ) -> RusotoFuture<RegisterAVSDeviceResponse, RegisterAVSDeviceError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.RegisterAVSDevice");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7180,9 +7440,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: RejectSkillRequest,
     ) -> RusotoFuture<RejectSkillResponse, RejectSkillError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.RejectSkill");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7209,9 +7474,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: ResolveRoomRequest,
     ) -> RusotoFuture<ResolveRoomResponse, ResolveRoomError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.ResolveRoom");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7238,9 +7508,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: RevokeInvitationRequest,
     ) -> RusotoFuture<RevokeInvitationResponse, RevokeInvitationError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.RevokeInvitation");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7267,9 +7542,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: SearchAddressBooksRequest,
     ) -> RusotoFuture<SearchAddressBooksResponse, SearchAddressBooksError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.SearchAddressBooks");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7296,9 +7576,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: SearchContactsRequest,
     ) -> RusotoFuture<SearchContactsResponse, SearchContactsError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.SearchContacts");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7325,9 +7610,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: SearchDevicesRequest,
     ) -> RusotoFuture<SearchDevicesResponse, SearchDevicesError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.SearchDevices");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7354,9 +7644,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: SearchProfilesRequest,
     ) -> RusotoFuture<SearchProfilesResponse, SearchProfilesError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.SearchProfiles");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7383,9 +7678,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: SearchRoomsRequest,
     ) -> RusotoFuture<SearchRoomsResponse, SearchRoomsError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.SearchRooms");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7412,9 +7712,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: SearchSkillGroupsRequest,
     ) -> RusotoFuture<SearchSkillGroupsResponse, SearchSkillGroupsError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.SearchSkillGroups");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7441,9 +7746,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: SearchUsersRequest,
     ) -> RusotoFuture<SearchUsersResponse, SearchUsersError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.SearchUsers");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7470,9 +7780,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: SendInvitationRequest,
     ) -> RusotoFuture<SendInvitationResponse, SendInvitationError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.SendInvitation");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7499,9 +7814,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: StartDeviceSyncRequest,
     ) -> RusotoFuture<StartDeviceSyncResponse, StartDeviceSyncError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.StartDeviceSync");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7529,9 +7849,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         input: StartSmartHomeApplianceDiscoveryRequest,
     ) -> RusotoFuture<StartSmartHomeApplianceDiscoveryResponse, StartSmartHomeApplianceDiscoveryError>
     {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AlexaForBusiness.StartSmartHomeApplianceDiscovery",
@@ -7560,9 +7885,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: TagResourceRequest,
     ) -> RusotoFuture<TagResourceResponse, TagResourceError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.TagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7589,9 +7919,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: UntagResourceRequest,
     ) -> RusotoFuture<UntagResourceResponse, UntagResourceError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.UntagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7618,9 +7953,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: UpdateAddressBookRequest,
     ) -> RusotoFuture<UpdateAddressBookResponse, UpdateAddressBookError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.UpdateAddressBook");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7647,9 +7987,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: UpdateBusinessReportScheduleRequest,
     ) -> RusotoFuture<UpdateBusinessReportScheduleResponse, UpdateBusinessReportScheduleError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AlexaForBusiness.UpdateBusinessReportSchedule",
@@ -7676,9 +8021,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: UpdateConferenceProviderRequest,
     ) -> RusotoFuture<UpdateConferenceProviderResponse, UpdateConferenceProviderError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.UpdateConferenceProvider");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7702,9 +8052,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: UpdateContactRequest,
     ) -> RusotoFuture<UpdateContactResponse, UpdateContactError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.UpdateContact");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7731,9 +8086,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: UpdateDeviceRequest,
     ) -> RusotoFuture<UpdateDeviceResponse, UpdateDeviceError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.UpdateDevice");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7760,9 +8120,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: UpdateProfileRequest,
     ) -> RusotoFuture<UpdateProfileResponse, UpdateProfileError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.UpdateProfile");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7789,9 +8154,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: UpdateRoomRequest,
     ) -> RusotoFuture<UpdateRoomResponse, UpdateRoomError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.UpdateRoom");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7818,9 +8188,14 @@ impl AlexaForBusiness for AlexaForBusinessClient {
         &self,
         input: UpdateSkillGroupRequest,
     ) -> RusotoFuture<UpdateSkillGroupResponse, UpdateSkillGroupError> {
-        let mut request = SignedRequest::new("POST", "a4b", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "a4b",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AlexaForBusiness.UpdateSkillGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/application-autoscaling/src/generated.rs
+++ b/rusoto/services/application-autoscaling/src/generated.rs
@@ -1253,9 +1253,14 @@ impl ApplicationAutoScaling for ApplicationAutoScalingClient {
         &self,
         input: DeleteScalingPolicyRequest,
     ) -> RusotoFuture<DeleteScalingPolicyResponse, DeleteScalingPolicyError> {
-        let mut request = SignedRequest::new("POST", "application-autoscaling", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "application-autoscaling",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("autoscaling".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AnyScaleFrontendService.DeleteScalingPolicy",
@@ -1284,9 +1289,14 @@ impl ApplicationAutoScaling for ApplicationAutoScalingClient {
         &self,
         input: DeleteScheduledActionRequest,
     ) -> RusotoFuture<DeleteScheduledActionResponse, DeleteScheduledActionError> {
-        let mut request = SignedRequest::new("POST", "application-autoscaling", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "application-autoscaling",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("autoscaling".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AnyScaleFrontendService.DeleteScheduledAction",
@@ -1315,9 +1325,14 @@ impl ApplicationAutoScaling for ApplicationAutoScalingClient {
         &self,
         input: DeregisterScalableTargetRequest,
     ) -> RusotoFuture<DeregisterScalableTargetResponse, DeregisterScalableTargetError> {
-        let mut request = SignedRequest::new("POST", "application-autoscaling", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "application-autoscaling",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("autoscaling".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AnyScaleFrontendService.DeregisterScalableTarget",
@@ -1344,9 +1359,14 @@ impl ApplicationAutoScaling for ApplicationAutoScalingClient {
         &self,
         input: DescribeScalableTargetsRequest,
     ) -> RusotoFuture<DescribeScalableTargetsResponse, DescribeScalableTargetsError> {
-        let mut request = SignedRequest::new("POST", "application-autoscaling", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "application-autoscaling",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("autoscaling".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AnyScaleFrontendService.DescribeScalableTargets",
@@ -1373,9 +1393,14 @@ impl ApplicationAutoScaling for ApplicationAutoScalingClient {
         &self,
         input: DescribeScalingActivitiesRequest,
     ) -> RusotoFuture<DescribeScalingActivitiesResponse, DescribeScalingActivitiesError> {
-        let mut request = SignedRequest::new("POST", "application-autoscaling", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "application-autoscaling",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("autoscaling".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AnyScaleFrontendService.DescribeScalingActivities",
@@ -1402,9 +1427,14 @@ impl ApplicationAutoScaling for ApplicationAutoScalingClient {
         &self,
         input: DescribeScalingPoliciesRequest,
     ) -> RusotoFuture<DescribeScalingPoliciesResponse, DescribeScalingPoliciesError> {
-        let mut request = SignedRequest::new("POST", "application-autoscaling", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "application-autoscaling",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("autoscaling".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AnyScaleFrontendService.DescribeScalingPolicies",
@@ -1431,9 +1461,14 @@ impl ApplicationAutoScaling for ApplicationAutoScalingClient {
         &self,
         input: DescribeScheduledActionsRequest,
     ) -> RusotoFuture<DescribeScheduledActionsResponse, DescribeScheduledActionsError> {
-        let mut request = SignedRequest::new("POST", "application-autoscaling", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "application-autoscaling",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("autoscaling".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AnyScaleFrontendService.DescribeScheduledActions",
@@ -1460,9 +1495,14 @@ impl ApplicationAutoScaling for ApplicationAutoScalingClient {
         &self,
         input: PutScalingPolicyRequest,
     ) -> RusotoFuture<PutScalingPolicyResponse, PutScalingPolicyError> {
-        let mut request = SignedRequest::new("POST", "application-autoscaling", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "application-autoscaling",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("autoscaling".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AnyScaleFrontendService.PutScalingPolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1489,9 +1529,14 @@ impl ApplicationAutoScaling for ApplicationAutoScalingClient {
         &self,
         input: PutScheduledActionRequest,
     ) -> RusotoFuture<PutScheduledActionResponse, PutScheduledActionError> {
-        let mut request = SignedRequest::new("POST", "application-autoscaling", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "application-autoscaling",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("autoscaling".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AnyScaleFrontendService.PutScheduledAction");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1518,9 +1563,14 @@ impl ApplicationAutoScaling for ApplicationAutoScalingClient {
         &self,
         input: RegisterScalableTargetRequest,
     ) -> RusotoFuture<RegisterScalableTargetResponse, RegisterScalableTargetError> {
-        let mut request = SignedRequest::new("POST", "application-autoscaling", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "application-autoscaling",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("autoscaling".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AnyScaleFrontendService.RegisterScalableTarget",

--- a/rusoto/services/appstream/src/generated.rs
+++ b/rusoto/services/appstream/src/generated.rs
@@ -4144,9 +4144,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: AssociateFleetRequest,
     ) -> RusotoFuture<AssociateFleetResult, AssociateFleetError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.AssociateFleet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4173,9 +4178,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: BatchAssociateUserStackRequest,
     ) -> RusotoFuture<BatchAssociateUserStackResult, BatchAssociateUserStackError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "PhotonAdminProxyService.BatchAssociateUserStack",
@@ -4202,9 +4212,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: BatchDisassociateUserStackRequest,
     ) -> RusotoFuture<BatchDisassociateUserStackResult, BatchDisassociateUserStackError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "PhotonAdminProxyService.BatchDisassociateUserStack",
@@ -4231,9 +4246,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: CopyImageRequest,
     ) -> RusotoFuture<CopyImageResponse, CopyImageError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.CopyImage");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4260,9 +4280,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: CreateDirectoryConfigRequest,
     ) -> RusotoFuture<CreateDirectoryConfigResult, CreateDirectoryConfigError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "PhotonAdminProxyService.CreateDirectoryConfig",
@@ -4291,9 +4316,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: CreateFleetRequest,
     ) -> RusotoFuture<CreateFleetResult, CreateFleetError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.CreateFleet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4320,9 +4350,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: CreateImageBuilderRequest,
     ) -> RusotoFuture<CreateImageBuilderResult, CreateImageBuilderError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.CreateImageBuilder");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4350,9 +4385,14 @@ impl AppStream for AppStreamClient {
         input: CreateImageBuilderStreamingURLRequest,
     ) -> RusotoFuture<CreateImageBuilderStreamingURLResult, CreateImageBuilderStreamingURLError>
     {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "PhotonAdminProxyService.CreateImageBuilderStreamingURL",
@@ -4379,9 +4419,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: CreateStackRequest,
     ) -> RusotoFuture<CreateStackResult, CreateStackError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.CreateStack");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4408,9 +4453,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: CreateStreamingURLRequest,
     ) -> RusotoFuture<CreateStreamingURLResult, CreateStreamingURLError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.CreateStreamingURL");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4437,9 +4487,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: CreateUserRequest,
     ) -> RusotoFuture<CreateUserResult, CreateUserError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.CreateUser");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4466,9 +4521,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: DeleteDirectoryConfigRequest,
     ) -> RusotoFuture<DeleteDirectoryConfigResult, DeleteDirectoryConfigError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "PhotonAdminProxyService.DeleteDirectoryConfig",
@@ -4497,9 +4557,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: DeleteFleetRequest,
     ) -> RusotoFuture<DeleteFleetResult, DeleteFleetError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.DeleteFleet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4526,9 +4591,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: DeleteImageRequest,
     ) -> RusotoFuture<DeleteImageResult, DeleteImageError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.DeleteImage");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4555,9 +4625,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: DeleteImageBuilderRequest,
     ) -> RusotoFuture<DeleteImageBuilderResult, DeleteImageBuilderError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.DeleteImageBuilder");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4584,9 +4659,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: DeleteImagePermissionsRequest,
     ) -> RusotoFuture<DeleteImagePermissionsResult, DeleteImagePermissionsError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "PhotonAdminProxyService.DeleteImagePermissions",
@@ -4615,9 +4695,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: DeleteStackRequest,
     ) -> RusotoFuture<DeleteStackResult, DeleteStackError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.DeleteStack");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4644,9 +4729,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: DeleteUserRequest,
     ) -> RusotoFuture<DeleteUserResult, DeleteUserError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.DeleteUser");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4673,9 +4763,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: DescribeDirectoryConfigsRequest,
     ) -> RusotoFuture<DescribeDirectoryConfigsResult, DescribeDirectoryConfigsError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "PhotonAdminProxyService.DescribeDirectoryConfigs",
@@ -4702,9 +4797,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: DescribeFleetsRequest,
     ) -> RusotoFuture<DescribeFleetsResult, DescribeFleetsError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.DescribeFleets");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4731,9 +4831,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: DescribeImageBuildersRequest,
     ) -> RusotoFuture<DescribeImageBuildersResult, DescribeImageBuildersError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "PhotonAdminProxyService.DescribeImageBuilders",
@@ -4762,9 +4867,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: DescribeImagePermissionsRequest,
     ) -> RusotoFuture<DescribeImagePermissionsResult, DescribeImagePermissionsError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "PhotonAdminProxyService.DescribeImagePermissions",
@@ -4791,9 +4901,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: DescribeImagesRequest,
     ) -> RusotoFuture<DescribeImagesResult, DescribeImagesError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.DescribeImages");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4820,9 +4935,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: DescribeSessionsRequest,
     ) -> RusotoFuture<DescribeSessionsResult, DescribeSessionsError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.DescribeSessions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4849,9 +4969,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: DescribeStacksRequest,
     ) -> RusotoFuture<DescribeStacksResult, DescribeStacksError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.DescribeStacks");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4878,9 +5003,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: DescribeUserStackAssociationsRequest,
     ) -> RusotoFuture<DescribeUserStackAssociationsResult, DescribeUserStackAssociationsError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "PhotonAdminProxyService.DescribeUserStackAssociations",
@@ -4907,9 +5037,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: DescribeUsersRequest,
     ) -> RusotoFuture<DescribeUsersResult, DescribeUsersError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.DescribeUsers");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4936,9 +5071,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: DisableUserRequest,
     ) -> RusotoFuture<DisableUserResult, DisableUserError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.DisableUser");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4965,9 +5105,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: DisassociateFleetRequest,
     ) -> RusotoFuture<DisassociateFleetResult, DisassociateFleetError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.DisassociateFleet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4994,9 +5139,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: EnableUserRequest,
     ) -> RusotoFuture<EnableUserResult, EnableUserError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.EnableUser");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5023,9 +5173,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: ExpireSessionRequest,
     ) -> RusotoFuture<ExpireSessionResult, ExpireSessionError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.ExpireSession");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5052,9 +5207,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: ListAssociatedFleetsRequest,
     ) -> RusotoFuture<ListAssociatedFleetsResult, ListAssociatedFleetsError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "PhotonAdminProxyService.ListAssociatedFleets",
@@ -5083,9 +5243,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: ListAssociatedStacksRequest,
     ) -> RusotoFuture<ListAssociatedStacksResult, ListAssociatedStacksError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "PhotonAdminProxyService.ListAssociatedStacks",
@@ -5114,9 +5279,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: ListTagsForResourceRequest,
     ) -> RusotoFuture<ListTagsForResourceResponse, ListTagsForResourceError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "PhotonAdminProxyService.ListTagsForResource",
@@ -5145,9 +5315,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: StartFleetRequest,
     ) -> RusotoFuture<StartFleetResult, StartFleetError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.StartFleet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5174,9 +5349,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: StartImageBuilderRequest,
     ) -> RusotoFuture<StartImageBuilderResult, StartImageBuilderError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.StartImageBuilder");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5200,9 +5380,14 @@ impl AppStream for AppStreamClient {
 
     /// <p>Stops the specified fleet.</p>
     fn stop_fleet(&self, input: StopFleetRequest) -> RusotoFuture<StopFleetResult, StopFleetError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.StopFleet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5228,9 +5413,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: StopImageBuilderRequest,
     ) -> RusotoFuture<StopImageBuilderResult, StopImageBuilderError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.StopImageBuilder");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5257,9 +5447,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: TagResourceRequest,
     ) -> RusotoFuture<TagResourceResponse, TagResourceError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.TagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5286,9 +5481,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: UntagResourceRequest,
     ) -> RusotoFuture<UntagResourceResponse, UntagResourceError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.UntagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5315,9 +5515,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: UpdateDirectoryConfigRequest,
     ) -> RusotoFuture<UpdateDirectoryConfigResult, UpdateDirectoryConfigError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "PhotonAdminProxyService.UpdateDirectoryConfig",
@@ -5346,9 +5551,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: UpdateFleetRequest,
     ) -> RusotoFuture<UpdateFleetResult, UpdateFleetError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.UpdateFleet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5375,9 +5585,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: UpdateImagePermissionsRequest,
     ) -> RusotoFuture<UpdateImagePermissionsResult, UpdateImagePermissionsError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "PhotonAdminProxyService.UpdateImagePermissions",
@@ -5406,9 +5621,14 @@ impl AppStream for AppStreamClient {
         &self,
         input: UpdateStackRequest,
     ) -> RusotoFuture<UpdateStackResult, UpdateStackError> {
-        let mut request = SignedRequest::new("POST", "appstream", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "appstream",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("appstream2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "PhotonAdminProxyService.UpdateStack");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/athena/src/generated.rs
+++ b/rusoto/services/athena/src/generated.rs
@@ -1519,9 +1519,14 @@ impl Athena for AthenaClient {
         &self,
         input: BatchGetNamedQueryInput,
     ) -> RusotoFuture<BatchGetNamedQueryOutput, BatchGetNamedQueryError> {
-        let mut request = SignedRequest::new("POST", "athena", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "athena",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonAthena.BatchGetNamedQuery");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1548,9 +1553,14 @@ impl Athena for AthenaClient {
         &self,
         input: BatchGetQueryExecutionInput,
     ) -> RusotoFuture<BatchGetQueryExecutionOutput, BatchGetQueryExecutionError> {
-        let mut request = SignedRequest::new("POST", "athena", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "athena",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonAthena.BatchGetQueryExecution");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1576,9 +1586,14 @@ impl Athena for AthenaClient {
         &self,
         input: CreateNamedQueryInput,
     ) -> RusotoFuture<CreateNamedQueryOutput, CreateNamedQueryError> {
-        let mut request = SignedRequest::new("POST", "athena", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "athena",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonAthena.CreateNamedQuery");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1605,9 +1620,14 @@ impl Athena for AthenaClient {
         &self,
         input: CreateWorkGroupInput,
     ) -> RusotoFuture<CreateWorkGroupOutput, CreateWorkGroupError> {
-        let mut request = SignedRequest::new("POST", "athena", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "athena",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonAthena.CreateWorkGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1634,9 +1654,14 @@ impl Athena for AthenaClient {
         &self,
         input: DeleteNamedQueryInput,
     ) -> RusotoFuture<DeleteNamedQueryOutput, DeleteNamedQueryError> {
-        let mut request = SignedRequest::new("POST", "athena", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "athena",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonAthena.DeleteNamedQuery");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1663,9 +1688,14 @@ impl Athena for AthenaClient {
         &self,
         input: DeleteWorkGroupInput,
     ) -> RusotoFuture<DeleteWorkGroupOutput, DeleteWorkGroupError> {
-        let mut request = SignedRequest::new("POST", "athena", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "athena",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonAthena.DeleteWorkGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1692,9 +1722,14 @@ impl Athena for AthenaClient {
         &self,
         input: GetNamedQueryInput,
     ) -> RusotoFuture<GetNamedQueryOutput, GetNamedQueryError> {
-        let mut request = SignedRequest::new("POST", "athena", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "athena",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonAthena.GetNamedQuery");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1721,9 +1756,14 @@ impl Athena for AthenaClient {
         &self,
         input: GetQueryExecutionInput,
     ) -> RusotoFuture<GetQueryExecutionOutput, GetQueryExecutionError> {
-        let mut request = SignedRequest::new("POST", "athena", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "athena",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonAthena.GetQueryExecution");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1750,9 +1790,14 @@ impl Athena for AthenaClient {
         &self,
         input: GetQueryResultsInput,
     ) -> RusotoFuture<GetQueryResultsOutput, GetQueryResultsError> {
-        let mut request = SignedRequest::new("POST", "athena", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "athena",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonAthena.GetQueryResults");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1779,9 +1824,14 @@ impl Athena for AthenaClient {
         &self,
         input: GetWorkGroupInput,
     ) -> RusotoFuture<GetWorkGroupOutput, GetWorkGroupError> {
-        let mut request = SignedRequest::new("POST", "athena", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "athena",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonAthena.GetWorkGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1808,9 +1858,14 @@ impl Athena for AthenaClient {
         &self,
         input: ListNamedQueriesInput,
     ) -> RusotoFuture<ListNamedQueriesOutput, ListNamedQueriesError> {
-        let mut request = SignedRequest::new("POST", "athena", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "athena",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonAthena.ListNamedQueries");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1837,9 +1892,14 @@ impl Athena for AthenaClient {
         &self,
         input: ListQueryExecutionsInput,
     ) -> RusotoFuture<ListQueryExecutionsOutput, ListQueryExecutionsError> {
-        let mut request = SignedRequest::new("POST", "athena", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "athena",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonAthena.ListQueryExecutions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1865,9 +1925,14 @@ impl Athena for AthenaClient {
         &self,
         input: ListWorkGroupsInput,
     ) -> RusotoFuture<ListWorkGroupsOutput, ListWorkGroupsError> {
-        let mut request = SignedRequest::new("POST", "athena", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "athena",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonAthena.ListWorkGroups");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1894,9 +1959,14 @@ impl Athena for AthenaClient {
         &self,
         input: StartQueryExecutionInput,
     ) -> RusotoFuture<StartQueryExecutionOutput, StartQueryExecutionError> {
-        let mut request = SignedRequest::new("POST", "athena", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "athena",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonAthena.StartQueryExecution");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1922,9 +1992,14 @@ impl Athena for AthenaClient {
         &self,
         input: StopQueryExecutionInput,
     ) -> RusotoFuture<StopQueryExecutionOutput, StopQueryExecutionError> {
-        let mut request = SignedRequest::new("POST", "athena", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "athena",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonAthena.StopQueryExecution");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1951,9 +2026,14 @@ impl Athena for AthenaClient {
         &self,
         input: UpdateWorkGroupInput,
     ) -> RusotoFuture<UpdateWorkGroupOutput, UpdateWorkGroupError> {
-        let mut request = SignedRequest::new("POST", "athena", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "athena",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonAthena.UpdateWorkGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/autoscaling-plans/src/generated.rs
+++ b/rusoto/services/autoscaling-plans/src/generated.rs
@@ -831,9 +831,14 @@ impl AutoscalingPlans for AutoscalingPlansClient {
         &self,
         input: CreateScalingPlanRequest,
     ) -> RusotoFuture<CreateScalingPlanResponse, CreateScalingPlanError> {
-        let mut request = SignedRequest::new("POST", "autoscaling-plans", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "autoscaling-plans",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("autoscaling".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AnyScaleScalingPlannerFrontendService.CreateScalingPlan",
@@ -863,9 +868,14 @@ impl AutoscalingPlans for AutoscalingPlansClient {
         &self,
         input: DeleteScalingPlanRequest,
     ) -> RusotoFuture<DeleteScalingPlanResponse, DeleteScalingPlanError> {
-        let mut request = SignedRequest::new("POST", "autoscaling-plans", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "autoscaling-plans",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("autoscaling".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AnyScaleScalingPlannerFrontendService.DeleteScalingPlan",
@@ -895,9 +905,14 @@ impl AutoscalingPlans for AutoscalingPlansClient {
         &self,
         input: DescribeScalingPlanResourcesRequest,
     ) -> RusotoFuture<DescribeScalingPlanResourcesResponse, DescribeScalingPlanResourcesError> {
-        let mut request = SignedRequest::new("POST", "autoscaling-plans", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "autoscaling-plans",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("autoscaling".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AnyScaleScalingPlannerFrontendService.DescribeScalingPlanResources",
@@ -924,9 +939,14 @@ impl AutoscalingPlans for AutoscalingPlansClient {
         &self,
         input: DescribeScalingPlansRequest,
     ) -> RusotoFuture<DescribeScalingPlansResponse, DescribeScalingPlansError> {
-        let mut request = SignedRequest::new("POST", "autoscaling-plans", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "autoscaling-plans",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("autoscaling".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AnyScaleScalingPlannerFrontendService.DescribeScalingPlans",
@@ -958,9 +978,14 @@ impl AutoscalingPlans for AutoscalingPlansClient {
         GetScalingPlanResourceForecastDataResponse,
         GetScalingPlanResourceForecastDataError,
     > {
-        let mut request = SignedRequest::new("POST", "autoscaling-plans", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "autoscaling-plans",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("autoscaling".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AnyScaleScalingPlannerFrontendService.GetScalingPlanResourceForecastData",
@@ -989,9 +1014,14 @@ impl AutoscalingPlans for AutoscalingPlansClient {
         &self,
         input: UpdateScalingPlanRequest,
     ) -> RusotoFuture<UpdateScalingPlanResponse, UpdateScalingPlanError> {
-        let mut request = SignedRequest::new("POST", "autoscaling-plans", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "autoscaling-plans",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("autoscaling".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AnyScaleScalingPlannerFrontendService.UpdateScalingPlan",

--- a/rusoto/services/budgets/src/generated.rs
+++ b/rusoto/services/budgets/src/generated.rs
@@ -1461,9 +1461,14 @@ impl Budgets for BudgetsClient {
         &self,
         input: CreateBudgetRequest,
     ) -> RusotoFuture<CreateBudgetResponse, CreateBudgetError> {
-        let mut request = SignedRequest::new("POST", "budgets", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "budgets",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSBudgetServiceGateway.CreateBudget");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1490,9 +1495,14 @@ impl Budgets for BudgetsClient {
         &self,
         input: CreateNotificationRequest,
     ) -> RusotoFuture<CreateNotificationResponse, CreateNotificationError> {
-        let mut request = SignedRequest::new("POST", "budgets", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "budgets",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSBudgetServiceGateway.CreateNotification");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1519,9 +1529,14 @@ impl Budgets for BudgetsClient {
         &self,
         input: CreateSubscriberRequest,
     ) -> RusotoFuture<CreateSubscriberResponse, CreateSubscriberError> {
-        let mut request = SignedRequest::new("POST", "budgets", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "budgets",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSBudgetServiceGateway.CreateSubscriber");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1548,9 +1563,14 @@ impl Budgets for BudgetsClient {
         &self,
         input: DeleteBudgetRequest,
     ) -> RusotoFuture<DeleteBudgetResponse, DeleteBudgetError> {
-        let mut request = SignedRequest::new("POST", "budgets", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "budgets",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSBudgetServiceGateway.DeleteBudget");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1577,9 +1597,14 @@ impl Budgets for BudgetsClient {
         &self,
         input: DeleteNotificationRequest,
     ) -> RusotoFuture<DeleteNotificationResponse, DeleteNotificationError> {
-        let mut request = SignedRequest::new("POST", "budgets", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "budgets",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSBudgetServiceGateway.DeleteNotification");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1606,9 +1631,14 @@ impl Budgets for BudgetsClient {
         &self,
         input: DeleteSubscriberRequest,
     ) -> RusotoFuture<DeleteSubscriberResponse, DeleteSubscriberError> {
-        let mut request = SignedRequest::new("POST", "budgets", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "budgets",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSBudgetServiceGateway.DeleteSubscriber");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1635,9 +1665,14 @@ impl Budgets for BudgetsClient {
         &self,
         input: DescribeBudgetRequest,
     ) -> RusotoFuture<DescribeBudgetResponse, DescribeBudgetError> {
-        let mut request = SignedRequest::new("POST", "budgets", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "budgets",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSBudgetServiceGateway.DescribeBudget");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1665,9 +1700,14 @@ impl Budgets for BudgetsClient {
         input: DescribeBudgetPerformanceHistoryRequest,
     ) -> RusotoFuture<DescribeBudgetPerformanceHistoryResponse, DescribeBudgetPerformanceHistoryError>
     {
-        let mut request = SignedRequest::new("POST", "budgets", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "budgets",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSBudgetServiceGateway.DescribeBudgetPerformanceHistory",
@@ -1696,9 +1736,14 @@ impl Budgets for BudgetsClient {
         &self,
         input: DescribeBudgetsRequest,
     ) -> RusotoFuture<DescribeBudgetsResponse, DescribeBudgetsError> {
-        let mut request = SignedRequest::new("POST", "budgets", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "budgets",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSBudgetServiceGateway.DescribeBudgets");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1726,9 +1771,14 @@ impl Budgets for BudgetsClient {
         input: DescribeNotificationsForBudgetRequest,
     ) -> RusotoFuture<DescribeNotificationsForBudgetResponse, DescribeNotificationsForBudgetError>
     {
-        let mut request = SignedRequest::new("POST", "budgets", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "budgets",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSBudgetServiceGateway.DescribeNotificationsForBudget",
@@ -1758,9 +1808,14 @@ impl Budgets for BudgetsClient {
         DescribeSubscribersForNotificationResponse,
         DescribeSubscribersForNotificationError,
     > {
-        let mut request = SignedRequest::new("POST", "budgets", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "budgets",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSBudgetServiceGateway.DescribeSubscribersForNotification",
@@ -1789,9 +1844,14 @@ impl Budgets for BudgetsClient {
         &self,
         input: UpdateBudgetRequest,
     ) -> RusotoFuture<UpdateBudgetResponse, UpdateBudgetError> {
-        let mut request = SignedRequest::new("POST", "budgets", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "budgets",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSBudgetServiceGateway.UpdateBudget");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1818,9 +1878,14 @@ impl Budgets for BudgetsClient {
         &self,
         input: UpdateNotificationRequest,
     ) -> RusotoFuture<UpdateNotificationResponse, UpdateNotificationError> {
-        let mut request = SignedRequest::new("POST", "budgets", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "budgets",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSBudgetServiceGateway.UpdateNotification");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1847,9 +1912,14 @@ impl Budgets for BudgetsClient {
         &self,
         input: UpdateSubscriberRequest,
     ) -> RusotoFuture<UpdateSubscriberResponse, UpdateSubscriberError> {
-        let mut request = SignedRequest::new("POST", "budgets", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "budgets",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSBudgetServiceGateway.UpdateSubscriber");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/ce/src/generated.rs
+++ b/rusoto/services/ce/src/generated.rs
@@ -1489,9 +1489,14 @@ impl CostExplorer for CostExplorerClient {
         &self,
         input: GetCostAndUsageRequest,
     ) -> RusotoFuture<GetCostAndUsageResponse, GetCostAndUsageError> {
-        let mut request = SignedRequest::new("POST", "ce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSInsightsIndexService.GetCostAndUsage");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1518,9 +1523,14 @@ impl CostExplorer for CostExplorerClient {
         &self,
         input: GetCostForecastRequest,
     ) -> RusotoFuture<GetCostForecastResponse, GetCostForecastError> {
-        let mut request = SignedRequest::new("POST", "ce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSInsightsIndexService.GetCostForecast");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1547,9 +1557,14 @@ impl CostExplorer for CostExplorerClient {
         &self,
         input: GetDimensionValuesRequest,
     ) -> RusotoFuture<GetDimensionValuesResponse, GetDimensionValuesError> {
-        let mut request = SignedRequest::new("POST", "ce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSInsightsIndexService.GetDimensionValues");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1576,9 +1591,14 @@ impl CostExplorer for CostExplorerClient {
         &self,
         input: GetReservationCoverageRequest,
     ) -> RusotoFuture<GetReservationCoverageResponse, GetReservationCoverageError> {
-        let mut request = SignedRequest::new("POST", "ce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSInsightsIndexService.GetReservationCoverage",
@@ -1610,9 +1630,14 @@ impl CostExplorer for CostExplorerClient {
         GetReservationPurchaseRecommendationResponse,
         GetReservationPurchaseRecommendationError,
     > {
-        let mut request = SignedRequest::new("POST", "ce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSInsightsIndexService.GetReservationPurchaseRecommendation",
@@ -1641,9 +1666,14 @@ impl CostExplorer for CostExplorerClient {
         &self,
         input: GetReservationUtilizationRequest,
     ) -> RusotoFuture<GetReservationUtilizationResponse, GetReservationUtilizationError> {
-        let mut request = SignedRequest::new("POST", "ce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSInsightsIndexService.GetReservationUtilization",
@@ -1667,9 +1697,14 @@ impl CostExplorer for CostExplorerClient {
 
     /// <p>Queries for available tag keys and tag values for a specified period. You can search the tag values for an arbitrary string. </p>
     fn get_tags(&self, input: GetTagsRequest) -> RusotoFuture<GetTagsResponse, GetTagsError> {
-        let mut request = SignedRequest::new("POST", "ce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSInsightsIndexService.GetTags");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/cloud9/src/generated.rs
+++ b/rusoto/services/cloud9/src/generated.rs
@@ -1185,9 +1185,14 @@ impl Cloud9 for Cloud9Client {
         &self,
         input: CreateEnvironmentEC2Request,
     ) -> RusotoFuture<CreateEnvironmentEC2Result, CreateEnvironmentEC2Error> {
-        let mut request = SignedRequest::new("POST", "cloud9", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloud9",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCloud9WorkspaceManagementService.CreateEnvironmentEC2",
@@ -1216,9 +1221,14 @@ impl Cloud9 for Cloud9Client {
         &self,
         input: CreateEnvironmentMembershipRequest,
     ) -> RusotoFuture<CreateEnvironmentMembershipResult, CreateEnvironmentMembershipError> {
-        let mut request = SignedRequest::new("POST", "cloud9", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloud9",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCloud9WorkspaceManagementService.CreateEnvironmentMembership",
@@ -1245,9 +1255,14 @@ impl Cloud9 for Cloud9Client {
         &self,
         input: DeleteEnvironmentRequest,
     ) -> RusotoFuture<DeleteEnvironmentResult, DeleteEnvironmentError> {
-        let mut request = SignedRequest::new("POST", "cloud9", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloud9",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCloud9WorkspaceManagementService.DeleteEnvironment",
@@ -1277,9 +1292,14 @@ impl Cloud9 for Cloud9Client {
         &self,
         input: DeleteEnvironmentMembershipRequest,
     ) -> RusotoFuture<DeleteEnvironmentMembershipResult, DeleteEnvironmentMembershipError> {
-        let mut request = SignedRequest::new("POST", "cloud9", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloud9",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCloud9WorkspaceManagementService.DeleteEnvironmentMembership",
@@ -1307,9 +1327,14 @@ impl Cloud9 for Cloud9Client {
         input: DescribeEnvironmentMembershipsRequest,
     ) -> RusotoFuture<DescribeEnvironmentMembershipsResult, DescribeEnvironmentMembershipsError>
     {
-        let mut request = SignedRequest::new("POST", "cloud9", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloud9",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCloud9WorkspaceManagementService.DescribeEnvironmentMemberships",
@@ -1336,9 +1361,14 @@ impl Cloud9 for Cloud9Client {
         &self,
         input: DescribeEnvironmentStatusRequest,
     ) -> RusotoFuture<DescribeEnvironmentStatusResult, DescribeEnvironmentStatusError> {
-        let mut request = SignedRequest::new("POST", "cloud9", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloud9",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCloud9WorkspaceManagementService.DescribeEnvironmentStatus",
@@ -1365,9 +1395,14 @@ impl Cloud9 for Cloud9Client {
         &self,
         input: DescribeEnvironmentsRequest,
     ) -> RusotoFuture<DescribeEnvironmentsResult, DescribeEnvironmentsError> {
-        let mut request = SignedRequest::new("POST", "cloud9", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloud9",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCloud9WorkspaceManagementService.DescribeEnvironments",
@@ -1396,9 +1431,14 @@ impl Cloud9 for Cloud9Client {
         &self,
         input: ListEnvironmentsRequest,
     ) -> RusotoFuture<ListEnvironmentsResult, ListEnvironmentsError> {
-        let mut request = SignedRequest::new("POST", "cloud9", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloud9",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCloud9WorkspaceManagementService.ListEnvironments",
@@ -1428,9 +1468,14 @@ impl Cloud9 for Cloud9Client {
         &self,
         input: UpdateEnvironmentRequest,
     ) -> RusotoFuture<UpdateEnvironmentResult, UpdateEnvironmentError> {
-        let mut request = SignedRequest::new("POST", "cloud9", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloud9",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCloud9WorkspaceManagementService.UpdateEnvironment",
@@ -1460,9 +1505,14 @@ impl Cloud9 for Cloud9Client {
         &self,
         input: UpdateEnvironmentMembershipRequest,
     ) -> RusotoFuture<UpdateEnvironmentMembershipResult, UpdateEnvironmentMembershipError> {
-        let mut request = SignedRequest::new("POST", "cloud9", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloud9",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCloud9WorkspaceManagementService.UpdateEnvironmentMembership",

--- a/rusoto/services/cloudhsm/src/generated.rs
+++ b/rusoto/services/cloudhsm/src/generated.rs
@@ -1648,9 +1648,14 @@ impl CloudHsm for CloudHsmClient {
         &self,
         input: AddTagsToResourceRequest,
     ) -> RusotoFuture<AddTagsToResourceResponse, AddTagsToResourceError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CloudHsmFrontendService.AddTagsToResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1677,9 +1682,14 @@ impl CloudHsm for CloudHsmClient {
         &self,
         input: CreateHapgRequest,
     ) -> RusotoFuture<CreateHapgResponse, CreateHapgError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CloudHsmFrontendService.CreateHapg");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1706,9 +1716,14 @@ impl CloudHsm for CloudHsmClient {
         &self,
         input: CreateHsmRequest,
     ) -> RusotoFuture<CreateHsmResponse, CreateHsmError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CloudHsmFrontendService.CreateHsm");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1735,9 +1750,14 @@ impl CloudHsm for CloudHsmClient {
         &self,
         input: CreateLunaClientRequest,
     ) -> RusotoFuture<CreateLunaClientResponse, CreateLunaClientError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CloudHsmFrontendService.CreateLunaClient");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1764,9 +1784,14 @@ impl CloudHsm for CloudHsmClient {
         &self,
         input: DeleteHapgRequest,
     ) -> RusotoFuture<DeleteHapgResponse, DeleteHapgError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CloudHsmFrontendService.DeleteHapg");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1793,9 +1818,14 @@ impl CloudHsm for CloudHsmClient {
         &self,
         input: DeleteHsmRequest,
     ) -> RusotoFuture<DeleteHsmResponse, DeleteHsmError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CloudHsmFrontendService.DeleteHsm");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1822,9 +1852,14 @@ impl CloudHsm for CloudHsmClient {
         &self,
         input: DeleteLunaClientRequest,
     ) -> RusotoFuture<DeleteLunaClientResponse, DeleteLunaClientError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CloudHsmFrontendService.DeleteLunaClient");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1851,9 +1886,14 @@ impl CloudHsm for CloudHsmClient {
         &self,
         input: DescribeHapgRequest,
     ) -> RusotoFuture<DescribeHapgResponse, DescribeHapgError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CloudHsmFrontendService.DescribeHapg");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1880,9 +1920,14 @@ impl CloudHsm for CloudHsmClient {
         &self,
         input: DescribeHsmRequest,
     ) -> RusotoFuture<DescribeHsmResponse, DescribeHsmError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CloudHsmFrontendService.DescribeHsm");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1909,9 +1954,14 @@ impl CloudHsm for CloudHsmClient {
         &self,
         input: DescribeLunaClientRequest,
     ) -> RusotoFuture<DescribeLunaClientResponse, DescribeLunaClientError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CloudHsmFrontendService.DescribeLunaClient");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1938,9 +1988,14 @@ impl CloudHsm for CloudHsmClient {
         &self,
         input: GetConfigRequest,
     ) -> RusotoFuture<GetConfigResponse, GetConfigError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CloudHsmFrontendService.GetConfig");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1966,9 +2021,14 @@ impl CloudHsm for CloudHsmClient {
     fn list_available_zones(
         &self,
     ) -> RusotoFuture<ListAvailableZonesResponse, ListAvailableZonesError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CloudHsmFrontendService.ListAvailableZones");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -1994,9 +2054,14 @@ impl CloudHsm for CloudHsmClient {
         &self,
         input: ListHapgsRequest,
     ) -> RusotoFuture<ListHapgsResponse, ListHapgsError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CloudHsmFrontendService.ListHapgs");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2020,9 +2085,14 @@ impl CloudHsm for CloudHsmClient {
 
     /// <p>This is documentation for <b>AWS CloudHSM Classic</b>. For more information, see <a href="http://aws.amazon.com/cloudhsm/faqs-classic/">AWS CloudHSM Classic FAQs</a>, the <a href="http://docs.aws.amazon.com/cloudhsm/classic/userguide/">AWS CloudHSM Classic User Guide</a>, and the <a href="http://docs.aws.amazon.com/cloudhsm/classic/APIReference/">AWS CloudHSM Classic API Reference</a>.</p> <p> <b>For information about the current version of AWS CloudHSM</b>, see <a href="http://aws.amazon.com/cloudhsm/">AWS CloudHSM</a>, the <a href="http://docs.aws.amazon.com/cloudhsm/latest/userguide/">AWS CloudHSM User Guide</a>, and the <a href="http://docs.aws.amazon.com/cloudhsm/latest/APIReference/">AWS CloudHSM API Reference</a>.</p> <p>Retrieves the identifiers of all of the HSMs provisioned for the current customer.</p> <p>This operation supports pagination with the use of the <code>NextToken</code> member. If more results are available, the <code>NextToken</code> member of the response contains a token that you pass in the next call to <code>ListHsms</code> to retrieve the next set of items.</p>
     fn list_hsms(&self, input: ListHsmsRequest) -> RusotoFuture<ListHsmsResponse, ListHsmsError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CloudHsmFrontendService.ListHsms");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2049,9 +2119,14 @@ impl CloudHsm for CloudHsmClient {
         &self,
         input: ListLunaClientsRequest,
     ) -> RusotoFuture<ListLunaClientsResponse, ListLunaClientsError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CloudHsmFrontendService.ListLunaClients");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2078,9 +2153,14 @@ impl CloudHsm for CloudHsmClient {
         &self,
         input: ListTagsForResourceRequest,
     ) -> RusotoFuture<ListTagsForResourceResponse, ListTagsForResourceError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CloudHsmFrontendService.ListTagsForResource",
@@ -2109,9 +2189,14 @@ impl CloudHsm for CloudHsmClient {
         &self,
         input: ModifyHapgRequest,
     ) -> RusotoFuture<ModifyHapgResponse, ModifyHapgError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CloudHsmFrontendService.ModifyHapg");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2138,9 +2223,14 @@ impl CloudHsm for CloudHsmClient {
         &self,
         input: ModifyHsmRequest,
     ) -> RusotoFuture<ModifyHsmResponse, ModifyHsmError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CloudHsmFrontendService.ModifyHsm");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2167,9 +2257,14 @@ impl CloudHsm for CloudHsmClient {
         &self,
         input: ModifyLunaClientRequest,
     ) -> RusotoFuture<ModifyLunaClientResponse, ModifyLunaClientError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CloudHsmFrontendService.ModifyLunaClient");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2196,9 +2291,14 @@ impl CloudHsm for CloudHsmClient {
         &self,
         input: RemoveTagsFromResourceRequest,
     ) -> RusotoFuture<RemoveTagsFromResourceResponse, RemoveTagsFromResourceError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CloudHsmFrontendService.RemoveTagsFromResource",

--- a/rusoto/services/cloudhsmv2/src/generated.rs
+++ b/rusoto/services/cloudhsmv2/src/generated.rs
@@ -1407,9 +1407,14 @@ impl CloudHsmv2 for CloudHsmv2Client {
         &self,
         input: CopyBackupToRegionRequest,
     ) -> RusotoFuture<CopyBackupToRegionResponse, CopyBackupToRegionError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("cloudhsmv2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "BaldrApiService.CopyBackupToRegion");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1436,9 +1441,14 @@ impl CloudHsmv2 for CloudHsmv2Client {
         &self,
         input: CreateClusterRequest,
     ) -> RusotoFuture<CreateClusterResponse, CreateClusterError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("cloudhsmv2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "BaldrApiService.CreateCluster");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1465,9 +1475,14 @@ impl CloudHsmv2 for CloudHsmv2Client {
         &self,
         input: CreateHsmRequest,
     ) -> RusotoFuture<CreateHsmResponse, CreateHsmError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("cloudhsmv2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "BaldrApiService.CreateHsm");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1494,9 +1509,14 @@ impl CloudHsmv2 for CloudHsmv2Client {
         &self,
         input: DeleteBackupRequest,
     ) -> RusotoFuture<DeleteBackupResponse, DeleteBackupError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("cloudhsmv2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "BaldrApiService.DeleteBackup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1523,9 +1543,14 @@ impl CloudHsmv2 for CloudHsmv2Client {
         &self,
         input: DeleteClusterRequest,
     ) -> RusotoFuture<DeleteClusterResponse, DeleteClusterError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("cloudhsmv2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "BaldrApiService.DeleteCluster");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1552,9 +1577,14 @@ impl CloudHsmv2 for CloudHsmv2Client {
         &self,
         input: DeleteHsmRequest,
     ) -> RusotoFuture<DeleteHsmResponse, DeleteHsmError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("cloudhsmv2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "BaldrApiService.DeleteHsm");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1581,9 +1611,14 @@ impl CloudHsmv2 for CloudHsmv2Client {
         &self,
         input: DescribeBackupsRequest,
     ) -> RusotoFuture<DescribeBackupsResponse, DescribeBackupsError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("cloudhsmv2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "BaldrApiService.DescribeBackups");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1610,9 +1645,14 @@ impl CloudHsmv2 for CloudHsmv2Client {
         &self,
         input: DescribeClustersRequest,
     ) -> RusotoFuture<DescribeClustersResponse, DescribeClustersError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("cloudhsmv2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "BaldrApiService.DescribeClusters");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1639,9 +1679,14 @@ impl CloudHsmv2 for CloudHsmv2Client {
         &self,
         input: InitializeClusterRequest,
     ) -> RusotoFuture<InitializeClusterResponse, InitializeClusterError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("cloudhsmv2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "BaldrApiService.InitializeCluster");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1665,9 +1710,14 @@ impl CloudHsmv2 for CloudHsmv2Client {
 
     /// <p>Gets a list of tags for the specified AWS CloudHSM cluster.</p> <p>This is a paginated operation, which means that each response might contain only a subset of all the tags. When the response contains only a subset of tags, it includes a <code>NextToken</code> value. Use this value in a subsequent <code>ListTags</code> request to get more tags. When you receive a response with no <code>NextToken</code> (or an empty or null value), that means there are no more tags to get.</p>
     fn list_tags(&self, input: ListTagsRequest) -> RusotoFuture<ListTagsResponse, ListTagsError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("cloudhsmv2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "BaldrApiService.ListTags");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1694,9 +1744,14 @@ impl CloudHsmv2 for CloudHsmv2Client {
         &self,
         input: RestoreBackupRequest,
     ) -> RusotoFuture<RestoreBackupResponse, RestoreBackupError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("cloudhsmv2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "BaldrApiService.RestoreBackup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1723,9 +1778,14 @@ impl CloudHsmv2 for CloudHsmv2Client {
         &self,
         input: TagResourceRequest,
     ) -> RusotoFuture<TagResourceResponse, TagResourceError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("cloudhsmv2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "BaldrApiService.TagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1752,9 +1812,14 @@ impl CloudHsmv2 for CloudHsmv2Client {
         &self,
         input: UntagResourceRequest,
     ) -> RusotoFuture<UntagResourceResponse, UntagResourceError> {
-        let mut request = SignedRequest::new("POST", "cloudhsm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudhsm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("cloudhsmv2".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "BaldrApiService.UntagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/cloudtrail/src/generated.rs
+++ b/rusoto/services/cloudtrail/src/generated.rs
@@ -2061,9 +2061,14 @@ impl CloudTrailClient {
 impl CloudTrail for CloudTrailClient {
     /// <p>Adds one or more tags to a trail, up to a limit of 50. Tags must be unique per trail. Overwrites an existing tag's value when a new value is specified for an existing tag key. If you specify a key without a value, the tag will be created with the specified key and a value of null. You can tag a trail that applies to all regions only from the region in which the trail was created (that is, from its home region).</p>
     fn add_tags(&self, input: AddTagsRequest) -> RusotoFuture<AddTagsResponse, AddTagsError> {
-        let mut request = SignedRequest::new("POST", "cloudtrail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudtrail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.AddTags",
@@ -2092,9 +2097,14 @@ impl CloudTrail for CloudTrailClient {
         &self,
         input: CreateTrailRequest,
     ) -> RusotoFuture<CreateTrailResponse, CreateTrailError> {
-        let mut request = SignedRequest::new("POST", "cloudtrail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudtrail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.CreateTrail",
@@ -2124,9 +2134,14 @@ impl CloudTrail for CloudTrailClient {
         &self,
         input: DeleteTrailRequest,
     ) -> RusotoFuture<DeleteTrailResponse, DeleteTrailError> {
-        let mut request = SignedRequest::new("POST", "cloudtrail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudtrail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.DeleteTrail",
@@ -2156,9 +2171,14 @@ impl CloudTrail for CloudTrailClient {
         &self,
         input: DescribeTrailsRequest,
     ) -> RusotoFuture<DescribeTrailsResponse, DescribeTrailsError> {
-        let mut request = SignedRequest::new("POST", "cloudtrail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudtrail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.DescribeTrails",
@@ -2188,9 +2208,14 @@ impl CloudTrail for CloudTrailClient {
         &self,
         input: GetEventSelectorsRequest,
     ) -> RusotoFuture<GetEventSelectorsResponse, GetEventSelectorsError> {
-        let mut request = SignedRequest::new("POST", "cloudtrail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudtrail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.GetEventSelectors",
@@ -2220,9 +2245,14 @@ impl CloudTrail for CloudTrailClient {
         &self,
         input: GetTrailStatusRequest,
     ) -> RusotoFuture<GetTrailStatusResponse, GetTrailStatusError> {
-        let mut request = SignedRequest::new("POST", "cloudtrail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudtrail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.GetTrailStatus",
@@ -2252,9 +2282,14 @@ impl CloudTrail for CloudTrailClient {
         &self,
         input: ListPublicKeysRequest,
     ) -> RusotoFuture<ListPublicKeysResponse, ListPublicKeysError> {
-        let mut request = SignedRequest::new("POST", "cloudtrail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudtrail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.ListPublicKeys",
@@ -2281,9 +2316,14 @@ impl CloudTrail for CloudTrailClient {
 
     /// <p>Lists the tags for the trail in the current region.</p>
     fn list_tags(&self, input: ListTagsRequest) -> RusotoFuture<ListTagsResponse, ListTagsError> {
-        let mut request = SignedRequest::new("POST", "cloudtrail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudtrail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.ListTags",
@@ -2313,9 +2353,14 @@ impl CloudTrail for CloudTrailClient {
         &self,
         input: LookupEventsRequest,
     ) -> RusotoFuture<LookupEventsResponse, LookupEventsError> {
-        let mut request = SignedRequest::new("POST", "cloudtrail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudtrail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.LookupEvents",
@@ -2345,9 +2390,14 @@ impl CloudTrail for CloudTrailClient {
         &self,
         input: PutEventSelectorsRequest,
     ) -> RusotoFuture<PutEventSelectorsResponse, PutEventSelectorsError> {
-        let mut request = SignedRequest::new("POST", "cloudtrail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudtrail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.PutEventSelectors",
@@ -2377,9 +2427,14 @@ impl CloudTrail for CloudTrailClient {
         &self,
         input: RemoveTagsRequest,
     ) -> RusotoFuture<RemoveTagsResponse, RemoveTagsError> {
-        let mut request = SignedRequest::new("POST", "cloudtrail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudtrail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.RemoveTags",
@@ -2409,9 +2464,14 @@ impl CloudTrail for CloudTrailClient {
         &self,
         input: StartLoggingRequest,
     ) -> RusotoFuture<StartLoggingResponse, StartLoggingError> {
-        let mut request = SignedRequest::new("POST", "cloudtrail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudtrail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.StartLogging",
@@ -2441,9 +2501,14 @@ impl CloudTrail for CloudTrailClient {
         &self,
         input: StopLoggingRequest,
     ) -> RusotoFuture<StopLoggingResponse, StopLoggingError> {
-        let mut request = SignedRequest::new("POST", "cloudtrail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudtrail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.StopLogging",
@@ -2473,9 +2538,14 @@ impl CloudTrail for CloudTrailClient {
         &self,
         input: UpdateTrailRequest,
     ) -> RusotoFuture<UpdateTrailResponse, UpdateTrailError> {
-        let mut request = SignedRequest::new("POST", "cloudtrail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cloudtrail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.UpdateTrail",

--- a/rusoto/services/codebuild/src/generated.rs
+++ b/rusoto/services/codebuild/src/generated.rs
@@ -2178,9 +2178,14 @@ impl CodeBuild for CodeBuildClient {
         &self,
         input: BatchDeleteBuildsInput,
     ) -> RusotoFuture<BatchDeleteBuildsOutput, BatchDeleteBuildsError> {
-        let mut request = SignedRequest::new("POST", "codebuild", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codebuild",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeBuild_20161006.BatchDeleteBuilds");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2207,9 +2212,14 @@ impl CodeBuild for CodeBuildClient {
         &self,
         input: BatchGetBuildsInput,
     ) -> RusotoFuture<BatchGetBuildsOutput, BatchGetBuildsError> {
-        let mut request = SignedRequest::new("POST", "codebuild", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codebuild",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeBuild_20161006.BatchGetBuilds");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2236,9 +2246,14 @@ impl CodeBuild for CodeBuildClient {
         &self,
         input: BatchGetProjectsInput,
     ) -> RusotoFuture<BatchGetProjectsOutput, BatchGetProjectsError> {
-        let mut request = SignedRequest::new("POST", "codebuild", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codebuild",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeBuild_20161006.BatchGetProjects");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2265,9 +2280,14 @@ impl CodeBuild for CodeBuildClient {
         &self,
         input: CreateProjectInput,
     ) -> RusotoFuture<CreateProjectOutput, CreateProjectError> {
-        let mut request = SignedRequest::new("POST", "codebuild", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codebuild",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeBuild_20161006.CreateProject");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2294,9 +2314,14 @@ impl CodeBuild for CodeBuildClient {
         &self,
         input: CreateWebhookInput,
     ) -> RusotoFuture<CreateWebhookOutput, CreateWebhookError> {
-        let mut request = SignedRequest::new("POST", "codebuild", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codebuild",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeBuild_20161006.CreateWebhook");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2323,9 +2348,14 @@ impl CodeBuild for CodeBuildClient {
         &self,
         input: DeleteProjectInput,
     ) -> RusotoFuture<DeleteProjectOutput, DeleteProjectError> {
-        let mut request = SignedRequest::new("POST", "codebuild", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codebuild",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeBuild_20161006.DeleteProject");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2352,9 +2382,14 @@ impl CodeBuild for CodeBuildClient {
         &self,
         input: DeleteSourceCredentialsInput,
     ) -> RusotoFuture<DeleteSourceCredentialsOutput, DeleteSourceCredentialsError> {
-        let mut request = SignedRequest::new("POST", "codebuild", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codebuild",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeBuild_20161006.DeleteSourceCredentials");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2378,9 +2413,14 @@ impl CodeBuild for CodeBuildClient {
         &self,
         input: DeleteWebhookInput,
     ) -> RusotoFuture<DeleteWebhookOutput, DeleteWebhookError> {
-        let mut request = SignedRequest::new("POST", "codebuild", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codebuild",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeBuild_20161006.DeleteWebhook");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2407,9 +2447,14 @@ impl CodeBuild for CodeBuildClient {
         &self,
         input: ImportSourceCredentialsInput,
     ) -> RusotoFuture<ImportSourceCredentialsOutput, ImportSourceCredentialsError> {
-        let mut request = SignedRequest::new("POST", "codebuild", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codebuild",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeBuild_20161006.ImportSourceCredentials");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2433,9 +2478,14 @@ impl CodeBuild for CodeBuildClient {
         &self,
         input: InvalidateProjectCacheInput,
     ) -> RusotoFuture<InvalidateProjectCacheOutput, InvalidateProjectCacheError> {
-        let mut request = SignedRequest::new("POST", "codebuild", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codebuild",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeBuild_20161006.InvalidateProjectCache");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2461,9 +2511,14 @@ impl CodeBuild for CodeBuildClient {
         &self,
         input: ListBuildsInput,
     ) -> RusotoFuture<ListBuildsOutput, ListBuildsError> {
-        let mut request = SignedRequest::new("POST", "codebuild", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codebuild",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeBuild_20161006.ListBuilds");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2490,9 +2545,14 @@ impl CodeBuild for CodeBuildClient {
         &self,
         input: ListBuildsForProjectInput,
     ) -> RusotoFuture<ListBuildsForProjectOutput, ListBuildsForProjectError> {
-        let mut request = SignedRequest::new("POST", "codebuild", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codebuild",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeBuild_20161006.ListBuildsForProject");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2517,9 +2577,14 @@ impl CodeBuild for CodeBuildClient {
     fn list_curated_environment_images(
         &self,
     ) -> RusotoFuture<ListCuratedEnvironmentImagesOutput, ListCuratedEnvironmentImagesError> {
-        let mut request = SignedRequest::new("POST", "codebuild", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codebuild",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeBuild_20161006.ListCuratedEnvironmentImages",
@@ -2545,9 +2610,14 @@ impl CodeBuild for CodeBuildClient {
         &self,
         input: ListProjectsInput,
     ) -> RusotoFuture<ListProjectsOutput, ListProjectsError> {
-        let mut request = SignedRequest::new("POST", "codebuild", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codebuild",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeBuild_20161006.ListProjects");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2573,9 +2643,14 @@ impl CodeBuild for CodeBuildClient {
     fn list_source_credentials(
         &self,
     ) -> RusotoFuture<ListSourceCredentialsOutput, ListSourceCredentialsError> {
-        let mut request = SignedRequest::new("POST", "codebuild", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codebuild",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeBuild_20161006.ListSourceCredentials");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -2600,9 +2675,14 @@ impl CodeBuild for CodeBuildClient {
         &self,
         input: StartBuildInput,
     ) -> RusotoFuture<StartBuildOutput, StartBuildError> {
-        let mut request = SignedRequest::new("POST", "codebuild", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codebuild",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeBuild_20161006.StartBuild");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2626,9 +2706,14 @@ impl CodeBuild for CodeBuildClient {
 
     /// <p>Attempts to stop running a build.</p>
     fn stop_build(&self, input: StopBuildInput) -> RusotoFuture<StopBuildOutput, StopBuildError> {
-        let mut request = SignedRequest::new("POST", "codebuild", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codebuild",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeBuild_20161006.StopBuild");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2654,9 +2739,14 @@ impl CodeBuild for CodeBuildClient {
         &self,
         input: UpdateProjectInput,
     ) -> RusotoFuture<UpdateProjectOutput, UpdateProjectError> {
-        let mut request = SignedRequest::new("POST", "codebuild", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codebuild",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeBuild_20161006.UpdateProject");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2683,9 +2773,14 @@ impl CodeBuild for CodeBuildClient {
         &self,
         input: UpdateWebhookInput,
     ) -> RusotoFuture<UpdateWebhookOutput, UpdateWebhookError> {
-        let mut request = SignedRequest::new("POST", "codebuild", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codebuild",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeBuild_20161006.UpdateWebhook");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/codecommit/src/generated.rs
+++ b/rusoto/services/codecommit/src/generated.rs
@@ -7091,9 +7091,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: BatchGetRepositoriesInput,
     ) -> RusotoFuture<BatchGetRepositoriesOutput, BatchGetRepositoriesError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.BatchGetRepositories");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7116,9 +7121,14 @@ impl CodeCommit for CodeCommitClient {
 
     /// <p><p>Creates a new branch in a repository and points the branch to a commit.</p> <note> <p>Calling the create branch operation does not set a repository&#39;s default branch. To do this, call the update default branch operation.</p> </note></p>
     fn create_branch(&self, input: CreateBranchInput) -> RusotoFuture<(), CreateBranchError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.CreateBranch");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7142,9 +7152,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: CreateCommitInput,
     ) -> RusotoFuture<CreateCommitOutput, CreateCommitError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.CreateCommit");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7171,9 +7186,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: CreatePullRequestInput,
     ) -> RusotoFuture<CreatePullRequestOutput, CreatePullRequestError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.CreatePullRequest");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7200,9 +7220,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: CreateRepositoryInput,
     ) -> RusotoFuture<CreateRepositoryOutput, CreateRepositoryError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.CreateRepository");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7229,9 +7254,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: DeleteBranchInput,
     ) -> RusotoFuture<DeleteBranchOutput, DeleteBranchError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.DeleteBranch");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7258,9 +7288,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: DeleteCommentContentInput,
     ) -> RusotoFuture<DeleteCommentContentOutput, DeleteCommentContentError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.DeleteCommentContent");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7286,9 +7321,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: DeleteFileInput,
     ) -> RusotoFuture<DeleteFileOutput, DeleteFileError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.DeleteFile");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7315,9 +7355,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: DeleteRepositoryInput,
     ) -> RusotoFuture<DeleteRepositoryOutput, DeleteRepositoryError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.DeleteRepository");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7344,9 +7389,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: DescribePullRequestEventsInput,
     ) -> RusotoFuture<DescribePullRequestEventsOutput, DescribePullRequestEventsError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeCommit_20150413.DescribePullRequestEvents",
@@ -7370,9 +7420,14 @@ impl CodeCommit for CodeCommitClient {
 
     /// <p>Returns the base-64 encoded content of an individual blob within a repository.</p>
     fn get_blob(&self, input: GetBlobInput) -> RusotoFuture<GetBlobOutput, GetBlobError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.GetBlob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7395,9 +7450,14 @@ impl CodeCommit for CodeCommitClient {
 
     /// <p>Returns information about a repository branch, including its name and the last commit ID.</p>
     fn get_branch(&self, input: GetBranchInput) -> RusotoFuture<GetBranchOutput, GetBranchError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.GetBranch");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7423,9 +7483,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: GetCommentInput,
     ) -> RusotoFuture<GetCommentOutput, GetCommentError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.GetComment");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7452,9 +7517,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: GetCommentsForComparedCommitInput,
     ) -> RusotoFuture<GetCommentsForComparedCommitOutput, GetCommentsForComparedCommitError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeCommit_20150413.GetCommentsForComparedCommit",
@@ -7481,9 +7551,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: GetCommentsForPullRequestInput,
     ) -> RusotoFuture<GetCommentsForPullRequestOutput, GetCommentsForPullRequestError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeCommit_20150413.GetCommentsForPullRequest",
@@ -7507,9 +7582,14 @@ impl CodeCommit for CodeCommitClient {
 
     /// <p>Returns information about a commit, including commit message and committer information.</p>
     fn get_commit(&self, input: GetCommitInput) -> RusotoFuture<GetCommitOutput, GetCommitError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.GetCommit");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7535,9 +7615,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: GetDifferencesInput,
     ) -> RusotoFuture<GetDifferencesOutput, GetDifferencesError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.GetDifferences");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7561,9 +7646,14 @@ impl CodeCommit for CodeCommitClient {
 
     /// <p>Returns the base-64 encoded contents of a specified file and its metadata.</p>
     fn get_file(&self, input: GetFileInput) -> RusotoFuture<GetFileOutput, GetFileError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.GetFile");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7586,9 +7676,14 @@ impl CodeCommit for CodeCommitClient {
 
     /// <p>Returns the contents of a specified folder in a repository.</p>
     fn get_folder(&self, input: GetFolderInput) -> RusotoFuture<GetFolderOutput, GetFolderError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.GetFolder");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7614,9 +7709,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: GetMergeConflictsInput,
     ) -> RusotoFuture<GetMergeConflictsOutput, GetMergeConflictsError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.GetMergeConflicts");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7643,9 +7743,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: GetPullRequestInput,
     ) -> RusotoFuture<GetPullRequestOutput, GetPullRequestError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.GetPullRequest");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7672,9 +7777,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: GetRepositoryInput,
     ) -> RusotoFuture<GetRepositoryOutput, GetRepositoryError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.GetRepository");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7701,9 +7811,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: GetRepositoryTriggersInput,
     ) -> RusotoFuture<GetRepositoryTriggersOutput, GetRepositoryTriggersError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.GetRepositoryTriggers");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7729,9 +7844,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: ListBranchesInput,
     ) -> RusotoFuture<ListBranchesOutput, ListBranchesError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.ListBranches");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7758,9 +7878,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: ListPullRequestsInput,
     ) -> RusotoFuture<ListPullRequestsOutput, ListPullRequestsError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.ListPullRequests");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7787,9 +7912,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: ListRepositoriesInput,
     ) -> RusotoFuture<ListRepositoriesOutput, ListRepositoriesError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.ListRepositories");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7816,9 +7946,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: MergePullRequestByFastForwardInput,
     ) -> RusotoFuture<MergePullRequestByFastForwardOutput, MergePullRequestByFastForwardError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeCommit_20150413.MergePullRequestByFastForward",
@@ -7845,9 +7980,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: PostCommentForComparedCommitInput,
     ) -> RusotoFuture<PostCommentForComparedCommitOutput, PostCommentForComparedCommitError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeCommit_20150413.PostCommentForComparedCommit",
@@ -7874,9 +8014,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: PostCommentForPullRequestInput,
     ) -> RusotoFuture<PostCommentForPullRequestOutput, PostCommentForPullRequestError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeCommit_20150413.PostCommentForPullRequest",
@@ -7903,9 +8048,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: PostCommentReplyInput,
     ) -> RusotoFuture<PostCommentReplyOutput, PostCommentReplyError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.PostCommentReply");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7929,9 +8079,14 @@ impl CodeCommit for CodeCommitClient {
 
     /// <p>Adds or updates a file in a branch in an AWS CodeCommit repository, and generates a commit for the addition in the specified branch.</p>
     fn put_file(&self, input: PutFileInput) -> RusotoFuture<PutFileOutput, PutFileError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.PutFile");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7957,9 +8112,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: PutRepositoryTriggersInput,
     ) -> RusotoFuture<PutRepositoryTriggersOutput, PutRepositoryTriggersError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.PutRepositoryTriggers");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7985,9 +8145,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: TestRepositoryTriggersInput,
     ) -> RusotoFuture<TestRepositoryTriggersOutput, TestRepositoryTriggersError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.TestRepositoryTriggers");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8013,9 +8178,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: UpdateCommentInput,
     ) -> RusotoFuture<UpdateCommentOutput, UpdateCommentError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.UpdateComment");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8042,9 +8212,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: UpdateDefaultBranchInput,
     ) -> RusotoFuture<(), UpdateDefaultBranchError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.UpdateDefaultBranch");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8067,9 +8242,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: UpdatePullRequestDescriptionInput,
     ) -> RusotoFuture<UpdatePullRequestDescriptionOutput, UpdatePullRequestDescriptionError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeCommit_20150413.UpdatePullRequestDescription",
@@ -8096,9 +8276,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: UpdatePullRequestStatusInput,
     ) -> RusotoFuture<UpdatePullRequestStatusOutput, UpdatePullRequestStatusError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeCommit_20150413.UpdatePullRequestStatus",
@@ -8125,9 +8310,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: UpdatePullRequestTitleInput,
     ) -> RusotoFuture<UpdatePullRequestTitleOutput, UpdatePullRequestTitleError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.UpdatePullRequestTitle");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8153,9 +8343,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: UpdateRepositoryDescriptionInput,
     ) -> RusotoFuture<(), UpdateRepositoryDescriptionError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeCommit_20150413.UpdateRepositoryDescription",
@@ -8179,9 +8374,14 @@ impl CodeCommit for CodeCommitClient {
         &self,
         input: UpdateRepositoryNameInput,
     ) -> RusotoFuture<(), UpdateRepositoryNameError> {
-        let mut request = SignedRequest::new("POST", "codecommit", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codecommit",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeCommit_20150413.UpdateRepositoryName");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/codedeploy/src/generated.rs
+++ b/rusoto/services/codedeploy/src/generated.rs
@@ -6021,9 +6021,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: AddTagsToOnPremisesInstancesInput,
     ) -> RusotoFuture<(), AddTagsToOnPremisesInstancesError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeDeploy_20141006.AddTagsToOnPremisesInstances",
@@ -6047,9 +6052,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: BatchGetApplicationRevisionsInput,
     ) -> RusotoFuture<BatchGetApplicationRevisionsOutput, BatchGetApplicationRevisionsError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeDeploy_20141006.BatchGetApplicationRevisions",
@@ -6076,9 +6086,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: BatchGetApplicationsInput,
     ) -> RusotoFuture<BatchGetApplicationsOutput, BatchGetApplicationsError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.BatchGetApplications");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6104,9 +6119,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: BatchGetDeploymentGroupsInput,
     ) -> RusotoFuture<BatchGetDeploymentGroupsOutput, BatchGetDeploymentGroupsError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeDeploy_20141006.BatchGetDeploymentGroups",
@@ -6133,9 +6153,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: BatchGetDeploymentInstancesInput,
     ) -> RusotoFuture<BatchGetDeploymentInstancesOutput, BatchGetDeploymentInstancesError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeDeploy_20141006.BatchGetDeploymentInstances",
@@ -6162,9 +6187,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: BatchGetDeploymentTargetsInput,
     ) -> RusotoFuture<BatchGetDeploymentTargetsOutput, BatchGetDeploymentTargetsError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeDeploy_20141006.BatchGetDeploymentTargets",
@@ -6191,9 +6221,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: BatchGetDeploymentsInput,
     ) -> RusotoFuture<BatchGetDeploymentsOutput, BatchGetDeploymentsError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.BatchGetDeployments");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6219,9 +6254,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: BatchGetOnPremisesInstancesInput,
     ) -> RusotoFuture<BatchGetOnPremisesInstancesOutput, BatchGetOnPremisesInstancesError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeDeploy_20141006.BatchGetOnPremisesInstances",
@@ -6248,9 +6288,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: ContinueDeploymentInput,
     ) -> RusotoFuture<(), ContinueDeploymentError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.ContinueDeployment");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6274,9 +6319,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: CreateApplicationInput,
     ) -> RusotoFuture<CreateApplicationOutput, CreateApplicationError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.CreateApplication");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6303,9 +6353,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: CreateDeploymentInput,
     ) -> RusotoFuture<CreateDeploymentOutput, CreateDeploymentError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.CreateDeployment");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6332,9 +6387,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: CreateDeploymentConfigInput,
     ) -> RusotoFuture<CreateDeploymentConfigOutput, CreateDeploymentConfigError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.CreateDeploymentConfig");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6360,9 +6420,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: CreateDeploymentGroupInput,
     ) -> RusotoFuture<CreateDeploymentGroupOutput, CreateDeploymentGroupError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.CreateDeploymentGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6388,9 +6453,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: DeleteApplicationInput,
     ) -> RusotoFuture<(), DeleteApplicationError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.DeleteApplication");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6414,9 +6484,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: DeleteDeploymentConfigInput,
     ) -> RusotoFuture<(), DeleteDeploymentConfigError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.DeleteDeploymentConfig");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6439,9 +6514,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: DeleteDeploymentGroupInput,
     ) -> RusotoFuture<DeleteDeploymentGroupOutput, DeleteDeploymentGroupError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.DeleteDeploymentGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6467,9 +6547,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: DeleteGitHubAccountTokenInput,
     ) -> RusotoFuture<DeleteGitHubAccountTokenOutput, DeleteGitHubAccountTokenError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeDeploy_20141006.DeleteGitHubAccountToken",
@@ -6496,9 +6581,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: DeregisterOnPremisesInstanceInput,
     ) -> RusotoFuture<(), DeregisterOnPremisesInstanceError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeDeploy_20141006.DeregisterOnPremisesInstance",
@@ -6522,9 +6612,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: GetApplicationInput,
     ) -> RusotoFuture<GetApplicationOutput, GetApplicationError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.GetApplication");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6551,9 +6646,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: GetApplicationRevisionInput,
     ) -> RusotoFuture<GetApplicationRevisionOutput, GetApplicationRevisionError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.GetApplicationRevision");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6579,9 +6679,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: GetDeploymentInput,
     ) -> RusotoFuture<GetDeploymentOutput, GetDeploymentError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.GetDeployment");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6608,9 +6713,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: GetDeploymentConfigInput,
     ) -> RusotoFuture<GetDeploymentConfigOutput, GetDeploymentConfigError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.GetDeploymentConfig");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6636,9 +6746,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: GetDeploymentGroupInput,
     ) -> RusotoFuture<GetDeploymentGroupOutput, GetDeploymentGroupError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.GetDeploymentGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6665,9 +6780,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: GetDeploymentInstanceInput,
     ) -> RusotoFuture<GetDeploymentInstanceOutput, GetDeploymentInstanceError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.GetDeploymentInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6693,9 +6813,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: GetDeploymentTargetInput,
     ) -> RusotoFuture<GetDeploymentTargetOutput, GetDeploymentTargetError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.GetDeploymentTarget");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6721,9 +6846,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: GetOnPremisesInstanceInput,
     ) -> RusotoFuture<GetOnPremisesInstanceOutput, GetOnPremisesInstanceError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.GetOnPremisesInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6749,9 +6879,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: ListApplicationRevisionsInput,
     ) -> RusotoFuture<ListApplicationRevisionsOutput, ListApplicationRevisionsError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeDeploy_20141006.ListApplicationRevisions",
@@ -6778,9 +6913,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: ListApplicationsInput,
     ) -> RusotoFuture<ListApplicationsOutput, ListApplicationsError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.ListApplications");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6807,9 +6947,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: ListDeploymentConfigsInput,
     ) -> RusotoFuture<ListDeploymentConfigsOutput, ListDeploymentConfigsError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.ListDeploymentConfigs");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6835,9 +6980,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: ListDeploymentGroupsInput,
     ) -> RusotoFuture<ListDeploymentGroupsOutput, ListDeploymentGroupsError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.ListDeploymentGroups");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6863,9 +7013,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: ListDeploymentInstancesInput,
     ) -> RusotoFuture<ListDeploymentInstancesOutput, ListDeploymentInstancesError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeDeploy_20141006.ListDeploymentInstances",
@@ -6892,9 +7047,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: ListDeploymentTargetsInput,
     ) -> RusotoFuture<ListDeploymentTargetsOutput, ListDeploymentTargetsError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.ListDeploymentTargets");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6920,9 +7080,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: ListDeploymentsInput,
     ) -> RusotoFuture<ListDeploymentsOutput, ListDeploymentsError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.ListDeployments");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6949,9 +7114,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: ListGitHubAccountTokenNamesInput,
     ) -> RusotoFuture<ListGitHubAccountTokenNamesOutput, ListGitHubAccountTokenNamesError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeDeploy_20141006.ListGitHubAccountTokenNames",
@@ -6978,9 +7148,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: ListOnPremisesInstancesInput,
     ) -> RusotoFuture<ListOnPremisesInstancesOutput, ListOnPremisesInstancesError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeDeploy_20141006.ListOnPremisesInstances",
@@ -7010,9 +7185,14 @@ impl CodeDeploy for CodeDeployClient {
         PutLifecycleEventHookExecutionStatusOutput,
         PutLifecycleEventHookExecutionStatusError,
     > {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeDeploy_20141006.PutLifecycleEventHookExecutionStatus",
@@ -7041,9 +7221,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: RegisterApplicationRevisionInput,
     ) -> RusotoFuture<(), RegisterApplicationRevisionError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeDeploy_20141006.RegisterApplicationRevision",
@@ -7067,9 +7252,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: RegisterOnPremisesInstanceInput,
     ) -> RusotoFuture<(), RegisterOnPremisesInstanceError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeDeploy_20141006.RegisterOnPremisesInstance",
@@ -7093,9 +7283,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: RemoveTagsFromOnPremisesInstancesInput,
     ) -> RusotoFuture<(), RemoveTagsFromOnPremisesInstancesError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeDeploy_20141006.RemoveTagsFromOnPremisesInstances",
@@ -7121,9 +7316,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: SkipWaitTimeForInstanceTerminationInput,
     ) -> RusotoFuture<(), SkipWaitTimeForInstanceTerminationError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodeDeploy_20141006.SkipWaitTimeForInstanceTermination",
@@ -7149,9 +7349,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: StopDeploymentInput,
     ) -> RusotoFuture<StopDeploymentOutput, StopDeploymentError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.StopDeployment");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7178,9 +7383,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: UpdateApplicationInput,
     ) -> RusotoFuture<(), UpdateApplicationError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.UpdateApplication");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7204,9 +7414,14 @@ impl CodeDeploy for CodeDeployClient {
         &self,
         input: UpdateDeploymentGroupInput,
     ) -> RusotoFuture<UpdateDeploymentGroupOutput, UpdateDeploymentGroupError> {
-        let mut request = SignedRequest::new("POST", "codedeploy", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codedeploy",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeDeploy_20141006.UpdateDeploymentGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/codepipeline/src/generated.rs
+++ b/rusoto/services/codepipeline/src/generated.rs
@@ -3179,9 +3179,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: AcknowledgeJobInput,
     ) -> RusotoFuture<AcknowledgeJobOutput, AcknowledgeJobError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodePipeline_20150709.AcknowledgeJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3208,9 +3213,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: AcknowledgeThirdPartyJobInput,
     ) -> RusotoFuture<AcknowledgeThirdPartyJobOutput, AcknowledgeThirdPartyJobError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodePipeline_20150709.AcknowledgeThirdPartyJob",
@@ -3237,9 +3247,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: CreateCustomActionTypeInput,
     ) -> RusotoFuture<CreateCustomActionTypeOutput, CreateCustomActionTypeError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodePipeline_20150709.CreateCustomActionType",
@@ -3268,9 +3283,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: CreatePipelineInput,
     ) -> RusotoFuture<CreatePipelineOutput, CreatePipelineError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodePipeline_20150709.CreatePipeline");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3297,9 +3317,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: DeleteCustomActionTypeInput,
     ) -> RusotoFuture<(), DeleteCustomActionTypeError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodePipeline_20150709.DeleteCustomActionType",
@@ -3322,9 +3347,14 @@ impl CodePipeline for CodePipelineClient {
 
     /// <p>Deletes the specified pipeline.</p>
     fn delete_pipeline(&self, input: DeletePipelineInput) -> RusotoFuture<(), DeletePipelineError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodePipeline_20150709.DeletePipeline");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3348,9 +3378,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: DeleteWebhookInput,
     ) -> RusotoFuture<DeleteWebhookOutput, DeleteWebhookError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodePipeline_20150709.DeleteWebhook");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3378,9 +3413,14 @@ impl CodePipeline for CodePipelineClient {
         input: DeregisterWebhookWithThirdPartyInput,
     ) -> RusotoFuture<DeregisterWebhookWithThirdPartyOutput, DeregisterWebhookWithThirdPartyError>
     {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodePipeline_20150709.DeregisterWebhookWithThirdParty",
@@ -3409,9 +3449,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: DisableStageTransitionInput,
     ) -> RusotoFuture<(), DisableStageTransitionError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodePipeline_20150709.DisableStageTransition",
@@ -3437,9 +3482,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: EnableStageTransitionInput,
     ) -> RusotoFuture<(), EnableStageTransitionError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodePipeline_20150709.EnableStageTransition",
@@ -3465,9 +3515,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: GetJobDetailsInput,
     ) -> RusotoFuture<GetJobDetailsOutput, GetJobDetailsError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodePipeline_20150709.GetJobDetails");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3494,9 +3549,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: GetPipelineInput,
     ) -> RusotoFuture<GetPipelineOutput, GetPipelineError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodePipeline_20150709.GetPipeline");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3523,9 +3583,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: GetPipelineExecutionInput,
     ) -> RusotoFuture<GetPipelineExecutionOutput, GetPipelineExecutionError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodePipeline_20150709.GetPipelineExecution");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3551,9 +3616,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: GetPipelineStateInput,
     ) -> RusotoFuture<GetPipelineStateOutput, GetPipelineStateError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodePipeline_20150709.GetPipelineState");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3580,9 +3650,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: GetThirdPartyJobDetailsInput,
     ) -> RusotoFuture<GetThirdPartyJobDetailsOutput, GetThirdPartyJobDetailsError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodePipeline_20150709.GetThirdPartyJobDetails",
@@ -3609,9 +3684,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: ListActionTypesInput,
     ) -> RusotoFuture<ListActionTypesOutput, ListActionTypesError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodePipeline_20150709.ListActionTypes");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3638,9 +3718,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: ListPipelineExecutionsInput,
     ) -> RusotoFuture<ListPipelineExecutionsOutput, ListPipelineExecutionsError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodePipeline_20150709.ListPipelineExecutions",
@@ -3669,9 +3754,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: ListPipelinesInput,
     ) -> RusotoFuture<ListPipelinesOutput, ListPipelinesError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodePipeline_20150709.ListPipelines");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3698,9 +3788,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: ListWebhooksInput,
     ) -> RusotoFuture<ListWebhooksOutput, ListWebhooksError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodePipeline_20150709.ListWebhooks");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3727,9 +3822,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: PollForJobsInput,
     ) -> RusotoFuture<PollForJobsOutput, PollForJobsError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodePipeline_20150709.PollForJobs");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3756,9 +3856,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: PollForThirdPartyJobsInput,
     ) -> RusotoFuture<PollForThirdPartyJobsOutput, PollForThirdPartyJobsError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodePipeline_20150709.PollForThirdPartyJobs",
@@ -3787,9 +3892,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: PutActionRevisionInput,
     ) -> RusotoFuture<PutActionRevisionOutput, PutActionRevisionError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodePipeline_20150709.PutActionRevision");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3816,9 +3926,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: PutApprovalResultInput,
     ) -> RusotoFuture<PutApprovalResultOutput, PutApprovalResultError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodePipeline_20150709.PutApprovalResult");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3845,9 +3960,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: PutJobFailureResultInput,
     ) -> RusotoFuture<(), PutJobFailureResultError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodePipeline_20150709.PutJobFailureResult");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3870,9 +3990,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: PutJobSuccessResultInput,
     ) -> RusotoFuture<(), PutJobSuccessResultError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodePipeline_20150709.PutJobSuccessResult");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3895,9 +4020,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: PutThirdPartyJobFailureResultInput,
     ) -> RusotoFuture<(), PutThirdPartyJobFailureResultError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodePipeline_20150709.PutThirdPartyJobFailureResult",
@@ -3921,9 +4051,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: PutThirdPartyJobSuccessResultInput,
     ) -> RusotoFuture<(), PutThirdPartyJobSuccessResultError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodePipeline_20150709.PutThirdPartyJobSuccessResult",
@@ -3947,9 +4082,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: PutWebhookInput,
     ) -> RusotoFuture<PutWebhookOutput, PutWebhookError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodePipeline_20150709.PutWebhook");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3976,9 +4116,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: RegisterWebhookWithThirdPartyInput,
     ) -> RusotoFuture<RegisterWebhookWithThirdPartyOutput, RegisterWebhookWithThirdPartyError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodePipeline_20150709.RegisterWebhookWithThirdParty",
@@ -4005,9 +4150,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: RetryStageExecutionInput,
     ) -> RusotoFuture<RetryStageExecutionOutput, RetryStageExecutionError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodePipeline_20150709.RetryStageExecution");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4033,9 +4183,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: StartPipelineExecutionInput,
     ) -> RusotoFuture<StartPipelineExecutionOutput, StartPipelineExecutionError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "CodePipeline_20150709.StartPipelineExecution",
@@ -4064,9 +4219,14 @@ impl CodePipeline for CodePipelineClient {
         &self,
         input: UpdatePipelineInput,
     ) -> RusotoFuture<UpdatePipelineOutput, UpdatePipelineError> {
-        let mut request = SignedRequest::new("POST", "codepipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codepipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodePipeline_20150709.UpdatePipeline");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/codestar/src/generated.rs
+++ b/rusoto/services/codestar/src/generated.rs
@@ -1667,9 +1667,14 @@ impl CodeStar for CodeStarClient {
         &self,
         input: AssociateTeamMemberRequest,
     ) -> RusotoFuture<AssociateTeamMemberResult, AssociateTeamMemberError> {
-        let mut request = SignedRequest::new("POST", "codestar", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codestar",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeStar_20170419.AssociateTeamMember");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1695,9 +1700,14 @@ impl CodeStar for CodeStarClient {
         &self,
         input: CreateProjectRequest,
     ) -> RusotoFuture<CreateProjectResult, CreateProjectError> {
-        let mut request = SignedRequest::new("POST", "codestar", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codestar",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeStar_20170419.CreateProject");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1724,9 +1734,14 @@ impl CodeStar for CodeStarClient {
         &self,
         input: CreateUserProfileRequest,
     ) -> RusotoFuture<CreateUserProfileResult, CreateUserProfileError> {
-        let mut request = SignedRequest::new("POST", "codestar", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codestar",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeStar_20170419.CreateUserProfile");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1753,9 +1768,14 @@ impl CodeStar for CodeStarClient {
         &self,
         input: DeleteProjectRequest,
     ) -> RusotoFuture<DeleteProjectResult, DeleteProjectError> {
-        let mut request = SignedRequest::new("POST", "codestar", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codestar",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeStar_20170419.DeleteProject");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1782,9 +1802,14 @@ impl CodeStar for CodeStarClient {
         &self,
         input: DeleteUserProfileRequest,
     ) -> RusotoFuture<DeleteUserProfileResult, DeleteUserProfileError> {
-        let mut request = SignedRequest::new("POST", "codestar", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codestar",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeStar_20170419.DeleteUserProfile");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1811,9 +1836,14 @@ impl CodeStar for CodeStarClient {
         &self,
         input: DescribeProjectRequest,
     ) -> RusotoFuture<DescribeProjectResult, DescribeProjectError> {
-        let mut request = SignedRequest::new("POST", "codestar", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codestar",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeStar_20170419.DescribeProject");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1840,9 +1870,14 @@ impl CodeStar for CodeStarClient {
         &self,
         input: DescribeUserProfileRequest,
     ) -> RusotoFuture<DescribeUserProfileResult, DescribeUserProfileError> {
-        let mut request = SignedRequest::new("POST", "codestar", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codestar",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeStar_20170419.DescribeUserProfile");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1868,9 +1903,14 @@ impl CodeStar for CodeStarClient {
         &self,
         input: DisassociateTeamMemberRequest,
     ) -> RusotoFuture<DisassociateTeamMemberResult, DisassociateTeamMemberError> {
-        let mut request = SignedRequest::new("POST", "codestar", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codestar",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeStar_20170419.DisassociateTeamMember");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1896,9 +1936,14 @@ impl CodeStar for CodeStarClient {
         &self,
         input: ListProjectsRequest,
     ) -> RusotoFuture<ListProjectsResult, ListProjectsError> {
-        let mut request = SignedRequest::new("POST", "codestar", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codestar",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeStar_20170419.ListProjects");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1925,9 +1970,14 @@ impl CodeStar for CodeStarClient {
         &self,
         input: ListResourcesRequest,
     ) -> RusotoFuture<ListResourcesResult, ListResourcesError> {
-        let mut request = SignedRequest::new("POST", "codestar", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codestar",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeStar_20170419.ListResources");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1954,9 +2004,14 @@ impl CodeStar for CodeStarClient {
         &self,
         input: ListTagsForProjectRequest,
     ) -> RusotoFuture<ListTagsForProjectResult, ListTagsForProjectError> {
-        let mut request = SignedRequest::new("POST", "codestar", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codestar",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeStar_20170419.ListTagsForProject");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1983,9 +2038,14 @@ impl CodeStar for CodeStarClient {
         &self,
         input: ListTeamMembersRequest,
     ) -> RusotoFuture<ListTeamMembersResult, ListTeamMembersError> {
-        let mut request = SignedRequest::new("POST", "codestar", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codestar",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeStar_20170419.ListTeamMembers");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2012,9 +2072,14 @@ impl CodeStar for CodeStarClient {
         &self,
         input: ListUserProfilesRequest,
     ) -> RusotoFuture<ListUserProfilesResult, ListUserProfilesError> {
-        let mut request = SignedRequest::new("POST", "codestar", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codestar",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeStar_20170419.ListUserProfiles");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2041,9 +2106,14 @@ impl CodeStar for CodeStarClient {
         &self,
         input: TagProjectRequest,
     ) -> RusotoFuture<TagProjectResult, TagProjectError> {
-        let mut request = SignedRequest::new("POST", "codestar", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codestar",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeStar_20170419.TagProject");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2070,9 +2140,14 @@ impl CodeStar for CodeStarClient {
         &self,
         input: UntagProjectRequest,
     ) -> RusotoFuture<UntagProjectResult, UntagProjectError> {
-        let mut request = SignedRequest::new("POST", "codestar", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codestar",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeStar_20170419.UntagProject");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2099,9 +2174,14 @@ impl CodeStar for CodeStarClient {
         &self,
         input: UpdateProjectRequest,
     ) -> RusotoFuture<UpdateProjectResult, UpdateProjectError> {
-        let mut request = SignedRequest::new("POST", "codestar", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codestar",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeStar_20170419.UpdateProject");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2128,9 +2208,14 @@ impl CodeStar for CodeStarClient {
         &self,
         input: UpdateTeamMemberRequest,
     ) -> RusotoFuture<UpdateTeamMemberResult, UpdateTeamMemberError> {
-        let mut request = SignedRequest::new("POST", "codestar", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codestar",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeStar_20170419.UpdateTeamMember");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2157,9 +2242,14 @@ impl CodeStar for CodeStarClient {
         &self,
         input: UpdateUserProfileRequest,
     ) -> RusotoFuture<UpdateUserProfileResult, UpdateUserProfileError> {
-        let mut request = SignedRequest::new("POST", "codestar", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "codestar",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "CodeStar_20170419.UpdateUserProfile");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/cognito-identity/src/generated.rs
+++ b/rusoto/services/cognito-identity/src/generated.rs
@@ -1967,9 +1967,14 @@ impl CognitoIdentity for CognitoIdentityClient {
         &self,
         input: CreateIdentityPoolInput,
     ) -> RusotoFuture<IdentityPool, CreateIdentityPoolError> {
-        let mut request = SignedRequest::new("POST", "cognito-identity", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-identity",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityService.CreateIdentityPool",
@@ -1998,9 +2003,14 @@ impl CognitoIdentity for CognitoIdentityClient {
         &self,
         input: DeleteIdentitiesInput,
     ) -> RusotoFuture<DeleteIdentitiesResponse, DeleteIdentitiesError> {
-        let mut request = SignedRequest::new("POST", "cognito-identity", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-identity",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSCognitoIdentityService.DeleteIdentities");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2027,9 +2037,14 @@ impl CognitoIdentity for CognitoIdentityClient {
         &self,
         input: DeleteIdentityPoolInput,
     ) -> RusotoFuture<(), DeleteIdentityPoolError> {
-        let mut request = SignedRequest::new("POST", "cognito-identity", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-identity",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityService.DeleteIdentityPool",
@@ -2056,9 +2071,14 @@ impl CognitoIdentity for CognitoIdentityClient {
         &self,
         input: DescribeIdentityInput,
     ) -> RusotoFuture<IdentityDescription, DescribeIdentityError> {
-        let mut request = SignedRequest::new("POST", "cognito-identity", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-identity",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSCognitoIdentityService.DescribeIdentity");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2085,9 +2105,14 @@ impl CognitoIdentity for CognitoIdentityClient {
         &self,
         input: DescribeIdentityPoolInput,
     ) -> RusotoFuture<IdentityPool, DescribeIdentityPoolError> {
-        let mut request = SignedRequest::new("POST", "cognito-identity", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-identity",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityService.DescribeIdentityPool",
@@ -2115,9 +2140,14 @@ impl CognitoIdentity for CognitoIdentityClient {
         &self,
         input: GetCredentialsForIdentityInput,
     ) -> RusotoFuture<GetCredentialsForIdentityResponse, GetCredentialsForIdentityError> {
-        let mut request = SignedRequest::new("POST", "cognito-identity", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-identity",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityService.GetCredentialsForIdentity",
@@ -2141,9 +2171,14 @@ impl CognitoIdentity for CognitoIdentityClient {
 
     /// <p>Generates (or retrieves) a Cognito ID. Supplying multiple logins will create an implicit linked account.</p> <p>This is a public API. You do not need any credentials to call this API.</p>
     fn get_id(&self, input: GetIdInput) -> RusotoFuture<GetIdResponse, GetIdError> {
-        let mut request = SignedRequest::new("POST", "cognito-identity", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-identity",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSCognitoIdentityService.GetId");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2169,9 +2204,14 @@ impl CognitoIdentity for CognitoIdentityClient {
         &self,
         input: GetIdentityPoolRolesInput,
     ) -> RusotoFuture<GetIdentityPoolRolesResponse, GetIdentityPoolRolesError> {
-        let mut request = SignedRequest::new("POST", "cognito-identity", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-identity",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityService.GetIdentityPoolRoles",
@@ -2200,9 +2240,14 @@ impl CognitoIdentity for CognitoIdentityClient {
         &self,
         input: GetOpenIdTokenInput,
     ) -> RusotoFuture<GetOpenIdTokenResponse, GetOpenIdTokenError> {
-        let mut request = SignedRequest::new("POST", "cognito-identity", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-identity",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSCognitoIdentityService.GetOpenIdToken");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2232,9 +2277,14 @@ impl CognitoIdentity for CognitoIdentityClient {
         GetOpenIdTokenForDeveloperIdentityResponse,
         GetOpenIdTokenForDeveloperIdentityError,
     > {
-        let mut request = SignedRequest::new("POST", "cognito-identity", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-identity",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityService.GetOpenIdTokenForDeveloperIdentity",
@@ -2263,9 +2313,14 @@ impl CognitoIdentity for CognitoIdentityClient {
         &self,
         input: ListIdentitiesInput,
     ) -> RusotoFuture<ListIdentitiesResponse, ListIdentitiesError> {
-        let mut request = SignedRequest::new("POST", "cognito-identity", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-identity",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSCognitoIdentityService.ListIdentities");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2292,9 +2347,14 @@ impl CognitoIdentity for CognitoIdentityClient {
         &self,
         input: ListIdentityPoolsInput,
     ) -> RusotoFuture<ListIdentityPoolsResponse, ListIdentityPoolsError> {
-        let mut request = SignedRequest::new("POST", "cognito-identity", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-identity",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityService.ListIdentityPools",
@@ -2324,9 +2384,14 @@ impl CognitoIdentity for CognitoIdentityClient {
         &self,
         input: LookupDeveloperIdentityInput,
     ) -> RusotoFuture<LookupDeveloperIdentityResponse, LookupDeveloperIdentityError> {
-        let mut request = SignedRequest::new("POST", "cognito-identity", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-identity",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityService.LookupDeveloperIdentity",
@@ -2353,9 +2418,14 @@ impl CognitoIdentity for CognitoIdentityClient {
         &self,
         input: MergeDeveloperIdentitiesInput,
     ) -> RusotoFuture<MergeDeveloperIdentitiesResponse, MergeDeveloperIdentitiesError> {
-        let mut request = SignedRequest::new("POST", "cognito-identity", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-identity",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityService.MergeDeveloperIdentities",
@@ -2382,9 +2452,14 @@ impl CognitoIdentity for CognitoIdentityClient {
         &self,
         input: SetIdentityPoolRolesInput,
     ) -> RusotoFuture<(), SetIdentityPoolRolesError> {
-        let mut request = SignedRequest::new("POST", "cognito-identity", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-identity",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityService.SetIdentityPoolRoles",
@@ -2410,9 +2485,14 @@ impl CognitoIdentity for CognitoIdentityClient {
         &self,
         input: UnlinkDeveloperIdentityInput,
     ) -> RusotoFuture<(), UnlinkDeveloperIdentityError> {
-        let mut request = SignedRequest::new("POST", "cognito-identity", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-identity",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityService.UnlinkDeveloperIdentity",
@@ -2433,9 +2513,14 @@ impl CognitoIdentity for CognitoIdentityClient {
 
     /// <p>Unlinks a federated identity from an existing account. Unlinked logins will be considered new identities next time they are seen. Removing the last linked login will make this identity inaccessible.</p> <p>This is a public API. You do not need any credentials to call this API.</p>
     fn unlink_identity(&self, input: UnlinkIdentityInput) -> RusotoFuture<(), UnlinkIdentityError> {
-        let mut request = SignedRequest::new("POST", "cognito-identity", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-identity",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSCognitoIdentityService.UnlinkIdentity");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2459,9 +2544,14 @@ impl CognitoIdentity for CognitoIdentityClient {
         &self,
         input: IdentityPool,
     ) -> RusotoFuture<IdentityPool, UpdateIdentityPoolError> {
-        let mut request = SignedRequest::new("POST", "cognito-identity", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-identity",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityService.UpdateIdentityPool",

--- a/rusoto/services/cognito-idp/src/generated.rs
+++ b/rusoto/services/cognito-idp/src/generated.rs
@@ -12229,9 +12229,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AddCustomAttributesRequest,
     ) -> RusotoFuture<AddCustomAttributesResponse, AddCustomAttributesError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AddCustomAttributes",
@@ -12260,9 +12265,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminAddUserToGroupRequest,
     ) -> RusotoFuture<(), AdminAddUserToGroupError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminAddUserToGroup",
@@ -12288,9 +12298,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminConfirmSignUpRequest,
     ) -> RusotoFuture<AdminConfirmSignUpResponse, AdminConfirmSignUpError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminConfirmSignUp",
@@ -12320,9 +12335,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminCreateUserRequest,
     ) -> RusotoFuture<AdminCreateUserResponse, AdminCreateUserError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminCreateUser",
@@ -12352,9 +12372,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminDeleteUserRequest,
     ) -> RusotoFuture<(), AdminDeleteUserError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminDeleteUser",
@@ -12381,9 +12406,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminDeleteUserAttributesRequest,
     ) -> RusotoFuture<AdminDeleteUserAttributesResponse, AdminDeleteUserAttributesError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminDeleteUserAttributes",
@@ -12410,9 +12440,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminDisableProviderForUserRequest,
     ) -> RusotoFuture<AdminDisableProviderForUserResponse, AdminDisableProviderForUserError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminDisableProviderForUser",
@@ -12439,9 +12474,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminDisableUserRequest,
     ) -> RusotoFuture<AdminDisableUserResponse, AdminDisableUserError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminDisableUser",
@@ -12471,9 +12511,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminEnableUserRequest,
     ) -> RusotoFuture<AdminEnableUserResponse, AdminEnableUserError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminEnableUser",
@@ -12503,9 +12548,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminForgetDeviceRequest,
     ) -> RusotoFuture<(), AdminForgetDeviceError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminForgetDevice",
@@ -12532,9 +12582,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminGetDeviceRequest,
     ) -> RusotoFuture<AdminGetDeviceResponse, AdminGetDeviceError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminGetDevice",
@@ -12564,9 +12619,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminGetUserRequest,
     ) -> RusotoFuture<AdminGetUserResponse, AdminGetUserError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminGetUser",
@@ -12596,9 +12656,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminInitiateAuthRequest,
     ) -> RusotoFuture<AdminInitiateAuthResponse, AdminInitiateAuthError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminInitiateAuth",
@@ -12628,9 +12693,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminLinkProviderForUserRequest,
     ) -> RusotoFuture<AdminLinkProviderForUserResponse, AdminLinkProviderForUserError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminLinkProviderForUser",
@@ -12657,9 +12727,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminListDevicesRequest,
     ) -> RusotoFuture<AdminListDevicesResponse, AdminListDevicesError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminListDevices",
@@ -12689,9 +12764,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminListGroupsForUserRequest,
     ) -> RusotoFuture<AdminListGroupsForUserResponse, AdminListGroupsForUserError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminListGroupsForUser",
@@ -12720,9 +12800,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminListUserAuthEventsRequest,
     ) -> RusotoFuture<AdminListUserAuthEventsResponse, AdminListUserAuthEventsError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminListUserAuthEvents",
@@ -12749,9 +12834,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminRemoveUserFromGroupRequest,
     ) -> RusotoFuture<(), AdminRemoveUserFromGroupError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminRemoveUserFromGroup",
@@ -12775,9 +12865,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminResetUserPasswordRequest,
     ) -> RusotoFuture<AdminResetUserPasswordResponse, AdminResetUserPasswordError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminResetUserPassword",
@@ -12806,9 +12901,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminRespondToAuthChallengeRequest,
     ) -> RusotoFuture<AdminRespondToAuthChallengeResponse, AdminRespondToAuthChallengeError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminRespondToAuthChallenge",
@@ -12835,9 +12935,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminSetUserMFAPreferenceRequest,
     ) -> RusotoFuture<AdminSetUserMFAPreferenceResponse, AdminSetUserMFAPreferenceError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminSetUserMFAPreference",
@@ -12864,9 +12969,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminSetUserSettingsRequest,
     ) -> RusotoFuture<AdminSetUserSettingsResponse, AdminSetUserSettingsError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminSetUserSettings",
@@ -12895,9 +13005,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminUpdateAuthEventFeedbackRequest,
     ) -> RusotoFuture<AdminUpdateAuthEventFeedbackResponse, AdminUpdateAuthEventFeedbackError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminUpdateAuthEventFeedback",
@@ -12924,9 +13039,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminUpdateDeviceStatusRequest,
     ) -> RusotoFuture<AdminUpdateDeviceStatusResponse, AdminUpdateDeviceStatusError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminUpdateDeviceStatus",
@@ -12953,9 +13073,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminUpdateUserAttributesRequest,
     ) -> RusotoFuture<AdminUpdateUserAttributesResponse, AdminUpdateUserAttributesError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminUpdateUserAttributes",
@@ -12982,9 +13107,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AdminUserGlobalSignOutRequest,
     ) -> RusotoFuture<AdminUserGlobalSignOutResponse, AdminUserGlobalSignOutError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AdminUserGlobalSignOut",
@@ -13013,9 +13143,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: AssociateSoftwareTokenRequest,
     ) -> RusotoFuture<AssociateSoftwareTokenResponse, AssociateSoftwareTokenError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.AssociateSoftwareToken",
@@ -13044,9 +13179,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: ChangePasswordRequest,
     ) -> RusotoFuture<ChangePasswordResponse, ChangePasswordError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.ChangePassword",
@@ -13076,9 +13216,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: ConfirmDeviceRequest,
     ) -> RusotoFuture<ConfirmDeviceResponse, ConfirmDeviceError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.ConfirmDevice",
@@ -13108,9 +13253,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: ConfirmForgotPasswordRequest,
     ) -> RusotoFuture<ConfirmForgotPasswordResponse, ConfirmForgotPasswordError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.ConfirmForgotPassword",
@@ -13139,9 +13289,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: ConfirmSignUpRequest,
     ) -> RusotoFuture<ConfirmSignUpResponse, ConfirmSignUpError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.ConfirmSignUp",
@@ -13171,9 +13326,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: CreateGroupRequest,
     ) -> RusotoFuture<CreateGroupResponse, CreateGroupError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.CreateGroup",
@@ -13203,9 +13363,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: CreateIdentityProviderRequest,
     ) -> RusotoFuture<CreateIdentityProviderResponse, CreateIdentityProviderError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.CreateIdentityProvider",
@@ -13234,9 +13399,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: CreateResourceServerRequest,
     ) -> RusotoFuture<CreateResourceServerResponse, CreateResourceServerError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.CreateResourceServer",
@@ -13265,9 +13435,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: CreateUserImportJobRequest,
     ) -> RusotoFuture<CreateUserImportJobResponse, CreateUserImportJobError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.CreateUserImportJob",
@@ -13296,9 +13471,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: CreateUserPoolRequest,
     ) -> RusotoFuture<CreateUserPoolResponse, CreateUserPoolError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.CreateUserPool",
@@ -13328,9 +13508,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: CreateUserPoolClientRequest,
     ) -> RusotoFuture<CreateUserPoolClientResponse, CreateUserPoolClientError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.CreateUserPoolClient",
@@ -13359,9 +13544,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: CreateUserPoolDomainRequest,
     ) -> RusotoFuture<CreateUserPoolDomainResponse, CreateUserPoolDomainError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.CreateUserPoolDomain",
@@ -13387,9 +13577,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
 
     /// <p>Deletes a group. Currently only groups with no members can be deleted.</p> <p>Requires developer credentials.</p>
     fn delete_group(&self, input: DeleteGroupRequest) -> RusotoFuture<(), DeleteGroupError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.DeleteGroup",
@@ -13416,9 +13611,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: DeleteIdentityProviderRequest,
     ) -> RusotoFuture<(), DeleteIdentityProviderError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.DeleteIdentityProvider",
@@ -13444,9 +13644,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: DeleteResourceServerRequest,
     ) -> RusotoFuture<(), DeleteResourceServerError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.DeleteResourceServer",
@@ -13469,9 +13674,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
 
     /// <p>Allows a user to delete himself or herself.</p>
     fn delete_user(&self, input: DeleteUserRequest) -> RusotoFuture<(), DeleteUserError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.DeleteUser",
@@ -13498,9 +13708,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: DeleteUserAttributesRequest,
     ) -> RusotoFuture<DeleteUserAttributesResponse, DeleteUserAttributesError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.DeleteUserAttributes",
@@ -13529,9 +13744,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: DeleteUserPoolRequest,
     ) -> RusotoFuture<(), DeleteUserPoolError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.DeleteUserPool",
@@ -13558,9 +13778,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: DeleteUserPoolClientRequest,
     ) -> RusotoFuture<(), DeleteUserPoolClientError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.DeleteUserPoolClient",
@@ -13586,9 +13811,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: DeleteUserPoolDomainRequest,
     ) -> RusotoFuture<DeleteUserPoolDomainResponse, DeleteUserPoolDomainError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.DeleteUserPoolDomain",
@@ -13617,9 +13847,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: DescribeIdentityProviderRequest,
     ) -> RusotoFuture<DescribeIdentityProviderResponse, DescribeIdentityProviderError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.DescribeIdentityProvider",
@@ -13646,9 +13881,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: DescribeResourceServerRequest,
     ) -> RusotoFuture<DescribeResourceServerResponse, DescribeResourceServerError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.DescribeResourceServer",
@@ -13677,9 +13917,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: DescribeRiskConfigurationRequest,
     ) -> RusotoFuture<DescribeRiskConfigurationResponse, DescribeRiskConfigurationError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.DescribeRiskConfiguration",
@@ -13706,9 +13951,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: DescribeUserImportJobRequest,
     ) -> RusotoFuture<DescribeUserImportJobResponse, DescribeUserImportJobError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.DescribeUserImportJob",
@@ -13737,9 +13987,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: DescribeUserPoolRequest,
     ) -> RusotoFuture<DescribeUserPoolResponse, DescribeUserPoolError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.DescribeUserPool",
@@ -13769,9 +14024,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: DescribeUserPoolClientRequest,
     ) -> RusotoFuture<DescribeUserPoolClientResponse, DescribeUserPoolClientError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.DescribeUserPoolClient",
@@ -13800,9 +14060,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: DescribeUserPoolDomainRequest,
     ) -> RusotoFuture<DescribeUserPoolDomainResponse, DescribeUserPoolDomainError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.DescribeUserPoolDomain",
@@ -13828,9 +14093,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
 
     /// <p>Forgets the specified device.</p>
     fn forget_device(&self, input: ForgetDeviceRequest) -> RusotoFuture<(), ForgetDeviceError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.ForgetDevice",
@@ -13857,9 +14127,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: ForgotPasswordRequest,
     ) -> RusotoFuture<ForgotPasswordResponse, ForgotPasswordError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.ForgotPassword",
@@ -13889,9 +14164,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: GetCSVHeaderRequest,
     ) -> RusotoFuture<GetCSVHeaderResponse, GetCSVHeaderError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.GetCSVHeader",
@@ -13921,9 +14201,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: GetDeviceRequest,
     ) -> RusotoFuture<GetDeviceResponse, GetDeviceError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.GetDevice",
@@ -13950,9 +14235,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
 
     /// <p>Gets a group.</p> <p>Requires developer credentials.</p>
     fn get_group(&self, input: GetGroupRequest) -> RusotoFuture<GetGroupResponse, GetGroupError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSCognitoIdentityProviderService.GetGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13980,9 +14270,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         input: GetIdentityProviderByIdentifierRequest,
     ) -> RusotoFuture<GetIdentityProviderByIdentifierResponse, GetIdentityProviderByIdentifierError>
     {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.GetIdentityProviderByIdentifier",
@@ -14011,9 +14306,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: GetSigningCertificateRequest,
     ) -> RusotoFuture<GetSigningCertificateResponse, GetSigningCertificateError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.GetSigningCertificate",
@@ -14042,9 +14342,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: GetUICustomizationRequest,
     ) -> RusotoFuture<GetUICustomizationResponse, GetUICustomizationError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.GetUICustomization",
@@ -14071,9 +14376,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
 
     /// <p>Gets the user attributes and metadata for a user.</p>
     fn get_user(&self, input: GetUserRequest) -> RusotoFuture<GetUserResponse, GetUserError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSCognitoIdentityProviderService.GetUser");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14100,9 +14410,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         input: GetUserAttributeVerificationCodeRequest,
     ) -> RusotoFuture<GetUserAttributeVerificationCodeResponse, GetUserAttributeVerificationCodeError>
     {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.GetUserAttributeVerificationCode",
@@ -14131,9 +14446,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: GetUserPoolMfaConfigRequest,
     ) -> RusotoFuture<GetUserPoolMfaConfigResponse, GetUserPoolMfaConfigError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.GetUserPoolMfaConfig",
@@ -14162,9 +14482,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: GlobalSignOutRequest,
     ) -> RusotoFuture<GlobalSignOutResponse, GlobalSignOutError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.GlobalSignOut",
@@ -14194,9 +14519,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: InitiateAuthRequest,
     ) -> RusotoFuture<InitiateAuthResponse, InitiateAuthError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.InitiateAuth",
@@ -14226,9 +14556,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: ListDevicesRequest,
     ) -> RusotoFuture<ListDevicesResponse, ListDevicesError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.ListDevices",
@@ -14258,9 +14593,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: ListGroupsRequest,
     ) -> RusotoFuture<ListGroupsResponse, ListGroupsError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.ListGroups",
@@ -14290,9 +14630,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: ListIdentityProvidersRequest,
     ) -> RusotoFuture<ListIdentityProvidersResponse, ListIdentityProvidersError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.ListIdentityProviders",
@@ -14321,9 +14666,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: ListResourceServersRequest,
     ) -> RusotoFuture<ListResourceServersResponse, ListResourceServersError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.ListResourceServers",
@@ -14352,9 +14702,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: ListUserImportJobsRequest,
     ) -> RusotoFuture<ListUserImportJobsResponse, ListUserImportJobsError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.ListUserImportJobs",
@@ -14384,9 +14739,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: ListUserPoolClientsRequest,
     ) -> RusotoFuture<ListUserPoolClientsResponse, ListUserPoolClientsError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.ListUserPoolClients",
@@ -14415,9 +14775,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: ListUserPoolsRequest,
     ) -> RusotoFuture<ListUserPoolsResponse, ListUserPoolsError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.ListUserPools",
@@ -14447,9 +14812,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: ListUsersRequest,
     ) -> RusotoFuture<ListUsersResponse, ListUsersError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.ListUsers",
@@ -14479,9 +14849,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: ListUsersInGroupRequest,
     ) -> RusotoFuture<ListUsersInGroupResponse, ListUsersInGroupError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.ListUsersInGroup",
@@ -14511,9 +14886,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: ResendConfirmationCodeRequest,
     ) -> RusotoFuture<ResendConfirmationCodeResponse, ResendConfirmationCodeError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.ResendConfirmationCode",
@@ -14542,9 +14922,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: RespondToAuthChallengeRequest,
     ) -> RusotoFuture<RespondToAuthChallengeResponse, RespondToAuthChallengeError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.RespondToAuthChallenge",
@@ -14573,9 +14958,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: SetRiskConfigurationRequest,
     ) -> RusotoFuture<SetRiskConfigurationResponse, SetRiskConfigurationError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.SetRiskConfiguration",
@@ -14604,9 +14994,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: SetUICustomizationRequest,
     ) -> RusotoFuture<SetUICustomizationResponse, SetUICustomizationError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.SetUICustomization",
@@ -14636,9 +15031,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: SetUserMFAPreferenceRequest,
     ) -> RusotoFuture<SetUserMFAPreferenceResponse, SetUserMFAPreferenceError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.SetUserMFAPreference",
@@ -14667,9 +15067,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: SetUserPoolMfaConfigRequest,
     ) -> RusotoFuture<SetUserPoolMfaConfigResponse, SetUserPoolMfaConfigError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.SetUserPoolMfaConfig",
@@ -14698,9 +15103,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: SetUserSettingsRequest,
     ) -> RusotoFuture<SetUserSettingsResponse, SetUserSettingsError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.SetUserSettings",
@@ -14727,9 +15137,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
 
     /// <p>Registers the user in the specified user pool and creates a user name, password, and user attributes.</p>
     fn sign_up(&self, input: SignUpRequest) -> RusotoFuture<SignUpResponse, SignUpError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSCognitoIdentityProviderService.SignUp");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14755,9 +15170,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: StartUserImportJobRequest,
     ) -> RusotoFuture<StartUserImportJobResponse, StartUserImportJobError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.StartUserImportJob",
@@ -14787,9 +15207,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: StopUserImportJobRequest,
     ) -> RusotoFuture<StopUserImportJobResponse, StopUserImportJobError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.StopUserImportJob",
@@ -14819,9 +15244,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: UpdateAuthEventFeedbackRequest,
     ) -> RusotoFuture<UpdateAuthEventFeedbackResponse, UpdateAuthEventFeedbackError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.UpdateAuthEventFeedback",
@@ -14848,9 +15278,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: UpdateDeviceStatusRequest,
     ) -> RusotoFuture<UpdateDeviceStatusResponse, UpdateDeviceStatusError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.UpdateDeviceStatus",
@@ -14880,9 +15315,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: UpdateGroupRequest,
     ) -> RusotoFuture<UpdateGroupResponse, UpdateGroupError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.UpdateGroup",
@@ -14912,9 +15352,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: UpdateIdentityProviderRequest,
     ) -> RusotoFuture<UpdateIdentityProviderResponse, UpdateIdentityProviderError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.UpdateIdentityProvider",
@@ -14943,9 +15388,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: UpdateResourceServerRequest,
     ) -> RusotoFuture<UpdateResourceServerResponse, UpdateResourceServerError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.UpdateResourceServer",
@@ -14974,9 +15424,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: UpdateUserAttributesRequest,
     ) -> RusotoFuture<UpdateUserAttributesResponse, UpdateUserAttributesError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.UpdateUserAttributes",
@@ -15005,9 +15460,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: UpdateUserPoolRequest,
     ) -> RusotoFuture<UpdateUserPoolResponse, UpdateUserPoolError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.UpdateUserPool",
@@ -15037,9 +15497,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: UpdateUserPoolClientRequest,
     ) -> RusotoFuture<UpdateUserPoolClientResponse, UpdateUserPoolClientError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.UpdateUserPoolClient",
@@ -15068,9 +15533,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: UpdateUserPoolDomainRequest,
     ) -> RusotoFuture<UpdateUserPoolDomainResponse, UpdateUserPoolDomainError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.UpdateUserPoolDomain",
@@ -15099,9 +15569,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: VerifySoftwareTokenRequest,
     ) -> RusotoFuture<VerifySoftwareTokenResponse, VerifySoftwareTokenError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.VerifySoftwareToken",
@@ -15130,9 +15605,14 @@ impl CognitoIdentityProvider for CognitoIdentityProviderClient {
         &self,
         input: VerifyUserAttributeRequest,
     ) -> RusotoFuture<VerifyUserAttributeResponse, VerifyUserAttributeError> {
-        let mut request = SignedRequest::new("POST", "cognito-idp", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cognito-idp",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSCognitoIdentityProviderService.VerifyUserAttribute",

--- a/rusoto/services/comprehend/src/generated.rs
+++ b/rusoto/services/comprehend/src/generated.rs
@@ -4739,9 +4739,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: BatchDetectDominantLanguageRequest,
     ) -> RusotoFuture<BatchDetectDominantLanguageResponse, BatchDetectDominantLanguageError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.BatchDetectDominantLanguage",
@@ -4768,9 +4773,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: BatchDetectEntitiesRequest,
     ) -> RusotoFuture<BatchDetectEntitiesResponse, BatchDetectEntitiesError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Comprehend_20171127.BatchDetectEntities");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4796,9 +4806,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: BatchDetectKeyPhrasesRequest,
     ) -> RusotoFuture<BatchDetectKeyPhrasesResponse, BatchDetectKeyPhrasesError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Comprehend_20171127.BatchDetectKeyPhrases");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4824,9 +4839,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: BatchDetectSentimentRequest,
     ) -> RusotoFuture<BatchDetectSentimentResponse, BatchDetectSentimentError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Comprehend_20171127.BatchDetectSentiment");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4852,9 +4872,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: BatchDetectSyntaxRequest,
     ) -> RusotoFuture<BatchDetectSyntaxResponse, BatchDetectSyntaxError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Comprehend_20171127.BatchDetectSyntax");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4881,9 +4906,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: CreateDocumentClassifierRequest,
     ) -> RusotoFuture<CreateDocumentClassifierResponse, CreateDocumentClassifierError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.CreateDocumentClassifier",
@@ -4910,9 +4940,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: CreateEntityRecognizerRequest,
     ) -> RusotoFuture<CreateEntityRecognizerResponse, CreateEntityRecognizerError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Comprehend_20171127.CreateEntityRecognizer");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4938,9 +4973,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: DeleteDocumentClassifierRequest,
     ) -> RusotoFuture<DeleteDocumentClassifierResponse, DeleteDocumentClassifierError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.DeleteDocumentClassifier",
@@ -4967,9 +5007,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: DeleteEntityRecognizerRequest,
     ) -> RusotoFuture<DeleteEntityRecognizerResponse, DeleteEntityRecognizerError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Comprehend_20171127.DeleteEntityRecognizer");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4998,9 +5043,14 @@ impl Comprehend for ComprehendClient {
         DescribeDocumentClassificationJobResponse,
         DescribeDocumentClassificationJobError,
     > {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.DescribeDocumentClassificationJob",
@@ -5029,9 +5079,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: DescribeDocumentClassifierRequest,
     ) -> RusotoFuture<DescribeDocumentClassifierResponse, DescribeDocumentClassifierError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.DescribeDocumentClassifier",
@@ -5061,9 +5116,14 @@ impl Comprehend for ComprehendClient {
         DescribeDominantLanguageDetectionJobResponse,
         DescribeDominantLanguageDetectionJobError,
     > {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.DescribeDominantLanguageDetectionJob",
@@ -5092,9 +5152,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: DescribeEntitiesDetectionJobRequest,
     ) -> RusotoFuture<DescribeEntitiesDetectionJobResponse, DescribeEntitiesDetectionJobError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.DescribeEntitiesDetectionJob",
@@ -5121,9 +5186,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: DescribeEntityRecognizerRequest,
     ) -> RusotoFuture<DescribeEntityRecognizerResponse, DescribeEntityRecognizerError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.DescribeEntityRecognizer",
@@ -5151,9 +5221,14 @@ impl Comprehend for ComprehendClient {
         input: DescribeKeyPhrasesDetectionJobRequest,
     ) -> RusotoFuture<DescribeKeyPhrasesDetectionJobResponse, DescribeKeyPhrasesDetectionJobError>
     {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.DescribeKeyPhrasesDetectionJob",
@@ -5181,9 +5256,14 @@ impl Comprehend for ComprehendClient {
         input: DescribeSentimentDetectionJobRequest,
     ) -> RusotoFuture<DescribeSentimentDetectionJobResponse, DescribeSentimentDetectionJobError>
     {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.DescribeSentimentDetectionJob",
@@ -5210,9 +5290,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: DescribeTopicsDetectionJobRequest,
     ) -> RusotoFuture<DescribeTopicsDetectionJobResponse, DescribeTopicsDetectionJobError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.DescribeTopicsDetectionJob",
@@ -5239,9 +5324,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: DetectDominantLanguageRequest,
     ) -> RusotoFuture<DetectDominantLanguageResponse, DetectDominantLanguageError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Comprehend_20171127.DetectDominantLanguage");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5267,9 +5357,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: DetectEntitiesRequest,
     ) -> RusotoFuture<DetectEntitiesResponse, DetectEntitiesError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Comprehend_20171127.DetectEntities");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5296,9 +5391,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: DetectKeyPhrasesRequest,
     ) -> RusotoFuture<DetectKeyPhrasesResponse, DetectKeyPhrasesError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Comprehend_20171127.DetectKeyPhrases");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5325,9 +5425,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: DetectSentimentRequest,
     ) -> RusotoFuture<DetectSentimentResponse, DetectSentimentError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Comprehend_20171127.DetectSentiment");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5354,9 +5459,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: DetectSyntaxRequest,
     ) -> RusotoFuture<DetectSyntaxResponse, DetectSyntaxError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Comprehend_20171127.DetectSyntax");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5384,9 +5494,14 @@ impl Comprehend for ComprehendClient {
         input: ListDocumentClassificationJobsRequest,
     ) -> RusotoFuture<ListDocumentClassificationJobsResponse, ListDocumentClassificationJobsError>
     {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.ListDocumentClassificationJobs",
@@ -5413,9 +5528,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: ListDocumentClassifiersRequest,
     ) -> RusotoFuture<ListDocumentClassifiersResponse, ListDocumentClassifiersError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.ListDocumentClassifiers",
@@ -5445,9 +5565,14 @@ impl Comprehend for ComprehendClient {
         ListDominantLanguageDetectionJobsResponse,
         ListDominantLanguageDetectionJobsError,
     > {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.ListDominantLanguageDetectionJobs",
@@ -5476,9 +5601,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: ListEntitiesDetectionJobsRequest,
     ) -> RusotoFuture<ListEntitiesDetectionJobsResponse, ListEntitiesDetectionJobsError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.ListEntitiesDetectionJobs",
@@ -5505,9 +5635,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: ListEntityRecognizersRequest,
     ) -> RusotoFuture<ListEntityRecognizersResponse, ListEntityRecognizersError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Comprehend_20171127.ListEntityRecognizers");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5533,9 +5668,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: ListKeyPhrasesDetectionJobsRequest,
     ) -> RusotoFuture<ListKeyPhrasesDetectionJobsResponse, ListKeyPhrasesDetectionJobsError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.ListKeyPhrasesDetectionJobs",
@@ -5562,9 +5702,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: ListSentimentDetectionJobsRequest,
     ) -> RusotoFuture<ListSentimentDetectionJobsResponse, ListSentimentDetectionJobsError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.ListSentimentDetectionJobs",
@@ -5591,9 +5736,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: ListTopicsDetectionJobsRequest,
     ) -> RusotoFuture<ListTopicsDetectionJobsResponse, ListTopicsDetectionJobsError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.ListTopicsDetectionJobs",
@@ -5621,9 +5771,14 @@ impl Comprehend for ComprehendClient {
         input: StartDocumentClassificationJobRequest,
     ) -> RusotoFuture<StartDocumentClassificationJobResponse, StartDocumentClassificationJobError>
     {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.StartDocumentClassificationJob",
@@ -5653,9 +5808,14 @@ impl Comprehend for ComprehendClient {
         StartDominantLanguageDetectionJobResponse,
         StartDominantLanguageDetectionJobError,
     > {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.StartDominantLanguageDetectionJob",
@@ -5684,9 +5844,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: StartEntitiesDetectionJobRequest,
     ) -> RusotoFuture<StartEntitiesDetectionJobResponse, StartEntitiesDetectionJobError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.StartEntitiesDetectionJob",
@@ -5713,9 +5878,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: StartKeyPhrasesDetectionJobRequest,
     ) -> RusotoFuture<StartKeyPhrasesDetectionJobResponse, StartKeyPhrasesDetectionJobError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.StartKeyPhrasesDetectionJob",
@@ -5742,9 +5912,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: StartSentimentDetectionJobRequest,
     ) -> RusotoFuture<StartSentimentDetectionJobResponse, StartSentimentDetectionJobError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.StartSentimentDetectionJob",
@@ -5771,9 +5946,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: StartTopicsDetectionJobRequest,
     ) -> RusotoFuture<StartTopicsDetectionJobResponse, StartTopicsDetectionJobError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.StartTopicsDetectionJob",
@@ -5801,9 +5981,14 @@ impl Comprehend for ComprehendClient {
         input: StopDominantLanguageDetectionJobRequest,
     ) -> RusotoFuture<StopDominantLanguageDetectionJobResponse, StopDominantLanguageDetectionJobError>
     {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.StopDominantLanguageDetectionJob",
@@ -5832,9 +6017,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: StopEntitiesDetectionJobRequest,
     ) -> RusotoFuture<StopEntitiesDetectionJobResponse, StopEntitiesDetectionJobError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.StopEntitiesDetectionJob",
@@ -5861,9 +6051,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: StopKeyPhrasesDetectionJobRequest,
     ) -> RusotoFuture<StopKeyPhrasesDetectionJobResponse, StopKeyPhrasesDetectionJobError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.StopKeyPhrasesDetectionJob",
@@ -5890,9 +6085,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: StopSentimentDetectionJobRequest,
     ) -> RusotoFuture<StopSentimentDetectionJobResponse, StopSentimentDetectionJobError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.StopSentimentDetectionJob",
@@ -5920,9 +6120,14 @@ impl Comprehend for ComprehendClient {
         input: StopTrainingDocumentClassifierRequest,
     ) -> RusotoFuture<StopTrainingDocumentClassifierResponse, StopTrainingDocumentClassifierError>
     {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.StopTrainingDocumentClassifier",
@@ -5949,9 +6154,14 @@ impl Comprehend for ComprehendClient {
         &self,
         input: StopTrainingEntityRecognizerRequest,
     ) -> RusotoFuture<StopTrainingEntityRecognizerResponse, StopTrainingEntityRecognizerError> {
-        let mut request = SignedRequest::new("POST", "comprehend", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehend",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Comprehend_20171127.StopTrainingEntityRecognizer",

--- a/rusoto/services/comprehendmedical/src/generated.rs
+++ b/rusoto/services/comprehendmedical/src/generated.rs
@@ -358,9 +358,14 @@ impl ComprehendMedical for ComprehendMedicalClient {
         &self,
         input: DetectEntitiesRequest,
     ) -> RusotoFuture<DetectEntitiesResponse, DetectEntitiesError> {
-        let mut request = SignedRequest::new("POST", "comprehendmedical", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehendmedical",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ComprehendMedical_20181030.DetectEntities");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -387,9 +392,14 @@ impl ComprehendMedical for ComprehendMedicalClient {
         &self,
         input: DetectPHIRequest,
     ) -> RusotoFuture<DetectPHIResponse, DetectPHIError> {
-        let mut request = SignedRequest::new("POST", "comprehendmedical", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "comprehendmedical",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ComprehendMedical_20181030.DetectPHI");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/config/src/generated.rs
+++ b/rusoto/services/config/src/generated.rs
@@ -4710,9 +4710,14 @@ impl ConfigService for ConfigServiceClient {
         input: BatchGetAggregateResourceConfigRequest,
     ) -> RusotoFuture<BatchGetAggregateResourceConfigResponse, BatchGetAggregateResourceConfigError>
     {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.BatchGetAggregateResourceConfig",
@@ -4741,9 +4746,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: BatchGetResourceConfigRequest,
     ) -> RusotoFuture<BatchGetResourceConfigResponse, BatchGetResourceConfigError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StarlingDoveService.BatchGetResourceConfig");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4769,9 +4779,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: DeleteAggregationAuthorizationRequest,
     ) -> RusotoFuture<(), DeleteAggregationAuthorizationError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.DeleteAggregationAuthorization",
@@ -4795,9 +4810,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: DeleteConfigRuleRequest,
     ) -> RusotoFuture<(), DeleteConfigRuleError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StarlingDoveService.DeleteConfigRule");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4821,9 +4841,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: DeleteConfigurationAggregatorRequest,
     ) -> RusotoFuture<(), DeleteConfigurationAggregatorError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.DeleteConfigurationAggregator",
@@ -4847,9 +4872,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: DeleteConfigurationRecorderRequest,
     ) -> RusotoFuture<(), DeleteConfigurationRecorderError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.DeleteConfigurationRecorder",
@@ -4873,9 +4903,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: DeleteDeliveryChannelRequest,
     ) -> RusotoFuture<(), DeleteDeliveryChannelError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StarlingDoveService.DeleteDeliveryChannel");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4898,9 +4933,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: DeleteEvaluationResultsRequest,
     ) -> RusotoFuture<DeleteEvaluationResultsResponse, DeleteEvaluationResultsError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.DeleteEvaluationResults",
@@ -4927,9 +4967,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: DeletePendingAggregationRequestRequest,
     ) -> RusotoFuture<(), DeletePendingAggregationRequestError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.DeletePendingAggregationRequest",
@@ -4955,9 +5000,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: DeleteRetentionConfigurationRequest,
     ) -> RusotoFuture<(), DeleteRetentionConfigurationError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.DeleteRetentionConfiguration",
@@ -4981,9 +5031,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: DeliverConfigSnapshotRequest,
     ) -> RusotoFuture<DeliverConfigSnapshotResponse, DeliverConfigSnapshotError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StarlingDoveService.DeliverConfigSnapshot");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5012,9 +5067,14 @@ impl ConfigService for ConfigServiceClient {
         DescribeAggregateComplianceByConfigRulesResponse,
         DescribeAggregateComplianceByConfigRulesError,
     > {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.DescribeAggregateComplianceByConfigRules",
@@ -5044,9 +5104,14 @@ impl ConfigService for ConfigServiceClient {
         DescribeAggregationAuthorizationsResponse,
         DescribeAggregationAuthorizationsError,
     > {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.DescribeAggregationAuthorizations",
@@ -5076,9 +5141,14 @@ impl ConfigService for ConfigServiceClient {
         input: DescribeComplianceByConfigRuleRequest,
     ) -> RusotoFuture<DescribeComplianceByConfigRuleResponse, DescribeComplianceByConfigRuleError>
     {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.DescribeComplianceByConfigRule",
@@ -5105,9 +5175,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: DescribeComplianceByResourceRequest,
     ) -> RusotoFuture<DescribeComplianceByResourceResponse, DescribeComplianceByResourceError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.DescribeComplianceByResource",
@@ -5137,9 +5212,14 @@ impl ConfigService for ConfigServiceClient {
         DescribeConfigRuleEvaluationStatusResponse,
         DescribeConfigRuleEvaluationStatusError,
     > {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.DescribeConfigRuleEvaluationStatus",
@@ -5168,9 +5248,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: DescribeConfigRulesRequest,
     ) -> RusotoFuture<DescribeConfigRulesResponse, DescribeConfigRulesError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StarlingDoveService.DescribeConfigRules");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5199,9 +5284,14 @@ impl ConfigService for ConfigServiceClient {
         DescribeConfigurationAggregatorSourcesStatusResponse,
         DescribeConfigurationAggregatorSourcesStatusError,
     > {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.DescribeConfigurationAggregatorSourcesStatus",
@@ -5228,9 +5318,14 @@ impl ConfigService for ConfigServiceClient {
         input: DescribeConfigurationAggregatorsRequest,
     ) -> RusotoFuture<DescribeConfigurationAggregatorsResponse, DescribeConfigurationAggregatorsError>
     {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.DescribeConfigurationAggregators",
@@ -5262,9 +5357,14 @@ impl ConfigService for ConfigServiceClient {
         DescribeConfigurationRecorderStatusResponse,
         DescribeConfigurationRecorderStatusError,
     > {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.DescribeConfigurationRecorderStatus",
@@ -5294,9 +5394,14 @@ impl ConfigService for ConfigServiceClient {
         input: DescribeConfigurationRecordersRequest,
     ) -> RusotoFuture<DescribeConfigurationRecordersResponse, DescribeConfigurationRecordersError>
     {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.DescribeConfigurationRecorders",
@@ -5324,9 +5429,14 @@ impl ConfigService for ConfigServiceClient {
         input: DescribeDeliveryChannelStatusRequest,
     ) -> RusotoFuture<DescribeDeliveryChannelStatusResponse, DescribeDeliveryChannelStatusError>
     {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.DescribeDeliveryChannelStatus",
@@ -5353,9 +5463,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: DescribeDeliveryChannelsRequest,
     ) -> RusotoFuture<DescribeDeliveryChannelsResponse, DescribeDeliveryChannelsError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.DescribeDeliveryChannels",
@@ -5385,9 +5500,14 @@ impl ConfigService for ConfigServiceClient {
         DescribePendingAggregationRequestsResponse,
         DescribePendingAggregationRequestsError,
     > {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.DescribePendingAggregationRequests",
@@ -5417,9 +5537,14 @@ impl ConfigService for ConfigServiceClient {
         input: DescribeRetentionConfigurationsRequest,
     ) -> RusotoFuture<DescribeRetentionConfigurationsResponse, DescribeRetentionConfigurationsError>
     {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.DescribeRetentionConfigurations",
@@ -5451,9 +5576,14 @@ impl ConfigService for ConfigServiceClient {
         GetAggregateComplianceDetailsByConfigRuleResponse,
         GetAggregateComplianceDetailsByConfigRuleError,
     > {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.GetAggregateComplianceDetailsByConfigRule",
@@ -5483,9 +5613,14 @@ impl ConfigService for ConfigServiceClient {
         GetAggregateConfigRuleComplianceSummaryResponse,
         GetAggregateConfigRuleComplianceSummaryError,
     > {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.GetAggregateConfigRuleComplianceSummary",
@@ -5517,9 +5652,14 @@ impl ConfigService for ConfigServiceClient {
         GetAggregateDiscoveredResourceCountsResponse,
         GetAggregateDiscoveredResourceCountsError,
     > {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.GetAggregateDiscoveredResourceCounts",
@@ -5548,9 +5688,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: GetAggregateResourceConfigRequest,
     ) -> RusotoFuture<GetAggregateResourceConfigResponse, GetAggregateResourceConfigError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.GetAggregateResourceConfig",
@@ -5578,9 +5723,14 @@ impl ConfigService for ConfigServiceClient {
         input: GetComplianceDetailsByConfigRuleRequest,
     ) -> RusotoFuture<GetComplianceDetailsByConfigRuleResponse, GetComplianceDetailsByConfigRuleError>
     {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.GetComplianceDetailsByConfigRule",
@@ -5610,9 +5760,14 @@ impl ConfigService for ConfigServiceClient {
         input: GetComplianceDetailsByResourceRequest,
     ) -> RusotoFuture<GetComplianceDetailsByResourceResponse, GetComplianceDetailsByResourceError>
     {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.GetComplianceDetailsByResource",
@@ -5639,9 +5794,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
     ) -> RusotoFuture<GetComplianceSummaryByConfigRuleResponse, GetComplianceSummaryByConfigRuleError>
     {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.GetComplianceSummaryByConfigRule",
@@ -5672,9 +5832,14 @@ impl ConfigService for ConfigServiceClient {
         GetComplianceSummaryByResourceTypeResponse,
         GetComplianceSummaryByResourceTypeError,
     > {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.GetComplianceSummaryByResourceType",
@@ -5703,9 +5868,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: GetDiscoveredResourceCountsRequest,
     ) -> RusotoFuture<GetDiscoveredResourceCountsResponse, GetDiscoveredResourceCountsError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.GetDiscoveredResourceCounts",
@@ -5732,9 +5902,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: GetResourceConfigHistoryRequest,
     ) -> RusotoFuture<GetResourceConfigHistoryResponse, GetResourceConfigHistoryError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.GetResourceConfigHistory",
@@ -5762,9 +5937,14 @@ impl ConfigService for ConfigServiceClient {
         input: ListAggregateDiscoveredResourcesRequest,
     ) -> RusotoFuture<ListAggregateDiscoveredResourcesResponse, ListAggregateDiscoveredResourcesError>
     {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.ListAggregateDiscoveredResources",
@@ -5793,9 +5973,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: ListDiscoveredResourcesRequest,
     ) -> RusotoFuture<ListDiscoveredResourcesResponse, ListDiscoveredResourcesError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.ListDiscoveredResources",
@@ -5822,9 +6007,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: PutAggregationAuthorizationRequest,
     ) -> RusotoFuture<PutAggregationAuthorizationResponse, PutAggregationAuthorizationError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.PutAggregationAuthorization",
@@ -5848,9 +6038,14 @@ impl ConfigService for ConfigServiceClient {
 
     /// <p>Adds or updates an AWS Config rule for evaluating whether your AWS resources comply with your desired configurations.</p> <p>You can use this action for custom AWS Config rules and AWS managed Config rules. A custom AWS Config rule is a rule that you develop and maintain. An AWS managed Config rule is a customizable, predefined rule that AWS Config provides.</p> <p>If you are adding a new custom AWS Config rule, you must first create the AWS Lambda function that the rule invokes to evaluate your resources. When you use the <code>PutConfigRule</code> action to add the rule to AWS Config, you must specify the Amazon Resource Name (ARN) that AWS Lambda assigns to the function. Specify the ARN for the <code>SourceIdentifier</code> key. This key is part of the <code>Source</code> object, which is part of the <code>ConfigRule</code> object. </p> <p>If you are adding an AWS managed Config rule, specify the rule's identifier for the <code>SourceIdentifier</code> key. To reference AWS managed Config rule identifiers, see <a href="http://docs.aws.amazon.com/config/latest/developerguide/evaluate-config_use-managed-rules.html">About AWS Managed Config Rules</a>.</p> <p>For any new rule that you add, specify the <code>ConfigRuleName</code> in the <code>ConfigRule</code> object. Do not specify the <code>ConfigRuleArn</code> or the <code>ConfigRuleId</code>. These values are generated by AWS Config for new rules.</p> <p>If you are updating a rule that you added previously, you can specify the rule by <code>ConfigRuleName</code>, <code>ConfigRuleId</code>, or <code>ConfigRuleArn</code> in the <code>ConfigRule</code> data type that you use in this request.</p> <p>The maximum number of rules that AWS Config supports is 50.</p> <p>For information about requesting a rule limit increase, see <a href="http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html#limits_config">AWS Config Limits</a> in the <i>AWS General Reference Guide</i>.</p> <p>For more information about developing and using AWS Config rules, see <a href="http://docs.aws.amazon.com/config/latest/developerguide/evaluate-config.html">Evaluating AWS Resource Configurations with AWS Config</a> in the <i>AWS Config Developer Guide</i>.</p>
     fn put_config_rule(&self, input: PutConfigRuleRequest) -> RusotoFuture<(), PutConfigRuleError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StarlingDoveService.PutConfigRule");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5874,9 +6069,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: PutConfigurationAggregatorRequest,
     ) -> RusotoFuture<PutConfigurationAggregatorResponse, PutConfigurationAggregatorError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.PutConfigurationAggregator",
@@ -5903,9 +6103,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: PutConfigurationRecorderRequest,
     ) -> RusotoFuture<(), PutConfigurationRecorderError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.PutConfigurationRecorder",
@@ -5929,9 +6134,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: PutDeliveryChannelRequest,
     ) -> RusotoFuture<(), PutDeliveryChannelError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StarlingDoveService.PutDeliveryChannel");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5955,9 +6165,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: PutEvaluationsRequest,
     ) -> RusotoFuture<PutEvaluationsResponse, PutEvaluationsError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StarlingDoveService.PutEvaluations");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5984,9 +6199,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: PutRetentionConfigurationRequest,
     ) -> RusotoFuture<PutRetentionConfigurationResponse, PutRetentionConfigurationError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.PutRetentionConfiguration",
@@ -6013,9 +6233,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: StartConfigRulesEvaluationRequest,
     ) -> RusotoFuture<StartConfigRulesEvaluationResponse, StartConfigRulesEvaluationError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.StartConfigRulesEvaluation",
@@ -6042,9 +6267,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: StartConfigurationRecorderRequest,
     ) -> RusotoFuture<(), StartConfigurationRecorderError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.StartConfigurationRecorder",
@@ -6068,9 +6298,14 @@ impl ConfigService for ConfigServiceClient {
         &self,
         input: StopConfigurationRecorderRequest,
     ) -> RusotoFuture<(), StopConfigurationRecorderError> {
-        let mut request = SignedRequest::new("POST", "config", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "config",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StarlingDoveService.StopConfigurationRecorder",

--- a/rusoto/services/cur/src/generated.rs
+++ b/rusoto/services/cur/src/generated.rs
@@ -281,9 +281,14 @@ impl CostAndUsageReport for CostAndUsageReportClient {
         &self,
         input: DeleteReportDefinitionRequest,
     ) -> RusotoFuture<DeleteReportDefinitionResponse, DeleteReportDefinitionError> {
-        let mut request = SignedRequest::new("POST", "cur", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cur",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrigamiServiceGatewayService.DeleteReportDefinition",
@@ -312,9 +317,14 @@ impl CostAndUsageReport for CostAndUsageReportClient {
         &self,
         input: DescribeReportDefinitionsRequest,
     ) -> RusotoFuture<DescribeReportDefinitionsResponse, DescribeReportDefinitionsError> {
-        let mut request = SignedRequest::new("POST", "cur", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cur",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrigamiServiceGatewayService.DescribeReportDefinitions",
@@ -341,9 +351,14 @@ impl CostAndUsageReport for CostAndUsageReportClient {
         &self,
         input: PutReportDefinitionRequest,
     ) -> RusotoFuture<PutReportDefinitionResponse, PutReportDefinitionError> {
-        let mut request = SignedRequest::new("POST", "cur", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "cur",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrigamiServiceGatewayService.PutReportDefinition",

--- a/rusoto/services/datapipeline/src/generated.rs
+++ b/rusoto/services/datapipeline/src/generated.rs
@@ -1827,9 +1827,14 @@ impl DataPipeline for DataPipelineClient {
         &self,
         input: ActivatePipelineInput,
     ) -> RusotoFuture<ActivatePipelineOutput, ActivatePipelineError> {
-        let mut request = SignedRequest::new("POST", "datapipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "datapipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DataPipeline.ActivatePipeline");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1853,9 +1858,14 @@ impl DataPipeline for DataPipelineClient {
 
     /// <p>Adds or modifies tags for the specified pipeline.</p>
     fn add_tags(&self, input: AddTagsInput) -> RusotoFuture<AddTagsOutput, AddTagsError> {
-        let mut request = SignedRequest::new("POST", "datapipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "datapipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DataPipeline.AddTags");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1881,9 +1891,14 @@ impl DataPipeline for DataPipelineClient {
         &self,
         input: CreatePipelineInput,
     ) -> RusotoFuture<CreatePipelineOutput, CreatePipelineError> {
-        let mut request = SignedRequest::new("POST", "datapipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "datapipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DataPipeline.CreatePipeline");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1910,9 +1925,14 @@ impl DataPipeline for DataPipelineClient {
         &self,
         input: DeactivatePipelineInput,
     ) -> RusotoFuture<DeactivatePipelineOutput, DeactivatePipelineError> {
-        let mut request = SignedRequest::new("POST", "datapipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "datapipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DataPipeline.DeactivatePipeline");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1936,9 +1956,14 @@ impl DataPipeline for DataPipelineClient {
 
     /// <p>Deletes a pipeline, its pipeline definition, and its run history. AWS Data Pipeline attempts to cancel instances associated with the pipeline that are currently being processed by task runners.</p> <p>Deleting a pipeline cannot be undone. You cannot query or restore a deleted pipeline. To temporarily pause a pipeline instead of deleting it, call <a>SetStatus</a> with the status set to <code>PAUSE</code> on individual components. Components that are paused by <a>SetStatus</a> can be resumed.</p>
     fn delete_pipeline(&self, input: DeletePipelineInput) -> RusotoFuture<(), DeletePipelineError> {
-        let mut request = SignedRequest::new("POST", "datapipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "datapipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DataPipeline.DeletePipeline");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1962,9 +1987,14 @@ impl DataPipeline for DataPipelineClient {
         &self,
         input: DescribeObjectsInput,
     ) -> RusotoFuture<DescribeObjectsOutput, DescribeObjectsError> {
-        let mut request = SignedRequest::new("POST", "datapipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "datapipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DataPipeline.DescribeObjects");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1991,9 +2021,14 @@ impl DataPipeline for DataPipelineClient {
         &self,
         input: DescribePipelinesInput,
     ) -> RusotoFuture<DescribePipelinesOutput, DescribePipelinesError> {
-        let mut request = SignedRequest::new("POST", "datapipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "datapipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DataPipeline.DescribePipelines");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2020,9 +2055,14 @@ impl DataPipeline for DataPipelineClient {
         &self,
         input: EvaluateExpressionInput,
     ) -> RusotoFuture<EvaluateExpressionOutput, EvaluateExpressionError> {
-        let mut request = SignedRequest::new("POST", "datapipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "datapipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DataPipeline.EvaluateExpression");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2049,9 +2089,14 @@ impl DataPipeline for DataPipelineClient {
         &self,
         input: GetPipelineDefinitionInput,
     ) -> RusotoFuture<GetPipelineDefinitionOutput, GetPipelineDefinitionError> {
-        let mut request = SignedRequest::new("POST", "datapipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "datapipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DataPipeline.GetPipelineDefinition");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2077,9 +2122,14 @@ impl DataPipeline for DataPipelineClient {
         &self,
         input: ListPipelinesInput,
     ) -> RusotoFuture<ListPipelinesOutput, ListPipelinesError> {
-        let mut request = SignedRequest::new("POST", "datapipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "datapipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DataPipeline.ListPipelines");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2106,9 +2156,14 @@ impl DataPipeline for DataPipelineClient {
         &self,
         input: PollForTaskInput,
     ) -> RusotoFuture<PollForTaskOutput, PollForTaskError> {
-        let mut request = SignedRequest::new("POST", "datapipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "datapipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DataPipeline.PollForTask");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2135,9 +2190,14 @@ impl DataPipeline for DataPipelineClient {
         &self,
         input: PutPipelineDefinitionInput,
     ) -> RusotoFuture<PutPipelineDefinitionOutput, PutPipelineDefinitionError> {
-        let mut request = SignedRequest::new("POST", "datapipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "datapipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DataPipeline.PutPipelineDefinition");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2163,9 +2223,14 @@ impl DataPipeline for DataPipelineClient {
         &self,
         input: QueryObjectsInput,
     ) -> RusotoFuture<QueryObjectsOutput, QueryObjectsError> {
-        let mut request = SignedRequest::new("POST", "datapipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "datapipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DataPipeline.QueryObjects");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2192,9 +2257,14 @@ impl DataPipeline for DataPipelineClient {
         &self,
         input: RemoveTagsInput,
     ) -> RusotoFuture<RemoveTagsOutput, RemoveTagsError> {
-        let mut request = SignedRequest::new("POST", "datapipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "datapipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DataPipeline.RemoveTags");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2221,9 +2291,14 @@ impl DataPipeline for DataPipelineClient {
         &self,
         input: ReportTaskProgressInput,
     ) -> RusotoFuture<ReportTaskProgressOutput, ReportTaskProgressError> {
-        let mut request = SignedRequest::new("POST", "datapipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "datapipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DataPipeline.ReportTaskProgress");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2250,9 +2325,14 @@ impl DataPipeline for DataPipelineClient {
         &self,
         input: ReportTaskRunnerHeartbeatInput,
     ) -> RusotoFuture<ReportTaskRunnerHeartbeatOutput, ReportTaskRunnerHeartbeatError> {
-        let mut request = SignedRequest::new("POST", "datapipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "datapipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DataPipeline.ReportTaskRunnerHeartbeat");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2273,9 +2353,14 @@ impl DataPipeline for DataPipelineClient {
 
     /// <p>Requests that the status of the specified physical or logical pipeline objects be updated in the specified pipeline. This update might not occur immediately, but is eventually consistent. The status that can be set depends on the type of object (for example, DataNode or Activity). You cannot perform this operation on <code>FINISHED</code> pipelines and attempting to do so returns <code>InvalidRequestException</code>.</p>
     fn set_status(&self, input: SetStatusInput) -> RusotoFuture<(), SetStatusError> {
-        let mut request = SignedRequest::new("POST", "datapipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "datapipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DataPipeline.SetStatus");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2299,9 +2384,14 @@ impl DataPipeline for DataPipelineClient {
         &self,
         input: SetTaskStatusInput,
     ) -> RusotoFuture<SetTaskStatusOutput, SetTaskStatusError> {
-        let mut request = SignedRequest::new("POST", "datapipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "datapipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DataPipeline.SetTaskStatus");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2328,9 +2418,14 @@ impl DataPipeline for DataPipelineClient {
         &self,
         input: ValidatePipelineDefinitionInput,
     ) -> RusotoFuture<ValidatePipelineDefinitionOutput, ValidatePipelineDefinitionError> {
-        let mut request = SignedRequest::new("POST", "datapipeline", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "datapipeline",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DataPipeline.ValidatePipelineDefinition");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/dax/src/generated.rs
+++ b/rusoto/services/dax/src/generated.rs
@@ -2533,9 +2533,14 @@ impl DynamodbAccelerator for DynamodbAcceleratorClient {
         &self,
         input: CreateClusterRequest,
     ) -> RusotoFuture<CreateClusterResponse, CreateClusterError> {
-        let mut request = SignedRequest::new("POST", "dax", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dax",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDAXV3.CreateCluster");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2562,9 +2567,14 @@ impl DynamodbAccelerator for DynamodbAcceleratorClient {
         &self,
         input: CreateParameterGroupRequest,
     ) -> RusotoFuture<CreateParameterGroupResponse, CreateParameterGroupError> {
-        let mut request = SignedRequest::new("POST", "dax", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dax",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDAXV3.CreateParameterGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2590,9 +2600,14 @@ impl DynamodbAccelerator for DynamodbAcceleratorClient {
         &self,
         input: CreateSubnetGroupRequest,
     ) -> RusotoFuture<CreateSubnetGroupResponse, CreateSubnetGroupError> {
-        let mut request = SignedRequest::new("POST", "dax", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dax",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDAXV3.CreateSubnetGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2619,9 +2634,14 @@ impl DynamodbAccelerator for DynamodbAcceleratorClient {
         &self,
         input: DecreaseReplicationFactorRequest,
     ) -> RusotoFuture<DecreaseReplicationFactorResponse, DecreaseReplicationFactorError> {
-        let mut request = SignedRequest::new("POST", "dax", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dax",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDAXV3.DecreaseReplicationFactor");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2645,9 +2665,14 @@ impl DynamodbAccelerator for DynamodbAcceleratorClient {
         &self,
         input: DeleteClusterRequest,
     ) -> RusotoFuture<DeleteClusterResponse, DeleteClusterError> {
-        let mut request = SignedRequest::new("POST", "dax", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dax",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDAXV3.DeleteCluster");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2674,9 +2699,14 @@ impl DynamodbAccelerator for DynamodbAcceleratorClient {
         &self,
         input: DeleteParameterGroupRequest,
     ) -> RusotoFuture<DeleteParameterGroupResponse, DeleteParameterGroupError> {
-        let mut request = SignedRequest::new("POST", "dax", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dax",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDAXV3.DeleteParameterGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2702,9 +2732,14 @@ impl DynamodbAccelerator for DynamodbAcceleratorClient {
         &self,
         input: DeleteSubnetGroupRequest,
     ) -> RusotoFuture<DeleteSubnetGroupResponse, DeleteSubnetGroupError> {
-        let mut request = SignedRequest::new("POST", "dax", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dax",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDAXV3.DeleteSubnetGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2731,9 +2766,14 @@ impl DynamodbAccelerator for DynamodbAcceleratorClient {
         &self,
         input: DescribeClustersRequest,
     ) -> RusotoFuture<DescribeClustersResponse, DescribeClustersError> {
-        let mut request = SignedRequest::new("POST", "dax", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dax",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDAXV3.DescribeClusters");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2760,9 +2800,14 @@ impl DynamodbAccelerator for DynamodbAcceleratorClient {
         &self,
         input: DescribeDefaultParametersRequest,
     ) -> RusotoFuture<DescribeDefaultParametersResponse, DescribeDefaultParametersError> {
-        let mut request = SignedRequest::new("POST", "dax", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dax",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDAXV3.DescribeDefaultParameters");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2786,9 +2831,14 @@ impl DynamodbAccelerator for DynamodbAcceleratorClient {
         &self,
         input: DescribeEventsRequest,
     ) -> RusotoFuture<DescribeEventsResponse, DescribeEventsError> {
-        let mut request = SignedRequest::new("POST", "dax", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dax",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDAXV3.DescribeEvents");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2815,9 +2865,14 @@ impl DynamodbAccelerator for DynamodbAcceleratorClient {
         &self,
         input: DescribeParameterGroupsRequest,
     ) -> RusotoFuture<DescribeParameterGroupsResponse, DescribeParameterGroupsError> {
-        let mut request = SignedRequest::new("POST", "dax", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dax",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDAXV3.DescribeParameterGroups");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2841,9 +2896,14 @@ impl DynamodbAccelerator for DynamodbAcceleratorClient {
         &self,
         input: DescribeParametersRequest,
     ) -> RusotoFuture<DescribeParametersResponse, DescribeParametersError> {
-        let mut request = SignedRequest::new("POST", "dax", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dax",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDAXV3.DescribeParameters");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2870,9 +2930,14 @@ impl DynamodbAccelerator for DynamodbAcceleratorClient {
         &self,
         input: DescribeSubnetGroupsRequest,
     ) -> RusotoFuture<DescribeSubnetGroupsResponse, DescribeSubnetGroupsError> {
-        let mut request = SignedRequest::new("POST", "dax", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dax",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDAXV3.DescribeSubnetGroups");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2898,9 +2963,14 @@ impl DynamodbAccelerator for DynamodbAcceleratorClient {
         &self,
         input: IncreaseReplicationFactorRequest,
     ) -> RusotoFuture<IncreaseReplicationFactorResponse, IncreaseReplicationFactorError> {
-        let mut request = SignedRequest::new("POST", "dax", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dax",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDAXV3.IncreaseReplicationFactor");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2921,9 +2991,14 @@ impl DynamodbAccelerator for DynamodbAcceleratorClient {
 
     /// <p>List all of the tags for a DAX cluster. You can call <code>ListTags</code> up to 10 times per second, per account.</p>
     fn list_tags(&self, input: ListTagsRequest) -> RusotoFuture<ListTagsResponse, ListTagsError> {
-        let mut request = SignedRequest::new("POST", "dax", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dax",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDAXV3.ListTags");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2950,9 +3025,14 @@ impl DynamodbAccelerator for DynamodbAcceleratorClient {
         &self,
         input: RebootNodeRequest,
     ) -> RusotoFuture<RebootNodeResponse, RebootNodeError> {
-        let mut request = SignedRequest::new("POST", "dax", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dax",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDAXV3.RebootNode");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2979,9 +3059,14 @@ impl DynamodbAccelerator for DynamodbAcceleratorClient {
         &self,
         input: TagResourceRequest,
     ) -> RusotoFuture<TagResourceResponse, TagResourceError> {
-        let mut request = SignedRequest::new("POST", "dax", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dax",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDAXV3.TagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3008,9 +3093,14 @@ impl DynamodbAccelerator for DynamodbAcceleratorClient {
         &self,
         input: UntagResourceRequest,
     ) -> RusotoFuture<UntagResourceResponse, UntagResourceError> {
-        let mut request = SignedRequest::new("POST", "dax", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dax",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDAXV3.UntagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3037,9 +3127,14 @@ impl DynamodbAccelerator for DynamodbAcceleratorClient {
         &self,
         input: UpdateClusterRequest,
     ) -> RusotoFuture<UpdateClusterResponse, UpdateClusterError> {
-        let mut request = SignedRequest::new("POST", "dax", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dax",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDAXV3.UpdateCluster");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3066,9 +3161,14 @@ impl DynamodbAccelerator for DynamodbAcceleratorClient {
         &self,
         input: UpdateParameterGroupRequest,
     ) -> RusotoFuture<UpdateParameterGroupResponse, UpdateParameterGroupError> {
-        let mut request = SignedRequest::new("POST", "dax", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dax",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDAXV3.UpdateParameterGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3094,9 +3194,14 @@ impl DynamodbAccelerator for DynamodbAcceleratorClient {
         &self,
         input: UpdateSubnetGroupRequest,
     ) -> RusotoFuture<UpdateSubnetGroupResponse, UpdateSubnetGroupError> {
-        let mut request = SignedRequest::new("POST", "dax", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dax",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDAXV3.UpdateSubnetGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/devicefarm/src/generated.rs
+++ b/rusoto/services/devicefarm/src/generated.rs
@@ -6648,9 +6648,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: CreateDevicePoolRequest,
     ) -> RusotoFuture<CreateDevicePoolResult, CreateDevicePoolError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.CreateDevicePool");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6677,9 +6682,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: CreateInstanceProfileRequest,
     ) -> RusotoFuture<CreateInstanceProfileResult, CreateInstanceProfileError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.CreateInstanceProfile");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6705,9 +6715,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: CreateNetworkProfileRequest,
     ) -> RusotoFuture<CreateNetworkProfileResult, CreateNetworkProfileError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.CreateNetworkProfile");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6733,9 +6748,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: CreateProjectRequest,
     ) -> RusotoFuture<CreateProjectResult, CreateProjectError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.CreateProject");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6762,9 +6782,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: CreateRemoteAccessSessionRequest,
     ) -> RusotoFuture<CreateRemoteAccessSessionResult, CreateRemoteAccessSessionError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DeviceFarm_20150623.CreateRemoteAccessSession",
@@ -6791,9 +6816,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: CreateUploadRequest,
     ) -> RusotoFuture<CreateUploadResult, CreateUploadError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.CreateUpload");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6820,9 +6850,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: CreateVPCEConfigurationRequest,
     ) -> RusotoFuture<CreateVPCEConfigurationResult, CreateVPCEConfigurationError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DeviceFarm_20150623.CreateVPCEConfiguration",
@@ -6849,9 +6884,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: DeleteDevicePoolRequest,
     ) -> RusotoFuture<DeleteDevicePoolResult, DeleteDevicePoolError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.DeleteDevicePool");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6878,9 +6918,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: DeleteInstanceProfileRequest,
     ) -> RusotoFuture<DeleteInstanceProfileResult, DeleteInstanceProfileError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.DeleteInstanceProfile");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6906,9 +6951,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: DeleteNetworkProfileRequest,
     ) -> RusotoFuture<DeleteNetworkProfileResult, DeleteNetworkProfileError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.DeleteNetworkProfile");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6934,9 +6984,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: DeleteProjectRequest,
     ) -> RusotoFuture<DeleteProjectResult, DeleteProjectError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.DeleteProject");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6963,9 +7018,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: DeleteRemoteAccessSessionRequest,
     ) -> RusotoFuture<DeleteRemoteAccessSessionResult, DeleteRemoteAccessSessionError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DeviceFarm_20150623.DeleteRemoteAccessSession",
@@ -6989,9 +7049,14 @@ impl DeviceFarm for DeviceFarmClient {
 
     /// <p>Deletes the run, given the run ARN.</p> <p> <b>Note</b> Deleting this resource does not stop an in-progress run.</p>
     fn delete_run(&self, input: DeleteRunRequest) -> RusotoFuture<DeleteRunResult, DeleteRunError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.DeleteRun");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7017,9 +7082,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: DeleteUploadRequest,
     ) -> RusotoFuture<DeleteUploadResult, DeleteUploadError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.DeleteUpload");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7046,9 +7116,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: DeleteVPCEConfigurationRequest,
     ) -> RusotoFuture<DeleteVPCEConfigurationResult, DeleteVPCEConfigurationError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DeviceFarm_20150623.DeleteVPCEConfiguration",
@@ -7074,9 +7149,14 @@ impl DeviceFarm for DeviceFarmClient {
     fn get_account_settings(
         &self,
     ) -> RusotoFuture<GetAccountSettingsResult, GetAccountSettingsError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.GetAccountSettings");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -7099,9 +7179,14 @@ impl DeviceFarm for DeviceFarmClient {
 
     /// <p>Gets information about a unique device type.</p>
     fn get_device(&self, input: GetDeviceRequest) -> RusotoFuture<GetDeviceResult, GetDeviceError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.GetDevice");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7127,9 +7212,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: GetDeviceInstanceRequest,
     ) -> RusotoFuture<GetDeviceInstanceResult, GetDeviceInstanceError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.GetDeviceInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7156,9 +7246,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: GetDevicePoolRequest,
     ) -> RusotoFuture<GetDevicePoolResult, GetDevicePoolError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.GetDevicePool");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7185,9 +7280,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: GetDevicePoolCompatibilityRequest,
     ) -> RusotoFuture<GetDevicePoolCompatibilityResult, GetDevicePoolCompatibilityError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DeviceFarm_20150623.GetDevicePoolCompatibility",
@@ -7214,9 +7314,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: GetInstanceProfileRequest,
     ) -> RusotoFuture<GetInstanceProfileResult, GetInstanceProfileError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.GetInstanceProfile");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7240,9 +7345,14 @@ impl DeviceFarm for DeviceFarmClient {
 
     /// <p>Gets information about a job.</p>
     fn get_job(&self, input: GetJobRequest) -> RusotoFuture<GetJobResult, GetJobError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.GetJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7268,9 +7378,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: GetNetworkProfileRequest,
     ) -> RusotoFuture<GetNetworkProfileResult, GetNetworkProfileError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.GetNetworkProfile");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7297,9 +7412,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: GetOfferingStatusRequest,
     ) -> RusotoFuture<GetOfferingStatusResult, GetOfferingStatusError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.GetOfferingStatus");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7326,9 +7446,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: GetProjectRequest,
     ) -> RusotoFuture<GetProjectResult, GetProjectError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.GetProject");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7355,9 +7480,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: GetRemoteAccessSessionRequest,
     ) -> RusotoFuture<GetRemoteAccessSessionResult, GetRemoteAccessSessionError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.GetRemoteAccessSession");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7380,9 +7510,14 @@ impl DeviceFarm for DeviceFarmClient {
 
     /// <p>Gets information about a run.</p>
     fn get_run(&self, input: GetRunRequest) -> RusotoFuture<GetRunResult, GetRunError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.GetRun");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7405,9 +7540,14 @@ impl DeviceFarm for DeviceFarmClient {
 
     /// <p>Gets information about a suite.</p>
     fn get_suite(&self, input: GetSuiteRequest) -> RusotoFuture<GetSuiteResult, GetSuiteError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.GetSuite");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7430,9 +7570,14 @@ impl DeviceFarm for DeviceFarmClient {
 
     /// <p>Gets information about a test.</p>
     fn get_test(&self, input: GetTestRequest) -> RusotoFuture<GetTestResult, GetTestError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.GetTest");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7455,9 +7600,14 @@ impl DeviceFarm for DeviceFarmClient {
 
     /// <p>Gets information about an upload.</p>
     fn get_upload(&self, input: GetUploadRequest) -> RusotoFuture<GetUploadResult, GetUploadError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.GetUpload");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7483,9 +7633,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: GetVPCEConfigurationRequest,
     ) -> RusotoFuture<GetVPCEConfigurationResult, GetVPCEConfigurationError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.GetVPCEConfiguration");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7511,9 +7666,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: InstallToRemoteAccessSessionRequest,
     ) -> RusotoFuture<InstallToRemoteAccessSessionResult, InstallToRemoteAccessSessionError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DeviceFarm_20150623.InstallToRemoteAccessSession",
@@ -7540,9 +7700,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: ListArtifactsRequest,
     ) -> RusotoFuture<ListArtifactsResult, ListArtifactsError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.ListArtifacts");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7569,9 +7734,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: ListDeviceInstancesRequest,
     ) -> RusotoFuture<ListDeviceInstancesResult, ListDeviceInstancesError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.ListDeviceInstances");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7597,9 +7767,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: ListDevicePoolsRequest,
     ) -> RusotoFuture<ListDevicePoolsResult, ListDevicePoolsError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.ListDevicePools");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7626,9 +7801,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: ListDevicesRequest,
     ) -> RusotoFuture<ListDevicesResult, ListDevicesError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.ListDevices");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7655,9 +7835,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: ListInstanceProfilesRequest,
     ) -> RusotoFuture<ListInstanceProfilesResult, ListInstanceProfilesError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.ListInstanceProfiles");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7680,9 +7865,14 @@ impl DeviceFarm for DeviceFarmClient {
 
     /// <p>Gets information about jobs for a given test run.</p>
     fn list_jobs(&self, input: ListJobsRequest) -> RusotoFuture<ListJobsResult, ListJobsError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.ListJobs");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7708,9 +7898,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: ListNetworkProfilesRequest,
     ) -> RusotoFuture<ListNetworkProfilesResult, ListNetworkProfilesError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.ListNetworkProfiles");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7736,9 +7931,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: ListOfferingPromotionsRequest,
     ) -> RusotoFuture<ListOfferingPromotionsResult, ListOfferingPromotionsError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.ListOfferingPromotions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7764,9 +7964,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: ListOfferingTransactionsRequest,
     ) -> RusotoFuture<ListOfferingTransactionsResult, ListOfferingTransactionsError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DeviceFarm_20150623.ListOfferingTransactions",
@@ -7793,9 +7998,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: ListOfferingsRequest,
     ) -> RusotoFuture<ListOfferingsResult, ListOfferingsError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.ListOfferings");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7822,9 +8032,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: ListProjectsRequest,
     ) -> RusotoFuture<ListProjectsResult, ListProjectsError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.ListProjects");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7851,9 +8066,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: ListRemoteAccessSessionsRequest,
     ) -> RusotoFuture<ListRemoteAccessSessionsResult, ListRemoteAccessSessionsError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DeviceFarm_20150623.ListRemoteAccessSessions",
@@ -7877,9 +8097,14 @@ impl DeviceFarm for DeviceFarmClient {
 
     /// <p>Gets information about runs, given an AWS Device Farm project ARN.</p>
     fn list_runs(&self, input: ListRunsRequest) -> RusotoFuture<ListRunsResult, ListRunsError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.ListRuns");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7905,9 +8130,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: ListSamplesRequest,
     ) -> RusotoFuture<ListSamplesResult, ListSamplesError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.ListSamples");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7934,9 +8164,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: ListSuitesRequest,
     ) -> RusotoFuture<ListSuitesResult, ListSuitesError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.ListSuites");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7960,9 +8195,14 @@ impl DeviceFarm for DeviceFarmClient {
 
     /// <p>Gets information about tests in a given test suite.</p>
     fn list_tests(&self, input: ListTestsRequest) -> RusotoFuture<ListTestsResult, ListTestsError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.ListTests");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7988,9 +8228,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: ListUniqueProblemsRequest,
     ) -> RusotoFuture<ListUniqueProblemsResult, ListUniqueProblemsError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.ListUniqueProblems");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8017,9 +8262,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: ListUploadsRequest,
     ) -> RusotoFuture<ListUploadsResult, ListUploadsError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.ListUploads");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8046,9 +8296,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: ListVPCEConfigurationsRequest,
     ) -> RusotoFuture<ListVPCEConfigurationsResult, ListVPCEConfigurationsError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.ListVPCEConfigurations");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8074,9 +8329,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: PurchaseOfferingRequest,
     ) -> RusotoFuture<PurchaseOfferingResult, PurchaseOfferingError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.PurchaseOffering");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8103,9 +8363,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: RenewOfferingRequest,
     ) -> RusotoFuture<RenewOfferingResult, RenewOfferingError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.RenewOffering");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8132,9 +8397,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: ScheduleRunRequest,
     ) -> RusotoFuture<ScheduleRunResult, ScheduleRunError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.ScheduleRun");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8158,9 +8428,14 @@ impl DeviceFarm for DeviceFarmClient {
 
     /// <p>Initiates a stop request for the current job. AWS Device Farm will immediately stop the job on the device where tests have not started executing, and you will not be billed for this device. On the device where tests have started executing, Setup Suite and Teardown Suite tests will run to completion before stopping execution on the device. You will be billed for Setup, Teardown, and any tests that were in progress or already completed.</p>
     fn stop_job(&self, input: StopJobRequest) -> RusotoFuture<StopJobResult, StopJobError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.StopJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8186,9 +8461,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: StopRemoteAccessSessionRequest,
     ) -> RusotoFuture<StopRemoteAccessSessionResult, StopRemoteAccessSessionError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DeviceFarm_20150623.StopRemoteAccessSession",
@@ -8212,9 +8492,14 @@ impl DeviceFarm for DeviceFarmClient {
 
     /// <p>Initiates a stop request for the current test run. AWS Device Farm will immediately stop the run on devices where tests have not started executing, and you will not be billed for these devices. On devices where tests have started executing, Setup Suite and Teardown Suite tests will run to completion before stopping execution on those devices. You will be billed for Setup, Teardown, and any tests that were in progress or already completed.</p>
     fn stop_run(&self, input: StopRunRequest) -> RusotoFuture<StopRunResult, StopRunError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.StopRun");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8240,9 +8525,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: UpdateDeviceInstanceRequest,
     ) -> RusotoFuture<UpdateDeviceInstanceResult, UpdateDeviceInstanceError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.UpdateDeviceInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8268,9 +8558,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: UpdateDevicePoolRequest,
     ) -> RusotoFuture<UpdateDevicePoolResult, UpdateDevicePoolError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.UpdateDevicePool");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8297,9 +8592,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: UpdateInstanceProfileRequest,
     ) -> RusotoFuture<UpdateInstanceProfileResult, UpdateInstanceProfileError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.UpdateInstanceProfile");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8325,9 +8625,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: UpdateNetworkProfileRequest,
     ) -> RusotoFuture<UpdateNetworkProfileResult, UpdateNetworkProfileError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.UpdateNetworkProfile");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8353,9 +8658,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: UpdateProjectRequest,
     ) -> RusotoFuture<UpdateProjectResult, UpdateProjectError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.UpdateProject");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8382,9 +8692,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: UpdateUploadRequest,
     ) -> RusotoFuture<UpdateUploadResult, UpdateUploadError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DeviceFarm_20150623.UpdateUpload");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8411,9 +8726,14 @@ impl DeviceFarm for DeviceFarmClient {
         &self,
         input: UpdateVPCEConfigurationRequest,
     ) -> RusotoFuture<UpdateVPCEConfigurationResult, UpdateVPCEConfigurationError> {
-        let mut request = SignedRequest::new("POST", "devicefarm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "devicefarm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DeviceFarm_20150623.UpdateVPCEConfiguration",

--- a/rusoto/services/directconnect/src/generated.rs
+++ b/rusoto/services/directconnect/src/generated.rs
@@ -3681,9 +3681,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: AllocateConnectionOnInterconnectRequest,
     ) -> RusotoFuture<Connection, AllocateConnectionOnInterconnectError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OvertureService.AllocateConnectionOnInterconnect",
@@ -3711,9 +3716,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: AllocateHostedConnectionRequest,
     ) -> RusotoFuture<Connection, AllocateHostedConnectionError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.AllocateHostedConnection");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3736,9 +3746,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: AllocatePrivateVirtualInterfaceRequest,
     ) -> RusotoFuture<VirtualInterface, AllocatePrivateVirtualInterfaceError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OvertureService.AllocatePrivateVirtualInterface",
@@ -3767,9 +3782,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: AllocatePublicVirtualInterfaceRequest,
     ) -> RusotoFuture<VirtualInterface, AllocatePublicVirtualInterfaceError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OvertureService.AllocatePublicVirtualInterface",
@@ -3796,9 +3816,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: AssociateConnectionWithLagRequest,
     ) -> RusotoFuture<Connection, AssociateConnectionWithLagError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.AssociateConnectionWithLag");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3821,9 +3846,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: AssociateHostedConnectionRequest,
     ) -> RusotoFuture<Connection, AssociateHostedConnectionError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.AssociateHostedConnection");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3846,9 +3876,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: AssociateVirtualInterfaceRequest,
     ) -> RusotoFuture<VirtualInterface, AssociateVirtualInterfaceError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.AssociateVirtualInterface");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3872,9 +3907,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: ConfirmConnectionRequest,
     ) -> RusotoFuture<ConfirmConnectionResponse, ConfirmConnectionError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.ConfirmConnection");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3902,9 +3942,14 @@ impl DirectConnect for DirectConnectClient {
         input: ConfirmPrivateVirtualInterfaceRequest,
     ) -> RusotoFuture<ConfirmPrivateVirtualInterfaceResponse, ConfirmPrivateVirtualInterfaceError>
     {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OvertureService.ConfirmPrivateVirtualInterface",
@@ -3932,9 +3977,14 @@ impl DirectConnect for DirectConnectClient {
         input: ConfirmPublicVirtualInterfaceRequest,
     ) -> RusotoFuture<ConfirmPublicVirtualInterfaceResponse, ConfirmPublicVirtualInterfaceError>
     {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OvertureService.ConfirmPublicVirtualInterface",
@@ -3961,9 +4011,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: CreateBGPPeerRequest,
     ) -> RusotoFuture<CreateBGPPeerResponse, CreateBGPPeerError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.CreateBGPPeer");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3990,9 +4045,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: CreateConnectionRequest,
     ) -> RusotoFuture<Connection, CreateConnectionError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.CreateConnection");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4018,9 +4078,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: CreateDirectConnectGatewayRequest,
     ) -> RusotoFuture<CreateDirectConnectGatewayResult, CreateDirectConnectGatewayError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.CreateDirectConnectGateway");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4047,9 +4112,14 @@ impl DirectConnect for DirectConnectClient {
         CreateDirectConnectGatewayAssociationResult,
         CreateDirectConnectGatewayAssociationError,
     > {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OvertureService.CreateDirectConnectGatewayAssociation",
@@ -4078,9 +4148,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: CreateInterconnectRequest,
     ) -> RusotoFuture<Interconnect, CreateInterconnectError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.CreateInterconnect");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4103,9 +4178,14 @@ impl DirectConnect for DirectConnectClient {
 
     /// <p>Creates a link aggregation group (LAG) with the specified number of bundled physical connections between the customer network and a specific AWS Direct Connect location. A LAG is a logical interface that uses the Link Aggregation Control Protocol (LACP) to aggregate multiple interfaces, enabling you to treat them as a single interface.</p> <p>All connections in a LAG must use the same bandwidth and must terminate at the same AWS Direct Connect endpoint.</p> <p>You can have up to 10 connections per LAG. Regardless of this limit, if you request more connections for the LAG than AWS Direct Connect can allocate on a single endpoint, no LAG is created.</p> <p>You can specify an existing physical connection or interconnect to include in the LAG (which counts towards the total number of connections). Doing so interrupts the current physical connection or hosted connections, and re-establishes them as a member of the LAG. The LAG will be created on the same AWS Direct Connect endpoint to which the connection terminates. Any virtual interfaces associated with the connection are automatically disassociated and re-associated with the LAG. The connection ID does not change.</p> <p>If the AWS account used to create a LAG is a registered AWS Direct Connect partner, the LAG is automatically enabled to host sub-connections. For a LAG owned by a partner, any associated virtual interfaces cannot be directly configured.</p>
     fn create_lag(&self, input: CreateLagRequest) -> RusotoFuture<Lag, CreateLagError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.CreateLag");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4131,9 +4211,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: CreatePrivateVirtualInterfaceRequest,
     ) -> RusotoFuture<VirtualInterface, CreatePrivateVirtualInterfaceError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OvertureService.CreatePrivateVirtualInterface",
@@ -4160,9 +4245,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: CreatePublicVirtualInterfaceRequest,
     ) -> RusotoFuture<VirtualInterface, CreatePublicVirtualInterfaceError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OvertureService.CreatePublicVirtualInterface",
@@ -4189,9 +4279,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: DeleteBGPPeerRequest,
     ) -> RusotoFuture<DeleteBGPPeerResponse, DeleteBGPPeerError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.DeleteBGPPeer");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4218,9 +4313,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: DeleteConnectionRequest,
     ) -> RusotoFuture<Connection, DeleteConnectionError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.DeleteConnection");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4246,9 +4346,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: DeleteDirectConnectGatewayRequest,
     ) -> RusotoFuture<DeleteDirectConnectGatewayResult, DeleteDirectConnectGatewayError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.DeleteDirectConnectGateway");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4275,9 +4380,14 @@ impl DirectConnect for DirectConnectClient {
         DeleteDirectConnectGatewayAssociationResult,
         DeleteDirectConnectGatewayAssociationError,
     > {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OvertureService.DeleteDirectConnectGatewayAssociation",
@@ -4306,9 +4416,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: DeleteInterconnectRequest,
     ) -> RusotoFuture<DeleteInterconnectResponse, DeleteInterconnectError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.DeleteInterconnect");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4332,9 +4447,14 @@ impl DirectConnect for DirectConnectClient {
 
     /// <p>Deletes the specified link aggregation group (LAG). You cannot delete a LAG if it has active virtual interfaces or hosted connections.</p>
     fn delete_lag(&self, input: DeleteLagRequest) -> RusotoFuture<Lag, DeleteLagError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.DeleteLag");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4360,9 +4480,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: DeleteVirtualInterfaceRequest,
     ) -> RusotoFuture<DeleteVirtualInterfaceResponse, DeleteVirtualInterfaceError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.DeleteVirtualInterface");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4388,9 +4513,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: DescribeConnectionLoaRequest,
     ) -> RusotoFuture<DescribeConnectionLoaResponse, DescribeConnectionLoaError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.DescribeConnectionLoa");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4416,9 +4546,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: DescribeConnectionsRequest,
     ) -> RusotoFuture<Connections, DescribeConnectionsError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.DescribeConnections");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4443,9 +4578,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: DescribeConnectionsOnInterconnectRequest,
     ) -> RusotoFuture<Connections, DescribeConnectionsOnInterconnectError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OvertureService.DescribeConnectionsOnInterconnect",
@@ -4476,9 +4616,14 @@ impl DirectConnect for DirectConnectClient {
         DescribeDirectConnectGatewayAssociationsResult,
         DescribeDirectConnectGatewayAssociationsError,
     > {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OvertureService.DescribeDirectConnectGatewayAssociations",
@@ -4508,9 +4653,14 @@ impl DirectConnect for DirectConnectClient {
         DescribeDirectConnectGatewayAttachmentsResult,
         DescribeDirectConnectGatewayAttachmentsError,
     > {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OvertureService.DescribeDirectConnectGatewayAttachments",
@@ -4539,9 +4689,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: DescribeDirectConnectGatewaysRequest,
     ) -> RusotoFuture<DescribeDirectConnectGatewaysResult, DescribeDirectConnectGatewaysError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OvertureService.DescribeDirectConnectGateways",
@@ -4568,9 +4723,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: DescribeHostedConnectionsRequest,
     ) -> RusotoFuture<Connections, DescribeHostedConnectionsError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.DescribeHostedConnections");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4593,9 +4753,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: DescribeInterconnectLoaRequest,
     ) -> RusotoFuture<DescribeInterconnectLoaResponse, DescribeInterconnectLoaError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.DescribeInterconnectLoa");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4619,9 +4784,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: DescribeInterconnectsRequest,
     ) -> RusotoFuture<Interconnects, DescribeInterconnectsError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.DescribeInterconnects");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4643,9 +4813,14 @@ impl DirectConnect for DirectConnectClient {
 
     /// <p>Describes all your link aggregation groups (LAG) or the specified LAG.</p>
     fn describe_lags(&self, input: DescribeLagsRequest) -> RusotoFuture<Lags, DescribeLagsError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.DescribeLags");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4668,9 +4843,14 @@ impl DirectConnect for DirectConnectClient {
 
     /// <p>Gets the LOA-CFA for a connection, interconnect, or link aggregation group (LAG).</p> <p>The Letter of Authorization - Connecting Facility Assignment (LOA-CFA) is a document that is used when establishing your cross connect to AWS at the colocation facility. For more information, see <a href="https://docs.aws.amazon.com/directconnect/latest/UserGuide/Colocation.html">Requesting Cross Connects at AWS Direct Connect Locations</a> in the <i>AWS Direct Connect User Guide</i>.</p>
     fn describe_loa(&self, input: DescribeLoaRequest) -> RusotoFuture<Loa, DescribeLoaError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.DescribeLoa");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4693,9 +4873,14 @@ impl DirectConnect for DirectConnectClient {
 
     /// <p>Lists the AWS Direct Connect locations in the current AWS Region. These are the locations that can be selected when calling <a>CreateConnection</a> or <a>CreateInterconnect</a>.</p>
     fn describe_locations(&self) -> RusotoFuture<Locations, DescribeLocationsError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.DescribeLocations");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -4720,9 +4905,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: DescribeTagsRequest,
     ) -> RusotoFuture<DescribeTagsResponse, DescribeTagsError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.DescribeTags");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4748,9 +4938,14 @@ impl DirectConnect for DirectConnectClient {
     fn describe_virtual_gateways(
         &self,
     ) -> RusotoFuture<VirtualGateways, DescribeVirtualGatewaysError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.DescribeVirtualGateways");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -4772,9 +4967,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: DescribeVirtualInterfacesRequest,
     ) -> RusotoFuture<VirtualInterfaces, DescribeVirtualInterfacesError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.DescribeVirtualInterfaces");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4798,9 +4998,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: DisassociateConnectionFromLagRequest,
     ) -> RusotoFuture<Connection, DisassociateConnectionFromLagError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OvertureService.DisassociateConnectionFromLag",
@@ -4826,9 +5031,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: TagResourceRequest,
     ) -> RusotoFuture<TagResourceResponse, TagResourceError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.TagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4855,9 +5065,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: UntagResourceRequest,
     ) -> RusotoFuture<UntagResourceResponse, UntagResourceError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.UntagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4881,9 +5096,14 @@ impl DirectConnect for DirectConnectClient {
 
     /// <p>Updates the attributes of the specified link aggregation group (LAG).</p> <p>You can update the following attributes:</p> <ul> <li> <p>The name of the LAG.</p> </li> <li> <p>The value for the minimum number of connections that must be operational for the LAG itself to be operational. </p> </li> </ul> <p>When you create a LAG, the default value for the minimum number of operational connections is zero (0). If you update this value and the number of operational connections falls below the specified value, the LAG automatically goes down to avoid over-utilization of the remaining connections. Adjust this value with care, as it could force the LAG down if it is set higher than the current number of operational connections.</p>
     fn update_lag(&self, input: UpdateLagRequest) -> RusotoFuture<Lag, UpdateLagError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OvertureService.UpdateLag");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4909,9 +5129,14 @@ impl DirectConnect for DirectConnectClient {
         &self,
         input: UpdateVirtualInterfaceAttributesRequest,
     ) -> RusotoFuture<VirtualInterface, UpdateVirtualInterfaceAttributesError> {
-        let mut request = SignedRequest::new("POST", "directconnect", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "directconnect",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OvertureService.UpdateVirtualInterfaceAttributes",

--- a/rusoto/services/discovery/src/generated.rs
+++ b/rusoto/services/discovery/src/generated.rs
@@ -2742,9 +2742,14 @@ impl Discovery for DiscoveryClient {
         AssociateConfigurationItemsToApplicationResponse,
         AssociateConfigurationItemsToApplicationError,
     > {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSPoseidonService_V2015_11_01.AssociateConfigurationItemsToApplication",
@@ -2771,9 +2776,14 @@ impl Discovery for DiscoveryClient {
         &self,
         input: BatchDeleteImportDataRequest,
     ) -> RusotoFuture<BatchDeleteImportDataResponse, BatchDeleteImportDataError> {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSPoseidonService_V2015_11_01.BatchDeleteImportData",
@@ -2802,9 +2812,14 @@ impl Discovery for DiscoveryClient {
         &self,
         input: CreateApplicationRequest,
     ) -> RusotoFuture<CreateApplicationResponse, CreateApplicationError> {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSPoseidonService_V2015_11_01.CreateApplication",
@@ -2834,9 +2849,14 @@ impl Discovery for DiscoveryClient {
         &self,
         input: CreateTagsRequest,
     ) -> RusotoFuture<CreateTagsResponse, CreateTagsError> {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSPoseidonService_V2015_11_01.CreateTags");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2863,9 +2883,14 @@ impl Discovery for DiscoveryClient {
         &self,
         input: DeleteApplicationsRequest,
     ) -> RusotoFuture<DeleteApplicationsResponse, DeleteApplicationsError> {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSPoseidonService_V2015_11_01.DeleteApplications",
@@ -2895,9 +2920,14 @@ impl Discovery for DiscoveryClient {
         &self,
         input: DeleteTagsRequest,
     ) -> RusotoFuture<DeleteTagsResponse, DeleteTagsError> {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSPoseidonService_V2015_11_01.DeleteTags");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2924,9 +2954,14 @@ impl Discovery for DiscoveryClient {
         &self,
         input: DescribeAgentsRequest,
     ) -> RusotoFuture<DescribeAgentsResponse, DescribeAgentsError> {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSPoseidonService_V2015_11_01.DescribeAgents",
@@ -2956,9 +2991,14 @@ impl Discovery for DiscoveryClient {
         &self,
         input: DescribeConfigurationsRequest,
     ) -> RusotoFuture<DescribeConfigurationsResponse, DescribeConfigurationsError> {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSPoseidonService_V2015_11_01.DescribeConfigurations",
@@ -2987,9 +3027,14 @@ impl Discovery for DiscoveryClient {
         &self,
         input: DescribeContinuousExportsRequest,
     ) -> RusotoFuture<DescribeContinuousExportsResponse, DescribeContinuousExportsError> {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSPoseidonService_V2015_11_01.DescribeContinuousExports",
@@ -3016,9 +3061,14 @@ impl Discovery for DiscoveryClient {
         &self,
         input: DescribeExportConfigurationsRequest,
     ) -> RusotoFuture<DescribeExportConfigurationsResponse, DescribeExportConfigurationsError> {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSPoseidonService_V2015_11_01.DescribeExportConfigurations",
@@ -3045,9 +3095,14 @@ impl Discovery for DiscoveryClient {
         &self,
         input: DescribeExportTasksRequest,
     ) -> RusotoFuture<DescribeExportTasksResponse, DescribeExportTasksError> {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSPoseidonService_V2015_11_01.DescribeExportTasks",
@@ -3076,9 +3131,14 @@ impl Discovery for DiscoveryClient {
         &self,
         input: DescribeImportTasksRequest,
     ) -> RusotoFuture<DescribeImportTasksResponse, DescribeImportTasksError> {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSPoseidonService_V2015_11_01.DescribeImportTasks",
@@ -3107,9 +3167,14 @@ impl Discovery for DiscoveryClient {
         &self,
         input: DescribeTagsRequest,
     ) -> RusotoFuture<DescribeTagsResponse, DescribeTagsError> {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSPoseidonService_V2015_11_01.DescribeTags",
@@ -3142,9 +3207,14 @@ impl Discovery for DiscoveryClient {
         DisassociateConfigurationItemsFromApplicationResponse,
         DisassociateConfigurationItemsFromApplicationError,
     > {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSPoseidonService_V2015_11_01.DisassociateConfigurationItemsFromApplication",
@@ -3169,9 +3239,14 @@ impl Discovery for DiscoveryClient {
     fn export_configurations(
         &self,
     ) -> RusotoFuture<ExportConfigurationsResponse, ExportConfigurationsError> {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSPoseidonService_V2015_11_01.ExportConfigurations",
@@ -3198,9 +3273,14 @@ impl Discovery for DiscoveryClient {
     fn get_discovery_summary(
         &self,
     ) -> RusotoFuture<GetDiscoverySummaryResponse, GetDiscoverySummaryError> {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSPoseidonService_V2015_11_01.GetDiscoverySummary",
@@ -3228,9 +3308,14 @@ impl Discovery for DiscoveryClient {
         &self,
         input: ListConfigurationsRequest,
     ) -> RusotoFuture<ListConfigurationsResponse, ListConfigurationsError> {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSPoseidonService_V2015_11_01.ListConfigurations",
@@ -3260,9 +3345,14 @@ impl Discovery for DiscoveryClient {
         &self,
         input: ListServerNeighborsRequest,
     ) -> RusotoFuture<ListServerNeighborsResponse, ListServerNeighborsError> {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSPoseidonService_V2015_11_01.ListServerNeighbors",
@@ -3290,9 +3380,14 @@ impl Discovery for DiscoveryClient {
     fn start_continuous_export(
         &self,
     ) -> RusotoFuture<StartContinuousExportResponse, StartContinuousExportError> {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSPoseidonService_V2015_11_01.StartContinuousExport",
@@ -3321,9 +3416,14 @@ impl Discovery for DiscoveryClient {
         input: StartDataCollectionByAgentIdsRequest,
     ) -> RusotoFuture<StartDataCollectionByAgentIdsResponse, StartDataCollectionByAgentIdsError>
     {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSPoseidonService_V2015_11_01.StartDataCollectionByAgentIds",
@@ -3350,9 +3450,14 @@ impl Discovery for DiscoveryClient {
         &self,
         input: StartExportTaskRequest,
     ) -> RusotoFuture<StartExportTaskResponse, StartExportTaskError> {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSPoseidonService_V2015_11_01.StartExportTask",
@@ -3382,9 +3487,14 @@ impl Discovery for DiscoveryClient {
         &self,
         input: StartImportTaskRequest,
     ) -> RusotoFuture<StartImportTaskResponse, StartImportTaskError> {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSPoseidonService_V2015_11_01.StartImportTask",
@@ -3414,9 +3524,14 @@ impl Discovery for DiscoveryClient {
         &self,
         input: StopContinuousExportRequest,
     ) -> RusotoFuture<StopContinuousExportResponse, StopContinuousExportError> {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSPoseidonService_V2015_11_01.StopContinuousExport",
@@ -3445,9 +3560,14 @@ impl Discovery for DiscoveryClient {
         &self,
         input: StopDataCollectionByAgentIdsRequest,
     ) -> RusotoFuture<StopDataCollectionByAgentIdsResponse, StopDataCollectionByAgentIdsError> {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSPoseidonService_V2015_11_01.StopDataCollectionByAgentIds",
@@ -3474,9 +3594,14 @@ impl Discovery for DiscoveryClient {
         &self,
         input: UpdateApplicationRequest,
     ) -> RusotoFuture<UpdateApplicationResponse, UpdateApplicationError> {
-        let mut request = SignedRequest::new("POST", "discovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "discovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSPoseidonService_V2015_11_01.UpdateApplication",

--- a/rusoto/services/dms/src/generated.rs
+++ b/rusoto/services/dms/src/generated.rs
@@ -4787,9 +4787,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: AddTagsToResourceMessage,
     ) -> RusotoFuture<AddTagsToResourceResponse, AddTagsToResourceError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.AddTagsToResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4816,9 +4821,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: CreateEndpointMessage,
     ) -> RusotoFuture<CreateEndpointResponse, CreateEndpointError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.CreateEndpoint");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4845,9 +4855,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: CreateEventSubscriptionMessage,
     ) -> RusotoFuture<CreateEventSubscriptionResponse, CreateEventSubscriptionError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.CreateEventSubscription");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4871,9 +4886,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: CreateReplicationInstanceMessage,
     ) -> RusotoFuture<CreateReplicationInstanceResponse, CreateReplicationInstanceError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonDMSv20160101.CreateReplicationInstance",
@@ -4900,9 +4920,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: CreateReplicationSubnetGroupMessage,
     ) -> RusotoFuture<CreateReplicationSubnetGroupResponse, CreateReplicationSubnetGroupError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonDMSv20160101.CreateReplicationSubnetGroup",
@@ -4929,9 +4954,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: CreateReplicationTaskMessage,
     ) -> RusotoFuture<CreateReplicationTaskResponse, CreateReplicationTaskError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.CreateReplicationTask");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4957,9 +4987,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: DeleteCertificateMessage,
     ) -> RusotoFuture<DeleteCertificateResponse, DeleteCertificateError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.DeleteCertificate");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4986,9 +5021,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: DeleteEndpointMessage,
     ) -> RusotoFuture<DeleteEndpointResponse, DeleteEndpointError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.DeleteEndpoint");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5015,9 +5055,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: DeleteEventSubscriptionMessage,
     ) -> RusotoFuture<DeleteEventSubscriptionResponse, DeleteEventSubscriptionError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.DeleteEventSubscription");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5041,9 +5086,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: DeleteReplicationInstanceMessage,
     ) -> RusotoFuture<DeleteReplicationInstanceResponse, DeleteReplicationInstanceError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonDMSv20160101.DeleteReplicationInstance",
@@ -5070,9 +5120,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: DeleteReplicationSubnetGroupMessage,
     ) -> RusotoFuture<DeleteReplicationSubnetGroupResponse, DeleteReplicationSubnetGroupError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonDMSv20160101.DeleteReplicationSubnetGroup",
@@ -5099,9 +5154,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: DeleteReplicationTaskMessage,
     ) -> RusotoFuture<DeleteReplicationTaskResponse, DeleteReplicationTaskError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.DeleteReplicationTask");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5126,9 +5186,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
     fn describe_account_attributes(
         &self,
     ) -> RusotoFuture<DescribeAccountAttributesResponse, DescribeAccountAttributesError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonDMSv20160101.DescribeAccountAttributes",
@@ -5154,9 +5219,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: DescribeCertificatesMessage,
     ) -> RusotoFuture<DescribeCertificatesResponse, DescribeCertificatesError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.DescribeCertificates");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5182,9 +5252,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: DescribeConnectionsMessage,
     ) -> RusotoFuture<DescribeConnectionsResponse, DescribeConnectionsError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.DescribeConnections");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5210,9 +5285,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: DescribeEndpointTypesMessage,
     ) -> RusotoFuture<DescribeEndpointTypesResponse, DescribeEndpointTypesError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.DescribeEndpointTypes");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5238,9 +5318,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: DescribeEndpointsMessage,
     ) -> RusotoFuture<DescribeEndpointsResponse, DescribeEndpointsError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.DescribeEndpoints");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5267,9 +5352,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: DescribeEventCategoriesMessage,
     ) -> RusotoFuture<DescribeEventCategoriesResponse, DescribeEventCategoriesError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.DescribeEventCategories");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5293,9 +5383,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: DescribeEventSubscriptionsMessage,
     ) -> RusotoFuture<DescribeEventSubscriptionsResponse, DescribeEventSubscriptionsError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonDMSv20160101.DescribeEventSubscriptions",
@@ -5322,9 +5417,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: DescribeEventsMessage,
     ) -> RusotoFuture<DescribeEventsResponse, DescribeEventsError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.DescribeEvents");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5354,9 +5454,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         DescribeOrderableReplicationInstancesResponse,
         DescribeOrderableReplicationInstancesError,
     > {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonDMSv20160101.DescribeOrderableReplicationInstances",
@@ -5385,9 +5490,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: DescribeRefreshSchemasStatusMessage,
     ) -> RusotoFuture<DescribeRefreshSchemasStatusResponse, DescribeRefreshSchemasStatusError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonDMSv20160101.DescribeRefreshSchemasStatus",
@@ -5417,9 +5527,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         DescribeReplicationInstanceTaskLogsResponse,
         DescribeReplicationInstanceTaskLogsError,
     > {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonDMSv20160101.DescribeReplicationInstanceTaskLogs",
@@ -5448,9 +5563,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: DescribeReplicationInstancesMessage,
     ) -> RusotoFuture<DescribeReplicationInstancesResponse, DescribeReplicationInstancesError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonDMSv20160101.DescribeReplicationInstances",
@@ -5478,9 +5598,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         input: DescribeReplicationSubnetGroupsMessage,
     ) -> RusotoFuture<DescribeReplicationSubnetGroupsResponse, DescribeReplicationSubnetGroupsError>
     {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonDMSv20160101.DescribeReplicationSubnetGroups",
@@ -5512,9 +5637,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         DescribeReplicationTaskAssessmentResultsResponse,
         DescribeReplicationTaskAssessmentResultsError,
     > {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonDMSv20160101.DescribeReplicationTaskAssessmentResults",
@@ -5541,9 +5671,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: DescribeReplicationTasksMessage,
     ) -> RusotoFuture<DescribeReplicationTasksResponse, DescribeReplicationTasksError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonDMSv20160101.DescribeReplicationTasks",
@@ -5570,9 +5705,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: DescribeSchemasMessage,
     ) -> RusotoFuture<DescribeSchemasResponse, DescribeSchemasError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.DescribeSchemas");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5599,9 +5739,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: DescribeTableStatisticsMessage,
     ) -> RusotoFuture<DescribeTableStatisticsResponse, DescribeTableStatisticsError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.DescribeTableStatistics");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5625,9 +5770,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: ImportCertificateMessage,
     ) -> RusotoFuture<ImportCertificateResponse, ImportCertificateError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.ImportCertificate");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5654,9 +5804,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: ListTagsForResourceMessage,
     ) -> RusotoFuture<ListTagsForResourceResponse, ListTagsForResourceError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.ListTagsForResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5682,9 +5837,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: ModifyEndpointMessage,
     ) -> RusotoFuture<ModifyEndpointResponse, ModifyEndpointError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.ModifyEndpoint");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5711,9 +5871,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: ModifyEventSubscriptionMessage,
     ) -> RusotoFuture<ModifyEventSubscriptionResponse, ModifyEventSubscriptionError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.ModifyEventSubscription");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5737,9 +5902,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: ModifyReplicationInstanceMessage,
     ) -> RusotoFuture<ModifyReplicationInstanceResponse, ModifyReplicationInstanceError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonDMSv20160101.ModifyReplicationInstance",
@@ -5766,9 +5936,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: ModifyReplicationSubnetGroupMessage,
     ) -> RusotoFuture<ModifyReplicationSubnetGroupResponse, ModifyReplicationSubnetGroupError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonDMSv20160101.ModifyReplicationSubnetGroup",
@@ -5795,9 +5970,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: ModifyReplicationTaskMessage,
     ) -> RusotoFuture<ModifyReplicationTaskResponse, ModifyReplicationTaskError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.ModifyReplicationTask");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5823,9 +6003,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: RebootReplicationInstanceMessage,
     ) -> RusotoFuture<RebootReplicationInstanceResponse, RebootReplicationInstanceError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonDMSv20160101.RebootReplicationInstance",
@@ -5852,9 +6037,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: RefreshSchemasMessage,
     ) -> RusotoFuture<RefreshSchemasResponse, RefreshSchemasError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.RefreshSchemas");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5881,9 +6071,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: ReloadTablesMessage,
     ) -> RusotoFuture<ReloadTablesResponse, ReloadTablesError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.ReloadTables");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5910,9 +6105,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: RemoveTagsFromResourceMessage,
     ) -> RusotoFuture<RemoveTagsFromResourceResponse, RemoveTagsFromResourceError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.RemoveTagsFromResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5938,9 +6138,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: StartReplicationTaskMessage,
     ) -> RusotoFuture<StartReplicationTaskResponse, StartReplicationTaskError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.StartReplicationTask");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5967,9 +6172,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         input: StartReplicationTaskAssessmentMessage,
     ) -> RusotoFuture<StartReplicationTaskAssessmentResponse, StartReplicationTaskAssessmentError>
     {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonDMSv20160101.StartReplicationTaskAssessment",
@@ -5996,9 +6206,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: StopReplicationTaskMessage,
     ) -> RusotoFuture<StopReplicationTaskResponse, StopReplicationTaskError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.StopReplicationTask");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6024,9 +6239,14 @@ impl DatabaseMigrationService for DatabaseMigrationServiceClient {
         &self,
         input: TestConnectionMessage,
     ) -> RusotoFuture<TestConnectionResponse, TestConnectionError> {
-        let mut request = SignedRequest::new("POST", "dms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonDMSv20160101.TestConnection");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/ds/src/generated.rs
+++ b/rusoto/services/ds/src/generated.rs
@@ -5189,9 +5189,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: AcceptSharedDirectoryRequest,
     ) -> RusotoFuture<AcceptSharedDirectoryResult, AcceptSharedDirectoryError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.AcceptSharedDirectory",
@@ -5220,9 +5225,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: AddIpRoutesRequest,
     ) -> RusotoFuture<AddIpRoutesResult, AddIpRoutesError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DirectoryService_20150416.AddIpRoutes");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5249,9 +5259,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: AddTagsToResourceRequest,
     ) -> RusotoFuture<AddTagsToResourceResult, AddTagsToResourceError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.AddTagsToResource",
@@ -5281,9 +5296,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: CancelSchemaExtensionRequest,
     ) -> RusotoFuture<CancelSchemaExtensionResult, CancelSchemaExtensionError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.CancelSchemaExtension",
@@ -5312,9 +5332,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: ConnectDirectoryRequest,
     ) -> RusotoFuture<ConnectDirectoryResult, ConnectDirectoryError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DirectoryService_20150416.ConnectDirectory");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5341,9 +5366,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: CreateAliasRequest,
     ) -> RusotoFuture<CreateAliasResult, CreateAliasError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DirectoryService_20150416.CreateAlias");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5370,9 +5400,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: CreateComputerRequest,
     ) -> RusotoFuture<CreateComputerResult, CreateComputerError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DirectoryService_20150416.CreateComputer");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5399,9 +5434,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: CreateConditionalForwarderRequest,
     ) -> RusotoFuture<CreateConditionalForwarderResult, CreateConditionalForwarderError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.CreateConditionalForwarder",
@@ -5428,9 +5468,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: CreateDirectoryRequest,
     ) -> RusotoFuture<CreateDirectoryResult, CreateDirectoryError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DirectoryService_20150416.CreateDirectory");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5457,9 +5502,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: CreateLogSubscriptionRequest,
     ) -> RusotoFuture<CreateLogSubscriptionResult, CreateLogSubscriptionError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.CreateLogSubscription",
@@ -5488,9 +5538,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: CreateMicrosoftADRequest,
     ) -> RusotoFuture<CreateMicrosoftADResult, CreateMicrosoftADError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.CreateMicrosoftAD",
@@ -5520,9 +5575,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: CreateSnapshotRequest,
     ) -> RusotoFuture<CreateSnapshotResult, CreateSnapshotError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DirectoryService_20150416.CreateSnapshot");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5549,9 +5609,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: CreateTrustRequest,
     ) -> RusotoFuture<CreateTrustResult, CreateTrustError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DirectoryService_20150416.CreateTrust");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5578,9 +5643,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: DeleteConditionalForwarderRequest,
     ) -> RusotoFuture<DeleteConditionalForwarderResult, DeleteConditionalForwarderError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.DeleteConditionalForwarder",
@@ -5607,9 +5677,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: DeleteDirectoryRequest,
     ) -> RusotoFuture<DeleteDirectoryResult, DeleteDirectoryError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DirectoryService_20150416.DeleteDirectory");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5636,9 +5711,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: DeleteLogSubscriptionRequest,
     ) -> RusotoFuture<DeleteLogSubscriptionResult, DeleteLogSubscriptionError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.DeleteLogSubscription",
@@ -5667,9 +5747,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: DeleteSnapshotRequest,
     ) -> RusotoFuture<DeleteSnapshotResult, DeleteSnapshotError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DirectoryService_20150416.DeleteSnapshot");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5696,9 +5781,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: DeleteTrustRequest,
     ) -> RusotoFuture<DeleteTrustResult, DeleteTrustError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DirectoryService_20150416.DeleteTrust");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5725,9 +5815,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: DeregisterEventTopicRequest,
     ) -> RusotoFuture<DeregisterEventTopicResult, DeregisterEventTopicError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.DeregisterEventTopic",
@@ -5756,9 +5851,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: DescribeConditionalForwardersRequest,
     ) -> RusotoFuture<DescribeConditionalForwardersResult, DescribeConditionalForwardersError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.DescribeConditionalForwarders",
@@ -5785,9 +5885,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: DescribeDirectoriesRequest,
     ) -> RusotoFuture<DescribeDirectoriesResult, DescribeDirectoriesError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.DescribeDirectories",
@@ -5816,9 +5921,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: DescribeDomainControllersRequest,
     ) -> RusotoFuture<DescribeDomainControllersResult, DescribeDomainControllersError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.DescribeDomainControllers",
@@ -5845,9 +5955,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: DescribeEventTopicsRequest,
     ) -> RusotoFuture<DescribeEventTopicsResult, DescribeEventTopicsError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.DescribeEventTopics",
@@ -5876,9 +5991,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: DescribeSharedDirectoriesRequest,
     ) -> RusotoFuture<DescribeSharedDirectoriesResult, DescribeSharedDirectoriesError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.DescribeSharedDirectories",
@@ -5905,9 +6025,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: DescribeSnapshotsRequest,
     ) -> RusotoFuture<DescribeSnapshotsResult, DescribeSnapshotsError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.DescribeSnapshots",
@@ -5937,9 +6062,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: DescribeTrustsRequest,
     ) -> RusotoFuture<DescribeTrustsResult, DescribeTrustsError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DirectoryService_20150416.DescribeTrusts");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5966,9 +6096,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: DisableRadiusRequest,
     ) -> RusotoFuture<DisableRadiusResult, DisableRadiusError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DirectoryService_20150416.DisableRadius");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5995,9 +6130,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: DisableSsoRequest,
     ) -> RusotoFuture<DisableSsoResult, DisableSsoError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DirectoryService_20150416.DisableSso");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6024,9 +6164,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: EnableRadiusRequest,
     ) -> RusotoFuture<EnableRadiusResult, EnableRadiusError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DirectoryService_20150416.EnableRadius");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6050,9 +6195,14 @@ impl DirectoryService for DirectoryServiceClient {
 
     /// <p>Enables single sign-on for a directory.</p>
     fn enable_sso(&self, input: EnableSsoRequest) -> RusotoFuture<EnableSsoResult, EnableSsoError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DirectoryService_20150416.EnableSso");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6077,9 +6227,14 @@ impl DirectoryService for DirectoryServiceClient {
     fn get_directory_limits(
         &self,
     ) -> RusotoFuture<GetDirectoryLimitsResult, GetDirectoryLimitsError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.GetDirectoryLimits",
@@ -6108,9 +6263,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: GetSnapshotLimitsRequest,
     ) -> RusotoFuture<GetSnapshotLimitsResult, GetSnapshotLimitsError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.GetSnapshotLimits",
@@ -6140,9 +6300,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: ListIpRoutesRequest,
     ) -> RusotoFuture<ListIpRoutesResult, ListIpRoutesError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DirectoryService_20150416.ListIpRoutes");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6169,9 +6334,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: ListLogSubscriptionsRequest,
     ) -> RusotoFuture<ListLogSubscriptionsResult, ListLogSubscriptionsError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.ListLogSubscriptions",
@@ -6200,9 +6370,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: ListSchemaExtensionsRequest,
     ) -> RusotoFuture<ListSchemaExtensionsResult, ListSchemaExtensionsError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.ListSchemaExtensions",
@@ -6231,9 +6406,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: ListTagsForResourceRequest,
     ) -> RusotoFuture<ListTagsForResourceResult, ListTagsForResourceError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.ListTagsForResource",
@@ -6262,9 +6442,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: RegisterEventTopicRequest,
     ) -> RusotoFuture<RegisterEventTopicResult, RegisterEventTopicError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.RegisterEventTopic",
@@ -6294,9 +6479,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: RejectSharedDirectoryRequest,
     ) -> RusotoFuture<RejectSharedDirectoryResult, RejectSharedDirectoryError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.RejectSharedDirectory",
@@ -6325,9 +6515,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: RemoveIpRoutesRequest,
     ) -> RusotoFuture<RemoveIpRoutesResult, RemoveIpRoutesError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DirectoryService_20150416.RemoveIpRoutes");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6354,9 +6549,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: RemoveTagsFromResourceRequest,
     ) -> RusotoFuture<RemoveTagsFromResourceResult, RemoveTagsFromResourceError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.RemoveTagsFromResource",
@@ -6385,9 +6585,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: ResetUserPasswordRequest,
     ) -> RusotoFuture<ResetUserPasswordResult, ResetUserPasswordError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.ResetUserPassword",
@@ -6417,9 +6622,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: RestoreFromSnapshotRequest,
     ) -> RusotoFuture<RestoreFromSnapshotResult, RestoreFromSnapshotError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.RestoreFromSnapshot",
@@ -6448,9 +6658,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: ShareDirectoryRequest,
     ) -> RusotoFuture<ShareDirectoryResult, ShareDirectoryError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DirectoryService_20150416.ShareDirectory");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6477,9 +6692,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: StartSchemaExtensionRequest,
     ) -> RusotoFuture<StartSchemaExtensionResult, StartSchemaExtensionError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.StartSchemaExtension",
@@ -6508,9 +6728,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: UnshareDirectoryRequest,
     ) -> RusotoFuture<UnshareDirectoryResult, UnshareDirectoryError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DirectoryService_20150416.UnshareDirectory");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6537,9 +6762,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: UpdateConditionalForwarderRequest,
     ) -> RusotoFuture<UpdateConditionalForwarderResult, UpdateConditionalForwarderError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.UpdateConditionalForwarder",
@@ -6567,9 +6797,14 @@ impl DirectoryService for DirectoryServiceClient {
         input: UpdateNumberOfDomainControllersRequest,
     ) -> RusotoFuture<UpdateNumberOfDomainControllersResult, UpdateNumberOfDomainControllersError>
     {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "DirectoryService_20150416.UpdateNumberOfDomainControllers",
@@ -6598,9 +6833,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: UpdateRadiusRequest,
     ) -> RusotoFuture<UpdateRadiusResult, UpdateRadiusError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DirectoryService_20150416.UpdateRadius");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6627,9 +6867,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: UpdateTrustRequest,
     ) -> RusotoFuture<UpdateTrustResult, UpdateTrustError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DirectoryService_20150416.UpdateTrust");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6656,9 +6901,14 @@ impl DirectoryService for DirectoryServiceClient {
         &self,
         input: VerifyTrustRequest,
     ) -> RusotoFuture<VerifyTrustResult, VerifyTrustError> {
-        let mut request = SignedRequest::new("POST", "ds", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ds",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "DirectoryService_20150416.VerifyTrust");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/dynamodb/src/generated.rs
+++ b/rusoto/services/dynamodb/src/generated.rs
@@ -4682,9 +4682,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: BatchGetItemInput,
     ) -> RusotoFuture<BatchGetItemOutput, BatchGetItemError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.BatchGetItem");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4711,9 +4716,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: BatchWriteItemInput,
     ) -> RusotoFuture<BatchWriteItemOutput, BatchWriteItemError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.BatchWriteItem");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4740,9 +4750,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: CreateBackupInput,
     ) -> RusotoFuture<CreateBackupOutput, CreateBackupError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.CreateBackup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4769,9 +4784,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: CreateGlobalTableInput,
     ) -> RusotoFuture<CreateGlobalTableOutput, CreateGlobalTableError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.CreateGlobalTable");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4798,9 +4818,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: CreateTableInput,
     ) -> RusotoFuture<CreateTableOutput, CreateTableError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.CreateTable");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4827,9 +4852,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: DeleteBackupInput,
     ) -> RusotoFuture<DeleteBackupOutput, DeleteBackupError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.DeleteBackup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4856,9 +4886,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: DeleteItemInput,
     ) -> RusotoFuture<DeleteItemOutput, DeleteItemError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.DeleteItem");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4885,9 +4920,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: DeleteTableInput,
     ) -> RusotoFuture<DeleteTableOutput, DeleteTableError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.DeleteTable");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4914,9 +4954,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: DescribeBackupInput,
     ) -> RusotoFuture<DescribeBackupOutput, DescribeBackupError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.DescribeBackup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4943,9 +4988,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: DescribeContinuousBackupsInput,
     ) -> RusotoFuture<DescribeContinuousBackupsOutput, DescribeContinuousBackupsError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header(
             "x-amz-target",
             "DynamoDB_20120810.DescribeContinuousBackups",
@@ -4971,9 +5021,14 @@ impl DynamoDb for DynamoDbClient {
     fn describe_endpoints(
         &self,
     ) -> RusotoFuture<DescribeEndpointsResponse, DescribeEndpointsError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.DescribeEndpoints");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -4999,9 +5054,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: DescribeGlobalTableInput,
     ) -> RusotoFuture<DescribeGlobalTableOutput, DescribeGlobalTableError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.DescribeGlobalTable");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5027,9 +5087,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: DescribeGlobalTableSettingsInput,
     ) -> RusotoFuture<DescribeGlobalTableSettingsOutput, DescribeGlobalTableSettingsError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header(
             "x-amz-target",
             "DynamoDB_20120810.DescribeGlobalTableSettings",
@@ -5053,9 +5118,14 @@ impl DynamoDb for DynamoDbClient {
 
     /// <p>Returns the current provisioned-capacity limits for your AWS account in a region, both for the region as a whole and for any one DynamoDB table that you create there.</p> <p>When you establish an AWS account, the account has initial limits on the maximum read capacity units and write capacity units that you can provision across all of your DynamoDB tables in a given region. Also, there are per-table limits that apply when you create a table there. For more information, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html">Limits</a> page in the <i>Amazon DynamoDB Developer Guide</i>.</p> <p>Although you can increase these limits by filing a case at <a href="https://console.aws.amazon.com/support/home#/">AWS Support Center</a>, obtaining the increase is not instantaneous. The <code>DescribeLimits</code> action lets you write code to compare the capacity you are currently using to those limits imposed by your account so that you have enough time to apply for an increase before you hit a limit.</p> <p>For example, you could use one of the AWS SDKs to do the following:</p> <ol> <li> <p>Call <code>DescribeLimits</code> for a particular region to obtain your current account limits on provisioned capacity there.</p> </li> <li> <p>Create a variable to hold the aggregate read capacity units provisioned for all your tables in that region, and one to hold the aggregate write capacity units. Zero them both.</p> </li> <li> <p>Call <code>ListTables</code> to obtain a list of all your DynamoDB tables.</p> </li> <li> <p>For each table name listed by <code>ListTables</code>, do the following:</p> <ul> <li> <p>Call <code>DescribeTable</code> with the table name.</p> </li> <li> <p>Use the data returned by <code>DescribeTable</code> to add the read capacity units and write capacity units provisioned for the table itself to your variables.</p> </li> <li> <p>If the table has one or more global secondary indexes (GSIs), loop over these GSIs and add their provisioned capacity values to your variables as well.</p> </li> </ul> </li> <li> <p>Report the account limits for that region returned by <code>DescribeLimits</code>, along with the total current provisioned capacity levels you have calculated.</p> </li> </ol> <p>This will let you see whether you are getting close to your account-level limits.</p> <p>The per-table limits apply only when you are creating a new table. They restrict the sum of the provisioned capacity of the new table itself and all its global secondary indexes.</p> <p>For existing tables and their GSIs, DynamoDB will not let you increase provisioned capacity extremely rapidly, but the only upper limit that applies is that the aggregate provisioned capacity over all your tables and GSIs cannot exceed either of the per-account limits.</p> <note> <p> <code>DescribeLimits</code> should only be called periodically. You can expect throttling errors if you call it more than once in a minute.</p> </note> <p>The <code>DescribeLimits</code> Request element has no content.</p>
     fn describe_limits(&self) -> RusotoFuture<DescribeLimitsOutput, DescribeLimitsError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.DescribeLimits");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -5081,9 +5151,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: DescribeTableInput,
     ) -> RusotoFuture<DescribeTableOutput, DescribeTableError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.DescribeTable");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5110,9 +5185,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: DescribeTimeToLiveInput,
     ) -> RusotoFuture<DescribeTimeToLiveOutput, DescribeTimeToLiveError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.DescribeTimeToLive");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5136,9 +5216,14 @@ impl DynamoDb for DynamoDbClient {
 
     /// <p>The <code>GetItem</code> operation returns a set of attributes for the item with the given primary key. If there is no matching item, <code>GetItem</code> does not return any data and there will be no <code>Item</code> element in the response.</p> <p> <code>GetItem</code> provides an eventually consistent read by default. If your application requires a strongly consistent read, set <code>ConsistentRead</code> to <code>true</code>. Although a strongly consistent read might take more time than an eventually consistent read, it always returns the last updated value.</p>
     fn get_item(&self, input: GetItemInput) -> RusotoFuture<GetItemOutput, GetItemError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.GetItem");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5164,9 +5249,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: ListBackupsInput,
     ) -> RusotoFuture<ListBackupsOutput, ListBackupsError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.ListBackups");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5193,9 +5283,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: ListGlobalTablesInput,
     ) -> RusotoFuture<ListGlobalTablesOutput, ListGlobalTablesError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.ListGlobalTables");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5222,9 +5317,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: ListTablesInput,
     ) -> RusotoFuture<ListTablesOutput, ListTablesError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.ListTables");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5251,9 +5351,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: ListTagsOfResourceInput,
     ) -> RusotoFuture<ListTagsOfResourceOutput, ListTagsOfResourceError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.ListTagsOfResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5277,9 +5382,14 @@ impl DynamoDb for DynamoDbClient {
 
     /// <p>Creates a new item, or replaces an old item with a new item. If an item that has the same primary key as the new item already exists in the specified table, the new item completely replaces the existing item. You can perform a conditional put operation (add a new item if one with the specified primary key doesn't exist), or replace an existing item if it has certain attribute values. You can return the item's attribute values in the same operation, using the <code>ReturnValues</code> parameter.</p> <important> <p>This topic provides general information about the <code>PutItem</code> API.</p> <p>For information on how to call the <code>PutItem</code> API using the AWS SDK in specific languages, see the following:</p> <ul> <li> <p> <a href="http://docs.aws.amazon.com/goto/aws-cli/dynamodb-2012-08-10/PutItem"> PutItem in the AWS Command Line Interface </a> </p> </li> <li> <p> <a href="http://docs.aws.amazon.com/goto/DotNetSDKV3/dynamodb-2012-08-10/PutItem"> PutItem in the AWS SDK for .NET </a> </p> </li> <li> <p> <a href="http://docs.aws.amazon.com/goto/SdkForCpp/dynamodb-2012-08-10/PutItem"> PutItem in the AWS SDK for C++ </a> </p> </li> <li> <p> <a href="http://docs.aws.amazon.com/goto/SdkForGoV1/dynamodb-2012-08-10/PutItem"> PutItem in the AWS SDK for Go </a> </p> </li> <li> <p> <a href="http://docs.aws.amazon.com/goto/SdkForJava/dynamodb-2012-08-10/PutItem"> PutItem in the AWS SDK for Java </a> </p> </li> <li> <p> <a href="http://docs.aws.amazon.com/goto/AWSJavaScriptSDK/dynamodb-2012-08-10/PutItem"> PutItem in the AWS SDK for JavaScript </a> </p> </li> <li> <p> <a href="http://docs.aws.amazon.com/goto/SdkForPHPV3/dynamodb-2012-08-10/PutItem"> PutItem in the AWS SDK for PHP V3 </a> </p> </li> <li> <p> <a href="http://docs.aws.amazon.com/goto/boto3/dynamodb-2012-08-10/PutItem"> PutItem in the AWS SDK for Python </a> </p> </li> <li> <p> <a href="http://docs.aws.amazon.com/goto/SdkForRubyV2/dynamodb-2012-08-10/PutItem"> PutItem in the AWS SDK for Ruby V2 </a> </p> </li> </ul> </important> <p>When you add an item, the primary key attribute(s) are the only required attributes. Attribute values cannot be null. String and Binary type attributes must have lengths greater than zero. Set type attributes cannot be empty. Requests with empty values will be rejected with a <code>ValidationException</code> exception.</p> <note> <p>To prevent a new item from replacing an existing item, use a conditional expression that contains the <code>attribute_not_exists</code> function with the name of the attribute being used as the partition key for the table. Since every record must contain that attribute, the <code>attribute_not_exists</code> function will only succeed if no matching item exists.</p> </note> <p>For more information about <code>PutItem</code>, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithItems.html">Working with Items</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
     fn put_item(&self, input: PutItemInput) -> RusotoFuture<PutItemOutput, PutItemError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.PutItem");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5302,9 +5412,14 @@ impl DynamoDb for DynamoDbClient {
 
     /// <p>The <code>Query</code> operation finds items based on primary key values. You can query any table or secondary index that has a composite primary key (a partition key and a sort key). </p> <p>Use the <code>KeyConditionExpression</code> parameter to provide a specific value for the partition key. The <code>Query</code> operation will return all of the items from the table or index with that partition key value. You can optionally narrow the scope of the <code>Query</code> operation by specifying a sort key value and a comparison operator in <code>KeyConditionExpression</code>. To further refine the <code>Query</code> results, you can optionally provide a <code>FilterExpression</code>. A <code>FilterExpression</code> determines which items within the results should be returned to you. All of the other results are discarded. </p> <p> A <code>Query</code> operation always returns a result set. If no matching items are found, the result set will be empty. Queries that do not return results consume the minimum number of read capacity units for that type of read operation. </p> <note> <p> DynamoDB calculates the number of read capacity units consumed based on item size, not on the amount of data that is returned to an application. The number of capacity units consumed will be the same whether you request all of the attributes (the default behavior) or just some of them (using a projection expression). The number will also be the same whether or not you use a <code>FilterExpression</code>. </p> </note> <p> <code>Query</code> results are always sorted by the sort key value. If the data type of the sort key is Number, the results are returned in numeric order; otherwise, the results are returned in order of UTF-8 bytes. By default, the sort order is ascending. To reverse the order, set the <code>ScanIndexForward</code> parameter to false. </p> <p> A single <code>Query</code> operation will read up to the maximum number of items set (if using the <code>Limit</code> parameter) or a maximum of 1 MB of data and then apply any filtering to the results using <code>FilterExpression</code>. If <code>LastEvaluatedKey</code> is present in the response, you will need to paginate the result set. For more information, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.html#Query.Pagination">Paginating the Results</a> in the <i>Amazon DynamoDB Developer Guide</i>. </p> <p> <code>FilterExpression</code> is applied after a <code>Query</code> finishes, but before the results are returned. A <code>FilterExpression</code> cannot contain partition key or sort key attributes. You need to specify those attributes in the <code>KeyConditionExpression</code>. </p> <note> <p> A <code>Query</code> operation can return an empty result set and a <code>LastEvaluatedKey</code> if all the items read for the page of results are filtered out. </p> </note> <p>You can query a table, a local secondary index, or a global secondary index. For a query on a table or on a local secondary index, you can set the <code>ConsistentRead</code> parameter to <code>true</code> and obtain a strongly consistent result. Global secondary indexes support eventually consistent reads only, so do not specify <code>ConsistentRead</code> when querying a global secondary index.</p>
     fn query(&self, input: QueryInput) -> RusotoFuture<QueryOutput, QueryError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.Query");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5330,9 +5445,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: RestoreTableFromBackupInput,
     ) -> RusotoFuture<RestoreTableFromBackupOutput, RestoreTableFromBackupError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.RestoreTableFromBackup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5358,9 +5478,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: RestoreTableToPointInTimeInput,
     ) -> RusotoFuture<RestoreTableToPointInTimeOutput, RestoreTableToPointInTimeError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header(
             "x-amz-target",
             "DynamoDB_20120810.RestoreTableToPointInTime",
@@ -5384,9 +5509,14 @@ impl DynamoDb for DynamoDbClient {
 
     /// <p>The <code>Scan</code> operation returns one or more items and item attributes by accessing every item in a table or a secondary index. To have DynamoDB return fewer items, you can provide a <code>FilterExpression</code> operation.</p> <p>If the total number of scanned items exceeds the maximum data set size limit of 1 MB, the scan stops and results are returned to the user as a <code>LastEvaluatedKey</code> value to continue the scan in a subsequent operation. The results also include the number of items exceeding the limit. A scan can result in no table data meeting the filter criteria. </p> <p>A single <code>Scan</code> operation will read up to the maximum number of items set (if using the <code>Limit</code> parameter) or a maximum of 1 MB of data and then apply any filtering to the results using <code>FilterExpression</code>. If <code>LastEvaluatedKey</code> is present in the response, you will need to paginate the result set. For more information, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.Pagination">Paginating the Results</a> in the <i>Amazon DynamoDB Developer Guide</i>. </p> <p> <code>Scan</code> operations proceed sequentially; however, for faster performance on a large table or secondary index, applications can request a parallel <code>Scan</code> operation by providing the <code>Segment</code> and <code>TotalSegments</code> parameters. For more information, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.ParallelScan">Parallel Scan</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p> <p> <code>Scan</code> uses eventually consistent reads when accessing the data in a table; therefore, the result set might not include the changes to data in the table immediately before the operation began. If you need a consistent copy of the data, as of the time that the <code>Scan</code> begins, you can set the <code>ConsistentRead</code> parameter to <code>true</code>.</p>
     fn scan(&self, input: ScanInput) -> RusotoFuture<ScanOutput, ScanError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.Scan");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5409,9 +5539,14 @@ impl DynamoDb for DynamoDbClient {
 
     /// <p>Associate a set of tags with an Amazon DynamoDB resource. You can then activate these user-defined tags so that they appear on the Billing and Cost Management console for cost allocation tracking. You can call TagResource up to 5 times per second, per account. </p> <p>For an overview on tagging DynamoDB resources, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tagging.html">Tagging for DynamoDB</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
     fn tag_resource(&self, input: TagResourceInput) -> RusotoFuture<(), TagResourceError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.TagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5435,9 +5570,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: TransactGetItemsInput,
     ) -> RusotoFuture<TransactGetItemsOutput, TransactGetItemsError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.TransactGetItems");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5464,9 +5604,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: TransactWriteItemsInput,
     ) -> RusotoFuture<TransactWriteItemsOutput, TransactWriteItemsError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.TransactWriteItems");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5490,9 +5635,14 @@ impl DynamoDb for DynamoDbClient {
 
     /// <p>Removes the association of tags from an Amazon DynamoDB resource. You can call UntagResource up to 5 times per second, per account. </p> <p>For an overview on tagging DynamoDB resources, see <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tagging.html">Tagging for DynamoDB</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>
     fn untag_resource(&self, input: UntagResourceInput) -> RusotoFuture<(), UntagResourceError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.UntagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5516,9 +5666,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: UpdateContinuousBackupsInput,
     ) -> RusotoFuture<UpdateContinuousBackupsOutput, UpdateContinuousBackupsError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.UpdateContinuousBackups");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5542,9 +5697,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: UpdateGlobalTableInput,
     ) -> RusotoFuture<UpdateGlobalTableOutput, UpdateGlobalTableError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.UpdateGlobalTable");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5571,9 +5731,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: UpdateGlobalTableSettingsInput,
     ) -> RusotoFuture<UpdateGlobalTableSettingsOutput, UpdateGlobalTableSettingsError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header(
             "x-amz-target",
             "DynamoDB_20120810.UpdateGlobalTableSettings",
@@ -5600,9 +5765,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: UpdateItemInput,
     ) -> RusotoFuture<UpdateItemOutput, UpdateItemError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.UpdateItem");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5629,9 +5799,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: UpdateTableInput,
     ) -> RusotoFuture<UpdateTableOutput, UpdateTableError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.UpdateTable");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5658,9 +5833,14 @@ impl DynamoDb for DynamoDbClient {
         &self,
         input: UpdateTimeToLiveInput,
     ) -> RusotoFuture<UpdateTimeToLiveOutput, UpdateTimeToLiveError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDB_20120810.UpdateTimeToLive");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/dynamodbstreams/src/generated.rs
+++ b/rusoto/services/dynamodbstreams/src/generated.rs
@@ -627,9 +627,14 @@ impl DynamoDbStreams for DynamoDbStreamsClient {
         &self,
         input: DescribeStreamInput,
     ) -> RusotoFuture<DescribeStreamOutput, DescribeStreamError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
         request.set_endpoint_prefix("streams.dynamodb".to_string());
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDBStreams_20120810.DescribeStream");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -656,9 +661,14 @@ impl DynamoDbStreams for DynamoDbStreamsClient {
         &self,
         input: GetRecordsInput,
     ) -> RusotoFuture<GetRecordsOutput, GetRecordsError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
         request.set_endpoint_prefix("streams.dynamodb".to_string());
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDBStreams_20120810.GetRecords");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -685,9 +695,14 @@ impl DynamoDbStreams for DynamoDbStreamsClient {
         &self,
         input: GetShardIteratorInput,
     ) -> RusotoFuture<GetShardIteratorOutput, GetShardIteratorError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
         request.set_endpoint_prefix("streams.dynamodb".to_string());
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDBStreams_20120810.GetShardIterator");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -714,9 +729,14 @@ impl DynamoDbStreams for DynamoDbStreamsClient {
         &self,
         input: ListStreamsInput,
     ) -> RusotoFuture<ListStreamsOutput, ListStreamsError> {
-        let mut request = SignedRequest::new("POST", "dynamodb", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "dynamodb",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
         request.set_endpoint_prefix("streams.dynamodb".to_string());
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "DynamoDBStreams_20120810.ListStreams");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/ecr/src/generated.rs
+++ b/rusoto/services/ecr/src/generated.rs
@@ -2588,9 +2588,14 @@ impl Ecr for EcrClient {
         &self,
         input: BatchCheckLayerAvailabilityRequest,
     ) -> RusotoFuture<BatchCheckLayerAvailabilityResponse, BatchCheckLayerAvailabilityError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.BatchCheckLayerAvailability",
@@ -2617,9 +2622,14 @@ impl Ecr for EcrClient {
         &self,
         input: BatchDeleteImageRequest,
     ) -> RusotoFuture<BatchDeleteImageResponse, BatchDeleteImageError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.BatchDeleteImage",
@@ -2649,9 +2659,14 @@ impl Ecr for EcrClient {
         &self,
         input: BatchGetImageRequest,
     ) -> RusotoFuture<BatchGetImageResponse, BatchGetImageError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.BatchGetImage",
@@ -2681,9 +2696,14 @@ impl Ecr for EcrClient {
         &self,
         input: CompleteLayerUploadRequest,
     ) -> RusotoFuture<CompleteLayerUploadResponse, CompleteLayerUploadError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.CompleteLayerUpload",
@@ -2712,9 +2732,14 @@ impl Ecr for EcrClient {
         &self,
         input: CreateRepositoryRequest,
     ) -> RusotoFuture<CreateRepositoryResponse, CreateRepositoryError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.CreateRepository",
@@ -2744,9 +2769,14 @@ impl Ecr for EcrClient {
         &self,
         input: DeleteLifecyclePolicyRequest,
     ) -> RusotoFuture<DeleteLifecyclePolicyResponse, DeleteLifecyclePolicyError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.DeleteLifecyclePolicy",
@@ -2775,9 +2805,14 @@ impl Ecr for EcrClient {
         &self,
         input: DeleteRepositoryRequest,
     ) -> RusotoFuture<DeleteRepositoryResponse, DeleteRepositoryError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.DeleteRepository",
@@ -2807,9 +2842,14 @@ impl Ecr for EcrClient {
         &self,
         input: DeleteRepositoryPolicyRequest,
     ) -> RusotoFuture<DeleteRepositoryPolicyResponse, DeleteRepositoryPolicyError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.DeleteRepositoryPolicy",
@@ -2838,9 +2878,14 @@ impl Ecr for EcrClient {
         &self,
         input: DescribeImagesRequest,
     ) -> RusotoFuture<DescribeImagesResponse, DescribeImagesError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.DescribeImages",
@@ -2870,9 +2915,14 @@ impl Ecr for EcrClient {
         &self,
         input: DescribeRepositoriesRequest,
     ) -> RusotoFuture<DescribeRepositoriesResponse, DescribeRepositoriesError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.DescribeRepositories",
@@ -2901,9 +2951,14 @@ impl Ecr for EcrClient {
         &self,
         input: GetAuthorizationTokenRequest,
     ) -> RusotoFuture<GetAuthorizationTokenResponse, GetAuthorizationTokenError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.GetAuthorizationToken",
@@ -2932,9 +2987,14 @@ impl Ecr for EcrClient {
         &self,
         input: GetDownloadUrlForLayerRequest,
     ) -> RusotoFuture<GetDownloadUrlForLayerResponse, GetDownloadUrlForLayerError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.GetDownloadUrlForLayer",
@@ -2963,9 +3023,14 @@ impl Ecr for EcrClient {
         &self,
         input: GetLifecyclePolicyRequest,
     ) -> RusotoFuture<GetLifecyclePolicyResponse, GetLifecyclePolicyError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.GetLifecyclePolicy",
@@ -2995,9 +3060,14 @@ impl Ecr for EcrClient {
         &self,
         input: GetLifecyclePolicyPreviewRequest,
     ) -> RusotoFuture<GetLifecyclePolicyPreviewResponse, GetLifecyclePolicyPreviewError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.GetLifecyclePolicyPreview",
@@ -3024,9 +3094,14 @@ impl Ecr for EcrClient {
         &self,
         input: GetRepositoryPolicyRequest,
     ) -> RusotoFuture<GetRepositoryPolicyResponse, GetRepositoryPolicyError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.GetRepositoryPolicy",
@@ -3055,9 +3130,14 @@ impl Ecr for EcrClient {
         &self,
         input: InitiateLayerUploadRequest,
     ) -> RusotoFuture<InitiateLayerUploadResponse, InitiateLayerUploadError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.InitiateLayerUpload",
@@ -3086,9 +3166,14 @@ impl Ecr for EcrClient {
         &self,
         input: ListImagesRequest,
     ) -> RusotoFuture<ListImagesResponse, ListImagesError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.ListImages",
@@ -3118,9 +3203,14 @@ impl Ecr for EcrClient {
         &self,
         input: ListTagsForResourceRequest,
     ) -> RusotoFuture<ListTagsForResourceResponse, ListTagsForResourceError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.ListTagsForResource",
@@ -3146,9 +3236,14 @@ impl Ecr for EcrClient {
 
     /// <p><p>Creates or updates the image manifest and tags associated with an image.</p> <note> <p>This operation is used by the Amazon ECR proxy, and it is not intended for general use by customers for pulling and pushing images. In most cases, you should use the <code>docker</code> CLI to pull, tag, and push images.</p> </note></p>
     fn put_image(&self, input: PutImageRequest) -> RusotoFuture<PutImageResponse, PutImageError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.PutImage",
@@ -3178,9 +3273,14 @@ impl Ecr for EcrClient {
         &self,
         input: PutLifecyclePolicyRequest,
     ) -> RusotoFuture<PutLifecyclePolicyResponse, PutLifecyclePolicyError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.PutLifecyclePolicy",
@@ -3210,9 +3310,14 @@ impl Ecr for EcrClient {
         &self,
         input: SetRepositoryPolicyRequest,
     ) -> RusotoFuture<SetRepositoryPolicyResponse, SetRepositoryPolicyError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.SetRepositoryPolicy",
@@ -3241,9 +3346,14 @@ impl Ecr for EcrClient {
         &self,
         input: StartLifecyclePolicyPreviewRequest,
     ) -> RusotoFuture<StartLifecyclePolicyPreviewResponse, StartLifecyclePolicyPreviewError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.StartLifecyclePolicyPreview",
@@ -3270,9 +3380,14 @@ impl Ecr for EcrClient {
         &self,
         input: TagResourceRequest,
     ) -> RusotoFuture<TagResourceResponse, TagResourceError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.TagResource",
@@ -3302,9 +3417,14 @@ impl Ecr for EcrClient {
         &self,
         input: UntagResourceRequest,
     ) -> RusotoFuture<UntagResourceResponse, UntagResourceError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.UntagResource",
@@ -3334,9 +3454,14 @@ impl Ecr for EcrClient {
         &self,
         input: UploadLayerPartRequest,
     ) -> RusotoFuture<UploadLayerPartResponse, UploadLayerPartError> {
-        let mut request = SignedRequest::new("POST", "ecr", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecr",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.ecr".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerRegistry_V20150921.UploadLayerPart",

--- a/rusoto/services/ecs/src/generated.rs
+++ b/rusoto/services/ecs/src/generated.rs
@@ -5017,9 +5017,14 @@ impl Ecs for EcsClient {
         &self,
         input: CreateClusterRequest,
     ) -> RusotoFuture<CreateClusterResponse, CreateClusterError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.CreateCluster",
@@ -5049,9 +5054,14 @@ impl Ecs for EcsClient {
         &self,
         input: CreateServiceRequest,
     ) -> RusotoFuture<CreateServiceResponse, CreateServiceError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.CreateService",
@@ -5081,9 +5091,14 @@ impl Ecs for EcsClient {
         &self,
         input: DeleteAccountSettingRequest,
     ) -> RusotoFuture<DeleteAccountSettingResponse, DeleteAccountSettingError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.DeleteAccountSetting",
@@ -5112,9 +5127,14 @@ impl Ecs for EcsClient {
         &self,
         input: DeleteAttributesRequest,
     ) -> RusotoFuture<DeleteAttributesResponse, DeleteAttributesError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.DeleteAttributes",
@@ -5144,9 +5164,14 @@ impl Ecs for EcsClient {
         &self,
         input: DeleteClusterRequest,
     ) -> RusotoFuture<DeleteClusterResponse, DeleteClusterError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.DeleteCluster",
@@ -5176,9 +5201,14 @@ impl Ecs for EcsClient {
         &self,
         input: DeleteServiceRequest,
     ) -> RusotoFuture<DeleteServiceResponse, DeleteServiceError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.DeleteService",
@@ -5208,9 +5238,14 @@ impl Ecs for EcsClient {
         &self,
         input: DeregisterContainerInstanceRequest,
     ) -> RusotoFuture<DeregisterContainerInstanceResponse, DeregisterContainerInstanceError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.DeregisterContainerInstance",
@@ -5237,9 +5272,14 @@ impl Ecs for EcsClient {
         &self,
         input: DeregisterTaskDefinitionRequest,
     ) -> RusotoFuture<DeregisterTaskDefinitionResponse, DeregisterTaskDefinitionError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.DeregisterTaskDefinition",
@@ -5266,9 +5306,14 @@ impl Ecs for EcsClient {
         &self,
         input: DescribeClustersRequest,
     ) -> RusotoFuture<DescribeClustersResponse, DescribeClustersError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.DescribeClusters",
@@ -5298,9 +5343,14 @@ impl Ecs for EcsClient {
         &self,
         input: DescribeContainerInstancesRequest,
     ) -> RusotoFuture<DescribeContainerInstancesResponse, DescribeContainerInstancesError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.DescribeContainerInstances",
@@ -5327,9 +5377,14 @@ impl Ecs for EcsClient {
         &self,
         input: DescribeServicesRequest,
     ) -> RusotoFuture<DescribeServicesResponse, DescribeServicesError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.DescribeServices",
@@ -5359,9 +5414,14 @@ impl Ecs for EcsClient {
         &self,
         input: DescribeTaskDefinitionRequest,
     ) -> RusotoFuture<DescribeTaskDefinitionResponse, DescribeTaskDefinitionError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.DescribeTaskDefinition",
@@ -5390,9 +5450,14 @@ impl Ecs for EcsClient {
         &self,
         input: DescribeTasksRequest,
     ) -> RusotoFuture<DescribeTasksResponse, DescribeTasksError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.DescribeTasks",
@@ -5422,9 +5487,14 @@ impl Ecs for EcsClient {
         &self,
         input: DiscoverPollEndpointRequest,
     ) -> RusotoFuture<DiscoverPollEndpointResponse, DiscoverPollEndpointError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.DiscoverPollEndpoint",
@@ -5453,9 +5523,14 @@ impl Ecs for EcsClient {
         &self,
         input: ListAccountSettingsRequest,
     ) -> RusotoFuture<ListAccountSettingsResponse, ListAccountSettingsError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.ListAccountSettings",
@@ -5484,9 +5559,14 @@ impl Ecs for EcsClient {
         &self,
         input: ListAttributesRequest,
     ) -> RusotoFuture<ListAttributesResponse, ListAttributesError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.ListAttributes",
@@ -5516,9 +5596,14 @@ impl Ecs for EcsClient {
         &self,
         input: ListClustersRequest,
     ) -> RusotoFuture<ListClustersResponse, ListClustersError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.ListClusters",
@@ -5548,9 +5633,14 @@ impl Ecs for EcsClient {
         &self,
         input: ListContainerInstancesRequest,
     ) -> RusotoFuture<ListContainerInstancesResponse, ListContainerInstancesError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.ListContainerInstances",
@@ -5579,9 +5669,14 @@ impl Ecs for EcsClient {
         &self,
         input: ListServicesRequest,
     ) -> RusotoFuture<ListServicesResponse, ListServicesError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.ListServices",
@@ -5611,9 +5706,14 @@ impl Ecs for EcsClient {
         &self,
         input: ListTagsForResourceRequest,
     ) -> RusotoFuture<ListTagsForResourceResponse, ListTagsForResourceError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.ListTagsForResource",
@@ -5642,9 +5742,14 @@ impl Ecs for EcsClient {
         &self,
         input: ListTaskDefinitionFamiliesRequest,
     ) -> RusotoFuture<ListTaskDefinitionFamiliesResponse, ListTaskDefinitionFamiliesError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.ListTaskDefinitionFamilies",
@@ -5671,9 +5776,14 @@ impl Ecs for EcsClient {
         &self,
         input: ListTaskDefinitionsRequest,
     ) -> RusotoFuture<ListTaskDefinitionsResponse, ListTaskDefinitionsError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.ListTaskDefinitions",
@@ -5702,9 +5812,14 @@ impl Ecs for EcsClient {
         &self,
         input: ListTasksRequest,
     ) -> RusotoFuture<ListTasksResponse, ListTasksError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.ListTasks",
@@ -5734,9 +5849,14 @@ impl Ecs for EcsClient {
         &self,
         input: PutAccountSettingRequest,
     ) -> RusotoFuture<PutAccountSettingResponse, PutAccountSettingError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.PutAccountSetting",
@@ -5766,9 +5886,14 @@ impl Ecs for EcsClient {
         &self,
         input: PutAccountSettingDefaultRequest,
     ) -> RusotoFuture<PutAccountSettingDefaultResponse, PutAccountSettingDefaultError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.PutAccountSettingDefault",
@@ -5795,9 +5920,14 @@ impl Ecs for EcsClient {
         &self,
         input: PutAttributesRequest,
     ) -> RusotoFuture<PutAttributesResponse, PutAttributesError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.PutAttributes",
@@ -5827,9 +5957,14 @@ impl Ecs for EcsClient {
         &self,
         input: RegisterContainerInstanceRequest,
     ) -> RusotoFuture<RegisterContainerInstanceResponse, RegisterContainerInstanceError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.RegisterContainerInstance",
@@ -5856,9 +5991,14 @@ impl Ecs for EcsClient {
         &self,
         input: RegisterTaskDefinitionRequest,
     ) -> RusotoFuture<RegisterTaskDefinitionResponse, RegisterTaskDefinitionError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.RegisterTaskDefinition",
@@ -5884,9 +6024,14 @@ impl Ecs for EcsClient {
 
     /// <p><p>Starts a new task using the specified task definition.</p> <p>You can allow Amazon ECS to place tasks for you, or you can customize how Amazon ECS places tasks using placement constraints and placement strategies. For more information, see <a href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/scheduling_tasks.html">Scheduling Tasks</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p> <p>Alternatively, you can use <a>StartTask</a> to use your own scheduler or place tasks manually on specific container instances.</p> <p>The Amazon ECS API follows an eventual consistency model, due to the distributed nature of the system supporting the API. This means that the result of an API command you run that affects your Amazon ECS resources might not be immediately visible to all subsequent commands you run. Keep this in mind when you carry out an API command that immediately follows a previous API command.</p> <p>To manage eventual consistency, you can do the following:</p> <ul> <li> <p>Confirm the state of the resource before you run a command to modify it. Run the DescribeTasks command using an exponential backoff algorithm to ensure that you allow enough time for the previous command to propagate through the system. To do this, run the DescribeTasks command repeatedly, starting with a couple of seconds of wait time and increasing gradually up to five minutes of wait time.</p> </li> <li> <p>Add wait time between subsequent commands, even if the DescribeTasks command returns an accurate response. Apply an exponential backoff algorithm starting with a couple of seconds of wait time, and increase gradually up to about five minutes of wait time.</p> </li> </ul></p>
     fn run_task(&self, input: RunTaskRequest) -> RusotoFuture<RunTaskResponse, RunTaskError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonEC2ContainerServiceV20141113.RunTask");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5912,9 +6057,14 @@ impl Ecs for EcsClient {
         &self,
         input: StartTaskRequest,
     ) -> RusotoFuture<StartTaskResponse, StartTaskError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.StartTask",
@@ -5941,9 +6091,14 @@ impl Ecs for EcsClient {
 
     /// <p><p>Stops a running task. Any tags associated with the task will be deleted.</p> <p>When <a>StopTask</a> is called on a task, the equivalent of <code>docker stop</code> is issued to the containers running in the task. This results in a <code>SIGTERM</code> value and a default 30-second timeout, after which the <code>SIGKILL</code> value is sent and the containers are forcibly stopped. If the container handles the <code>SIGTERM</code> value gracefully and exits within 30 seconds from receiving it, no <code>SIGKILL</code> value is sent.</p> <note> <p>The default 30-second timeout can be configured on the Amazon ECS container agent with the <code>ECS<em>CONTAINER</em>STOP_TIMEOUT</code> variable. For more information, see <a href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html">Amazon ECS Container Agent Configuration</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p> </note></p>
     fn stop_task(&self, input: StopTaskRequest) -> RusotoFuture<StopTaskResponse, StopTaskError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.StopTask",
@@ -5973,9 +6128,14 @@ impl Ecs for EcsClient {
         &self,
         input: SubmitContainerStateChangeRequest,
     ) -> RusotoFuture<SubmitContainerStateChangeResponse, SubmitContainerStateChangeError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.SubmitContainerStateChange",
@@ -6002,9 +6162,14 @@ impl Ecs for EcsClient {
         &self,
         input: SubmitTaskStateChangeRequest,
     ) -> RusotoFuture<SubmitTaskStateChangeResponse, SubmitTaskStateChangeError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.SubmitTaskStateChange",
@@ -6033,9 +6198,14 @@ impl Ecs for EcsClient {
         &self,
         input: TagResourceRequest,
     ) -> RusotoFuture<TagResourceResponse, TagResourceError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.TagResource",
@@ -6065,9 +6235,14 @@ impl Ecs for EcsClient {
         &self,
         input: UntagResourceRequest,
     ) -> RusotoFuture<UntagResourceResponse, UntagResourceError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.UntagResource",
@@ -6097,9 +6272,14 @@ impl Ecs for EcsClient {
         &self,
         input: UpdateContainerAgentRequest,
     ) -> RusotoFuture<UpdateContainerAgentResponse, UpdateContainerAgentError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.UpdateContainerAgent",
@@ -6129,9 +6309,14 @@ impl Ecs for EcsClient {
         input: UpdateContainerInstancesStateRequest,
     ) -> RusotoFuture<UpdateContainerInstancesStateResponse, UpdateContainerInstancesStateError>
     {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.UpdateContainerInstancesState",
@@ -6158,9 +6343,14 @@ impl Ecs for EcsClient {
         &self,
         input: UpdateServiceRequest,
     ) -> RusotoFuture<UpdateServiceResponse, UpdateServiceError> {
-        let mut request = SignedRequest::new("POST", "ecs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ecs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonEC2ContainerServiceV20141113.UpdateService",

--- a/rusoto/services/emr/src/generated.rs
+++ b/rusoto/services/emr/src/generated.rs
@@ -3580,9 +3580,14 @@ impl Emr for EmrClient {
         &self,
         input: AddInstanceFleetInput,
     ) -> RusotoFuture<AddInstanceFleetOutput, AddInstanceFleetError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ElasticMapReduce.AddInstanceFleet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3609,9 +3614,14 @@ impl Emr for EmrClient {
         &self,
         input: AddInstanceGroupsInput,
     ) -> RusotoFuture<AddInstanceGroupsOutput, AddInstanceGroupsError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ElasticMapReduce.AddInstanceGroups");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3638,9 +3648,14 @@ impl Emr for EmrClient {
         &self,
         input: AddJobFlowStepsInput,
     ) -> RusotoFuture<AddJobFlowStepsOutput, AddJobFlowStepsError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ElasticMapReduce.AddJobFlowSteps");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3664,9 +3679,14 @@ impl Emr for EmrClient {
 
     /// <p>Adds tags to an Amazon EMR resource. Tags make it easier to associate clusters in various ways, such as grouping clusters to track your Amazon EMR resource allocation costs. For more information, see <a href="http://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-tags.html">Tag Clusters</a>. </p>
     fn add_tags(&self, input: AddTagsInput) -> RusotoFuture<AddTagsOutput, AddTagsError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ElasticMapReduce.AddTags");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3692,9 +3712,14 @@ impl Emr for EmrClient {
         &self,
         input: CancelStepsInput,
     ) -> RusotoFuture<CancelStepsOutput, CancelStepsError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ElasticMapReduce.CancelSteps");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3721,9 +3746,14 @@ impl Emr for EmrClient {
         &self,
         input: CreateSecurityConfigurationInput,
     ) -> RusotoFuture<CreateSecurityConfigurationOutput, CreateSecurityConfigurationError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "ElasticMapReduce.CreateSecurityConfiguration",
@@ -3750,9 +3780,14 @@ impl Emr for EmrClient {
         &self,
         input: DeleteSecurityConfigurationInput,
     ) -> RusotoFuture<DeleteSecurityConfigurationOutput, DeleteSecurityConfigurationError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "ElasticMapReduce.DeleteSecurityConfiguration",
@@ -3779,9 +3814,14 @@ impl Emr for EmrClient {
         &self,
         input: DescribeClusterInput,
     ) -> RusotoFuture<DescribeClusterOutput, DescribeClusterError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ElasticMapReduce.DescribeCluster");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3808,9 +3848,14 @@ impl Emr for EmrClient {
         &self,
         input: DescribeJobFlowsInput,
     ) -> RusotoFuture<DescribeJobFlowsOutput, DescribeJobFlowsError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ElasticMapReduce.DescribeJobFlows");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3837,9 +3882,14 @@ impl Emr for EmrClient {
         &self,
         input: DescribeSecurityConfigurationInput,
     ) -> RusotoFuture<DescribeSecurityConfigurationOutput, DescribeSecurityConfigurationError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "ElasticMapReduce.DescribeSecurityConfiguration",
@@ -3866,9 +3916,14 @@ impl Emr for EmrClient {
         &self,
         input: DescribeStepInput,
     ) -> RusotoFuture<DescribeStepOutput, DescribeStepError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ElasticMapReduce.DescribeStep");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3895,9 +3950,14 @@ impl Emr for EmrClient {
         &self,
         input: ListBootstrapActionsInput,
     ) -> RusotoFuture<ListBootstrapActionsOutput, ListBootstrapActionsError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ElasticMapReduce.ListBootstrapActions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3923,9 +3983,14 @@ impl Emr for EmrClient {
         &self,
         input: ListClustersInput,
     ) -> RusotoFuture<ListClustersOutput, ListClustersError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ElasticMapReduce.ListClusters");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3952,9 +4017,14 @@ impl Emr for EmrClient {
         &self,
         input: ListInstanceFleetsInput,
     ) -> RusotoFuture<ListInstanceFleetsOutput, ListInstanceFleetsError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ElasticMapReduce.ListInstanceFleets");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3981,9 +4051,14 @@ impl Emr for EmrClient {
         &self,
         input: ListInstanceGroupsInput,
     ) -> RusotoFuture<ListInstanceGroupsOutput, ListInstanceGroupsError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ElasticMapReduce.ListInstanceGroups");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4010,9 +4085,14 @@ impl Emr for EmrClient {
         &self,
         input: ListInstancesInput,
     ) -> RusotoFuture<ListInstancesOutput, ListInstancesError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ElasticMapReduce.ListInstances");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4039,9 +4119,14 @@ impl Emr for EmrClient {
         &self,
         input: ListSecurityConfigurationsInput,
     ) -> RusotoFuture<ListSecurityConfigurationsOutput, ListSecurityConfigurationsError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "ElasticMapReduce.ListSecurityConfigurations",
@@ -4065,9 +4150,14 @@ impl Emr for EmrClient {
 
     /// <p>Provides a list of steps for the cluster in reverse order unless you specify stepIds with the request.</p>
     fn list_steps(&self, input: ListStepsInput) -> RusotoFuture<ListStepsOutput, ListStepsError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ElasticMapReduce.ListSteps");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4093,9 +4183,14 @@ impl Emr for EmrClient {
         &self,
         input: ModifyInstanceFleetInput,
     ) -> RusotoFuture<(), ModifyInstanceFleetError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ElasticMapReduce.ModifyInstanceFleet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4118,9 +4213,14 @@ impl Emr for EmrClient {
         &self,
         input: ModifyInstanceGroupsInput,
     ) -> RusotoFuture<(), ModifyInstanceGroupsError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ElasticMapReduce.ModifyInstanceGroups");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4143,9 +4243,14 @@ impl Emr for EmrClient {
         &self,
         input: PutAutoScalingPolicyInput,
     ) -> RusotoFuture<PutAutoScalingPolicyOutput, PutAutoScalingPolicyError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ElasticMapReduce.PutAutoScalingPolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4171,9 +4276,14 @@ impl Emr for EmrClient {
         &self,
         input: RemoveAutoScalingPolicyInput,
     ) -> RusotoFuture<RemoveAutoScalingPolicyOutput, RemoveAutoScalingPolicyError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ElasticMapReduce.RemoveAutoScalingPolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4197,9 +4307,14 @@ impl Emr for EmrClient {
         &self,
         input: RemoveTagsInput,
     ) -> RusotoFuture<RemoveTagsOutput, RemoveTagsError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ElasticMapReduce.RemoveTags");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4226,9 +4341,14 @@ impl Emr for EmrClient {
         &self,
         input: RunJobFlowInput,
     ) -> RusotoFuture<RunJobFlowOutput, RunJobFlowError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ElasticMapReduce.RunJobFlow");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4255,9 +4375,14 @@ impl Emr for EmrClient {
         &self,
         input: SetTerminationProtectionInput,
     ) -> RusotoFuture<(), SetTerminationProtectionError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ElasticMapReduce.SetTerminationProtection");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4278,9 +4403,14 @@ impl Emr for EmrClient {
         &self,
         input: SetVisibleToAllUsersInput,
     ) -> RusotoFuture<(), SetVisibleToAllUsersError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ElasticMapReduce.SetVisibleToAllUsers");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4303,9 +4433,14 @@ impl Emr for EmrClient {
         &self,
         input: TerminateJobFlowsInput,
     ) -> RusotoFuture<(), TerminateJobFlowsError> {
-        let mut request = SignedRequest::new("POST", "elasticmapreduce", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "elasticmapreduce",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "ElasticMapReduce.TerminateJobFlows");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/events/src/generated.rs
+++ b/rusoto/services/events/src/generated.rs
@@ -1447,9 +1447,14 @@ impl CloudWatchEventsClient {
 impl CloudWatchEvents for CloudWatchEventsClient {
     /// <p>Deletes the specified rule.</p> <p>Before you can delete the rule, you must remove all targets, using <a>RemoveTargets</a>.</p> <p>When you delete a rule, incoming events might continue to match to the deleted rule. Allow a short period of time for changes to take effect.</p> <p>Managed rules are rules created and managed by another AWS service on your behalf. These rules are created by those other AWS services to support functionality in those services. You can delete these rules using the <code>Force</code> option, but you should do so only if you are sure the other service is not still using that rule.</p>
     fn delete_rule(&self, input: DeleteRuleRequest) -> RusotoFuture<(), DeleteRuleError> {
-        let mut request = SignedRequest::new("POST", "events", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "events",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSEvents.DeleteRule");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1470,9 +1475,14 @@ impl CloudWatchEvents for CloudWatchEventsClient {
 
     /// <p>Displays the external AWS accounts that are permitted to write events to your account using your account's event bus, and the associated policy. To enable your account to receive events from other accounts, use <a>PutPermission</a>.</p>
     fn describe_event_bus(&self) -> RusotoFuture<DescribeEventBusResponse, DescribeEventBusError> {
-        let mut request = SignedRequest::new("POST", "events", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "events",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSEvents.DescribeEventBus");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -1498,9 +1508,14 @@ impl CloudWatchEvents for CloudWatchEventsClient {
         &self,
         input: DescribeRuleRequest,
     ) -> RusotoFuture<DescribeRuleResponse, DescribeRuleError> {
-        let mut request = SignedRequest::new("POST", "events", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "events",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSEvents.DescribeRule");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1524,9 +1539,14 @@ impl CloudWatchEvents for CloudWatchEventsClient {
 
     /// <p>Disables the specified rule. A disabled rule won't match any events, and won't self-trigger if it has a schedule expression.</p> <p>When you disable a rule, incoming events might continue to match to the disabled rule. Allow a short period of time for changes to take effect.</p>
     fn disable_rule(&self, input: DisableRuleRequest) -> RusotoFuture<(), DisableRuleError> {
-        let mut request = SignedRequest::new("POST", "events", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "events",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSEvents.DisableRule");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1547,9 +1567,14 @@ impl CloudWatchEvents for CloudWatchEventsClient {
 
     /// <p>Enables the specified rule. If the rule does not exist, the operation fails.</p> <p>When you enable a rule, incoming events might not immediately start matching to a newly enabled rule. Allow a short period of time for changes to take effect.</p>
     fn enable_rule(&self, input: EnableRuleRequest) -> RusotoFuture<(), EnableRuleError> {
-        let mut request = SignedRequest::new("POST", "events", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "events",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSEvents.EnableRule");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1573,9 +1598,14 @@ impl CloudWatchEvents for CloudWatchEventsClient {
         &self,
         input: ListRuleNamesByTargetRequest,
     ) -> RusotoFuture<ListRuleNamesByTargetResponse, ListRuleNamesByTargetError> {
-        let mut request = SignedRequest::new("POST", "events", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "events",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSEvents.ListRuleNamesByTarget");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1601,9 +1631,14 @@ impl CloudWatchEvents for CloudWatchEventsClient {
         &self,
         input: ListRulesRequest,
     ) -> RusotoFuture<ListRulesResponse, ListRulesError> {
-        let mut request = SignedRequest::new("POST", "events", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "events",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSEvents.ListRules");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1630,9 +1665,14 @@ impl CloudWatchEvents for CloudWatchEventsClient {
         &self,
         input: ListTargetsByRuleRequest,
     ) -> RusotoFuture<ListTargetsByRuleResponse, ListTargetsByRuleError> {
-        let mut request = SignedRequest::new("POST", "events", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "events",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSEvents.ListTargetsByRule");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1659,9 +1699,14 @@ impl CloudWatchEvents for CloudWatchEventsClient {
         &self,
         input: PutEventsRequest,
     ) -> RusotoFuture<PutEventsResponse, PutEventsError> {
-        let mut request = SignedRequest::new("POST", "events", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "events",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSEvents.PutEvents");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1685,9 +1730,14 @@ impl CloudWatchEvents for CloudWatchEventsClient {
 
     /// <p>Running <code>PutPermission</code> permits the specified AWS account or AWS organization to put events to your account's default <i>event bus</i>. CloudWatch Events rules in your account are triggered by these events arriving to your default event bus. </p> <p>For another account to send events to your account, that external account must have a CloudWatch Events rule with your account's default event bus as a target.</p> <p>To enable multiple AWS accounts to put events to your default event bus, run <code>PutPermission</code> once for each of these accounts. Or, if all the accounts are members of the same AWS organization, you can run <code>PutPermission</code> once specifying <code>Principal</code> as "*" and specifying the AWS organization ID in <code>Condition</code>, to grant permissions to all accounts in that organization.</p> <p>If you grant permissions using an organization, then accounts in that organization must specify a <code>RoleArn</code> with proper permissions when they use <code>PutTarget</code> to add your account's event bus as a target. For more information, see <a href="http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatchEvents-CrossAccountEventDelivery.html">Sending and Receiving Events Between AWS Accounts</a> in the <i>Amazon CloudWatch Events User Guide</i>.</p> <p>The permission policy on the default event bus cannot exceed 10 KB in size.</p>
     fn put_permission(&self, input: PutPermissionRequest) -> RusotoFuture<(), PutPermissionError> {
-        let mut request = SignedRequest::new("POST", "events", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "events",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSEvents.PutPermission");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1708,9 +1758,14 @@ impl CloudWatchEvents for CloudWatchEventsClient {
 
     /// <p>Creates or updates the specified rule. Rules are enabled by default, or based on value of the state. You can disable a rule using <a>DisableRule</a>.</p> <p>If you are updating an existing rule, the rule is replaced with what you specify in this <code>PutRule</code> command. If you omit arguments in <code>PutRule</code>, the old values for those arguments are not kept. Instead, they are replaced with null values.</p> <p>When you create or update a rule, incoming events might not immediately start matching to new or updated rules. Allow a short period of time for changes to take effect.</p> <p>A rule must contain at least an EventPattern or ScheduleExpression. Rules with EventPatterns are triggered when a matching event is observed. Rules with ScheduleExpressions self-trigger based on the given schedule. A rule can have both an EventPattern and a ScheduleExpression, in which case the rule triggers on matching events as well as on a schedule.</p> <p>Most services in AWS treat : or / as the same character in Amazon Resource Names (ARNs). However, CloudWatch Events uses an exact match in event patterns and rules. Be sure to use the correct ARN characters when creating event patterns so that they match the ARN syntax in the event you want to match.</p> <p>In CloudWatch Events, it is possible to create rules that lead to infinite loops, where a rule is fired repeatedly. For example, a rule might detect that ACLs have changed on an S3 bucket, and trigger software to change them to the desired state. If the rule is not written carefully, the subsequent change to the ACLs fires the rule again, creating an infinite loop.</p> <p>To prevent this, write the rules so that the triggered actions do not re-fire the same rule. For example, your rule could fire only if ACLs are found to be in a bad state, instead of after any change. </p> <p>An infinite loop can quickly cause higher than expected charges. We recommend that you use budgeting, which alerts you when charges exceed your specified limit. For more information, see <a href="http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/budgets-managing-costs.html">Managing Your Costs with Budgets</a>.</p>
     fn put_rule(&self, input: PutRuleRequest) -> RusotoFuture<PutRuleResponse, PutRuleError> {
-        let mut request = SignedRequest::new("POST", "events", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "events",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSEvents.PutRule");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1736,9 +1791,14 @@ impl CloudWatchEvents for CloudWatchEventsClient {
         &self,
         input: PutTargetsRequest,
     ) -> RusotoFuture<PutTargetsResponse, PutTargetsError> {
-        let mut request = SignedRequest::new("POST", "events", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "events",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSEvents.PutTargets");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1765,9 +1825,14 @@ impl CloudWatchEvents for CloudWatchEventsClient {
         &self,
         input: RemovePermissionRequest,
     ) -> RusotoFuture<(), RemovePermissionError> {
-        let mut request = SignedRequest::new("POST", "events", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "events",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSEvents.RemovePermission");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1791,9 +1856,14 @@ impl CloudWatchEvents for CloudWatchEventsClient {
         &self,
         input: RemoveTargetsRequest,
     ) -> RusotoFuture<RemoveTargetsResponse, RemoveTargetsError> {
-        let mut request = SignedRequest::new("POST", "events", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "events",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSEvents.RemoveTargets");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1820,9 +1890,14 @@ impl CloudWatchEvents for CloudWatchEventsClient {
         &self,
         input: TestEventPatternRequest,
     ) -> RusotoFuture<TestEventPatternResponse, TestEventPatternError> {
-        let mut request = SignedRequest::new("POST", "events", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "events",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSEvents.TestEventPattern");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/firehose/src/generated.rs
+++ b/rusoto/services/firehose/src/generated.rs
@@ -2117,9 +2117,14 @@ impl KinesisFirehose for KinesisFirehoseClient {
         &self,
         input: CreateDeliveryStreamInput,
     ) -> RusotoFuture<CreateDeliveryStreamOutput, CreateDeliveryStreamError> {
-        let mut request = SignedRequest::new("POST", "firehose", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "firehose",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Firehose_20150804.CreateDeliveryStream");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2145,9 +2150,14 @@ impl KinesisFirehose for KinesisFirehoseClient {
         &self,
         input: DeleteDeliveryStreamInput,
     ) -> RusotoFuture<DeleteDeliveryStreamOutput, DeleteDeliveryStreamError> {
-        let mut request = SignedRequest::new("POST", "firehose", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "firehose",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Firehose_20150804.DeleteDeliveryStream");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2173,9 +2183,14 @@ impl KinesisFirehose for KinesisFirehoseClient {
         &self,
         input: DescribeDeliveryStreamInput,
     ) -> RusotoFuture<DescribeDeliveryStreamOutput, DescribeDeliveryStreamError> {
-        let mut request = SignedRequest::new("POST", "firehose", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "firehose",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Firehose_20150804.DescribeDeliveryStream");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2201,9 +2216,14 @@ impl KinesisFirehose for KinesisFirehoseClient {
         &self,
         input: ListDeliveryStreamsInput,
     ) -> RusotoFuture<ListDeliveryStreamsOutput, ListDeliveryStreamsError> {
-        let mut request = SignedRequest::new("POST", "firehose", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "firehose",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Firehose_20150804.ListDeliveryStreams");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2229,9 +2249,14 @@ impl KinesisFirehose for KinesisFirehoseClient {
         &self,
         input: ListTagsForDeliveryStreamInput,
     ) -> RusotoFuture<ListTagsForDeliveryStreamOutput, ListTagsForDeliveryStreamError> {
-        let mut request = SignedRequest::new("POST", "firehose", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "firehose",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Firehose_20150804.ListTagsForDeliveryStream",
@@ -2255,9 +2280,14 @@ impl KinesisFirehose for KinesisFirehoseClient {
 
     /// <p><p>Writes a single data record into an Amazon Kinesis Data Firehose delivery stream. To write multiple data records into a delivery stream, use <a>PutRecordBatch</a>. Applications using these operations are referred to as producers.</p> <p>By default, each delivery stream can take in up to 2,000 transactions per second, 5,000 records per second, or 5 MB per second. If you use <a>PutRecord</a> and <a>PutRecordBatch</a>, the limits are an aggregate across these two operations for each delivery stream. For more information about limits and how to request an increase, see <a href="http://docs.aws.amazon.com/firehose/latest/dev/limits.html">Amazon Kinesis Data Firehose Limits</a>. </p> <p>You must specify the name of the delivery stream and the data record when using <a>PutRecord</a>. The data record consists of a data blob that can be up to 1,000 KB in size, and any kind of data. For example, it can be a segment from a log file, geographic location data, website clickstream data, and so on.</p> <p>Kinesis Data Firehose buffers records before delivering them to the destination. To disambiguate the data blobs at the destination, a common solution is to use delimiters in the data, such as a newline (<code>\n</code>) or some other character unique within the data. This allows the consumer application to parse individual data items when reading the data from the destination.</p> <p>The <code>PutRecord</code> operation returns a <code>RecordId</code>, which is a unique string assigned to each record. Producer applications can use this ID for purposes such as auditability and investigation.</p> <p>If the <code>PutRecord</code> operation throws a <code>ServiceUnavailableException</code>, back off and retry. If the exception persists, it is possible that the throughput limits have been exceeded for the delivery stream. </p> <p>Data records sent to Kinesis Data Firehose are stored for 24 hours from the time they are added to a delivery stream as it tries to send the records to the destination. If the destination is unreachable for more than 24 hours, the data is no longer available.</p> <important> <p>Don&#39;t concatenate two or more base64 strings to form the data fields of your records. Instead, concatenate the raw data, then perform base64 encoding.</p> </important></p>
     fn put_record(&self, input: PutRecordInput) -> RusotoFuture<PutRecordOutput, PutRecordError> {
-        let mut request = SignedRequest::new("POST", "firehose", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "firehose",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Firehose_20150804.PutRecord");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2283,9 +2313,14 @@ impl KinesisFirehose for KinesisFirehoseClient {
         &self,
         input: PutRecordBatchInput,
     ) -> RusotoFuture<PutRecordBatchOutput, PutRecordBatchError> {
-        let mut request = SignedRequest::new("POST", "firehose", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "firehose",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Firehose_20150804.PutRecordBatch");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2312,9 +2347,14 @@ impl KinesisFirehose for KinesisFirehoseClient {
         &self,
         input: StartDeliveryStreamEncryptionInput,
     ) -> RusotoFuture<StartDeliveryStreamEncryptionOutput, StartDeliveryStreamEncryptionError> {
-        let mut request = SignedRequest::new("POST", "firehose", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "firehose",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Firehose_20150804.StartDeliveryStreamEncryption",
@@ -2341,9 +2381,14 @@ impl KinesisFirehose for KinesisFirehoseClient {
         &self,
         input: StopDeliveryStreamEncryptionInput,
     ) -> RusotoFuture<StopDeliveryStreamEncryptionOutput, StopDeliveryStreamEncryptionError> {
-        let mut request = SignedRequest::new("POST", "firehose", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "firehose",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Firehose_20150804.StopDeliveryStreamEncryption",
@@ -2370,9 +2415,14 @@ impl KinesisFirehose for KinesisFirehoseClient {
         &self,
         input: TagDeliveryStreamInput,
     ) -> RusotoFuture<TagDeliveryStreamOutput, TagDeliveryStreamError> {
-        let mut request = SignedRequest::new("POST", "firehose", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "firehose",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Firehose_20150804.TagDeliveryStream");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2399,9 +2449,14 @@ impl KinesisFirehose for KinesisFirehoseClient {
         &self,
         input: UntagDeliveryStreamInput,
     ) -> RusotoFuture<UntagDeliveryStreamOutput, UntagDeliveryStreamError> {
-        let mut request = SignedRequest::new("POST", "firehose", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "firehose",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Firehose_20150804.UntagDeliveryStream");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2427,9 +2482,14 @@ impl KinesisFirehose for KinesisFirehoseClient {
         &self,
         input: UpdateDestinationInput,
     ) -> RusotoFuture<UpdateDestinationOutput, UpdateDestinationError> {
-        let mut request = SignedRequest::new("POST", "firehose", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "firehose",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Firehose_20150804.UpdateDestination");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/fms/src/generated.rs
+++ b/rusoto/services/fms/src/generated.rs
@@ -1169,9 +1169,14 @@ impl Fms for FmsClient {
         &self,
         input: AssociateAdminAccountRequest,
     ) -> RusotoFuture<(), AssociateAdminAccountError> {
-        let mut request = SignedRequest::new("POST", "fms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "fms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSFMS_20180101.AssociateAdminAccount");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1191,9 +1196,14 @@ impl Fms for FmsClient {
 
     /// <p>Deletes an AWS Firewall Manager association with the IAM role and the Amazon Simple Notification Service (SNS) topic that is used to record AWS Firewall Manager SNS logs.</p>
     fn delete_notification_channel(&self) -> RusotoFuture<(), DeleteNotificationChannelError> {
-        let mut request = SignedRequest::new("POST", "fms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "fms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSFMS_20180101.DeleteNotificationChannel");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -1210,9 +1220,14 @@ impl Fms for FmsClient {
 
     /// <p>Permanently deletes an AWS Firewall Manager policy. </p>
     fn delete_policy(&self, input: DeletePolicyRequest) -> RusotoFuture<(), DeletePolicyError> {
-        let mut request = SignedRequest::new("POST", "fms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "fms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSFMS_20180101.DeletePolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1233,9 +1248,14 @@ impl Fms for FmsClient {
 
     /// <p>Disassociates the account that has been set as the AWS Firewall Manager administrator account. To set a different account as the administrator account, you must submit an <code>AssociateAdminAccount</code> request .</p>
     fn disassociate_admin_account(&self) -> RusotoFuture<(), DisassociateAdminAccountError> {
-        let mut request = SignedRequest::new("POST", "fms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "fms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSFMS_20180101.DisassociateAdminAccount");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -1252,9 +1272,14 @@ impl Fms for FmsClient {
 
     /// <p>Returns the AWS Organizations master account that is associated with AWS Firewall Manager as the AWS Firewall Manager administrator.</p>
     fn get_admin_account(&self) -> RusotoFuture<GetAdminAccountResponse, GetAdminAccountError> {
-        let mut request = SignedRequest::new("POST", "fms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "fms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSFMS_20180101.GetAdminAccount");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -1280,9 +1305,14 @@ impl Fms for FmsClient {
         &self,
         input: GetComplianceDetailRequest,
     ) -> RusotoFuture<GetComplianceDetailResponse, GetComplianceDetailError> {
-        let mut request = SignedRequest::new("POST", "fms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "fms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSFMS_20180101.GetComplianceDetail");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1307,9 +1337,14 @@ impl Fms for FmsClient {
     fn get_notification_channel(
         &self,
     ) -> RusotoFuture<GetNotificationChannelResponse, GetNotificationChannelError> {
-        let mut request = SignedRequest::new("POST", "fms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "fms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSFMS_20180101.GetNotificationChannel");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -1334,9 +1369,14 @@ impl Fms for FmsClient {
         &self,
         input: GetPolicyRequest,
     ) -> RusotoFuture<GetPolicyResponse, GetPolicyError> {
-        let mut request = SignedRequest::new("POST", "fms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "fms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSFMS_20180101.GetPolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1363,9 +1403,14 @@ impl Fms for FmsClient {
         &self,
         input: ListComplianceStatusRequest,
     ) -> RusotoFuture<ListComplianceStatusResponse, ListComplianceStatusError> {
-        let mut request = SignedRequest::new("POST", "fms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "fms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSFMS_20180101.ListComplianceStatus");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1391,9 +1436,14 @@ impl Fms for FmsClient {
         &self,
         input: ListMemberAccountsRequest,
     ) -> RusotoFuture<ListMemberAccountsResponse, ListMemberAccountsError> {
-        let mut request = SignedRequest::new("POST", "fms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "fms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSFMS_20180101.ListMemberAccounts");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1420,9 +1470,14 @@ impl Fms for FmsClient {
         &self,
         input: ListPoliciesRequest,
     ) -> RusotoFuture<ListPoliciesResponse, ListPoliciesError> {
-        let mut request = SignedRequest::new("POST", "fms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "fms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSFMS_20180101.ListPolicies");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1449,9 +1504,14 @@ impl Fms for FmsClient {
         &self,
         input: PutNotificationChannelRequest,
     ) -> RusotoFuture<(), PutNotificationChannelError> {
-        let mut request = SignedRequest::new("POST", "fms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "fms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSFMS_20180101.PutNotificationChannel");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1474,9 +1534,14 @@ impl Fms for FmsClient {
         &self,
         input: PutPolicyRequest,
     ) -> RusotoFuture<PutPolicyResponse, PutPolicyError> {
-        let mut request = SignedRequest::new("POST", "fms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "fms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSFMS_20180101.PutPolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/fsx/src/generated.rs
+++ b/rusoto/services/fsx/src/generated.rs
@@ -1502,9 +1502,14 @@ impl Fsx for FsxClient {
         &self,
         input: CreateBackupRequest,
     ) -> RusotoFuture<CreateBackupResponse, CreateBackupError> {
-        let mut request = SignedRequest::new("POST", "fsx", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "fsx",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSSimbaAPIService_v20180301.CreateBackup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1531,9 +1536,14 @@ impl Fsx for FsxClient {
         &self,
         input: CreateFileSystemRequest,
     ) -> RusotoFuture<CreateFileSystemResponse, CreateFileSystemError> {
-        let mut request = SignedRequest::new("POST", "fsx", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "fsx",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSSimbaAPIService_v20180301.CreateFileSystem",
@@ -1563,9 +1573,14 @@ impl Fsx for FsxClient {
         &self,
         input: CreateFileSystemFromBackupRequest,
     ) -> RusotoFuture<CreateFileSystemFromBackupResponse, CreateFileSystemFromBackupError> {
-        let mut request = SignedRequest::new("POST", "fsx", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "fsx",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSSimbaAPIService_v20180301.CreateFileSystemFromBackup",
@@ -1592,9 +1607,14 @@ impl Fsx for FsxClient {
         &self,
         input: DeleteBackupRequest,
     ) -> RusotoFuture<DeleteBackupResponse, DeleteBackupError> {
-        let mut request = SignedRequest::new("POST", "fsx", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "fsx",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSSimbaAPIService_v20180301.DeleteBackup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1621,9 +1641,14 @@ impl Fsx for FsxClient {
         &self,
         input: DeleteFileSystemRequest,
     ) -> RusotoFuture<DeleteFileSystemResponse, DeleteFileSystemError> {
-        let mut request = SignedRequest::new("POST", "fsx", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "fsx",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSSimbaAPIService_v20180301.DeleteFileSystem",
@@ -1653,9 +1678,14 @@ impl Fsx for FsxClient {
         &self,
         input: DescribeBackupsRequest,
     ) -> RusotoFuture<DescribeBackupsResponse, DescribeBackupsError> {
-        let mut request = SignedRequest::new("POST", "fsx", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "fsx",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSSimbaAPIService_v20180301.DescribeBackups",
@@ -1685,9 +1715,14 @@ impl Fsx for FsxClient {
         &self,
         input: DescribeFileSystemsRequest,
     ) -> RusotoFuture<DescribeFileSystemsResponse, DescribeFileSystemsError> {
-        let mut request = SignedRequest::new("POST", "fsx", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "fsx",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSSimbaAPIService_v20180301.DescribeFileSystems",
@@ -1716,9 +1751,14 @@ impl Fsx for FsxClient {
         &self,
         input: ListTagsForResourceRequest,
     ) -> RusotoFuture<ListTagsForResourceResponse, ListTagsForResourceError> {
-        let mut request = SignedRequest::new("POST", "fsx", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "fsx",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSSimbaAPIService_v20180301.ListTagsForResource",
@@ -1747,9 +1787,14 @@ impl Fsx for FsxClient {
         &self,
         input: TagResourceRequest,
     ) -> RusotoFuture<TagResourceResponse, TagResourceError> {
-        let mut request = SignedRequest::new("POST", "fsx", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "fsx",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSSimbaAPIService_v20180301.TagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1776,9 +1821,14 @@ impl Fsx for FsxClient {
         &self,
         input: UntagResourceRequest,
     ) -> RusotoFuture<UntagResourceResponse, UntagResourceError> {
-        let mut request = SignedRequest::new("POST", "fsx", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "fsx",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSSimbaAPIService_v20180301.UntagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1805,9 +1855,14 @@ impl Fsx for FsxClient {
         &self,
         input: UpdateFileSystemRequest,
     ) -> RusotoFuture<UpdateFileSystemResponse, UpdateFileSystemError> {
-        let mut request = SignedRequest::new("POST", "fsx", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "fsx",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSSimbaAPIService_v20180301.UpdateFileSystem",

--- a/rusoto/services/gamelift/src/generated.rs
+++ b/rusoto/services/gamelift/src/generated.rs
@@ -7298,9 +7298,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: AcceptMatchInput,
     ) -> RusotoFuture<AcceptMatchOutput, AcceptMatchError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.AcceptMatch");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7327,9 +7332,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: CreateAliasInput,
     ) -> RusotoFuture<CreateAliasOutput, CreateAliasError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.CreateAlias");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7356,9 +7366,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: CreateBuildInput,
     ) -> RusotoFuture<CreateBuildOutput, CreateBuildError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.CreateBuild");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7385,9 +7400,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: CreateFleetInput,
     ) -> RusotoFuture<CreateFleetOutput, CreateFleetError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.CreateFleet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7414,9 +7434,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: CreateGameSessionInput,
     ) -> RusotoFuture<CreateGameSessionOutput, CreateGameSessionError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.CreateGameSession");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7443,9 +7468,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: CreateGameSessionQueueInput,
     ) -> RusotoFuture<CreateGameSessionQueueOutput, CreateGameSessionQueueError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.CreateGameSessionQueue");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7472,9 +7502,14 @@ impl GameLift for GameLiftClient {
         input: CreateMatchmakingConfigurationInput,
     ) -> RusotoFuture<CreateMatchmakingConfigurationOutput, CreateMatchmakingConfigurationError>
     {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.CreateMatchmakingConfiguration");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7498,9 +7533,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: CreateMatchmakingRuleSetInput,
     ) -> RusotoFuture<CreateMatchmakingRuleSetOutput, CreateMatchmakingRuleSetError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.CreateMatchmakingRuleSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7524,9 +7564,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: CreatePlayerSessionInput,
     ) -> RusotoFuture<CreatePlayerSessionOutput, CreatePlayerSessionError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.CreatePlayerSession");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7552,9 +7597,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: CreatePlayerSessionsInput,
     ) -> RusotoFuture<CreatePlayerSessionsOutput, CreatePlayerSessionsError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.CreatePlayerSessions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7580,9 +7630,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: CreateVpcPeeringAuthorizationInput,
     ) -> RusotoFuture<CreateVpcPeeringAuthorizationOutput, CreateVpcPeeringAuthorizationError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.CreateVpcPeeringAuthorization");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7606,9 +7661,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: CreateVpcPeeringConnectionInput,
     ) -> RusotoFuture<CreateVpcPeeringConnectionOutput, CreateVpcPeeringConnectionError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.CreateVpcPeeringConnection");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7629,9 +7689,14 @@ impl GameLift for GameLiftClient {
 
     /// <p><p>Deletes an alias. This action removes all record of the alias. Game clients attempting to access a server process using the deleted alias receive an error. To delete an alias, specify the alias ID to be deleted.</p> <ul> <li> <p> <a>CreateAlias</a> </p> </li> <li> <p> <a>ListAliases</a> </p> </li> <li> <p> <a>DescribeAlias</a> </p> </li> <li> <p> <a>UpdateAlias</a> </p> </li> <li> <p> <a>DeleteAlias</a> </p> </li> <li> <p> <a>ResolveAlias</a> </p> </li> </ul></p>
     fn delete_alias(&self, input: DeleteAliasInput) -> RusotoFuture<(), DeleteAliasError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DeleteAlias");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7652,9 +7717,14 @@ impl GameLift for GameLiftClient {
 
     /// <p><p>Deletes a build. This action permanently deletes the build record and any uploaded build files.</p> <p>To delete a build, specify its ID. Deleting a build does not affect the status of any active fleets using the build, but you can no longer create new fleets with the deleted build.</p> <ul> <li> <p> <a>CreateBuild</a> </p> </li> <li> <p> <a>ListBuilds</a> </p> </li> <li> <p> <a>DescribeBuild</a> </p> </li> <li> <p> <a>UpdateBuild</a> </p> </li> <li> <p> <a>DeleteBuild</a> </p> </li> </ul></p>
     fn delete_build(&self, input: DeleteBuildInput) -> RusotoFuture<(), DeleteBuildError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DeleteBuild");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7675,9 +7745,14 @@ impl GameLift for GameLiftClient {
 
     /// <p><p>Deletes everything related to a fleet. Before deleting a fleet, you must set the fleet&#39;s desired capacity to zero. See <a>UpdateFleetCapacity</a>.</p> <p>This action removes the fleet&#39;s resources and the fleet record. Once a fleet is deleted, you can no longer use that fleet.</p> <ul> <li> <p> <a>CreateFleet</a> </p> </li> <li> <p> <a>ListFleets</a> </p> </li> <li> <p> <a>DeleteFleet</a> </p> </li> <li> <p>Describe fleets:</p> <ul> <li> <p> <a>DescribeFleetAttributes</a> </p> </li> <li> <p> <a>DescribeFleetCapacity</a> </p> </li> <li> <p> <a>DescribeFleetPortSettings</a> </p> </li> <li> <p> <a>DescribeFleetUtilization</a> </p> </li> <li> <p> <a>DescribeRuntimeConfiguration</a> </p> </li> <li> <p> <a>DescribeEC2InstanceLimits</a> </p> </li> <li> <p> <a>DescribeFleetEvents</a> </p> </li> </ul> </li> <li> <p>Update fleets:</p> <ul> <li> <p> <a>UpdateFleetAttributes</a> </p> </li> <li> <p> <a>UpdateFleetCapacity</a> </p> </li> <li> <p> <a>UpdateFleetPortSettings</a> </p> </li> <li> <p> <a>UpdateRuntimeConfiguration</a> </p> </li> </ul> </li> <li> <p>Manage fleet actions:</p> <ul> <li> <p> <a>StartFleetActions</a> </p> </li> <li> <p> <a>StopFleetActions</a> </p> </li> </ul> </li> </ul></p>
     fn delete_fleet(&self, input: DeleteFleetInput) -> RusotoFuture<(), DeleteFleetError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DeleteFleet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7701,9 +7776,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: DeleteGameSessionQueueInput,
     ) -> RusotoFuture<DeleteGameSessionQueueOutput, DeleteGameSessionQueueError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DeleteGameSessionQueue");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7730,9 +7810,14 @@ impl GameLift for GameLiftClient {
         input: DeleteMatchmakingConfigurationInput,
     ) -> RusotoFuture<DeleteMatchmakingConfigurationOutput, DeleteMatchmakingConfigurationError>
     {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DeleteMatchmakingConfiguration");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7756,9 +7841,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: DeleteMatchmakingRuleSetInput,
     ) -> RusotoFuture<DeleteMatchmakingRuleSetOutput, DeleteMatchmakingRuleSetError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DeleteMatchmakingRuleSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7782,9 +7872,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: DeleteScalingPolicyInput,
     ) -> RusotoFuture<(), DeleteScalingPolicyError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DeleteScalingPolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7807,9 +7902,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: DeleteVpcPeeringAuthorizationInput,
     ) -> RusotoFuture<DeleteVpcPeeringAuthorizationOutput, DeleteVpcPeeringAuthorizationError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DeleteVpcPeeringAuthorization");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7833,9 +7933,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: DeleteVpcPeeringConnectionInput,
     ) -> RusotoFuture<DeleteVpcPeeringConnectionOutput, DeleteVpcPeeringConnectionError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DeleteVpcPeeringConnection");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7859,9 +7964,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: DescribeAliasInput,
     ) -> RusotoFuture<DescribeAliasOutput, DescribeAliasError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DescribeAlias");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7888,9 +7998,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: DescribeBuildInput,
     ) -> RusotoFuture<DescribeBuildOutput, DescribeBuildError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DescribeBuild");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7917,9 +8032,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: DescribeEC2InstanceLimitsInput,
     ) -> RusotoFuture<DescribeEC2InstanceLimitsOutput, DescribeEC2InstanceLimitsError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DescribeEC2InstanceLimits");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7943,9 +8063,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: DescribeFleetAttributesInput,
     ) -> RusotoFuture<DescribeFleetAttributesOutput, DescribeFleetAttributesError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DescribeFleetAttributes");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7969,9 +8094,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: DescribeFleetCapacityInput,
     ) -> RusotoFuture<DescribeFleetCapacityOutput, DescribeFleetCapacityError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DescribeFleetCapacity");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7997,9 +8127,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: DescribeFleetEventsInput,
     ) -> RusotoFuture<DescribeFleetEventsOutput, DescribeFleetEventsError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DescribeFleetEvents");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8025,9 +8160,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: DescribeFleetPortSettingsInput,
     ) -> RusotoFuture<DescribeFleetPortSettingsOutput, DescribeFleetPortSettingsError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DescribeFleetPortSettings");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8051,9 +8191,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: DescribeFleetUtilizationInput,
     ) -> RusotoFuture<DescribeFleetUtilizationOutput, DescribeFleetUtilizationError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DescribeFleetUtilization");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8077,9 +8222,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: DescribeGameSessionDetailsInput,
     ) -> RusotoFuture<DescribeGameSessionDetailsOutput, DescribeGameSessionDetailsError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DescribeGameSessionDetails");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8103,9 +8253,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: DescribeGameSessionPlacementInput,
     ) -> RusotoFuture<DescribeGameSessionPlacementOutput, DescribeGameSessionPlacementError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DescribeGameSessionPlacement");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8129,9 +8284,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: DescribeGameSessionQueuesInput,
     ) -> RusotoFuture<DescribeGameSessionQueuesOutput, DescribeGameSessionQueuesError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DescribeGameSessionQueues");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8155,9 +8315,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: DescribeGameSessionsInput,
     ) -> RusotoFuture<DescribeGameSessionsOutput, DescribeGameSessionsError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DescribeGameSessions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8183,9 +8348,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: DescribeInstancesInput,
     ) -> RusotoFuture<DescribeInstancesOutput, DescribeInstancesError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DescribeInstances");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8212,9 +8382,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: DescribeMatchmakingInput,
     ) -> RusotoFuture<DescribeMatchmakingOutput, DescribeMatchmakingError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DescribeMatchmaking");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8241,9 +8416,14 @@ impl GameLift for GameLiftClient {
         input: DescribeMatchmakingConfigurationsInput,
     ) -> RusotoFuture<DescribeMatchmakingConfigurationsOutput, DescribeMatchmakingConfigurationsError>
     {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DescribeMatchmakingConfigurations");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8269,9 +8449,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: DescribeMatchmakingRuleSetsInput,
     ) -> RusotoFuture<DescribeMatchmakingRuleSetsOutput, DescribeMatchmakingRuleSetsError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DescribeMatchmakingRuleSets");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8295,9 +8480,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: DescribePlayerSessionsInput,
     ) -> RusotoFuture<DescribePlayerSessionsOutput, DescribePlayerSessionsError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DescribePlayerSessions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8323,9 +8513,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: DescribeRuntimeConfigurationInput,
     ) -> RusotoFuture<DescribeRuntimeConfigurationOutput, DescribeRuntimeConfigurationError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DescribeRuntimeConfiguration");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8349,9 +8544,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: DescribeScalingPoliciesInput,
     ) -> RusotoFuture<DescribeScalingPoliciesOutput, DescribeScalingPoliciesError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DescribeScalingPolicies");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8375,9 +8575,14 @@ impl GameLift for GameLiftClient {
         &self,
     ) -> RusotoFuture<DescribeVpcPeeringAuthorizationsOutput, DescribeVpcPeeringAuthorizationsError>
     {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DescribeVpcPeeringAuthorizations");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -8402,9 +8607,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: DescribeVpcPeeringConnectionsInput,
     ) -> RusotoFuture<DescribeVpcPeeringConnectionsOutput, DescribeVpcPeeringConnectionsError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.DescribeVpcPeeringConnections");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8428,9 +8638,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: GetGameSessionLogUrlInput,
     ) -> RusotoFuture<GetGameSessionLogUrlOutput, GetGameSessionLogUrlError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.GetGameSessionLogUrl");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8456,9 +8671,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: GetInstanceAccessInput,
     ) -> RusotoFuture<GetInstanceAccessOutput, GetInstanceAccessError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.GetInstanceAccess");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8485,9 +8705,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: ListAliasesInput,
     ) -> RusotoFuture<ListAliasesOutput, ListAliasesError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.ListAliases");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8514,9 +8739,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: ListBuildsInput,
     ) -> RusotoFuture<ListBuildsOutput, ListBuildsError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.ListBuilds");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8543,9 +8773,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: ListFleetsInput,
     ) -> RusotoFuture<ListFleetsOutput, ListFleetsError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.ListFleets");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8572,9 +8807,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: PutScalingPolicyInput,
     ) -> RusotoFuture<PutScalingPolicyOutput, PutScalingPolicyError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.PutScalingPolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8601,9 +8841,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: RequestUploadCredentialsInput,
     ) -> RusotoFuture<RequestUploadCredentialsOutput, RequestUploadCredentialsError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.RequestUploadCredentials");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8627,9 +8872,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: ResolveAliasInput,
     ) -> RusotoFuture<ResolveAliasOutput, ResolveAliasError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.ResolveAlias");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8656,9 +8906,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: SearchGameSessionsInput,
     ) -> RusotoFuture<SearchGameSessionsOutput, SearchGameSessionsError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.SearchGameSessions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8685,9 +8940,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: StartFleetActionsInput,
     ) -> RusotoFuture<StartFleetActionsOutput, StartFleetActionsError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.StartFleetActions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8714,9 +8974,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: StartGameSessionPlacementInput,
     ) -> RusotoFuture<StartGameSessionPlacementOutput, StartGameSessionPlacementError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.StartGameSessionPlacement");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8740,9 +9005,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: StartMatchBackfillInput,
     ) -> RusotoFuture<StartMatchBackfillOutput, StartMatchBackfillError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.StartMatchBackfill");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8769,9 +9039,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: StartMatchmakingInput,
     ) -> RusotoFuture<StartMatchmakingOutput, StartMatchmakingError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.StartMatchmaking");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8798,9 +9073,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: StopFleetActionsInput,
     ) -> RusotoFuture<StopFleetActionsOutput, StopFleetActionsError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.StopFleetActions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8827,9 +9107,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: StopGameSessionPlacementInput,
     ) -> RusotoFuture<StopGameSessionPlacementOutput, StopGameSessionPlacementError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.StopGameSessionPlacement");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8853,9 +9138,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: StopMatchmakingInput,
     ) -> RusotoFuture<StopMatchmakingOutput, StopMatchmakingError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.StopMatchmaking");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8882,9 +9172,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: UpdateAliasInput,
     ) -> RusotoFuture<UpdateAliasOutput, UpdateAliasError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.UpdateAlias");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8911,9 +9206,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: UpdateBuildInput,
     ) -> RusotoFuture<UpdateBuildOutput, UpdateBuildError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.UpdateBuild");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8940,9 +9240,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: UpdateFleetAttributesInput,
     ) -> RusotoFuture<UpdateFleetAttributesOutput, UpdateFleetAttributesError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.UpdateFleetAttributes");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8968,9 +9273,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: UpdateFleetCapacityInput,
     ) -> RusotoFuture<UpdateFleetCapacityOutput, UpdateFleetCapacityError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.UpdateFleetCapacity");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8996,9 +9306,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: UpdateFleetPortSettingsInput,
     ) -> RusotoFuture<UpdateFleetPortSettingsOutput, UpdateFleetPortSettingsError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.UpdateFleetPortSettings");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9022,9 +9337,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: UpdateGameSessionInput,
     ) -> RusotoFuture<UpdateGameSessionOutput, UpdateGameSessionError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.UpdateGameSession");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9051,9 +9371,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: UpdateGameSessionQueueInput,
     ) -> RusotoFuture<UpdateGameSessionQueueOutput, UpdateGameSessionQueueError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.UpdateGameSessionQueue");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9080,9 +9405,14 @@ impl GameLift for GameLiftClient {
         input: UpdateMatchmakingConfigurationInput,
     ) -> RusotoFuture<UpdateMatchmakingConfigurationOutput, UpdateMatchmakingConfigurationError>
     {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.UpdateMatchmakingConfiguration");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9106,9 +9436,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: UpdateRuntimeConfigurationInput,
     ) -> RusotoFuture<UpdateRuntimeConfigurationOutput, UpdateRuntimeConfigurationError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.UpdateRuntimeConfiguration");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9132,9 +9467,14 @@ impl GameLift for GameLiftClient {
         &self,
         input: ValidateMatchmakingRuleSetInput,
     ) -> RusotoFuture<ValidateMatchmakingRuleSetOutput, ValidateMatchmakingRuleSetError> {
-        let mut request = SignedRequest::new("POST", "gamelift", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "gamelift",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "GameLift.ValidateMatchmakingRuleSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/glue/src/generated.rs
+++ b/rusoto/services/glue/src/generated.rs
@@ -9175,9 +9175,14 @@ impl Glue for GlueClient {
         &self,
         input: BatchCreatePartitionRequest,
     ) -> RusotoFuture<BatchCreatePartitionResponse, BatchCreatePartitionError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.BatchCreatePartition");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9203,9 +9208,14 @@ impl Glue for GlueClient {
         &self,
         input: BatchDeleteConnectionRequest,
     ) -> RusotoFuture<BatchDeleteConnectionResponse, BatchDeleteConnectionError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.BatchDeleteConnection");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9231,9 +9241,14 @@ impl Glue for GlueClient {
         &self,
         input: BatchDeletePartitionRequest,
     ) -> RusotoFuture<BatchDeletePartitionResponse, BatchDeletePartitionError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.BatchDeletePartition");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9259,9 +9274,14 @@ impl Glue for GlueClient {
         &self,
         input: BatchDeleteTableRequest,
     ) -> RusotoFuture<BatchDeleteTableResponse, BatchDeleteTableError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.BatchDeleteTable");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9288,9 +9308,14 @@ impl Glue for GlueClient {
         &self,
         input: BatchDeleteTableVersionRequest,
     ) -> RusotoFuture<BatchDeleteTableVersionResponse, BatchDeleteTableVersionError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.BatchDeleteTableVersion");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9314,9 +9339,14 @@ impl Glue for GlueClient {
         &self,
         input: BatchGetPartitionRequest,
     ) -> RusotoFuture<BatchGetPartitionResponse, BatchGetPartitionError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.BatchGetPartition");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9343,9 +9373,14 @@ impl Glue for GlueClient {
         &self,
         input: BatchStopJobRunRequest,
     ) -> RusotoFuture<BatchStopJobRunResponse, GlueBatchStopJobRunError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.BatchStopJobRun");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9371,9 +9406,14 @@ impl Glue for GlueClient {
         &self,
         input: CreateClassifierRequest,
     ) -> RusotoFuture<CreateClassifierResponse, CreateClassifierError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.CreateClassifier");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9400,9 +9440,14 @@ impl Glue for GlueClient {
         &self,
         input: CreateConnectionRequest,
     ) -> RusotoFuture<CreateConnectionResponse, CreateConnectionError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.CreateConnection");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9429,9 +9474,14 @@ impl Glue for GlueClient {
         &self,
         input: CreateCrawlerRequest,
     ) -> RusotoFuture<CreateCrawlerResponse, CreateCrawlerError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.CreateCrawler");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9458,9 +9508,14 @@ impl Glue for GlueClient {
         &self,
         input: CreateDatabaseRequest,
     ) -> RusotoFuture<CreateDatabaseResponse, CreateDatabaseError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.CreateDatabase");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9487,9 +9542,14 @@ impl Glue for GlueClient {
         &self,
         input: CreateDevEndpointRequest,
     ) -> RusotoFuture<CreateDevEndpointResponse, CreateDevEndpointError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.CreateDevEndpoint");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9516,9 +9576,14 @@ impl Glue for GlueClient {
         &self,
         input: CreateJobRequest,
     ) -> RusotoFuture<CreateJobResponse, CreateJobError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.CreateJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9545,9 +9610,14 @@ impl Glue for GlueClient {
         &self,
         input: CreatePartitionRequest,
     ) -> RusotoFuture<CreatePartitionResponse, CreatePartitionError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.CreatePartition");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9574,9 +9644,14 @@ impl Glue for GlueClient {
         &self,
         input: CreateScriptRequest,
     ) -> RusotoFuture<CreateScriptResponse, CreateScriptError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.CreateScript");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9603,9 +9678,14 @@ impl Glue for GlueClient {
         &self,
         input: CreateSecurityConfigurationRequest,
     ) -> RusotoFuture<CreateSecurityConfigurationResponse, CreateSecurityConfigurationError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.CreateSecurityConfiguration");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9629,9 +9709,14 @@ impl Glue for GlueClient {
         &self,
         input: CreateTableRequest,
     ) -> RusotoFuture<CreateTableResponse, CreateTableError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.CreateTable");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9658,9 +9743,14 @@ impl Glue for GlueClient {
         &self,
         input: CreateTriggerRequest,
     ) -> RusotoFuture<CreateTriggerResponse, CreateTriggerError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.CreateTrigger");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9687,9 +9777,14 @@ impl Glue for GlueClient {
         &self,
         input: CreateUserDefinedFunctionRequest,
     ) -> RusotoFuture<CreateUserDefinedFunctionResponse, CreateUserDefinedFunctionError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.CreateUserDefinedFunction");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9713,9 +9808,14 @@ impl Glue for GlueClient {
         &self,
         input: DeleteClassifierRequest,
     ) -> RusotoFuture<DeleteClassifierResponse, DeleteClassifierError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.DeleteClassifier");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9742,9 +9842,14 @@ impl Glue for GlueClient {
         &self,
         input: DeleteConnectionRequest,
     ) -> RusotoFuture<DeleteConnectionResponse, DeleteConnectionError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.DeleteConnection");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9771,9 +9876,14 @@ impl Glue for GlueClient {
         &self,
         input: DeleteCrawlerRequest,
     ) -> RusotoFuture<DeleteCrawlerResponse, DeleteCrawlerError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.DeleteCrawler");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9800,9 +9910,14 @@ impl Glue for GlueClient {
         &self,
         input: DeleteDatabaseRequest,
     ) -> RusotoFuture<DeleteDatabaseResponse, DeleteDatabaseError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.DeleteDatabase");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9829,9 +9944,14 @@ impl Glue for GlueClient {
         &self,
         input: DeleteDevEndpointRequest,
     ) -> RusotoFuture<DeleteDevEndpointResponse, DeleteDevEndpointError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.DeleteDevEndpoint");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9858,9 +9978,14 @@ impl Glue for GlueClient {
         &self,
         input: DeleteJobRequest,
     ) -> RusotoFuture<DeleteJobResponse, DeleteJobError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.DeleteJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9887,9 +10012,14 @@ impl Glue for GlueClient {
         &self,
         input: DeletePartitionRequest,
     ) -> RusotoFuture<DeletePartitionResponse, DeletePartitionError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.DeletePartition");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9916,9 +10046,14 @@ impl Glue for GlueClient {
         &self,
         input: DeleteResourcePolicyRequest,
     ) -> RusotoFuture<DeleteResourcePolicyResponse, DeleteResourcePolicyError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.DeleteResourcePolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9944,9 +10079,14 @@ impl Glue for GlueClient {
         &self,
         input: DeleteSecurityConfigurationRequest,
     ) -> RusotoFuture<DeleteSecurityConfigurationResponse, DeleteSecurityConfigurationError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.DeleteSecurityConfiguration");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9970,9 +10110,14 @@ impl Glue for GlueClient {
         &self,
         input: DeleteTableRequest,
     ) -> RusotoFuture<DeleteTableResponse, DeleteTableError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.DeleteTable");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9999,9 +10144,14 @@ impl Glue for GlueClient {
         &self,
         input: DeleteTableVersionRequest,
     ) -> RusotoFuture<DeleteTableVersionResponse, DeleteTableVersionError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.DeleteTableVersion");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10028,9 +10178,14 @@ impl Glue for GlueClient {
         &self,
         input: DeleteTriggerRequest,
     ) -> RusotoFuture<DeleteTriggerResponse, DeleteTriggerError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.DeleteTrigger");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10057,9 +10212,14 @@ impl Glue for GlueClient {
         &self,
         input: DeleteUserDefinedFunctionRequest,
     ) -> RusotoFuture<DeleteUserDefinedFunctionResponse, DeleteUserDefinedFunctionError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.DeleteUserDefinedFunction");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10083,9 +10243,14 @@ impl Glue for GlueClient {
         &self,
         input: GetCatalogImportStatusRequest,
     ) -> RusotoFuture<GetCatalogImportStatusResponse, GetCatalogImportStatusError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetCatalogImportStatus");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10111,9 +10276,14 @@ impl Glue for GlueClient {
         &self,
         input: GetClassifierRequest,
     ) -> RusotoFuture<GetClassifierResponse, GetClassifierError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetClassifier");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10140,9 +10310,14 @@ impl Glue for GlueClient {
         &self,
         input: GetClassifiersRequest,
     ) -> RusotoFuture<GetClassifiersResponse, GetClassifiersError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetClassifiers");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10169,9 +10344,14 @@ impl Glue for GlueClient {
         &self,
         input: GetConnectionRequest,
     ) -> RusotoFuture<GetConnectionResponse, GetConnectionError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetConnection");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10198,9 +10378,14 @@ impl Glue for GlueClient {
         &self,
         input: GetConnectionsRequest,
     ) -> RusotoFuture<GetConnectionsResponse, GetConnectionsError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetConnections");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10227,9 +10412,14 @@ impl Glue for GlueClient {
         &self,
         input: GetCrawlerRequest,
     ) -> RusotoFuture<GetCrawlerResponse, GetCrawlerError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetCrawler");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10256,9 +10446,14 @@ impl Glue for GlueClient {
         &self,
         input: GetCrawlerMetricsRequest,
     ) -> RusotoFuture<GetCrawlerMetricsResponse, GetCrawlerMetricsError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetCrawlerMetrics");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10285,9 +10480,14 @@ impl Glue for GlueClient {
         &self,
         input: GetCrawlersRequest,
     ) -> RusotoFuture<GetCrawlersResponse, GetCrawlersError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetCrawlers");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10315,9 +10515,14 @@ impl Glue for GlueClient {
         input: GetDataCatalogEncryptionSettingsRequest,
     ) -> RusotoFuture<GetDataCatalogEncryptionSettingsResponse, GetDataCatalogEncryptionSettingsError>
     {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetDataCatalogEncryptionSettings");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10343,9 +10548,14 @@ impl Glue for GlueClient {
         &self,
         input: GetDatabaseRequest,
     ) -> RusotoFuture<GetDatabaseResponse, GetDatabaseError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetDatabase");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10372,9 +10582,14 @@ impl Glue for GlueClient {
         &self,
         input: GetDatabasesRequest,
     ) -> RusotoFuture<GetDatabasesResponse, GetDatabasesError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetDatabases");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10401,9 +10616,14 @@ impl Glue for GlueClient {
         &self,
         input: GetDataflowGraphRequest,
     ) -> RusotoFuture<GetDataflowGraphResponse, GetDataflowGraphError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetDataflowGraph");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10430,9 +10650,14 @@ impl Glue for GlueClient {
         &self,
         input: GetDevEndpointRequest,
     ) -> RusotoFuture<GetDevEndpointResponse, GetDevEndpointError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetDevEndpoint");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10459,9 +10684,14 @@ impl Glue for GlueClient {
         &self,
         input: GetDevEndpointsRequest,
     ) -> RusotoFuture<GetDevEndpointsResponse, GetDevEndpointsError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetDevEndpoints");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10485,9 +10715,14 @@ impl Glue for GlueClient {
 
     /// <p>Retrieves an existing job definition.</p>
     fn get_job(&self, input: GetJobRequest) -> RusotoFuture<GetJobResponse, GetJobError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10513,9 +10748,14 @@ impl Glue for GlueClient {
         &self,
         input: GetJobRunRequest,
     ) -> RusotoFuture<GetJobRunResponse, GetJobRunError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetJobRun");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10542,9 +10782,14 @@ impl Glue for GlueClient {
         &self,
         input: GetJobRunsRequest,
     ) -> RusotoFuture<GetJobRunsResponse, GetJobRunsError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetJobRuns");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10568,9 +10813,14 @@ impl Glue for GlueClient {
 
     /// <p>Retrieves all current job definitions.</p>
     fn get_jobs(&self, input: GetJobsRequest) -> RusotoFuture<GetJobsResponse, GetJobsError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetJobs");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10596,9 +10846,14 @@ impl Glue for GlueClient {
         &self,
         input: GetMappingRequest,
     ) -> RusotoFuture<GetMappingResponse, GetMappingError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetMapping");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10625,9 +10880,14 @@ impl Glue for GlueClient {
         &self,
         input: GetPartitionRequest,
     ) -> RusotoFuture<GetPartitionResponse, GetPartitionError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetPartition");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10654,9 +10914,14 @@ impl Glue for GlueClient {
         &self,
         input: GetPartitionsRequest,
     ) -> RusotoFuture<GetPartitionsResponse, GetPartitionsError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetPartitions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10680,9 +10945,14 @@ impl Glue for GlueClient {
 
     /// <p>Gets code to perform a specified mapping.</p>
     fn get_plan(&self, input: GetPlanRequest) -> RusotoFuture<GetPlanResponse, GetPlanError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetPlan");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10707,9 +10977,14 @@ impl Glue for GlueClient {
     fn get_resource_policy(
         &self,
     ) -> RusotoFuture<GetResourcePolicyResponse, GetResourcePolicyError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetResourcePolicy");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -10735,9 +11010,14 @@ impl Glue for GlueClient {
         &self,
         input: GetSecurityConfigurationRequest,
     ) -> RusotoFuture<GetSecurityConfigurationResponse, GetSecurityConfigurationError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetSecurityConfiguration");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10761,9 +11041,14 @@ impl Glue for GlueClient {
         &self,
         input: GetSecurityConfigurationsRequest,
     ) -> RusotoFuture<GetSecurityConfigurationsResponse, GetSecurityConfigurationsError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetSecurityConfigurations");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10784,9 +11069,14 @@ impl Glue for GlueClient {
 
     /// <p>Retrieves the <code>Table</code> definition in a Data Catalog for a specified table.</p>
     fn get_table(&self, input: GetTableRequest) -> RusotoFuture<GetTableResponse, GetTableError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetTable");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10813,9 +11103,14 @@ impl Glue for GlueClient {
         &self,
         input: GetTableVersionRequest,
     ) -> RusotoFuture<GetTableVersionResponse, GetTableVersionError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetTableVersion");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10842,9 +11137,14 @@ impl Glue for GlueClient {
         &self,
         input: GetTableVersionsRequest,
     ) -> RusotoFuture<GetTableVersionsResponse, GetTableVersionsError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetTableVersions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10871,9 +11171,14 @@ impl Glue for GlueClient {
         &self,
         input: GetTablesRequest,
     ) -> RusotoFuture<GetTablesResponse, GetTablesError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetTables");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10900,9 +11205,14 @@ impl Glue for GlueClient {
         &self,
         input: GetTriggerRequest,
     ) -> RusotoFuture<GetTriggerResponse, GetTriggerError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetTrigger");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10929,9 +11239,14 @@ impl Glue for GlueClient {
         &self,
         input: GetTriggersRequest,
     ) -> RusotoFuture<GetTriggersResponse, GetTriggersError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetTriggers");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10958,9 +11273,14 @@ impl Glue for GlueClient {
         &self,
         input: GetUserDefinedFunctionRequest,
     ) -> RusotoFuture<GetUserDefinedFunctionResponse, GetUserDefinedFunctionError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetUserDefinedFunction");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -10986,9 +11306,14 @@ impl Glue for GlueClient {
         &self,
         input: GetUserDefinedFunctionsRequest,
     ) -> RusotoFuture<GetUserDefinedFunctionsResponse, GetUserDefinedFunctionsError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.GetUserDefinedFunctions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -11012,9 +11337,14 @@ impl Glue for GlueClient {
         &self,
         input: ImportCatalogToGlueRequest,
     ) -> RusotoFuture<ImportCatalogToGlueResponse, ImportCatalogToGlueError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.ImportCatalogToGlue");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -11041,9 +11371,14 @@ impl Glue for GlueClient {
         input: PutDataCatalogEncryptionSettingsRequest,
     ) -> RusotoFuture<PutDataCatalogEncryptionSettingsResponse, PutDataCatalogEncryptionSettingsError>
     {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.PutDataCatalogEncryptionSettings");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -11069,9 +11404,14 @@ impl Glue for GlueClient {
         &self,
         input: PutResourcePolicyRequest,
     ) -> RusotoFuture<PutResourcePolicyResponse, PutResourcePolicyError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.PutResourcePolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -11098,9 +11438,14 @@ impl Glue for GlueClient {
         &self,
         input: ResetJobBookmarkRequest,
     ) -> RusotoFuture<ResetJobBookmarkResponse, ResetJobBookmarkError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.ResetJobBookmark");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -11127,9 +11472,14 @@ impl Glue for GlueClient {
         &self,
         input: StartCrawlerRequest,
     ) -> RusotoFuture<StartCrawlerResponse, StartCrawlerError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.StartCrawler");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -11156,9 +11506,14 @@ impl Glue for GlueClient {
         &self,
         input: StartCrawlerScheduleRequest,
     ) -> RusotoFuture<StartCrawlerScheduleResponse, StartCrawlerScheduleError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.StartCrawlerSchedule");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -11184,9 +11539,14 @@ impl Glue for GlueClient {
         &self,
         input: StartJobRunRequest,
     ) -> RusotoFuture<StartJobRunResponse, StartJobRunError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.StartJobRun");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -11213,9 +11573,14 @@ impl Glue for GlueClient {
         &self,
         input: StartTriggerRequest,
     ) -> RusotoFuture<StartTriggerResponse, StartTriggerError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.StartTrigger");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -11242,9 +11607,14 @@ impl Glue for GlueClient {
         &self,
         input: StopCrawlerRequest,
     ) -> RusotoFuture<StopCrawlerResponse, StopCrawlerError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.StopCrawler");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -11271,9 +11641,14 @@ impl Glue for GlueClient {
         &self,
         input: StopCrawlerScheduleRequest,
     ) -> RusotoFuture<StopCrawlerScheduleResponse, StopCrawlerScheduleError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.StopCrawlerSchedule");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -11299,9 +11674,14 @@ impl Glue for GlueClient {
         &self,
         input: StopTriggerRequest,
     ) -> RusotoFuture<StopTriggerResponse, StopTriggerError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.StopTrigger");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -11328,9 +11708,14 @@ impl Glue for GlueClient {
         &self,
         input: UpdateClassifierRequest,
     ) -> RusotoFuture<UpdateClassifierResponse, UpdateClassifierError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.UpdateClassifier");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -11357,9 +11742,14 @@ impl Glue for GlueClient {
         &self,
         input: UpdateConnectionRequest,
     ) -> RusotoFuture<UpdateConnectionResponse, UpdateConnectionError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.UpdateConnection");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -11386,9 +11776,14 @@ impl Glue for GlueClient {
         &self,
         input: UpdateCrawlerRequest,
     ) -> RusotoFuture<UpdateCrawlerResponse, UpdateCrawlerError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.UpdateCrawler");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -11415,9 +11810,14 @@ impl Glue for GlueClient {
         &self,
         input: UpdateCrawlerScheduleRequest,
     ) -> RusotoFuture<UpdateCrawlerScheduleResponse, UpdateCrawlerScheduleError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.UpdateCrawlerSchedule");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -11443,9 +11843,14 @@ impl Glue for GlueClient {
         &self,
         input: UpdateDatabaseRequest,
     ) -> RusotoFuture<UpdateDatabaseResponse, UpdateDatabaseError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.UpdateDatabase");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -11472,9 +11877,14 @@ impl Glue for GlueClient {
         &self,
         input: UpdateDevEndpointRequest,
     ) -> RusotoFuture<UpdateDevEndpointResponse, UpdateDevEndpointError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.UpdateDevEndpoint");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -11501,9 +11911,14 @@ impl Glue for GlueClient {
         &self,
         input: UpdateJobRequest,
     ) -> RusotoFuture<UpdateJobResponse, UpdateJobError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.UpdateJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -11530,9 +11945,14 @@ impl Glue for GlueClient {
         &self,
         input: UpdatePartitionRequest,
     ) -> RusotoFuture<UpdatePartitionResponse, UpdatePartitionError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.UpdatePartition");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -11559,9 +11979,14 @@ impl Glue for GlueClient {
         &self,
         input: UpdateTableRequest,
     ) -> RusotoFuture<UpdateTableResponse, UpdateTableError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.UpdateTable");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -11588,9 +12013,14 @@ impl Glue for GlueClient {
         &self,
         input: UpdateTriggerRequest,
     ) -> RusotoFuture<UpdateTriggerResponse, UpdateTriggerError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.UpdateTrigger");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -11617,9 +12047,14 @@ impl Glue for GlueClient {
         &self,
         input: UpdateUserDefinedFunctionRequest,
     ) -> RusotoFuture<UpdateUserDefinedFunctionResponse, UpdateUserDefinedFunctionError> {
-        let mut request = SignedRequest::new("POST", "glue", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "glue",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSGlue.UpdateUserDefinedFunction");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/health/src/generated.rs
+++ b/rusoto/services/health/src/generated.rs
@@ -759,9 +759,14 @@ impl AWSHealth for AWSHealthClient {
         &self,
         input: DescribeAffectedEntitiesRequest,
     ) -> RusotoFuture<DescribeAffectedEntitiesResponse, DescribeAffectedEntitiesError> {
-        let mut request = SignedRequest::new("POST", "health", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "health",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSHealth_20160804.DescribeAffectedEntities",
@@ -788,9 +793,14 @@ impl AWSHealth for AWSHealthClient {
         &self,
         input: DescribeEntityAggregatesRequest,
     ) -> RusotoFuture<DescribeEntityAggregatesResponse, DescribeEntityAggregatesError> {
-        let mut request = SignedRequest::new("POST", "health", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "health",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSHealth_20160804.DescribeEntityAggregates",
@@ -817,9 +827,14 @@ impl AWSHealth for AWSHealthClient {
         &self,
         input: DescribeEventAggregatesRequest,
     ) -> RusotoFuture<DescribeEventAggregatesResponse, DescribeEventAggregatesError> {
-        let mut request = SignedRequest::new("POST", "health", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "health",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSHealth_20160804.DescribeEventAggregates");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -843,9 +858,14 @@ impl AWSHealth for AWSHealthClient {
         &self,
         input: DescribeEventDetailsRequest,
     ) -> RusotoFuture<DescribeEventDetailsResponse, DescribeEventDetailsError> {
-        let mut request = SignedRequest::new("POST", "health", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "health",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSHealth_20160804.DescribeEventDetails");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -871,9 +891,14 @@ impl AWSHealth for AWSHealthClient {
         &self,
         input: DescribeEventTypesRequest,
     ) -> RusotoFuture<DescribeEventTypesResponse, DescribeEventTypesError> {
-        let mut request = SignedRequest::new("POST", "health", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "health",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSHealth_20160804.DescribeEventTypes");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -900,9 +925,14 @@ impl AWSHealth for AWSHealthClient {
         &self,
         input: DescribeEventsRequest,
     ) -> RusotoFuture<DescribeEventsResponse, DescribeEventsError> {
-        let mut request = SignedRequest::new("POST", "health", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "health",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSHealth_20160804.DescribeEvents");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/inspector/src/generated.rs
+++ b/rusoto/services/inspector/src/generated.rs
@@ -3847,9 +3847,14 @@ impl Inspector for InspectorClient {
         &self,
         input: AddAttributesToFindingsRequest,
     ) -> RusotoFuture<AddAttributesToFindingsResponse, AddAttributesToFindingsError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.AddAttributesToFindings");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3873,9 +3878,14 @@ impl Inspector for InspectorClient {
         &self,
         input: CreateAssessmentTargetRequest,
     ) -> RusotoFuture<CreateAssessmentTargetResponse, CreateAssessmentTargetError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.CreateAssessmentTarget");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3901,9 +3911,14 @@ impl Inspector for InspectorClient {
         &self,
         input: CreateAssessmentTemplateRequest,
     ) -> RusotoFuture<CreateAssessmentTemplateResponse, CreateAssessmentTemplateError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.CreateAssessmentTemplate");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3927,9 +3942,14 @@ impl Inspector for InspectorClient {
         &self,
         input: CreateExclusionsPreviewRequest,
     ) -> RusotoFuture<CreateExclusionsPreviewResponse, CreateExclusionsPreviewError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.CreateExclusionsPreview");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3953,9 +3973,14 @@ impl Inspector for InspectorClient {
         &self,
         input: CreateResourceGroupRequest,
     ) -> RusotoFuture<CreateResourceGroupResponse, CreateResourceGroupError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.CreateResourceGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3981,9 +4006,14 @@ impl Inspector for InspectorClient {
         &self,
         input: DeleteAssessmentRunRequest,
     ) -> RusotoFuture<(), DeleteAssessmentRunError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.DeleteAssessmentRun");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4006,9 +4036,14 @@ impl Inspector for InspectorClient {
         &self,
         input: DeleteAssessmentTargetRequest,
     ) -> RusotoFuture<(), DeleteAssessmentTargetError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.DeleteAssessmentTarget");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4031,9 +4066,14 @@ impl Inspector for InspectorClient {
         &self,
         input: DeleteAssessmentTemplateRequest,
     ) -> RusotoFuture<(), DeleteAssessmentTemplateError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.DeleteAssessmentTemplate");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4054,9 +4094,14 @@ impl Inspector for InspectorClient {
         &self,
         input: DescribeAssessmentRunsRequest,
     ) -> RusotoFuture<DescribeAssessmentRunsResponse, DescribeAssessmentRunsError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.DescribeAssessmentRuns");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4082,9 +4127,14 @@ impl Inspector for InspectorClient {
         &self,
         input: DescribeAssessmentTargetsRequest,
     ) -> RusotoFuture<DescribeAssessmentTargetsResponse, DescribeAssessmentTargetsError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.DescribeAssessmentTargets");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4108,9 +4158,14 @@ impl Inspector for InspectorClient {
         &self,
         input: DescribeAssessmentTemplatesRequest,
     ) -> RusotoFuture<DescribeAssessmentTemplatesResponse, DescribeAssessmentTemplatesError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "InspectorService.DescribeAssessmentTemplates",
@@ -4137,9 +4192,14 @@ impl Inspector for InspectorClient {
         &self,
     ) -> RusotoFuture<DescribeCrossAccountAccessRoleResponse, DescribeCrossAccountAccessRoleError>
     {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "InspectorService.DescribeCrossAccountAccessRole",
@@ -4165,9 +4225,14 @@ impl Inspector for InspectorClient {
         &self,
         input: DescribeExclusionsRequest,
     ) -> RusotoFuture<DescribeExclusionsResponse, DescribeExclusionsError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.DescribeExclusions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4194,9 +4259,14 @@ impl Inspector for InspectorClient {
         &self,
         input: DescribeFindingsRequest,
     ) -> RusotoFuture<DescribeFindingsResponse, DescribeFindingsError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.DescribeFindings");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4223,9 +4293,14 @@ impl Inspector for InspectorClient {
         &self,
         input: DescribeResourceGroupsRequest,
     ) -> RusotoFuture<DescribeResourceGroupsResponse, DescribeResourceGroupsError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.DescribeResourceGroups");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4251,9 +4326,14 @@ impl Inspector for InspectorClient {
         &self,
         input: DescribeRulesPackagesRequest,
     ) -> RusotoFuture<DescribeRulesPackagesResponse, DescribeRulesPackagesError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.DescribeRulesPackages");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4279,9 +4359,14 @@ impl Inspector for InspectorClient {
         &self,
         input: GetAssessmentReportRequest,
     ) -> RusotoFuture<GetAssessmentReportResponse, GetAssessmentReportError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.GetAssessmentReport");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4307,9 +4392,14 @@ impl Inspector for InspectorClient {
         &self,
         input: GetExclusionsPreviewRequest,
     ) -> RusotoFuture<GetExclusionsPreviewResponse, GetExclusionsPreviewError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.GetExclusionsPreview");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4335,9 +4425,14 @@ impl Inspector for InspectorClient {
         &self,
         input: GetTelemetryMetadataRequest,
     ) -> RusotoFuture<GetTelemetryMetadataResponse, GetTelemetryMetadataError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.GetTelemetryMetadata");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4363,9 +4458,14 @@ impl Inspector for InspectorClient {
         &self,
         input: ListAssessmentRunAgentsRequest,
     ) -> RusotoFuture<ListAssessmentRunAgentsResponse, ListAssessmentRunAgentsError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.ListAssessmentRunAgents");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4389,9 +4489,14 @@ impl Inspector for InspectorClient {
         &self,
         input: ListAssessmentRunsRequest,
     ) -> RusotoFuture<ListAssessmentRunsResponse, ListAssessmentRunsError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.ListAssessmentRuns");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4418,9 +4523,14 @@ impl Inspector for InspectorClient {
         &self,
         input: ListAssessmentTargetsRequest,
     ) -> RusotoFuture<ListAssessmentTargetsResponse, ListAssessmentTargetsError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.ListAssessmentTargets");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4446,9 +4556,14 @@ impl Inspector for InspectorClient {
         &self,
         input: ListAssessmentTemplatesRequest,
     ) -> RusotoFuture<ListAssessmentTemplatesResponse, ListAssessmentTemplatesError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.ListAssessmentTemplates");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4472,9 +4587,14 @@ impl Inspector for InspectorClient {
         &self,
         input: ListEventSubscriptionsRequest,
     ) -> RusotoFuture<ListEventSubscriptionsResponse, ListEventSubscriptionsError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.ListEventSubscriptions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4500,9 +4620,14 @@ impl Inspector for InspectorClient {
         &self,
         input: ListExclusionsRequest,
     ) -> RusotoFuture<ListExclusionsResponse, ListExclusionsError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.ListExclusions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4529,9 +4654,14 @@ impl Inspector for InspectorClient {
         &self,
         input: ListFindingsRequest,
     ) -> RusotoFuture<ListFindingsResponse, ListFindingsError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.ListFindings");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4558,9 +4688,14 @@ impl Inspector for InspectorClient {
         &self,
         input: ListRulesPackagesRequest,
     ) -> RusotoFuture<ListRulesPackagesResponse, ListRulesPackagesError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.ListRulesPackages");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4587,9 +4722,14 @@ impl Inspector for InspectorClient {
         &self,
         input: ListTagsForResourceRequest,
     ) -> RusotoFuture<ListTagsForResourceResponse, ListTagsForResourceError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.ListTagsForResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4615,9 +4755,14 @@ impl Inspector for InspectorClient {
         &self,
         input: PreviewAgentsRequest,
     ) -> RusotoFuture<PreviewAgentsResponse, PreviewAgentsError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.PreviewAgents");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4644,9 +4789,14 @@ impl Inspector for InspectorClient {
         &self,
         input: RegisterCrossAccountAccessRoleRequest,
     ) -> RusotoFuture<(), RegisterCrossAccountAccessRoleError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "InspectorService.RegisterCrossAccountAccessRole",
@@ -4670,9 +4820,14 @@ impl Inspector for InspectorClient {
         &self,
         input: RemoveAttributesFromFindingsRequest,
     ) -> RusotoFuture<RemoveAttributesFromFindingsResponse, RemoveAttributesFromFindingsError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "InspectorService.RemoveAttributesFromFindings",
@@ -4699,9 +4854,14 @@ impl Inspector for InspectorClient {
         &self,
         input: SetTagsForResourceRequest,
     ) -> RusotoFuture<(), SetTagsForResourceError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.SetTagsForResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4725,9 +4885,14 @@ impl Inspector for InspectorClient {
         &self,
         input: StartAssessmentRunRequest,
     ) -> RusotoFuture<StartAssessmentRunResponse, StartAssessmentRunError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.StartAssessmentRun");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4754,9 +4919,14 @@ impl Inspector for InspectorClient {
         &self,
         input: StopAssessmentRunRequest,
     ) -> RusotoFuture<(), StopAssessmentRunError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.StopAssessmentRun");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4780,9 +4950,14 @@ impl Inspector for InspectorClient {
         &self,
         input: SubscribeToEventRequest,
     ) -> RusotoFuture<(), SubscribeToEventError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.SubscribeToEvent");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4806,9 +4981,14 @@ impl Inspector for InspectorClient {
         &self,
         input: UnsubscribeFromEventRequest,
     ) -> RusotoFuture<(), UnsubscribeFromEventError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.UnsubscribeFromEvent");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4831,9 +5011,14 @@ impl Inspector for InspectorClient {
         &self,
         input: UpdateAssessmentTargetRequest,
     ) -> RusotoFuture<(), UpdateAssessmentTargetError> {
-        let mut request = SignedRequest::new("POST", "inspector", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "inspector",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "InspectorService.UpdateAssessmentTarget");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/kinesis/src/generated.rs
+++ b/rusoto/services/kinesis/src/generated.rs
@@ -2799,9 +2799,14 @@ impl Kinesis for KinesisClient {
         &self,
         input: AddTagsToStreamInput,
     ) -> RusotoFuture<(), AddTagsToStreamError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.AddTagsToStream");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2822,9 +2827,14 @@ impl Kinesis for KinesisClient {
 
     /// <p>Creates a Kinesis data stream. A stream captures and transports data records that are continuously emitted from different data sources or <i>producers</i>. Scale-out within a stream is explicitly supported by means of shards, which are uniquely identified groups of data records in a stream.</p> <p>You specify and control the number of shards that a stream is composed of. Each shard can support reads up to five transactions per second, up to a maximum data read total of 2 MB per second. Each shard can support writes up to 1,000 records per second, up to a maximum data write total of 1 MB per second. If the amount of data input increases or decreases, you can add or remove shards.</p> <p>The stream name identifies the stream. The name is scoped to the AWS account used by the application. It is also scoped by AWS Region. That is, two streams in two different accounts can have the same name, and two streams in the same account, but in two different Regions, can have the same name.</p> <p> <code>CreateStream</code> is an asynchronous operation. Upon receiving a <code>CreateStream</code> request, Kinesis Data Streams immediately returns and sets the stream status to <code>CREATING</code>. After the stream is created, Kinesis Data Streams sets the stream status to <code>ACTIVE</code>. You should perform read and write operations only on an <code>ACTIVE</code> stream. </p> <p>You receive a <code>LimitExceededException</code> when making a <code>CreateStream</code> request when you try to do one of the following:</p> <ul> <li> <p>Have more than five streams in the <code>CREATING</code> state at any point in time.</p> </li> <li> <p>Create more shards than are authorized for your account.</p> </li> </ul> <p>For the default shard limit for an AWS account, see <a href="http://docs.aws.amazon.com/kinesis/latest/dev/service-sizes-and-limits.html">Amazon Kinesis Data Streams Limits</a> in the <i>Amazon Kinesis Data Streams Developer Guide</i>. To increase this limit, <a href="http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html">contact AWS Support</a>.</p> <p>You can use <code>DescribeStream</code> to check the stream status, which is returned in <code>StreamStatus</code>.</p> <p> <a>CreateStream</a> has a limit of five transactions per second per account.</p>
     fn create_stream(&self, input: CreateStreamInput) -> RusotoFuture<(), CreateStreamError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.CreateStream");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2848,9 +2858,14 @@ impl Kinesis for KinesisClient {
         &self,
         input: DecreaseStreamRetentionPeriodInput,
     ) -> RusotoFuture<(), DecreaseStreamRetentionPeriodError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Kinesis_20131202.DecreaseStreamRetentionPeriod",
@@ -2871,9 +2886,14 @@ impl Kinesis for KinesisClient {
 
     /// <p>Deletes a Kinesis data stream and all its shards and data. You must shut down any applications that are operating on the stream before you delete the stream. If an application attempts to operate on a deleted stream, it receives the exception <code>ResourceNotFoundException</code>.</p> <p>If the stream is in the <code>ACTIVE</code> state, you can delete it. After a <code>DeleteStream</code> request, the specified stream is in the <code>DELETING</code> state until Kinesis Data Streams completes the deletion.</p> <p> <b>Note:</b> Kinesis Data Streams might continue to accept data read and write operations, such as <a>PutRecord</a>, <a>PutRecords</a>, and <a>GetRecords</a>, on a stream in the <code>DELETING</code> state until the stream deletion is complete.</p> <p>When you delete a stream, any shards in that stream are also deleted, and any tags are dissociated from the stream.</p> <p>You can use the <a>DescribeStream</a> operation to check the state of the stream, which is returned in <code>StreamStatus</code>.</p> <p> <a>DeleteStream</a> has a limit of five transactions per second per account.</p>
     fn delete_stream(&self, input: DeleteStreamInput) -> RusotoFuture<(), DeleteStreamError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.DeleteStream");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2897,9 +2917,14 @@ impl Kinesis for KinesisClient {
         &self,
         input: DeregisterStreamConsumerInput,
     ) -> RusotoFuture<(), DeregisterStreamConsumerError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.DeregisterStreamConsumer");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2917,9 +2942,14 @@ impl Kinesis for KinesisClient {
 
     /// <p>Describes the shard limits and usage for the account.</p> <p>If you update your account limits, the old limits might be returned for a few minutes.</p> <p>This operation has a limit of one transaction per second per account.</p>
     fn describe_limits(&self) -> RusotoFuture<DescribeLimitsOutput, DescribeLimitsError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.DescribeLimits");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -2945,9 +2975,14 @@ impl Kinesis for KinesisClient {
         &self,
         input: DescribeStreamInput,
     ) -> RusotoFuture<DescribeStreamOutput, DescribeStreamError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.DescribeStream");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2974,9 +3009,14 @@ impl Kinesis for KinesisClient {
         &self,
         input: DescribeStreamConsumerInput,
     ) -> RusotoFuture<DescribeStreamConsumerOutput, DescribeStreamConsumerError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.DescribeStreamConsumer");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3002,9 +3042,14 @@ impl Kinesis for KinesisClient {
         &self,
         input: DescribeStreamSummaryInput,
     ) -> RusotoFuture<DescribeStreamSummaryOutput, DescribeStreamSummaryError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.DescribeStreamSummary");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3030,9 +3075,14 @@ impl Kinesis for KinesisClient {
         &self,
         input: DisableEnhancedMonitoringInput,
     ) -> RusotoFuture<EnhancedMonitoringOutput, DisableEnhancedMonitoringError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.DisableEnhancedMonitoring");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3056,9 +3106,14 @@ impl Kinesis for KinesisClient {
         &self,
         input: EnableEnhancedMonitoringInput,
     ) -> RusotoFuture<EnhancedMonitoringOutput, EnableEnhancedMonitoringError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.EnableEnhancedMonitoring");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3082,9 +3137,14 @@ impl Kinesis for KinesisClient {
         &self,
         input: GetRecordsInput,
     ) -> RusotoFuture<GetRecordsOutput, GetRecordsError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.GetRecords");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3111,9 +3171,14 @@ impl Kinesis for KinesisClient {
         &self,
         input: GetShardIteratorInput,
     ) -> RusotoFuture<GetShardIteratorOutput, GetShardIteratorError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.GetShardIterator");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3140,9 +3205,14 @@ impl Kinesis for KinesisClient {
         &self,
         input: IncreaseStreamRetentionPeriodInput,
     ) -> RusotoFuture<(), IncreaseStreamRetentionPeriodError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Kinesis_20131202.IncreaseStreamRetentionPeriod",
@@ -3166,9 +3236,14 @@ impl Kinesis for KinesisClient {
         &self,
         input: ListShardsInput,
     ) -> RusotoFuture<ListShardsOutput, ListShardsError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.ListShards");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3195,9 +3270,14 @@ impl Kinesis for KinesisClient {
         &self,
         input: ListStreamConsumersInput,
     ) -> RusotoFuture<ListStreamConsumersOutput, ListStreamConsumersError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.ListStreamConsumers");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3223,9 +3303,14 @@ impl Kinesis for KinesisClient {
         &self,
         input: ListStreamsInput,
     ) -> RusotoFuture<ListStreamsOutput, ListStreamsError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.ListStreams");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3252,9 +3337,14 @@ impl Kinesis for KinesisClient {
         &self,
         input: ListTagsForStreamInput,
     ) -> RusotoFuture<ListTagsForStreamOutput, ListTagsForStreamError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.ListTagsForStream");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3278,9 +3368,14 @@ impl Kinesis for KinesisClient {
 
     /// <p>Merges two adjacent shards in a Kinesis data stream and combines them into a single shard to reduce the stream's capacity to ingest and transport data. Two shards are considered adjacent if the union of the hash key ranges for the two shards form a contiguous set with no gaps. For example, if you have two shards, one with a hash key range of 276...381 and the other with a hash key range of 382...454, then you could merge these two shards into a single shard that would have a hash key range of 276...454. After the merge, the single child shard receives data for all hash key values covered by the two parent shards.</p> <p> <code>MergeShards</code> is called when there is a need to reduce the overall capacity of a stream because of excess capacity that is not being used. You must specify the shard to be merged and the adjacent shard for a stream. For more information about merging shards, see <a href="http://docs.aws.amazon.com/kinesis/latest/dev/kinesis-using-sdk-java-resharding-merge.html">Merge Two Shards</a> in the <i>Amazon Kinesis Data Streams Developer Guide</i>.</p> <p>If the stream is in the <code>ACTIVE</code> state, you can call <code>MergeShards</code>. If a stream is in the <code>CREATING</code>, <code>UPDATING</code>, or <code>DELETING</code> state, <code>MergeShards</code> returns a <code>ResourceInUseException</code>. If the specified stream does not exist, <code>MergeShards</code> returns a <code>ResourceNotFoundException</code>. </p> <p>You can use <a>DescribeStream</a> to check the state of the stream, which is returned in <code>StreamStatus</code>.</p> <p> <code>MergeShards</code> is an asynchronous operation. Upon receiving a <code>MergeShards</code> request, Amazon Kinesis Data Streams immediately returns a response and sets the <code>StreamStatus</code> to <code>UPDATING</code>. After the operation is completed, Kinesis Data Streams sets the <code>StreamStatus</code> to <code>ACTIVE</code>. Read and write operations continue to work while the stream is in the <code>UPDATING</code> state. </p> <p>You use <a>DescribeStream</a> to determine the shard IDs that are specified in the <code>MergeShards</code> request. </p> <p>If you try to operate on too many streams in parallel using <a>CreateStream</a>, <a>DeleteStream</a>, <code>MergeShards</code>, or <a>SplitShard</a>, you receive a <code>LimitExceededException</code>. </p> <p> <code>MergeShards</code> has a limit of five transactions per second per account.</p>
     fn merge_shards(&self, input: MergeShardsInput) -> RusotoFuture<(), MergeShardsError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.MergeShards");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3301,9 +3396,14 @@ impl Kinesis for KinesisClient {
 
     /// <p>Writes a single data record into an Amazon Kinesis data stream. Call <code>PutRecord</code> to send data into the stream for real-time ingestion and subsequent processing, one record at a time. Each shard can support writes up to 1,000 records per second, up to a maximum data write total of 1 MB per second.</p> <p>You must specify the name of the stream that captures, stores, and transports the data; a partition key; and the data blob itself.</p> <p>The data blob can be any type of data; for example, a segment from a log file, geographic/location data, website clickstream data, and so on.</p> <p>The partition key is used by Kinesis Data Streams to distribute data across shards. Kinesis Data Streams segregates the data records that belong to a stream into multiple shards, using the partition key associated with each data record to determine the shard to which a given data record belongs.</p> <p>Partition keys are Unicode strings, with a maximum length limit of 256 characters for each key. An MD5 hash function is used to map partition keys to 128-bit integer values and to map associated data records to shards using the hash key ranges of the shards. You can override hashing the partition key to determine the shard by explicitly specifying a hash value using the <code>ExplicitHashKey</code> parameter. For more information, see <a href="http://docs.aws.amazon.com/kinesis/latest/dev/developing-producers-with-sdk.html#kinesis-using-sdk-java-add-data-to-stream">Adding Data to a Stream</a> in the <i>Amazon Kinesis Data Streams Developer Guide</i>.</p> <p> <code>PutRecord</code> returns the shard ID of where the data record was placed and the sequence number that was assigned to the data record.</p> <p>Sequence numbers increase over time and are specific to a shard within a stream, not across all shards within a stream. To guarantee strictly increasing ordering, write serially to a shard and use the <code>SequenceNumberForOrdering</code> parameter. For more information, see <a href="http://docs.aws.amazon.com/kinesis/latest/dev/developing-producers-with-sdk.html#kinesis-using-sdk-java-add-data-to-stream">Adding Data to a Stream</a> in the <i>Amazon Kinesis Data Streams Developer Guide</i>.</p> <p>If a <code>PutRecord</code> request cannot be processed because of insufficient provisioned throughput on the shard involved in the request, <code>PutRecord</code> throws <code>ProvisionedThroughputExceededException</code>. </p> <p>By default, data records are accessible for 24 hours from the time that they are added to a stream. You can use <a>IncreaseStreamRetentionPeriod</a> or <a>DecreaseStreamRetentionPeriod</a> to modify this retention period.</p>
     fn put_record(&self, input: PutRecordInput) -> RusotoFuture<PutRecordOutput, PutRecordError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.PutRecord");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3329,9 +3429,14 @@ impl Kinesis for KinesisClient {
         &self,
         input: PutRecordsInput,
     ) -> RusotoFuture<PutRecordsOutput, PutRecordsError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.PutRecords");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3358,9 +3463,14 @@ impl Kinesis for KinesisClient {
         &self,
         input: RegisterStreamConsumerInput,
     ) -> RusotoFuture<RegisterStreamConsumerOutput, RegisterStreamConsumerError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.RegisterStreamConsumer");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3386,9 +3496,14 @@ impl Kinesis for KinesisClient {
         &self,
         input: RemoveTagsFromStreamInput,
     ) -> RusotoFuture<(), RemoveTagsFromStreamError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.RemoveTagsFromStream");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3408,9 +3523,14 @@ impl Kinesis for KinesisClient {
 
     /// <p>Splits a shard into two new shards in the Kinesis data stream, to increase the stream's capacity to ingest and transport data. <code>SplitShard</code> is called when there is a need to increase the overall capacity of a stream because of an expected increase in the volume of data records being ingested. </p> <p>You can also use <code>SplitShard</code> when a shard appears to be approaching its maximum utilization; for example, the producers sending data into the specific shard are suddenly sending more than previously anticipated. You can also call <code>SplitShard</code> to increase stream capacity, so that more Kinesis Data Streams applications can simultaneously read data from the stream for real-time processing. </p> <p>You must specify the shard to be split and the new hash key, which is the position in the shard where the shard gets split in two. In many cases, the new hash key might be the average of the beginning and ending hash key, but it can be any hash key value in the range being mapped into the shard. For more information, see <a href="http://docs.aws.amazon.com/kinesis/latest/dev/kinesis-using-sdk-java-resharding-split.html">Split a Shard</a> in the <i>Amazon Kinesis Data Streams Developer Guide</i>.</p> <p>You can use <a>DescribeStream</a> to determine the shard ID and hash key values for the <code>ShardToSplit</code> and <code>NewStartingHashKey</code> parameters that are specified in the <code>SplitShard</code> request.</p> <p> <code>SplitShard</code> is an asynchronous operation. Upon receiving a <code>SplitShard</code> request, Kinesis Data Streams immediately returns a response and sets the stream status to <code>UPDATING</code>. After the operation is completed, Kinesis Data Streams sets the stream status to <code>ACTIVE</code>. Read and write operations continue to work while the stream is in the <code>UPDATING</code> state. </p> <p>You can use <code>DescribeStream</code> to check the status of the stream, which is returned in <code>StreamStatus</code>. If the stream is in the <code>ACTIVE</code> state, you can call <code>SplitShard</code>. If a stream is in <code>CREATING</code> or <code>UPDATING</code> or <code>DELETING</code> states, <code>DescribeStream</code> returns a <code>ResourceInUseException</code>.</p> <p>If the specified stream does not exist, <code>DescribeStream</code> returns a <code>ResourceNotFoundException</code>. If you try to create more shards than are authorized for your account, you receive a <code>LimitExceededException</code>. </p> <p>For the default shard limit for an AWS account, see <a href="http://docs.aws.amazon.com/kinesis/latest/dev/service-sizes-and-limits.html">Kinesis Data Streams Limits</a> in the <i>Amazon Kinesis Data Streams Developer Guide</i>. To increase this limit, <a href="http://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html">contact AWS Support</a>.</p> <p>If you try to operate on too many streams simultaneously using <a>CreateStream</a>, <a>DeleteStream</a>, <a>MergeShards</a>, and/or <a>SplitShard</a>, you receive a <code>LimitExceededException</code>. </p> <p> <code>SplitShard</code> has a limit of five transactions per second per account.</p>
     fn split_shard(&self, input: SplitShardInput) -> RusotoFuture<(), SplitShardError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.SplitShard");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3434,9 +3554,14 @@ impl Kinesis for KinesisClient {
         &self,
         input: StartStreamEncryptionInput,
     ) -> RusotoFuture<(), StartStreamEncryptionError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.StartStreamEncryption");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3459,9 +3584,14 @@ impl Kinesis for KinesisClient {
         &self,
         input: StopStreamEncryptionInput,
     ) -> RusotoFuture<(), StopStreamEncryptionError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.StopStreamEncryption");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3484,9 +3614,14 @@ impl Kinesis for KinesisClient {
         &self,
         input: SubscribeToShardInput,
     ) -> RusotoFuture<SubscribeToShardOutput, SubscribeToShardError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.SubscribeToShard");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3513,9 +3648,14 @@ impl Kinesis for KinesisClient {
         &self,
         input: UpdateShardCountInput,
     ) -> RusotoFuture<UpdateShardCountOutput, UpdateShardCountError> {
-        let mut request = SignedRequest::new("POST", "kinesis", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesis",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Kinesis_20131202.UpdateShardCount");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/kinesisanalytics/src/generated.rs
+++ b/rusoto/services/kinesisanalytics/src/generated.rs
@@ -2411,9 +2411,14 @@ impl KinesisAnalytics for KinesisAnalyticsClient {
         AddApplicationCloudWatchLoggingOptionResponse,
         AddApplicationCloudWatchLoggingOptionError,
     > {
-        let mut request = SignedRequest::new("POST", "kinesisanalytics", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesisanalytics",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "KinesisAnalytics_20150814.AddApplicationCloudWatchLoggingOption",
@@ -2442,9 +2447,14 @@ impl KinesisAnalytics for KinesisAnalyticsClient {
         &self,
         input: AddApplicationInputRequest,
     ) -> RusotoFuture<AddApplicationInputResponse, AddApplicationInputError> {
-        let mut request = SignedRequest::new("POST", "kinesisanalytics", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesisanalytics",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "KinesisAnalytics_20150814.AddApplicationInput",
@@ -2476,9 +2486,14 @@ impl KinesisAnalytics for KinesisAnalyticsClient {
         AddApplicationInputProcessingConfigurationResponse,
         AddApplicationInputProcessingConfigurationError,
     > {
-        let mut request = SignedRequest::new("POST", "kinesisanalytics", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesisanalytics",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "KinesisAnalytics_20150814.AddApplicationInputProcessingConfiguration",
@@ -2505,9 +2520,14 @@ impl KinesisAnalytics for KinesisAnalyticsClient {
         &self,
         input: AddApplicationOutputRequest,
     ) -> RusotoFuture<AddApplicationOutputResponse, AddApplicationOutputError> {
-        let mut request = SignedRequest::new("POST", "kinesisanalytics", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesisanalytics",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "KinesisAnalytics_20150814.AddApplicationOutput",
@@ -2539,9 +2559,14 @@ impl KinesisAnalytics for KinesisAnalyticsClient {
         AddApplicationReferenceDataSourceResponse,
         AddApplicationReferenceDataSourceError,
     > {
-        let mut request = SignedRequest::new("POST", "kinesisanalytics", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesisanalytics",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "KinesisAnalytics_20150814.AddApplicationReferenceDataSource",
@@ -2570,9 +2595,14 @@ impl KinesisAnalytics for KinesisAnalyticsClient {
         &self,
         input: CreateApplicationRequest,
     ) -> RusotoFuture<CreateApplicationResponse, CreateApplicationError> {
-        let mut request = SignedRequest::new("POST", "kinesisanalytics", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesisanalytics",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "KinesisAnalytics_20150814.CreateApplication",
@@ -2602,9 +2632,14 @@ impl KinesisAnalytics for KinesisAnalyticsClient {
         &self,
         input: DeleteApplicationRequest,
     ) -> RusotoFuture<DeleteApplicationResponse, DeleteApplicationError> {
-        let mut request = SignedRequest::new("POST", "kinesisanalytics", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesisanalytics",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "KinesisAnalytics_20150814.DeleteApplication",
@@ -2637,9 +2672,14 @@ impl KinesisAnalytics for KinesisAnalyticsClient {
         DeleteApplicationCloudWatchLoggingOptionResponse,
         DeleteApplicationCloudWatchLoggingOptionError,
     > {
-        let mut request = SignedRequest::new("POST", "kinesisanalytics", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesisanalytics",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "KinesisAnalytics_20150814.DeleteApplicationCloudWatchLoggingOption",
@@ -2669,9 +2709,14 @@ impl KinesisAnalytics for KinesisAnalyticsClient {
         DeleteApplicationInputProcessingConfigurationResponse,
         DeleteApplicationInputProcessingConfigurationError,
     > {
-        let mut request = SignedRequest::new("POST", "kinesisanalytics", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesisanalytics",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "KinesisAnalytics_20150814.DeleteApplicationInputProcessingConfiguration",
@@ -2697,9 +2742,14 @@ impl KinesisAnalytics for KinesisAnalyticsClient {
         &self,
         input: DeleteApplicationOutputRequest,
     ) -> RusotoFuture<DeleteApplicationOutputResponse, DeleteApplicationOutputError> {
-        let mut request = SignedRequest::new("POST", "kinesisanalytics", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesisanalytics",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "KinesisAnalytics_20150814.DeleteApplicationOutput",
@@ -2729,9 +2779,14 @@ impl KinesisAnalytics for KinesisAnalyticsClient {
         DeleteApplicationReferenceDataSourceResponse,
         DeleteApplicationReferenceDataSourceError,
     > {
-        let mut request = SignedRequest::new("POST", "kinesisanalytics", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesisanalytics",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "KinesisAnalytics_20150814.DeleteApplicationReferenceDataSource",
@@ -2760,9 +2815,14 @@ impl KinesisAnalytics for KinesisAnalyticsClient {
         &self,
         input: DescribeApplicationRequest,
     ) -> RusotoFuture<DescribeApplicationResponse, DescribeApplicationError> {
-        let mut request = SignedRequest::new("POST", "kinesisanalytics", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesisanalytics",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "KinesisAnalytics_20150814.DescribeApplication",
@@ -2791,9 +2851,14 @@ impl KinesisAnalytics for KinesisAnalyticsClient {
         &self,
         input: DiscoverInputSchemaRequest,
     ) -> RusotoFuture<DiscoverInputSchemaResponse, DiscoverInputSchemaError> {
-        let mut request = SignedRequest::new("POST", "kinesisanalytics", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesisanalytics",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "KinesisAnalytics_20150814.DiscoverInputSchema",
@@ -2822,9 +2887,14 @@ impl KinesisAnalytics for KinesisAnalyticsClient {
         &self,
         input: ListApplicationsRequest,
     ) -> RusotoFuture<ListApplicationsResponse, ListApplicationsError> {
-        let mut request = SignedRequest::new("POST", "kinesisanalytics", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesisanalytics",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "KinesisAnalytics_20150814.ListApplications");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2851,9 +2921,14 @@ impl KinesisAnalytics for KinesisAnalyticsClient {
         &self,
         input: StartApplicationRequest,
     ) -> RusotoFuture<StartApplicationResponse, StartApplicationError> {
-        let mut request = SignedRequest::new("POST", "kinesisanalytics", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesisanalytics",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "KinesisAnalytics_20150814.StartApplication");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2880,9 +2955,14 @@ impl KinesisAnalytics for KinesisAnalyticsClient {
         &self,
         input: StopApplicationRequest,
     ) -> RusotoFuture<StopApplicationResponse, StopApplicationError> {
-        let mut request = SignedRequest::new("POST", "kinesisanalytics", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesisanalytics",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "KinesisAnalytics_20150814.StopApplication");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2909,9 +2989,14 @@ impl KinesisAnalytics for KinesisAnalyticsClient {
         &self,
         input: UpdateApplicationRequest,
     ) -> RusotoFuture<UpdateApplicationResponse, UpdateApplicationError> {
-        let mut request = SignedRequest::new("POST", "kinesisanalytics", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kinesisanalytics",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "KinesisAnalytics_20150814.UpdateApplication",

--- a/rusoto/services/kms/src/generated.rs
+++ b/rusoto/services/kms/src/generated.rs
@@ -4077,9 +4077,14 @@ impl Kms for KmsClient {
         &self,
         input: CancelKeyDeletionRequest,
     ) -> RusotoFuture<CancelKeyDeletionResponse, CancelKeyDeletionError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.CancelKeyDeletion");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4106,9 +4111,14 @@ impl Kms for KmsClient {
         &self,
         input: ConnectCustomKeyStoreRequest,
     ) -> RusotoFuture<ConnectCustomKeyStoreResponse, ConnectCustomKeyStoreError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.ConnectCustomKeyStore");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4131,9 +4141,14 @@ impl Kms for KmsClient {
 
     /// <p>Creates a display name for a customer master key (CMK). You can use an alias to identify a CMK in selected operations, such as <a>Encrypt</a> and <a>GenerateDataKey</a>. </p> <p>Each CMK can have multiple aliases, but each alias points to only one CMK. The alias name must be unique in the AWS account and region. To simplify code that runs in multiple regions, use the same alias name, but point it to a different CMK in each region. </p> <p>Because an alias is not a property of a CMK, you can delete and change the aliases of a CMK without affecting the CMK. Also, aliases do not appear in the response from the <a>DescribeKey</a> operation. To get the aliases of all CMKs, use the <a>ListAliases</a> operation.</p> <p>An alias must start with the word <code>alias</code> followed by a forward slash (<code>alias/</code>). The alias name can contain only alphanumeric characters, forward slashes (/), underscores (_), and dashes (-). Alias names cannot begin with <code>aws</code>; that alias name prefix is reserved by Amazon Web Services (AWS).</p> <p>The alias and the CMK it is mapped to must be in the same AWS account and the same region. You cannot perform this operation on an alias in a different AWS account.</p> <p>To map an existing alias to a different CMK, call <a>UpdateAlias</a>.</p> <p>The result of this operation varies with the key state of the CMK. For details, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html">How Key State Affects Use of a Customer Master Key</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>
     fn create_alias(&self, input: CreateAliasRequest) -> RusotoFuture<(), CreateAliasError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.CreateAlias");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4157,9 +4172,14 @@ impl Kms for KmsClient {
         &self,
         input: CreateCustomKeyStoreRequest,
     ) -> RusotoFuture<CreateCustomKeyStoreResponse, CreateCustomKeyStoreError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.CreateCustomKeyStore");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4185,9 +4205,14 @@ impl Kms for KmsClient {
         &self,
         input: CreateGrantRequest,
     ) -> RusotoFuture<CreateGrantResponse, CreateGrantError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.CreateGrant");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4214,9 +4239,14 @@ impl Kms for KmsClient {
         &self,
         input: CreateKeyRequest,
     ) -> RusotoFuture<CreateKeyResponse, CreateKeyError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.CreateKey");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4240,9 +4270,14 @@ impl Kms for KmsClient {
 
     /// <p>Decrypts ciphertext. Ciphertext is plaintext that has been previously encrypted by using any of the following operations:</p> <ul> <li> <p> <a>GenerateDataKey</a> </p> </li> <li> <p> <a>GenerateDataKeyWithoutPlaintext</a> </p> </li> <li> <p> <a>Encrypt</a> </p> </li> </ul> <p>Note that if a caller has been granted access permissions to all keys (through, for example, IAM user policies that grant <code>Decrypt</code> permission on all resources), then ciphertext encrypted by using keys in other accounts where the key grants access to the caller can be decrypted. To remedy this, we recommend that you do not grant <code>Decrypt</code> access in an IAM user policy. Instead grant <code>Decrypt</code> access only in key policies. If you must grant <code>Decrypt</code> access in an IAM user policy, you should scope the resource to specific keys or to specific trusted accounts.</p> <p>The result of this operation varies with the key state of the CMK. For details, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html">How Key State Affects Use of a Customer Master Key</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>
     fn decrypt(&self, input: DecryptRequest) -> RusotoFuture<DecryptResponse, DecryptError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.Decrypt");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4265,9 +4300,14 @@ impl Kms for KmsClient {
 
     /// <p>Deletes the specified alias. You cannot perform this operation on an alias in a different AWS account. </p> <p>Because an alias is not a property of a CMK, you can delete and change the aliases of a CMK without affecting the CMK. Also, aliases do not appear in the response from the <a>DescribeKey</a> operation. To get the aliases of all CMKs, use the <a>ListAliases</a> operation. </p> <p>Each CMK can have multiple aliases. To change the alias of a CMK, use <a>DeleteAlias</a> to delete the current alias and <a>CreateAlias</a> to create a new alias. To associate an existing alias with a different customer master key (CMK), call <a>UpdateAlias</a>.</p>
     fn delete_alias(&self, input: DeleteAliasRequest) -> RusotoFuture<(), DeleteAliasError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.DeleteAlias");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4291,9 +4331,14 @@ impl Kms for KmsClient {
         &self,
         input: DeleteCustomKeyStoreRequest,
     ) -> RusotoFuture<DeleteCustomKeyStoreResponse, DeleteCustomKeyStoreError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.DeleteCustomKeyStore");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4319,9 +4364,14 @@ impl Kms for KmsClient {
         &self,
         input: DeleteImportedKeyMaterialRequest,
     ) -> RusotoFuture<(), DeleteImportedKeyMaterialError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.DeleteImportedKeyMaterial");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4342,9 +4392,14 @@ impl Kms for KmsClient {
         &self,
         input: DescribeCustomKeyStoresRequest,
     ) -> RusotoFuture<DescribeCustomKeyStoresResponse, DescribeCustomKeyStoresError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.DescribeCustomKeyStores");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4368,9 +4423,14 @@ impl Kms for KmsClient {
         &self,
         input: DescribeKeyRequest,
     ) -> RusotoFuture<DescribeKeyResponse, DescribeKeyError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.DescribeKey");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4394,9 +4454,14 @@ impl Kms for KmsClient {
 
     /// <p>Sets the state of a customer master key (CMK) to disabled, thereby preventing its use for cryptographic operations. You cannot perform this operation on a CMK in a different AWS account.</p> <p>For more information about how key state affects the use of a CMK, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html">How Key State Affects the Use of a Customer Master Key</a> in the <i>AWS Key Management Service Developer Guide</i>.</p> <p>The result of this operation varies with the key state of the CMK. For details, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html">How Key State Affects Use of a Customer Master Key</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>
     fn disable_key(&self, input: DisableKeyRequest) -> RusotoFuture<(), DisableKeyError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.DisableKey");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4420,9 +4485,14 @@ impl Kms for KmsClient {
         &self,
         input: DisableKeyRotationRequest,
     ) -> RusotoFuture<(), DisableKeyRotationError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.DisableKeyRotation");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4446,9 +4516,14 @@ impl Kms for KmsClient {
         &self,
         input: DisconnectCustomKeyStoreRequest,
     ) -> RusotoFuture<DisconnectCustomKeyStoreResponse, DisconnectCustomKeyStoreError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.DisconnectCustomKeyStore");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4469,9 +4544,14 @@ impl Kms for KmsClient {
 
     /// <p>Sets the key state of a customer master key (CMK) to enabled. This allows you to use the CMK for cryptographic operations. You cannot perform this operation on a CMK in a different AWS account.</p> <p>The result of this operation varies with the key state of the CMK. For details, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html">How Key State Affects Use of a Customer Master Key</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>
     fn enable_key(&self, input: EnableKeyRequest) -> RusotoFuture<(), EnableKeyError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.EnableKey");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4495,9 +4575,14 @@ impl Kms for KmsClient {
         &self,
         input: EnableKeyRotationRequest,
     ) -> RusotoFuture<(), EnableKeyRotationError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.EnableKeyRotation");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4518,9 +4603,14 @@ impl Kms for KmsClient {
 
     /// <p>Encrypts plaintext into ciphertext by using a customer master key (CMK). The <code>Encrypt</code> operation has two primary use cases:</p> <ul> <li> <p>You can encrypt up to 4 kilobytes (4096 bytes) of arbitrary data such as an RSA key, a database password, or other sensitive information.</p> </li> <li> <p>To move encrypted data from one AWS region to another, you can use this operation to encrypt in the new region the plaintext data key that was used to encrypt the data in the original region. This provides you with an encrypted copy of the data key that can be decrypted in the new region and used there to decrypt the encrypted data.</p> </li> </ul> <p>To perform this operation on a CMK in a different AWS account, specify the key ARN or alias ARN in the value of the KeyId parameter.</p> <p>Unless you are moving encrypted data from one region to another, you don't use this operation to encrypt a generated data key within a region. To get data keys that are already encrypted, call the <a>GenerateDataKey</a> or <a>GenerateDataKeyWithoutPlaintext</a> operation. Data keys don't need to be encrypted again by calling <code>Encrypt</code>.</p> <p>To encrypt data locally in your application, use the <a>GenerateDataKey</a> operation to return a plaintext data encryption key and a copy of the key encrypted under the CMK of your choosing.</p> <p>The result of this operation varies with the key state of the CMK. For details, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html">How Key State Affects Use of a Customer Master Key</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>
     fn encrypt(&self, input: EncryptRequest) -> RusotoFuture<EncryptResponse, EncryptError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.Encrypt");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4546,9 +4636,14 @@ impl Kms for KmsClient {
         &self,
         input: GenerateDataKeyRequest,
     ) -> RusotoFuture<GenerateDataKeyResponse, GenerateDataKeyError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.GenerateDataKey");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4576,9 +4671,14 @@ impl Kms for KmsClient {
         input: GenerateDataKeyWithoutPlaintextRequest,
     ) -> RusotoFuture<GenerateDataKeyWithoutPlaintextResponse, GenerateDataKeyWithoutPlaintextError>
     {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "TrentService.GenerateDataKeyWithoutPlaintext",
@@ -4607,9 +4707,14 @@ impl Kms for KmsClient {
         &self,
         input: GenerateRandomRequest,
     ) -> RusotoFuture<GenerateRandomResponse, GenerateRandomError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.GenerateRandom");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4636,9 +4741,14 @@ impl Kms for KmsClient {
         &self,
         input: GetKeyPolicyRequest,
     ) -> RusotoFuture<GetKeyPolicyResponse, GetKeyPolicyError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.GetKeyPolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4665,9 +4775,14 @@ impl Kms for KmsClient {
         &self,
         input: GetKeyRotationStatusRequest,
     ) -> RusotoFuture<GetKeyRotationStatusResponse, GetKeyRotationStatusError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.GetKeyRotationStatus");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4693,9 +4808,14 @@ impl Kms for KmsClient {
         &self,
         input: GetParametersForImportRequest,
     ) -> RusotoFuture<GetParametersForImportResponse, GetParametersForImportError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.GetParametersForImport");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4721,9 +4841,14 @@ impl Kms for KmsClient {
         &self,
         input: ImportKeyMaterialRequest,
     ) -> RusotoFuture<ImportKeyMaterialResponse, ImportKeyMaterialError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.ImportKeyMaterial");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4750,9 +4875,14 @@ impl Kms for KmsClient {
         &self,
         input: ListAliasesRequest,
     ) -> RusotoFuture<ListAliasesResponse, ListAliasesError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.ListAliases");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4779,9 +4909,14 @@ impl Kms for KmsClient {
         &self,
         input: ListGrantsRequest,
     ) -> RusotoFuture<ListGrantsResponse, ListGrantsError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.ListGrants");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4808,9 +4943,14 @@ impl Kms for KmsClient {
         &self,
         input: ListKeyPoliciesRequest,
     ) -> RusotoFuture<ListKeyPoliciesResponse, ListKeyPoliciesError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.ListKeyPolicies");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4834,9 +4974,14 @@ impl Kms for KmsClient {
 
     /// <p>Gets a list of all customer master keys (CMKs) in the caller's AWS account and region.</p>
     fn list_keys(&self, input: ListKeysRequest) -> RusotoFuture<ListKeysResponse, ListKeysError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.ListKeys");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4863,9 +5008,14 @@ impl Kms for KmsClient {
         &self,
         input: ListResourceTagsRequest,
     ) -> RusotoFuture<ListResourceTagsResponse, ListResourceTagsError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.ListResourceTags");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4892,9 +5042,14 @@ impl Kms for KmsClient {
         &self,
         input: ListRetirableGrantsRequest,
     ) -> RusotoFuture<ListGrantsResponse, ListRetirableGrantsError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.ListRetirableGrants");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4917,9 +5072,14 @@ impl Kms for KmsClient {
 
     /// <p>Attaches a key policy to the specified customer master key (CMK). You cannot perform this operation on a CMK in a different AWS account.</p> <p>For more information about key policies, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html">Key Policies</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>
     fn put_key_policy(&self, input: PutKeyPolicyRequest) -> RusotoFuture<(), PutKeyPolicyError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.PutKeyPolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4943,9 +5103,14 @@ impl Kms for KmsClient {
         &self,
         input: ReEncryptRequest,
     ) -> RusotoFuture<ReEncryptResponse, ReEncryptError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.ReEncrypt");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4969,9 +5134,14 @@ impl Kms for KmsClient {
 
     /// <p>Retires a grant. To clean up, you can retire a grant when you're done using it. You should revoke a grant when you intend to actively deny operations that depend on it. The following are permitted to call this API:</p> <ul> <li> <p>The AWS account (root user) under which the grant was created</p> </li> <li> <p>The <code>RetiringPrincipal</code>, if present in the grant</p> </li> <li> <p>The <code>GranteePrincipal</code>, if <code>RetireGrant</code> is an operation specified in the grant</p> </li> </ul> <p>You must identify the grant to retire by its grant token or by a combination of the grant ID and the Amazon Resource Name (ARN) of the customer master key (CMK). A grant token is a unique variable-length base64-encoded string. A grant ID is a 64 character unique identifier of a grant. The <a>CreateGrant</a> operation returns both.</p>
     fn retire_grant(&self, input: RetireGrantRequest) -> RusotoFuture<(), RetireGrantError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.RetireGrant");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4992,9 +5162,14 @@ impl Kms for KmsClient {
 
     /// <p>Revokes the specified grant for the specified customer master key (CMK). You can revoke a grant to actively deny operations that depend on it.</p> <p>To perform this operation on a CMK in a different AWS account, specify the key ARN in the value of the <code>KeyId</code> parameter.</p>
     fn revoke_grant(&self, input: RevokeGrantRequest) -> RusotoFuture<(), RevokeGrantError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.RevokeGrant");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5018,9 +5193,14 @@ impl Kms for KmsClient {
         &self,
         input: ScheduleKeyDeletionRequest,
     ) -> RusotoFuture<ScheduleKeyDeletionResponse, ScheduleKeyDeletionError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.ScheduleKeyDeletion");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5043,9 +5223,14 @@ impl Kms for KmsClient {
 
     /// <p>Adds or edits tags for a customer master key (CMK). You cannot perform this operation on a CMK in a different AWS account.</p> <p>Each tag consists of a tag key and a tag value. Tag keys and tag values are both required, but tag values can be empty (null) strings.</p> <p>You can only use a tag key once for each CMK. If you use the tag key again, AWS KMS replaces the current tag value with the specified value.</p> <p>For information about the rules that apply to tag keys and tag values, see <a href="http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/allocation-tag-restrictions.html">User-Defined Tag Restrictions</a> in the <i>AWS Billing and Cost Management User Guide</i>.</p> <p>The result of this operation varies with the key state of the CMK. For details, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html">How Key State Affects Use of a Customer Master Key</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>
     fn tag_resource(&self, input: TagResourceRequest) -> RusotoFuture<(), TagResourceError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.TagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5066,9 +5251,14 @@ impl Kms for KmsClient {
 
     /// <p>Removes the specified tags from the specified customer master key (CMK). You cannot perform this operation on a CMK in a different AWS account.</p> <p>To remove a tag, specify the tag key. To change the tag value of an existing tag key, use <a>TagResource</a>.</p> <p>The result of this operation varies with the key state of the CMK. For details, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html">How Key State Affects Use of a Customer Master Key</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>
     fn untag_resource(&self, input: UntagResourceRequest) -> RusotoFuture<(), UntagResourceError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.UntagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5089,9 +5279,14 @@ impl Kms for KmsClient {
 
     /// <p>Associates an existing alias with a different customer master key (CMK). Each CMK can have multiple aliases, but the aliases must be unique within the account and region. You cannot perform this operation on an alias in a different AWS account.</p> <p>This operation works only on existing aliases. To change the alias of a CMK to a new value, use <a>CreateAlias</a> to create a new alias and <a>DeleteAlias</a> to delete the old alias.</p> <p>Because an alias is not a property of a CMK, you can create, update, and delete the aliases of a CMK without affecting the CMK. Also, aliases do not appear in the response from the <a>DescribeKey</a> operation. To get the aliases of all CMKs in the account, use the <a>ListAliases</a> operation. </p> <p>An alias name can contain only alphanumeric characters, forward slashes (/), underscores (_), and dashes (-). An alias must start with the word <code>alias</code> followed by a forward slash (<code>alias/</code>). The alias name can contain only alphanumeric characters, forward slashes (/), underscores (_), and dashes (-). Alias names cannot begin with <code>aws</code>; that alias name prefix is reserved by Amazon Web Services (AWS).</p> <p>The result of this operation varies with the key state of the CMK. For details, see <a href="http://docs.aws.amazon.com/kms/latest/developerguide/key-state.html">How Key State Affects Use of a Customer Master Key</a> in the <i>AWS Key Management Service Developer Guide</i>.</p>
     fn update_alias(&self, input: UpdateAliasRequest) -> RusotoFuture<(), UpdateAliasError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.UpdateAlias");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5115,9 +5310,14 @@ impl Kms for KmsClient {
         &self,
         input: UpdateCustomKeyStoreRequest,
     ) -> RusotoFuture<UpdateCustomKeyStoreResponse, UpdateCustomKeyStoreError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.UpdateCustomKeyStore");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5143,9 +5343,14 @@ impl Kms for KmsClient {
         &self,
         input: UpdateKeyDescriptionRequest,
     ) -> RusotoFuture<(), UpdateKeyDescriptionError> {
-        let mut request = SignedRequest::new("POST", "kms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "kms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "TrentService.UpdateKeyDescription");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/license-manager/src/generated.rs
+++ b/rusoto/services/license-manager/src/generated.rs
@@ -1842,9 +1842,14 @@ impl LicenseManager for LicenseManagerClient {
         &self,
         input: CreateLicenseConfigurationRequest,
     ) -> RusotoFuture<CreateLicenseConfigurationResponse, CreateLicenseConfigurationError> {
-        let mut request = SignedRequest::new("POST", "license-manager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "license-manager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSLicenseManager.CreateLicenseConfiguration",
@@ -1871,9 +1876,14 @@ impl LicenseManager for LicenseManagerClient {
         &self,
         input: DeleteLicenseConfigurationRequest,
     ) -> RusotoFuture<DeleteLicenseConfigurationResponse, DeleteLicenseConfigurationError> {
-        let mut request = SignedRequest::new("POST", "license-manager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "license-manager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSLicenseManager.DeleteLicenseConfiguration",
@@ -1900,9 +1910,14 @@ impl LicenseManager for LicenseManagerClient {
         &self,
         input: GetLicenseConfigurationRequest,
     ) -> RusotoFuture<GetLicenseConfigurationResponse, GetLicenseConfigurationError> {
-        let mut request = SignedRequest::new("POST", "license-manager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "license-manager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSLicenseManager.GetLicenseConfiguration");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1925,9 +1940,14 @@ impl LicenseManager for LicenseManagerClient {
     fn get_service_settings(
         &self,
     ) -> RusotoFuture<GetServiceSettingsResponse, GetServiceSettingsError> {
-        let mut request = SignedRequest::new("POST", "license-manager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "license-manager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSLicenseManager.GetServiceSettings");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -1956,9 +1976,14 @@ impl LicenseManager for LicenseManagerClient {
         ListAssociationsForLicenseConfigurationResponse,
         ListAssociationsForLicenseConfigurationError,
     > {
-        let mut request = SignedRequest::new("POST", "license-manager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "license-manager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSLicenseManager.ListAssociationsForLicenseConfiguration",
@@ -1987,9 +2012,14 @@ impl LicenseManager for LicenseManagerClient {
         &self,
         input: ListLicenseConfigurationsRequest,
     ) -> RusotoFuture<ListLicenseConfigurationsResponse, ListLicenseConfigurationsError> {
-        let mut request = SignedRequest::new("POST", "license-manager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "license-manager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSLicenseManager.ListLicenseConfigurations",
@@ -2019,9 +2049,14 @@ impl LicenseManager for LicenseManagerClient {
         ListLicenseSpecificationsForResourceResponse,
         ListLicenseSpecificationsForResourceError,
     > {
-        let mut request = SignedRequest::new("POST", "license-manager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "license-manager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSLicenseManager.ListLicenseSpecificationsForResource",
@@ -2050,9 +2085,14 @@ impl LicenseManager for LicenseManagerClient {
         &self,
         input: ListResourceInventoryRequest,
     ) -> RusotoFuture<ListResourceInventoryResponse, ListResourceInventoryError> {
-        let mut request = SignedRequest::new("POST", "license-manager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "license-manager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSLicenseManager.ListResourceInventory");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2078,9 +2118,14 @@ impl LicenseManager for LicenseManagerClient {
         &self,
         input: ListTagsForResourceRequest,
     ) -> RusotoFuture<ListTagsForResourceResponse, ListTagsForResourceError> {
-        let mut request = SignedRequest::new("POST", "license-manager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "license-manager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSLicenseManager.ListTagsForResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2107,9 +2152,14 @@ impl LicenseManager for LicenseManagerClient {
         input: ListUsageForLicenseConfigurationRequest,
     ) -> RusotoFuture<ListUsageForLicenseConfigurationResponse, ListUsageForLicenseConfigurationError>
     {
-        let mut request = SignedRequest::new("POST", "license-manager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "license-manager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSLicenseManager.ListUsageForLicenseConfiguration",
@@ -2138,9 +2188,14 @@ impl LicenseManager for LicenseManagerClient {
         &self,
         input: TagResourceRequest,
     ) -> RusotoFuture<TagResourceResponse, TagResourceError> {
-        let mut request = SignedRequest::new("POST", "license-manager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "license-manager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSLicenseManager.TagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2167,9 +2222,14 @@ impl LicenseManager for LicenseManagerClient {
         &self,
         input: UntagResourceRequest,
     ) -> RusotoFuture<UntagResourceResponse, UntagResourceError> {
-        let mut request = SignedRequest::new("POST", "license-manager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "license-manager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSLicenseManager.UntagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2196,9 +2256,14 @@ impl LicenseManager for LicenseManagerClient {
         &self,
         input: UpdateLicenseConfigurationRequest,
     ) -> RusotoFuture<UpdateLicenseConfigurationResponse, UpdateLicenseConfigurationError> {
-        let mut request = SignedRequest::new("POST", "license-manager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "license-manager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSLicenseManager.UpdateLicenseConfiguration",
@@ -2228,9 +2293,14 @@ impl LicenseManager for LicenseManagerClient {
         UpdateLicenseSpecificationsForResourceResponse,
         UpdateLicenseSpecificationsForResourceError,
     > {
-        let mut request = SignedRequest::new("POST", "license-manager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "license-manager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSLicenseManager.UpdateLicenseSpecificationsForResource",
@@ -2259,9 +2329,14 @@ impl LicenseManager for LicenseManagerClient {
         &self,
         input: UpdateServiceSettingsRequest,
     ) -> RusotoFuture<UpdateServiceSettingsResponse, UpdateServiceSettingsError> {
-        let mut request = SignedRequest::new("POST", "license-manager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "license-manager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSLicenseManager.UpdateServiceSettings");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/lightsail/src/generated.rs
+++ b/rusoto/services/lightsail/src/generated.rs
@@ -12063,9 +12063,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: AllocateStaticIpRequest,
     ) -> RusotoFuture<AllocateStaticIpResult, AllocateStaticIpError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.AllocateStaticIp");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -12092,9 +12097,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: AttachDiskRequest,
     ) -> RusotoFuture<AttachDiskResult, AttachDiskError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.AttachDisk");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -12121,9 +12131,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: AttachInstancesToLoadBalancerRequest,
     ) -> RusotoFuture<AttachInstancesToLoadBalancerResult, AttachInstancesToLoadBalancerError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.AttachInstancesToLoadBalancer",
@@ -12151,9 +12166,14 @@ impl Lightsail for LightsailClient {
         input: AttachLoadBalancerTlsCertificateRequest,
     ) -> RusotoFuture<AttachLoadBalancerTlsCertificateResult, AttachLoadBalancerTlsCertificateError>
     {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.AttachLoadBalancerTlsCertificate",
@@ -12182,9 +12202,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: AttachStaticIpRequest,
     ) -> RusotoFuture<AttachStaticIpResult, AttachStaticIpError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.AttachStaticIp");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -12211,9 +12236,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: CloseInstancePublicPortsRequest,
     ) -> RusotoFuture<CloseInstancePublicPortsResult, CloseInstancePublicPortsError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.CloseInstancePublicPorts",
@@ -12240,9 +12270,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: CopySnapshotRequest,
     ) -> RusotoFuture<CopySnapshotResult, CopySnapshotError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.CopySnapshot");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -12269,9 +12304,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: CreateCloudFormationStackRequest,
     ) -> RusotoFuture<CreateCloudFormationStackResult, CreateCloudFormationStackError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.CreateCloudFormationStack",
@@ -12298,9 +12338,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: CreateDiskRequest,
     ) -> RusotoFuture<CreateDiskResult, CreateDiskError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.CreateDisk");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -12327,9 +12372,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: CreateDiskFromSnapshotRequest,
     ) -> RusotoFuture<CreateDiskFromSnapshotResult, CreateDiskFromSnapshotError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.CreateDiskFromSnapshot");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -12355,9 +12405,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: CreateDiskSnapshotRequest,
     ) -> RusotoFuture<CreateDiskSnapshotResult, CreateDiskSnapshotError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.CreateDiskSnapshot");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -12384,9 +12439,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: CreateDomainRequest,
     ) -> RusotoFuture<CreateDomainResult, CreateDomainError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.CreateDomain");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -12413,9 +12473,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: CreateDomainEntryRequest,
     ) -> RusotoFuture<CreateDomainEntryResult, CreateDomainEntryError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.CreateDomainEntry");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -12442,9 +12507,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: CreateInstanceSnapshotRequest,
     ) -> RusotoFuture<CreateInstanceSnapshotResult, CreateInstanceSnapshotError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.CreateInstanceSnapshot");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -12470,9 +12540,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: CreateInstancesRequest,
     ) -> RusotoFuture<CreateInstancesResult, CreateInstancesError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.CreateInstances");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -12499,9 +12574,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: CreateInstancesFromSnapshotRequest,
     ) -> RusotoFuture<CreateInstancesFromSnapshotResult, CreateInstancesFromSnapshotError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.CreateInstancesFromSnapshot",
@@ -12528,9 +12608,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: CreateKeyPairRequest,
     ) -> RusotoFuture<CreateKeyPairResult, CreateKeyPairError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.CreateKeyPair");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -12557,9 +12642,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: CreateLoadBalancerRequest,
     ) -> RusotoFuture<CreateLoadBalancerResult, CreateLoadBalancerError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.CreateLoadBalancer");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -12587,9 +12677,14 @@ impl Lightsail for LightsailClient {
         input: CreateLoadBalancerTlsCertificateRequest,
     ) -> RusotoFuture<CreateLoadBalancerTlsCertificateResult, CreateLoadBalancerTlsCertificateError>
     {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.CreateLoadBalancerTlsCertificate",
@@ -12618,9 +12713,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: CreateRelationalDatabaseRequest,
     ) -> RusotoFuture<CreateRelationalDatabaseResult, CreateRelationalDatabaseError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.CreateRelationalDatabase",
@@ -12650,9 +12750,14 @@ impl Lightsail for LightsailClient {
         CreateRelationalDatabaseFromSnapshotResult,
         CreateRelationalDatabaseFromSnapshotError,
     > {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.CreateRelationalDatabaseFromSnapshot",
@@ -12682,9 +12787,14 @@ impl Lightsail for LightsailClient {
         input: CreateRelationalDatabaseSnapshotRequest,
     ) -> RusotoFuture<CreateRelationalDatabaseSnapshotResult, CreateRelationalDatabaseSnapshotError>
     {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.CreateRelationalDatabaseSnapshot",
@@ -12713,9 +12823,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: DeleteDiskRequest,
     ) -> RusotoFuture<DeleteDiskResult, DeleteDiskError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.DeleteDisk");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -12742,9 +12857,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: DeleteDiskSnapshotRequest,
     ) -> RusotoFuture<DeleteDiskSnapshotResult, DeleteDiskSnapshotError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.DeleteDiskSnapshot");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -12771,9 +12891,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: DeleteDomainRequest,
     ) -> RusotoFuture<DeleteDomainResult, DeleteDomainError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.DeleteDomain");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -12800,9 +12925,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: DeleteDomainEntryRequest,
     ) -> RusotoFuture<DeleteDomainEntryResult, DeleteDomainEntryError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.DeleteDomainEntry");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -12829,9 +12959,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: DeleteInstanceRequest,
     ) -> RusotoFuture<DeleteInstanceResult, DeleteInstanceError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.DeleteInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -12858,9 +12993,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: DeleteInstanceSnapshotRequest,
     ) -> RusotoFuture<DeleteInstanceSnapshotResult, DeleteInstanceSnapshotError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.DeleteInstanceSnapshot");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -12886,9 +13026,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: DeleteKeyPairRequest,
     ) -> RusotoFuture<DeleteKeyPairResult, DeleteKeyPairError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.DeleteKeyPair");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -12915,9 +13060,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: DeleteLoadBalancerRequest,
     ) -> RusotoFuture<DeleteLoadBalancerResult, DeleteLoadBalancerError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.DeleteLoadBalancer");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -12945,9 +13095,14 @@ impl Lightsail for LightsailClient {
         input: DeleteLoadBalancerTlsCertificateRequest,
     ) -> RusotoFuture<DeleteLoadBalancerTlsCertificateResult, DeleteLoadBalancerTlsCertificateError>
     {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.DeleteLoadBalancerTlsCertificate",
@@ -12976,9 +13131,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: DeleteRelationalDatabaseRequest,
     ) -> RusotoFuture<DeleteRelationalDatabaseResult, DeleteRelationalDatabaseError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.DeleteRelationalDatabase",
@@ -13006,9 +13166,14 @@ impl Lightsail for LightsailClient {
         input: DeleteRelationalDatabaseSnapshotRequest,
     ) -> RusotoFuture<DeleteRelationalDatabaseSnapshotResult, DeleteRelationalDatabaseSnapshotError>
     {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.DeleteRelationalDatabaseSnapshot",
@@ -13037,9 +13202,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: DetachDiskRequest,
     ) -> RusotoFuture<DetachDiskResult, DetachDiskError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.DetachDisk");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13067,9 +13237,14 @@ impl Lightsail for LightsailClient {
         input: DetachInstancesFromLoadBalancerRequest,
     ) -> RusotoFuture<DetachInstancesFromLoadBalancerResult, DetachInstancesFromLoadBalancerError>
     {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.DetachInstancesFromLoadBalancer",
@@ -13098,9 +13273,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: DetachStaticIpRequest,
     ) -> RusotoFuture<DetachStaticIpResult, DetachStaticIpError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.DetachStaticIp");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13126,9 +13306,14 @@ impl Lightsail for LightsailClient {
     fn download_default_key_pair(
         &self,
     ) -> RusotoFuture<DownloadDefaultKeyPairResult, DownloadDefaultKeyPairError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.DownloadDefaultKeyPair");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -13153,9 +13338,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: ExportSnapshotRequest,
     ) -> RusotoFuture<ExportSnapshotResult, ExportSnapshotError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.ExportSnapshot");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13182,9 +13372,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetActiveNamesRequest,
     ) -> RusotoFuture<GetActiveNamesResult, GetActiveNamesError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetActiveNames");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13211,9 +13406,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetBlueprintsRequest,
     ) -> RusotoFuture<GetBlueprintsResult, GetBlueprintsError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetBlueprints");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13240,9 +13440,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetBundlesRequest,
     ) -> RusotoFuture<GetBundlesResult, GetBundlesError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetBundles");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13269,9 +13474,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetCloudFormationStackRecordsRequest,
     ) -> RusotoFuture<GetCloudFormationStackRecordsResult, GetCloudFormationStackRecordsError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.GetCloudFormationStackRecords",
@@ -13295,9 +13505,14 @@ impl Lightsail for LightsailClient {
 
     /// <p>Returns information about a specific block storage disk.</p>
     fn get_disk(&self, input: GetDiskRequest) -> RusotoFuture<GetDiskResult, GetDiskError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetDisk");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13323,9 +13538,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetDiskSnapshotRequest,
     ) -> RusotoFuture<GetDiskSnapshotResult, GetDiskSnapshotError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetDiskSnapshot");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13352,9 +13572,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetDiskSnapshotsRequest,
     ) -> RusotoFuture<GetDiskSnapshotsResult, GetDiskSnapshotsError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetDiskSnapshots");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13378,9 +13603,14 @@ impl Lightsail for LightsailClient {
 
     /// <p>Returns information about all block storage disks in your AWS account and region.</p> <p>If you are describing a long list of disks, you can paginate the output to make the list more manageable. You can use the pageToken and nextPageToken values to retrieve the next items in the list.</p>
     fn get_disks(&self, input: GetDisksRequest) -> RusotoFuture<GetDisksResult, GetDisksError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetDisks");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13403,9 +13633,14 @@ impl Lightsail for LightsailClient {
 
     /// <p>Returns information about a specific domain recordset.</p>
     fn get_domain(&self, input: GetDomainRequest) -> RusotoFuture<GetDomainResult, GetDomainError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetDomain");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13431,9 +13666,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetDomainsRequest,
     ) -> RusotoFuture<GetDomainsResult, GetDomainsError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetDomains");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13460,9 +13700,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetExportSnapshotRecordsRequest,
     ) -> RusotoFuture<GetExportSnapshotRecordsResult, GetExportSnapshotRecordsError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.GetExportSnapshotRecords",
@@ -13489,9 +13734,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetInstanceRequest,
     ) -> RusotoFuture<GetInstanceResult, GetInstanceError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13518,9 +13768,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetInstanceAccessDetailsRequest,
     ) -> RusotoFuture<GetInstanceAccessDetailsResult, GetInstanceAccessDetailsError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.GetInstanceAccessDetails",
@@ -13547,9 +13802,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetInstanceMetricDataRequest,
     ) -> RusotoFuture<GetInstanceMetricDataResult, GetInstanceMetricDataError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetInstanceMetricData");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13575,9 +13835,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetInstancePortStatesRequest,
     ) -> RusotoFuture<GetInstancePortStatesResult, GetInstancePortStatesError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetInstancePortStates");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13603,9 +13868,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetInstanceSnapshotRequest,
     ) -> RusotoFuture<GetInstanceSnapshotResult, GetInstanceSnapshotError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetInstanceSnapshot");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13631,9 +13901,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetInstanceSnapshotsRequest,
     ) -> RusotoFuture<GetInstanceSnapshotsResult, GetInstanceSnapshotsError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetInstanceSnapshots");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13659,9 +13934,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetInstanceStateRequest,
     ) -> RusotoFuture<GetInstanceStateResult, GetInstanceStateError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetInstanceState");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13688,9 +13968,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetInstancesRequest,
     ) -> RusotoFuture<GetInstancesResult, GetInstancesError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetInstances");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13717,9 +14002,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetKeyPairRequest,
     ) -> RusotoFuture<GetKeyPairResult, GetKeyPairError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetKeyPair");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13746,9 +14036,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetKeyPairsRequest,
     ) -> RusotoFuture<GetKeyPairsResult, GetKeyPairsError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetKeyPairs");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13775,9 +14070,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetLoadBalancerRequest,
     ) -> RusotoFuture<GetLoadBalancerResult, GetLoadBalancerError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetLoadBalancer");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13804,9 +14104,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetLoadBalancerMetricDataRequest,
     ) -> RusotoFuture<GetLoadBalancerMetricDataResult, GetLoadBalancerMetricDataError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.GetLoadBalancerMetricData",
@@ -13834,9 +14139,14 @@ impl Lightsail for LightsailClient {
         input: GetLoadBalancerTlsCertificatesRequest,
     ) -> RusotoFuture<GetLoadBalancerTlsCertificatesResult, GetLoadBalancerTlsCertificatesError>
     {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.GetLoadBalancerTlsCertificates",
@@ -13863,9 +14173,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetLoadBalancersRequest,
     ) -> RusotoFuture<GetLoadBalancersResult, GetLoadBalancersError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetLoadBalancers");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13892,9 +14207,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetOperationRequest,
     ) -> RusotoFuture<GetOperationResult, GetOperationError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetOperation");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13921,9 +14241,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetOperationsRequest,
     ) -> RusotoFuture<GetOperationsResult, GetOperationsError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetOperations");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13950,9 +14275,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetOperationsForResourceRequest,
     ) -> RusotoFuture<GetOperationsForResourceResult, GetOperationsForResourceError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.GetOperationsForResource",
@@ -13979,9 +14309,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetRegionsRequest,
     ) -> RusotoFuture<GetRegionsResult, GetRegionsError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetRegions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14008,9 +14343,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetRelationalDatabaseRequest,
     ) -> RusotoFuture<GetRelationalDatabaseResult, GetRelationalDatabaseError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetRelationalDatabase");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14037,9 +14377,14 @@ impl Lightsail for LightsailClient {
         input: GetRelationalDatabaseBlueprintsRequest,
     ) -> RusotoFuture<GetRelationalDatabaseBlueprintsResult, GetRelationalDatabaseBlueprintsError>
     {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.GetRelationalDatabaseBlueprints",
@@ -14068,9 +14413,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetRelationalDatabaseBundlesRequest,
     ) -> RusotoFuture<GetRelationalDatabaseBundlesResult, GetRelationalDatabaseBundlesError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.GetRelationalDatabaseBundles",
@@ -14097,9 +14447,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetRelationalDatabaseEventsRequest,
     ) -> RusotoFuture<GetRelationalDatabaseEventsResult, GetRelationalDatabaseEventsError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.GetRelationalDatabaseEvents",
@@ -14127,9 +14482,14 @@ impl Lightsail for LightsailClient {
         input: GetRelationalDatabaseLogEventsRequest,
     ) -> RusotoFuture<GetRelationalDatabaseLogEventsResult, GetRelationalDatabaseLogEventsError>
     {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.GetRelationalDatabaseLogEvents",
@@ -14157,9 +14517,14 @@ impl Lightsail for LightsailClient {
         input: GetRelationalDatabaseLogStreamsRequest,
     ) -> RusotoFuture<GetRelationalDatabaseLogStreamsResult, GetRelationalDatabaseLogStreamsError>
     {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.GetRelationalDatabaseLogStreams",
@@ -14191,9 +14556,14 @@ impl Lightsail for LightsailClient {
         GetRelationalDatabaseMasterUserPasswordResult,
         GetRelationalDatabaseMasterUserPasswordError,
     > {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.GetRelationalDatabaseMasterUserPassword",
@@ -14223,9 +14593,14 @@ impl Lightsail for LightsailClient {
         input: GetRelationalDatabaseMetricDataRequest,
     ) -> RusotoFuture<GetRelationalDatabaseMetricDataResult, GetRelationalDatabaseMetricDataError>
     {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.GetRelationalDatabaseMetricData",
@@ -14255,9 +14630,14 @@ impl Lightsail for LightsailClient {
         input: GetRelationalDatabaseParametersRequest,
     ) -> RusotoFuture<GetRelationalDatabaseParametersResult, GetRelationalDatabaseParametersError>
     {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.GetRelationalDatabaseParameters",
@@ -14286,9 +14666,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetRelationalDatabaseSnapshotRequest,
     ) -> RusotoFuture<GetRelationalDatabaseSnapshotResult, GetRelationalDatabaseSnapshotError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.GetRelationalDatabaseSnapshot",
@@ -14316,9 +14701,14 @@ impl Lightsail for LightsailClient {
         input: GetRelationalDatabaseSnapshotsRequest,
     ) -> RusotoFuture<GetRelationalDatabaseSnapshotsResult, GetRelationalDatabaseSnapshotsError>
     {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.GetRelationalDatabaseSnapshots",
@@ -14345,9 +14735,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetRelationalDatabasesRequest,
     ) -> RusotoFuture<GetRelationalDatabasesResult, GetRelationalDatabasesError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetRelationalDatabases");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14373,9 +14768,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetStaticIpRequest,
     ) -> RusotoFuture<GetStaticIpResult, GetStaticIpError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetStaticIp");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14402,9 +14802,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: GetStaticIpsRequest,
     ) -> RusotoFuture<GetStaticIpsResult, GetStaticIpsError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.GetStaticIps");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14431,9 +14836,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: ImportKeyPairRequest,
     ) -> RusotoFuture<ImportKeyPairResult, ImportKeyPairError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.ImportKeyPair");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14457,9 +14867,14 @@ impl Lightsail for LightsailClient {
 
     /// <p>Returns a Boolean value indicating whether your Lightsail VPC is peered.</p>
     fn is_vpc_peered(&self) -> RusotoFuture<IsVpcPeeredResult, IsVpcPeeredError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.IsVpcPeered");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -14485,9 +14900,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: OpenInstancePublicPortsRequest,
     ) -> RusotoFuture<OpenInstancePublicPortsResult, OpenInstancePublicPortsError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.OpenInstancePublicPorts");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14508,9 +14928,14 @@ impl Lightsail for LightsailClient {
 
     /// <p>Tries to peer the Lightsail VPC with the user's default VPC.</p>
     fn peer_vpc(&self) -> RusotoFuture<PeerVpcResult, PeerVpcError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.PeerVpc");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -14535,9 +14960,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: PutInstancePublicPortsRequest,
     ) -> RusotoFuture<PutInstancePublicPortsResult, PutInstancePublicPortsError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.PutInstancePublicPorts");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14563,9 +14993,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: RebootInstanceRequest,
     ) -> RusotoFuture<RebootInstanceResult, RebootInstanceError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.RebootInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14592,9 +15027,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: RebootRelationalDatabaseRequest,
     ) -> RusotoFuture<RebootRelationalDatabaseResult, RebootRelationalDatabaseError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.RebootRelationalDatabase",
@@ -14621,9 +15061,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: ReleaseStaticIpRequest,
     ) -> RusotoFuture<ReleaseStaticIpResult, ReleaseStaticIpError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.ReleaseStaticIp");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14650,9 +15095,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: StartInstanceRequest,
     ) -> RusotoFuture<StartInstanceResult, StartInstanceError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.StartInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14679,9 +15129,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: StartRelationalDatabaseRequest,
     ) -> RusotoFuture<StartRelationalDatabaseResult, StartRelationalDatabaseError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.StartRelationalDatabase");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14705,9 +15160,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: StopInstanceRequest,
     ) -> RusotoFuture<StopInstanceResult, StopInstanceError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.StopInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14734,9 +15194,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: StopRelationalDatabaseRequest,
     ) -> RusotoFuture<StopRelationalDatabaseResult, StopRelationalDatabaseError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.StopRelationalDatabase");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14762,9 +15227,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: TagResourceRequest,
     ) -> RusotoFuture<TagResourceResult, TagResourceError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.TagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14788,9 +15258,14 @@ impl Lightsail for LightsailClient {
 
     /// <p>Attempts to unpeer the Lightsail VPC from the user's default VPC.</p>
     fn unpeer_vpc(&self) -> RusotoFuture<UnpeerVpcResult, UnpeerVpcError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.UnpeerVpc");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -14815,9 +15290,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: UntagResourceRequest,
     ) -> RusotoFuture<UntagResourceResult, UntagResourceError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.UntagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14844,9 +15324,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: UpdateDomainEntryRequest,
     ) -> RusotoFuture<UpdateDomainEntryResult, UpdateDomainEntryError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Lightsail_20161128.UpdateDomainEntry");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14873,9 +15358,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: UpdateLoadBalancerAttributeRequest,
     ) -> RusotoFuture<UpdateLoadBalancerAttributeResult, UpdateLoadBalancerAttributeError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.UpdateLoadBalancerAttribute",
@@ -14902,9 +15392,14 @@ impl Lightsail for LightsailClient {
         &self,
         input: UpdateRelationalDatabaseRequest,
     ) -> RusotoFuture<UpdateRelationalDatabaseResult, UpdateRelationalDatabaseError> {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.UpdateRelationalDatabase",
@@ -14934,9 +15429,14 @@ impl Lightsail for LightsailClient {
         UpdateRelationalDatabaseParametersResult,
         UpdateRelationalDatabaseParametersError,
     > {
-        let mut request = SignedRequest::new("POST", "lightsail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "lightsail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Lightsail_20161128.UpdateRelationalDatabaseParameters",

--- a/rusoto/services/logs/src/generated.rs
+++ b/rusoto/services/logs/src/generated.rs
@@ -3493,9 +3493,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: AssociateKmsKeyRequest,
     ) -> RusotoFuture<(), AssociateKmsKeyError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.AssociateKmsKey");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3519,9 +3524,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: CancelExportTaskRequest,
     ) -> RusotoFuture<(), CancelExportTaskError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.CancelExportTask");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3545,9 +3555,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: CreateExportTaskRequest,
     ) -> RusotoFuture<CreateExportTaskResponse, CreateExportTaskError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.CreateExportTask");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3574,9 +3589,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: CreateLogGroupRequest,
     ) -> RusotoFuture<(), CreateLogGroupError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.CreateLogGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3600,9 +3620,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: CreateLogStreamRequest,
     ) -> RusotoFuture<(), CreateLogStreamError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.CreateLogStream");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3626,9 +3651,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: DeleteDestinationRequest,
     ) -> RusotoFuture<(), DeleteDestinationError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.DeleteDestination");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3652,9 +3682,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: DeleteLogGroupRequest,
     ) -> RusotoFuture<(), DeleteLogGroupError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.DeleteLogGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3678,9 +3713,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: DeleteLogStreamRequest,
     ) -> RusotoFuture<(), DeleteLogStreamError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.DeleteLogStream");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3704,9 +3744,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: DeleteMetricFilterRequest,
     ) -> RusotoFuture<(), DeleteMetricFilterError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.DeleteMetricFilter");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3730,9 +3775,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: DeleteResourcePolicyRequest,
     ) -> RusotoFuture<(), DeleteResourcePolicyError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.DeleteResourcePolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3755,9 +3805,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: DeleteRetentionPolicyRequest,
     ) -> RusotoFuture<(), DeleteRetentionPolicyError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.DeleteRetentionPolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3780,9 +3835,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: DeleteSubscriptionFilterRequest,
     ) -> RusotoFuture<(), DeleteSubscriptionFilterError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.DeleteSubscriptionFilter");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3803,9 +3863,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: DescribeDestinationsRequest,
     ) -> RusotoFuture<DescribeDestinationsResponse, DescribeDestinationsError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.DescribeDestinations");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3831,9 +3896,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: DescribeExportTasksRequest,
     ) -> RusotoFuture<DescribeExportTasksResponse, DescribeExportTasksError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.DescribeExportTasks");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3859,9 +3929,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: DescribeLogGroupsRequest,
     ) -> RusotoFuture<DescribeLogGroupsResponse, DescribeLogGroupsError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.DescribeLogGroups");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3888,9 +3963,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: DescribeLogStreamsRequest,
     ) -> RusotoFuture<DescribeLogStreamsResponse, DescribeLogStreamsError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.DescribeLogStreams");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3917,9 +3997,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: DescribeMetricFiltersRequest,
     ) -> RusotoFuture<DescribeMetricFiltersResponse, DescribeMetricFiltersError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.DescribeMetricFilters");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3945,9 +4030,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: DescribeQueriesRequest,
     ) -> RusotoFuture<DescribeQueriesResponse, DescribeQueriesError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.DescribeQueries");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3974,9 +4064,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: DescribeResourcePoliciesRequest,
     ) -> RusotoFuture<DescribeResourcePoliciesResponse, DescribeResourcePoliciesError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.DescribeResourcePolicies");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4000,9 +4095,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: DescribeSubscriptionFiltersRequest,
     ) -> RusotoFuture<DescribeSubscriptionFiltersResponse, DescribeSubscriptionFiltersError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.DescribeSubscriptionFilters");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4026,9 +4126,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: DisassociateKmsKeyRequest,
     ) -> RusotoFuture<(), DisassociateKmsKeyError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.DisassociateKmsKey");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4052,9 +4157,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: FilterLogEventsRequest,
     ) -> RusotoFuture<FilterLogEventsResponse, FilterLogEventsError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.FilterLogEvents");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4081,9 +4191,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: GetLogEventsRequest,
     ) -> RusotoFuture<GetLogEventsResponse, GetLogEventsError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.GetLogEvents");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4110,9 +4225,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: GetLogGroupFieldsRequest,
     ) -> RusotoFuture<GetLogGroupFieldsResponse, GetLogGroupFieldsError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.GetLogGroupFields");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4139,9 +4259,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: GetLogRecordRequest,
     ) -> RusotoFuture<GetLogRecordResponse, GetLogRecordError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.GetLogRecord");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4168,9 +4293,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: GetQueryResultsRequest,
     ) -> RusotoFuture<GetQueryResultsResponse, GetQueryResultsError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.GetQueryResults");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4197,9 +4327,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: ListTagsLogGroupRequest,
     ) -> RusotoFuture<ListTagsLogGroupResponse, ListTagsLogGroupError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.ListTagsLogGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4226,9 +4361,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: PutDestinationRequest,
     ) -> RusotoFuture<PutDestinationResponse, PutDestinationError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.PutDestination");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4255,9 +4395,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: PutDestinationPolicyRequest,
     ) -> RusotoFuture<(), PutDestinationPolicyError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.PutDestinationPolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4280,9 +4425,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: PutLogEventsRequest,
     ) -> RusotoFuture<PutLogEventsResponse, PutLogEventsError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.PutLogEvents");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4309,9 +4459,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: PutMetricFilterRequest,
     ) -> RusotoFuture<(), PutMetricFilterError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.PutMetricFilter");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4335,9 +4490,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: PutResourcePolicyRequest,
     ) -> RusotoFuture<PutResourcePolicyResponse, PutResourcePolicyError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.PutResourcePolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4364,9 +4524,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: PutRetentionPolicyRequest,
     ) -> RusotoFuture<(), PutRetentionPolicyError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.PutRetentionPolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4390,9 +4555,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: PutSubscriptionFilterRequest,
     ) -> RusotoFuture<(), PutSubscriptionFilterError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.PutSubscriptionFilter");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4415,9 +4585,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: StartQueryRequest,
     ) -> RusotoFuture<StartQueryResponse, StartQueryError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.StartQuery");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4444,9 +4619,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: StopQueryRequest,
     ) -> RusotoFuture<StopQueryResponse, StopQueryError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.StopQuery");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4470,9 +4650,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
 
     /// <p>Adds or updates the specified tags for the specified log group.</p> <p>To list the tags for a log group, use <a>ListTagsLogGroup</a>. To remove tags, use <a>UntagLogGroup</a>.</p> <p>For more information about tags, see <a href="http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/log-group-tagging.html">Tag Log Groups in Amazon CloudWatch Logs</a> in the <i>Amazon CloudWatch Logs User Guide</i>.</p>
     fn tag_log_group(&self, input: TagLogGroupRequest) -> RusotoFuture<(), TagLogGroupError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.TagLogGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4496,9 +4681,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
         &self,
         input: TestMetricFilterRequest,
     ) -> RusotoFuture<TestMetricFilterResponse, TestMetricFilterError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.TestMetricFilter");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4522,9 +4712,14 @@ impl CloudWatchLogs for CloudWatchLogsClient {
 
     /// <p>Removes the specified tags from the specified log group.</p> <p>To list the tags for a log group, use <a>ListTagsLogGroup</a>. To add tags, use <a>UntagLogGroup</a>.</p>
     fn untag_log_group(&self, input: UntagLogGroupRequest) -> RusotoFuture<(), UntagLogGroupError> {
-        let mut request = SignedRequest::new("POST", "logs", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "logs",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Logs_20140328.UntagLogGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/machinelearning/src/generated.rs
+++ b/rusoto/services/machinelearning/src/generated.rs
@@ -3126,9 +3126,14 @@ impl MachineLearningClient {
 impl MachineLearning for MachineLearningClient {
     /// <p>Adds one or more tags to an object, up to a limit of 10. Each tag consists of a key and an optional value. If you add a tag using a key that is already associated with the ML object, <code>AddTags</code> updates the tag's value.</p>
     fn add_tags(&self, input: AddTagsInput) -> RusotoFuture<AddTagsOutput, AddTagsError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.AddTags");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3154,9 +3159,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: CreateBatchPredictionInput,
     ) -> RusotoFuture<CreateBatchPredictionOutput, CreateBatchPredictionError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.CreateBatchPrediction");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3182,9 +3192,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: CreateDataSourceFromRDSInput,
     ) -> RusotoFuture<CreateDataSourceFromRDSOutput, CreateDataSourceFromRDSError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.CreateDataSourceFromRDS");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3208,9 +3223,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: CreateDataSourceFromRedshiftInput,
     ) -> RusotoFuture<CreateDataSourceFromRedshiftOutput, CreateDataSourceFromRedshiftError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonML_20141212.CreateDataSourceFromRedshift",
@@ -3237,9 +3257,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: CreateDataSourceFromS3Input,
     ) -> RusotoFuture<CreateDataSourceFromS3Output, CreateDataSourceFromS3Error> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.CreateDataSourceFromS3");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3265,9 +3290,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: CreateEvaluationInput,
     ) -> RusotoFuture<CreateEvaluationOutput, CreateEvaluationError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.CreateEvaluation");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3294,9 +3324,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: CreateMLModelInput,
     ) -> RusotoFuture<CreateMLModelOutput, CreateMLModelError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.CreateMLModel");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3323,9 +3358,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: CreateRealtimeEndpointInput,
     ) -> RusotoFuture<CreateRealtimeEndpointOutput, CreateRealtimeEndpointError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.CreateRealtimeEndpoint");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3351,9 +3391,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: DeleteBatchPredictionInput,
     ) -> RusotoFuture<DeleteBatchPredictionOutput, DeleteBatchPredictionError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.DeleteBatchPrediction");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3379,9 +3424,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: DeleteDataSourceInput,
     ) -> RusotoFuture<DeleteDataSourceOutput, DeleteDataSourceError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.DeleteDataSource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3408,9 +3458,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: DeleteEvaluationInput,
     ) -> RusotoFuture<DeleteEvaluationOutput, DeleteEvaluationError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.DeleteEvaluation");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3437,9 +3492,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: DeleteMLModelInput,
     ) -> RusotoFuture<DeleteMLModelOutput, DeleteMLModelError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.DeleteMLModel");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3466,9 +3526,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: DeleteRealtimeEndpointInput,
     ) -> RusotoFuture<DeleteRealtimeEndpointOutput, DeleteRealtimeEndpointError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.DeleteRealtimeEndpoint");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3494,9 +3559,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: DeleteTagsInput,
     ) -> RusotoFuture<DeleteTagsOutput, DeleteTagsError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.DeleteTags");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3523,9 +3593,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: DescribeBatchPredictionsInput,
     ) -> RusotoFuture<DescribeBatchPredictionsOutput, DescribeBatchPredictionsError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.DescribeBatchPredictions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3549,9 +3624,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: DescribeDataSourcesInput,
     ) -> RusotoFuture<DescribeDataSourcesOutput, DescribeDataSourcesError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.DescribeDataSources");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3577,9 +3657,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: DescribeEvaluationsInput,
     ) -> RusotoFuture<DescribeEvaluationsOutput, DescribeEvaluationsError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.DescribeEvaluations");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3605,9 +3690,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: DescribeMLModelsInput,
     ) -> RusotoFuture<DescribeMLModelsOutput, DescribeMLModelsError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.DescribeMLModels");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3634,9 +3724,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: DescribeTagsInput,
     ) -> RusotoFuture<DescribeTagsOutput, DescribeTagsError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.DescribeTags");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3663,9 +3758,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: GetBatchPredictionInput,
     ) -> RusotoFuture<GetBatchPredictionOutput, GetBatchPredictionError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.GetBatchPrediction");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3692,9 +3792,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: GetDataSourceInput,
     ) -> RusotoFuture<GetDataSourceOutput, GetDataSourceError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.GetDataSource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3721,9 +3826,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: GetEvaluationInput,
     ) -> RusotoFuture<GetEvaluationOutput, GetEvaluationError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.GetEvaluation");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3750,9 +3860,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: GetMLModelInput,
     ) -> RusotoFuture<GetMLModelOutput, GetMLModelError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.GetMLModel");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3776,9 +3891,14 @@ impl MachineLearning for MachineLearningClient {
 
     /// <p><p>Generates a prediction for the observation using the specified <code>ML Model</code>.</p> <note><title>Note</title> <p>Not all response parameters will be populated. Whether a response parameter is populated depends on the type of model requested.</p></note></p>
     fn predict(&self, input: PredictInput) -> RusotoFuture<PredictOutput, PredictError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.Predict");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3804,9 +3924,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: UpdateBatchPredictionInput,
     ) -> RusotoFuture<UpdateBatchPredictionOutput, UpdateBatchPredictionError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.UpdateBatchPrediction");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3832,9 +3957,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: UpdateDataSourceInput,
     ) -> RusotoFuture<UpdateDataSourceOutput, UpdateDataSourceError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.UpdateDataSource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3861,9 +3991,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: UpdateEvaluationInput,
     ) -> RusotoFuture<UpdateEvaluationOutput, UpdateEvaluationError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.UpdateEvaluation");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3890,9 +4025,14 @@ impl MachineLearning for MachineLearningClient {
         &self,
         input: UpdateMLModelInput,
     ) -> RusotoFuture<UpdateMLModelOutput, UpdateMLModelError> {
-        let mut request = SignedRequest::new("POST", "machinelearning", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "machinelearning",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonML_20141212.UpdateMLModel");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/macie/src/generated.rs
+++ b/rusoto/services/macie/src/generated.rs
@@ -649,9 +649,14 @@ impl Macie for MacieClient {
         &self,
         input: AssociateMemberAccountRequest,
     ) -> RusotoFuture<(), AssociateMemberAccountError> {
-        let mut request = SignedRequest::new("POST", "macie", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "macie",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MacieService.AssociateMemberAccount");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -674,9 +679,14 @@ impl Macie for MacieClient {
         &self,
         input: AssociateS3ResourcesRequest,
     ) -> RusotoFuture<AssociateS3ResourcesResult, AssociateS3ResourcesError> {
-        let mut request = SignedRequest::new("POST", "macie", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "macie",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MacieService.AssociateS3Resources");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -702,9 +712,14 @@ impl Macie for MacieClient {
         &self,
         input: DisassociateMemberAccountRequest,
     ) -> RusotoFuture<(), DisassociateMemberAccountError> {
-        let mut request = SignedRequest::new("POST", "macie", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "macie",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MacieService.DisassociateMemberAccount");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -725,9 +740,14 @@ impl Macie for MacieClient {
         &self,
         input: DisassociateS3ResourcesRequest,
     ) -> RusotoFuture<DisassociateS3ResourcesResult, DisassociateS3ResourcesError> {
-        let mut request = SignedRequest::new("POST", "macie", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "macie",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MacieService.DisassociateS3Resources");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -751,9 +771,14 @@ impl Macie for MacieClient {
         &self,
         input: ListMemberAccountsRequest,
     ) -> RusotoFuture<ListMemberAccountsResult, ListMemberAccountsError> {
-        let mut request = SignedRequest::new("POST", "macie", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "macie",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MacieService.ListMemberAccounts");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -780,9 +805,14 @@ impl Macie for MacieClient {
         &self,
         input: ListS3ResourcesRequest,
     ) -> RusotoFuture<ListS3ResourcesResult, ListS3ResourcesError> {
-        let mut request = SignedRequest::new("POST", "macie", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "macie",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MacieService.ListS3Resources");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -809,9 +839,14 @@ impl Macie for MacieClient {
         &self,
         input: UpdateS3ResourcesRequest,
     ) -> RusotoFuture<UpdateS3ResourcesResult, UpdateS3ResourcesError> {
-        let mut request = SignedRequest::new("POST", "macie", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "macie",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MacieService.UpdateS3Resources");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/marketplace-entitlement/src/generated.rs
+++ b/rusoto/services/marketplace-entitlement/src/generated.rs
@@ -203,9 +203,14 @@ impl MarketplaceEntitlement for MarketplaceEntitlementClient {
         &self,
         input: GetEntitlementsRequest,
     ) -> RusotoFuture<GetEntitlementsResult, GetEntitlementsError> {
-        let mut request = SignedRequest::new("POST", "aws-marketplace", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "aws-marketplace",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("entitlement.marketplace".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSMPEntitlementService.GetEntitlements");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/marketplacecommerceanalytics/src/generated.rs
+++ b/rusoto/services/marketplacecommerceanalytics/src/generated.rs
@@ -226,10 +226,14 @@ impl MarketplaceCommerceAnalytics for MarketplaceCommerceAnalyticsClient {
         &self,
         input: GenerateDataSetRequest,
     ) -> RusotoFuture<GenerateDataSetResult, GenerateDataSetError> {
-        let mut request =
-            SignedRequest::new("POST", "marketplacecommerceanalytics", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "marketplacecommerceanalytics",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MarketplaceCommerceAnalytics20150701.GenerateDataSet",
@@ -259,10 +263,14 @@ impl MarketplaceCommerceAnalytics for MarketplaceCommerceAnalyticsClient {
         &self,
         input: StartSupportDataExportRequest,
     ) -> RusotoFuture<StartSupportDataExportResult, StartSupportDataExportError> {
-        let mut request =
-            SignedRequest::new("POST", "marketplacecommerceanalytics", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "marketplacecommerceanalytics",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MarketplaceCommerceAnalytics20150701.StartSupportDataExport",

--- a/rusoto/services/mediastore/src/generated.rs
+++ b/rusoto/services/mediastore/src/generated.rs
@@ -1021,9 +1021,14 @@ impl MediaStore for MediaStoreClient {
         &self,
         input: CreateContainerInput,
     ) -> RusotoFuture<CreateContainerOutput, CreateContainerError> {
-        let mut request = SignedRequest::new("POST", "mediastore", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mediastore",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MediaStore_20170901.CreateContainer");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1050,9 +1055,14 @@ impl MediaStore for MediaStoreClient {
         &self,
         input: DeleteContainerInput,
     ) -> RusotoFuture<DeleteContainerOutput, DeleteContainerError> {
-        let mut request = SignedRequest::new("POST", "mediastore", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mediastore",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MediaStore_20170901.DeleteContainer");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1079,9 +1089,14 @@ impl MediaStore for MediaStoreClient {
         &self,
         input: DeleteContainerPolicyInput,
     ) -> RusotoFuture<DeleteContainerPolicyOutput, DeleteContainerPolicyError> {
-        let mut request = SignedRequest::new("POST", "mediastore", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mediastore",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MediaStore_20170901.DeleteContainerPolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1107,9 +1122,14 @@ impl MediaStore for MediaStoreClient {
         &self,
         input: DeleteCorsPolicyInput,
     ) -> RusotoFuture<DeleteCorsPolicyOutput, DeleteCorsPolicyError> {
-        let mut request = SignedRequest::new("POST", "mediastore", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mediastore",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MediaStore_20170901.DeleteCorsPolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1136,9 +1156,14 @@ impl MediaStore for MediaStoreClient {
         &self,
         input: DeleteLifecyclePolicyInput,
     ) -> RusotoFuture<DeleteLifecyclePolicyOutput, DeleteLifecyclePolicyError> {
-        let mut request = SignedRequest::new("POST", "mediastore", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mediastore",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MediaStore_20170901.DeleteLifecyclePolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1164,9 +1189,14 @@ impl MediaStore for MediaStoreClient {
         &self,
         input: DescribeContainerInput,
     ) -> RusotoFuture<DescribeContainerOutput, DescribeContainerError> {
-        let mut request = SignedRequest::new("POST", "mediastore", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mediastore",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MediaStore_20170901.DescribeContainer");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1193,9 +1223,14 @@ impl MediaStore for MediaStoreClient {
         &self,
         input: GetContainerPolicyInput,
     ) -> RusotoFuture<GetContainerPolicyOutput, GetContainerPolicyError> {
-        let mut request = SignedRequest::new("POST", "mediastore", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mediastore",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MediaStore_20170901.GetContainerPolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1222,9 +1257,14 @@ impl MediaStore for MediaStoreClient {
         &self,
         input: GetCorsPolicyInput,
     ) -> RusotoFuture<GetCorsPolicyOutput, GetCorsPolicyError> {
-        let mut request = SignedRequest::new("POST", "mediastore", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mediastore",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MediaStore_20170901.GetCorsPolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1251,9 +1291,14 @@ impl MediaStore for MediaStoreClient {
         &self,
         input: GetLifecyclePolicyInput,
     ) -> RusotoFuture<GetLifecyclePolicyOutput, GetLifecyclePolicyError> {
-        let mut request = SignedRequest::new("POST", "mediastore", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mediastore",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MediaStore_20170901.GetLifecyclePolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1280,9 +1325,14 @@ impl MediaStore for MediaStoreClient {
         &self,
         input: ListContainersInput,
     ) -> RusotoFuture<ListContainersOutput, ListContainersError> {
-        let mut request = SignedRequest::new("POST", "mediastore", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mediastore",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MediaStore_20170901.ListContainers");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1309,9 +1359,14 @@ impl MediaStore for MediaStoreClient {
         &self,
         input: PutContainerPolicyInput,
     ) -> RusotoFuture<PutContainerPolicyOutput, PutContainerPolicyError> {
-        let mut request = SignedRequest::new("POST", "mediastore", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mediastore",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MediaStore_20170901.PutContainerPolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1338,9 +1393,14 @@ impl MediaStore for MediaStoreClient {
         &self,
         input: PutCorsPolicyInput,
     ) -> RusotoFuture<PutCorsPolicyOutput, PutCorsPolicyError> {
-        let mut request = SignedRequest::new("POST", "mediastore", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mediastore",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MediaStore_20170901.PutCorsPolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1367,9 +1427,14 @@ impl MediaStore for MediaStoreClient {
         &self,
         input: PutLifecyclePolicyInput,
     ) -> RusotoFuture<PutLifecyclePolicyOutput, PutLifecyclePolicyError> {
-        let mut request = SignedRequest::new("POST", "mediastore", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mediastore",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MediaStore_20170901.PutLifecyclePolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/meteringmarketplace/src/generated.rs
+++ b/rusoto/services/meteringmarketplace/src/generated.rs
@@ -511,9 +511,14 @@ impl MarketplaceMetering for MarketplaceMeteringClient {
         &self,
         input: BatchMeterUsageRequest,
     ) -> RusotoFuture<BatchMeterUsageResult, BatchMeterUsageError> {
-        let mut request = SignedRequest::new("POST", "aws-marketplace", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "aws-marketplace",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("metering.marketplace".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSMPMeteringService.BatchMeterUsage");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -540,9 +545,14 @@ impl MarketplaceMetering for MarketplaceMeteringClient {
         &self,
         input: MeterUsageRequest,
     ) -> RusotoFuture<MeterUsageResult, MeterUsageError> {
-        let mut request = SignedRequest::new("POST", "aws-marketplace", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "aws-marketplace",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("metering.marketplace".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSMPMeteringService.MeterUsage");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -569,9 +579,14 @@ impl MarketplaceMetering for MarketplaceMeteringClient {
         &self,
         input: RegisterUsageRequest,
     ) -> RusotoFuture<RegisterUsageResult, RegisterUsageError> {
-        let mut request = SignedRequest::new("POST", "aws-marketplace", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "aws-marketplace",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("metering.marketplace".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSMPMeteringService.RegisterUsage");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -598,9 +613,14 @@ impl MarketplaceMetering for MarketplaceMeteringClient {
         &self,
         input: ResolveCustomerRequest,
     ) -> RusotoFuture<ResolveCustomerResult, ResolveCustomerError> {
-        let mut request = SignedRequest::new("POST", "aws-marketplace", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "aws-marketplace",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("metering.marketplace".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSMPMeteringService.ResolveCustomer");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/mgh/src/generated.rs
+++ b/rusoto/services/mgh/src/generated.rs
@@ -1860,9 +1860,14 @@ impl MigrationHub for MigrationHubClient {
         &self,
         input: AssociateCreatedArtifactRequest,
     ) -> RusotoFuture<AssociateCreatedArtifactResult, AssociateCreatedArtifactError> {
-        let mut request = SignedRequest::new("POST", "mgh", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mgh",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSMigrationHub.AssociateCreatedArtifact");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1886,9 +1891,14 @@ impl MigrationHub for MigrationHubClient {
         &self,
         input: AssociateDiscoveredResourceRequest,
     ) -> RusotoFuture<AssociateDiscoveredResourceResult, AssociateDiscoveredResourceError> {
-        let mut request = SignedRequest::new("POST", "mgh", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mgh",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSMigrationHub.AssociateDiscoveredResource",
@@ -1915,9 +1925,14 @@ impl MigrationHub for MigrationHubClient {
         &self,
         input: CreateProgressUpdateStreamRequest,
     ) -> RusotoFuture<CreateProgressUpdateStreamResult, CreateProgressUpdateStreamError> {
-        let mut request = SignedRequest::new("POST", "mgh", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mgh",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSMigrationHub.CreateProgressUpdateStream");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1941,9 +1956,14 @@ impl MigrationHub for MigrationHubClient {
         &self,
         input: DeleteProgressUpdateStreamRequest,
     ) -> RusotoFuture<DeleteProgressUpdateStreamResult, DeleteProgressUpdateStreamError> {
-        let mut request = SignedRequest::new("POST", "mgh", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mgh",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSMigrationHub.DeleteProgressUpdateStream");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1967,9 +1987,14 @@ impl MigrationHub for MigrationHubClient {
         &self,
         input: DescribeApplicationStateRequest,
     ) -> RusotoFuture<DescribeApplicationStateResult, DescribeApplicationStateError> {
-        let mut request = SignedRequest::new("POST", "mgh", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mgh",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSMigrationHub.DescribeApplicationState");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1993,9 +2018,14 @@ impl MigrationHub for MigrationHubClient {
         &self,
         input: DescribeMigrationTaskRequest,
     ) -> RusotoFuture<DescribeMigrationTaskResult, DescribeMigrationTaskError> {
-        let mut request = SignedRequest::new("POST", "mgh", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mgh",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSMigrationHub.DescribeMigrationTask");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2021,9 +2051,14 @@ impl MigrationHub for MigrationHubClient {
         &self,
         input: DisassociateCreatedArtifactRequest,
     ) -> RusotoFuture<DisassociateCreatedArtifactResult, DisassociateCreatedArtifactError> {
-        let mut request = SignedRequest::new("POST", "mgh", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mgh",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSMigrationHub.DisassociateCreatedArtifact",
@@ -2051,9 +2086,14 @@ impl MigrationHub for MigrationHubClient {
         input: DisassociateDiscoveredResourceRequest,
     ) -> RusotoFuture<DisassociateDiscoveredResourceResult, DisassociateDiscoveredResourceError>
     {
-        let mut request = SignedRequest::new("POST", "mgh", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mgh",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSMigrationHub.DisassociateDiscoveredResource",
@@ -2080,9 +2120,14 @@ impl MigrationHub for MigrationHubClient {
         &self,
         input: ImportMigrationTaskRequest,
     ) -> RusotoFuture<ImportMigrationTaskResult, ImportMigrationTaskError> {
-        let mut request = SignedRequest::new("POST", "mgh", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mgh",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSMigrationHub.ImportMigrationTask");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2108,9 +2153,14 @@ impl MigrationHub for MigrationHubClient {
         &self,
         input: ListCreatedArtifactsRequest,
     ) -> RusotoFuture<ListCreatedArtifactsResult, ListCreatedArtifactsError> {
-        let mut request = SignedRequest::new("POST", "mgh", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mgh",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSMigrationHub.ListCreatedArtifacts");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2136,9 +2186,14 @@ impl MigrationHub for MigrationHubClient {
         &self,
         input: ListDiscoveredResourcesRequest,
     ) -> RusotoFuture<ListDiscoveredResourcesResult, ListDiscoveredResourcesError> {
-        let mut request = SignedRequest::new("POST", "mgh", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mgh",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSMigrationHub.ListDiscoveredResources");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2162,9 +2217,14 @@ impl MigrationHub for MigrationHubClient {
         &self,
         input: ListMigrationTasksRequest,
     ) -> RusotoFuture<ListMigrationTasksResult, ListMigrationTasksError> {
-        let mut request = SignedRequest::new("POST", "mgh", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mgh",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSMigrationHub.ListMigrationTasks");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2191,9 +2251,14 @@ impl MigrationHub for MigrationHubClient {
         &self,
         input: ListProgressUpdateStreamsRequest,
     ) -> RusotoFuture<ListProgressUpdateStreamsResult, ListProgressUpdateStreamsError> {
-        let mut request = SignedRequest::new("POST", "mgh", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mgh",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSMigrationHub.ListProgressUpdateStreams");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2217,9 +2282,14 @@ impl MigrationHub for MigrationHubClient {
         &self,
         input: NotifyApplicationStateRequest,
     ) -> RusotoFuture<NotifyApplicationStateResult, NotifyApplicationStateError> {
-        let mut request = SignedRequest::new("POST", "mgh", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mgh",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSMigrationHub.NotifyApplicationState");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2245,9 +2315,14 @@ impl MigrationHub for MigrationHubClient {
         &self,
         input: NotifyMigrationTaskStateRequest,
     ) -> RusotoFuture<NotifyMigrationTaskStateResult, NotifyMigrationTaskStateError> {
-        let mut request = SignedRequest::new("POST", "mgh", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mgh",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSMigrationHub.NotifyMigrationTaskState");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2271,9 +2346,14 @@ impl MigrationHub for MigrationHubClient {
         &self,
         input: PutResourceAttributesRequest,
     ) -> RusotoFuture<PutResourceAttributesResult, PutResourceAttributesError> {
-        let mut request = SignedRequest::new("POST", "mgh", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mgh",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSMigrationHub.PutResourceAttributes");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/mturk/src/generated.rs
+++ b/rusoto/services/mturk/src/generated.rs
@@ -3401,9 +3401,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: AcceptQualificationRequestRequest,
     ) -> RusotoFuture<AcceptQualificationRequestResponse, AcceptQualificationRequestError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.AcceptQualificationRequest",
@@ -3430,9 +3435,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: ApproveAssignmentRequest,
     ) -> RusotoFuture<ApproveAssignmentResponse, ApproveAssignmentError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.ApproveAssignment",
@@ -3463,9 +3473,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         input: AssociateQualificationWithWorkerRequest,
     ) -> RusotoFuture<AssociateQualificationWithWorkerResponse, AssociateQualificationWithWorkerError>
     {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.AssociateQualificationWithWorker",
@@ -3497,9 +3512,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         CreateAdditionalAssignmentsForHITResponse,
         CreateAdditionalAssignmentsForHITError,
     > {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.CreateAdditionalAssignmentsForHIT",
@@ -3528,9 +3548,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: CreateHITRequest,
     ) -> RusotoFuture<CreateHITResponse, CreateHITError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MTurkRequesterServiceV20170117.CreateHIT");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3557,9 +3582,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: CreateHITTypeRequest,
     ) -> RusotoFuture<CreateHITTypeResponse, CreateHITTypeError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.CreateHITType",
@@ -3589,9 +3619,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: CreateHITWithHITTypeRequest,
     ) -> RusotoFuture<CreateHITWithHITTypeResponse, CreateHITWithHITTypeError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.CreateHITWithHITType",
@@ -3620,9 +3655,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: CreateQualificationTypeRequest,
     ) -> RusotoFuture<CreateQualificationTypeResponse, CreateQualificationTypeError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.CreateQualificationType",
@@ -3649,9 +3689,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: CreateWorkerBlockRequest,
     ) -> RusotoFuture<CreateWorkerBlockResponse, CreateWorkerBlockError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.CreateWorkerBlock",
@@ -3681,9 +3726,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: DeleteHITRequest,
     ) -> RusotoFuture<DeleteHITResponse, DeleteHITError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MTurkRequesterServiceV20170117.DeleteHIT");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3710,9 +3760,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: DeleteQualificationTypeRequest,
     ) -> RusotoFuture<DeleteQualificationTypeResponse, DeleteQualificationTypeError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.DeleteQualificationType",
@@ -3739,9 +3794,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: DeleteWorkerBlockRequest,
     ) -> RusotoFuture<DeleteWorkerBlockResponse, DeleteWorkerBlockError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.DeleteWorkerBlock",
@@ -3774,9 +3834,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         DisassociateQualificationFromWorkerResponse,
         DisassociateQualificationFromWorkerError,
     > {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.DisassociateQualificationFromWorker",
@@ -3804,9 +3869,14 @@ impl MechanicalTurk for MechanicalTurkClient {
     fn get_account_balance(
         &self,
     ) -> RusotoFuture<GetAccountBalanceResponse, GetAccountBalanceError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.GetAccountBalance",
@@ -3835,9 +3905,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: GetAssignmentRequest,
     ) -> RusotoFuture<GetAssignmentResponse, GetAssignmentError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.GetAssignment",
@@ -3867,9 +3942,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: GetFileUploadURLRequest,
     ) -> RusotoFuture<GetFileUploadURLResponse, GetFileUploadURLError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.GetFileUploadURL",
@@ -3896,9 +3976,14 @@ impl MechanicalTurk for MechanicalTurkClient {
 
     /// <p> The <code>GetHIT</code> operation retrieves the details of the specified HIT. </p>
     fn get_hit(&self, input: GetHITRequest) -> RusotoFuture<GetHITResponse, GetHITError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MTurkRequesterServiceV20170117.GetHIT");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3924,9 +4009,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: GetQualificationScoreRequest,
     ) -> RusotoFuture<GetQualificationScoreResponse, GetQualificationScoreError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.GetQualificationScore",
@@ -3955,9 +4045,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: GetQualificationTypeRequest,
     ) -> RusotoFuture<GetQualificationTypeResponse, GetQualificationTypeError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.GetQualificationType",
@@ -3986,9 +4081,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: ListAssignmentsForHITRequest,
     ) -> RusotoFuture<ListAssignmentsForHITResponse, ListAssignmentsForHITError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.ListAssignmentsForHIT",
@@ -4017,9 +4117,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: ListBonusPaymentsRequest,
     ) -> RusotoFuture<ListBonusPaymentsResponse, ListBonusPaymentsError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.ListBonusPayments",
@@ -4046,9 +4151,14 @@ impl MechanicalTurk for MechanicalTurkClient {
 
     /// <p> The <code>ListHITs</code> operation returns all of a Requester's HITs. The operation returns HITs of any status, except for HITs that have been deleted of with the DeleteHIT operation or that have been auto-deleted. </p>
     fn list_hi_ts(&self, input: ListHITsRequest) -> RusotoFuture<ListHITsResponse, ListHITsError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MTurkRequesterServiceV20170117.ListHITs");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4075,9 +4185,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: ListHITsForQualificationTypeRequest,
     ) -> RusotoFuture<ListHITsForQualificationTypeResponse, ListHITsForQualificationTypeError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.ListHITsForQualificationType",
@@ -4104,9 +4219,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: ListQualificationRequestsRequest,
     ) -> RusotoFuture<ListQualificationRequestsResponse, ListQualificationRequestsError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.ListQualificationRequests",
@@ -4133,9 +4253,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: ListQualificationTypesRequest,
     ) -> RusotoFuture<ListQualificationTypesResponse, ListQualificationTypesError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.ListQualificationTypes",
@@ -4165,9 +4290,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         input: ListReviewPolicyResultsForHITRequest,
     ) -> RusotoFuture<ListReviewPolicyResultsForHITResponse, ListReviewPolicyResultsForHITError>
     {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.ListReviewPolicyResultsForHIT",
@@ -4194,9 +4324,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: ListReviewableHITsRequest,
     ) -> RusotoFuture<ListReviewableHITsResponse, ListReviewableHITsError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.ListReviewableHITs",
@@ -4226,9 +4361,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: ListWorkerBlocksRequest,
     ) -> RusotoFuture<ListWorkerBlocksResponse, ListWorkerBlocksError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.ListWorkerBlocks",
@@ -4259,9 +4399,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         input: ListWorkersWithQualificationTypeRequest,
     ) -> RusotoFuture<ListWorkersWithQualificationTypeResponse, ListWorkersWithQualificationTypeError>
     {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.ListWorkersWithQualificationType",
@@ -4290,9 +4435,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: NotifyWorkersRequest,
     ) -> RusotoFuture<NotifyWorkersResponse, NotifyWorkersError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.NotifyWorkers",
@@ -4322,9 +4472,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: RejectAssignmentRequest,
     ) -> RusotoFuture<RejectAssignmentResponse, RejectAssignmentError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.RejectAssignment",
@@ -4354,9 +4509,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: RejectQualificationRequestRequest,
     ) -> RusotoFuture<RejectQualificationRequestResponse, RejectQualificationRequestError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.RejectQualificationRequest",
@@ -4383,9 +4543,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: SendBonusRequest,
     ) -> RusotoFuture<SendBonusResponse, SendBonusError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "MTurkRequesterServiceV20170117.SendBonus");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4412,9 +4577,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: SendTestEventNotificationRequest,
     ) -> RusotoFuture<SendTestEventNotificationResponse, SendTestEventNotificationError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.SendTestEventNotification",
@@ -4441,9 +4611,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: UpdateExpirationForHITRequest,
     ) -> RusotoFuture<UpdateExpirationForHITResponse, UpdateExpirationForHITError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.UpdateExpirationForHIT",
@@ -4472,9 +4647,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: UpdateHITReviewStatusRequest,
     ) -> RusotoFuture<UpdateHITReviewStatusResponse, UpdateHITReviewStatusError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.UpdateHITReviewStatus",
@@ -4503,9 +4683,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: UpdateHITTypeOfHITRequest,
     ) -> RusotoFuture<UpdateHITTypeOfHITResponse, UpdateHITTypeOfHITError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.UpdateHITTypeOfHIT",
@@ -4535,9 +4720,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: UpdateNotificationSettingsRequest,
     ) -> RusotoFuture<UpdateNotificationSettingsResponse, UpdateNotificationSettingsError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.UpdateNotificationSettings",
@@ -4564,9 +4754,14 @@ impl MechanicalTurk for MechanicalTurkClient {
         &self,
         input: UpdateQualificationTypeRequest,
     ) -> RusotoFuture<UpdateQualificationTypeResponse, UpdateQualificationTypeError> {
-        let mut request = SignedRequest::new("POST", "mturk-requester", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "mturk-requester",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "MTurkRequesterServiceV20170117.UpdateQualificationType",

--- a/rusoto/services/opsworks/src/generated.rs
+++ b/rusoto/services/opsworks/src/generated.rs
@@ -6145,9 +6145,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: AssignInstanceRequest,
     ) -> RusotoFuture<(), AssignInstanceError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.AssignInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6168,9 +6173,14 @@ impl OpsWorks for OpsWorksClient {
 
     /// <p>Assigns one of the stack's registered Amazon EBS volumes to a specified instance. The volume must first be registered with the stack by calling <a>RegisterVolume</a>. After you register the volume, you must call <a>UpdateVolume</a> to specify a mount point before calling <code>AssignVolume</code>. For more information, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/resources.html">Resource Management</a>.</p> <p> <b>Required Permissions</b>: To use this action, an IAM user must have a Manage permissions level for the stack, or an attached policy that explicitly grants permissions. For more information on user permissions, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html">Managing User Permissions</a>.</p>
     fn assign_volume(&self, input: AssignVolumeRequest) -> RusotoFuture<(), AssignVolumeError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.AssignVolume");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6194,9 +6204,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: AssociateElasticIpRequest,
     ) -> RusotoFuture<(), AssociateElasticIpError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.AssociateElasticIp");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6220,9 +6235,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: AttachElasticLoadBalancerRequest,
     ) -> RusotoFuture<(), AttachElasticLoadBalancerError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OpsWorks_20130218.AttachElasticLoadBalancer",
@@ -6246,9 +6266,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: CloneStackRequest,
     ) -> RusotoFuture<CloneStackResult, CloneStackError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.CloneStack");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6272,9 +6297,14 @@ impl OpsWorks for OpsWorksClient {
 
     /// <p>Creates an app for a specified stack. For more information, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/workingapps-creating.html">Creating Apps</a>.</p> <p> <b>Required Permissions</b>: To use this action, an IAM user must have a Manage permissions level for the stack, or an attached policy that explicitly grants permissions. For more information on user permissions, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html">Managing User Permissions</a>.</p>
     fn create_app(&self, input: CreateAppRequest) -> RusotoFuture<CreateAppResult, CreateAppError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.CreateApp");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6300,9 +6330,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: CreateDeploymentRequest,
     ) -> RusotoFuture<CreateDeploymentResult, CreateDeploymentError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.CreateDeployment");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6329,9 +6364,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: CreateInstanceRequest,
     ) -> RusotoFuture<CreateInstanceResult, CreateInstanceError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.CreateInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6358,9 +6398,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: CreateLayerRequest,
     ) -> RusotoFuture<CreateLayerResult, CreateLayerError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.CreateLayer");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6387,9 +6432,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: CreateStackRequest,
     ) -> RusotoFuture<CreateStackResult, CreateStackError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.CreateStack");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6416,9 +6466,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: CreateUserProfileRequest,
     ) -> RusotoFuture<CreateUserProfileResult, CreateUserProfileError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.CreateUserProfile");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6442,9 +6497,14 @@ impl OpsWorks for OpsWorksClient {
 
     /// <p>Deletes a specified app.</p> <p> <b>Required Permissions</b>: To use this action, an IAM user must have a Manage permissions level for the stack, or an attached policy that explicitly grants permissions. For more information on user permissions, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html">Managing User Permissions</a>.</p>
     fn delete_app(&self, input: DeleteAppRequest) -> RusotoFuture<(), DeleteAppError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DeleteApp");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6468,9 +6528,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DeleteInstanceRequest,
     ) -> RusotoFuture<(), DeleteInstanceError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DeleteInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6491,9 +6556,14 @@ impl OpsWorks for OpsWorksClient {
 
     /// <p>Deletes a specified layer. You must first stop and then delete all associated instances or unassign registered instances. For more information, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/workinglayers-basics-delete.html">How to Delete a Layer</a>.</p> <p> <b>Required Permissions</b>: To use this action, an IAM user must have a Manage permissions level for the stack, or an attached policy that explicitly grants permissions. For more information on user permissions, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html">Managing User Permissions</a>.</p>
     fn delete_layer(&self, input: DeleteLayerRequest) -> RusotoFuture<(), DeleteLayerError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DeleteLayer");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6514,9 +6584,14 @@ impl OpsWorks for OpsWorksClient {
 
     /// <p>Deletes a specified stack. You must first delete all instances, layers, and apps or deregister registered instances. For more information, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/workingstacks-shutting.html">Shut Down a Stack</a>.</p> <p> <b>Required Permissions</b>: To use this action, an IAM user must have a Manage permissions level for the stack, or an attached policy that explicitly grants permissions. For more information on user permissions, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html">Managing User Permissions</a>.</p>
     fn delete_stack(&self, input: DeleteStackRequest) -> RusotoFuture<(), DeleteStackError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DeleteStack");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6540,9 +6615,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DeleteUserProfileRequest,
     ) -> RusotoFuture<(), DeleteUserProfileError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DeleteUserProfile");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6566,9 +6646,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DeregisterEcsClusterRequest,
     ) -> RusotoFuture<(), DeregisterEcsClusterError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DeregisterEcsCluster");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6591,9 +6676,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DeregisterElasticIpRequest,
     ) -> RusotoFuture<(), DeregisterElasticIpError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DeregisterElasticIp");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6616,9 +6706,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DeregisterInstanceRequest,
     ) -> RusotoFuture<(), DeregisterInstanceError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DeregisterInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6642,9 +6737,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DeregisterRdsDbInstanceRequest,
     ) -> RusotoFuture<(), DeregisterRdsDbInstanceError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DeregisterRdsDbInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6665,9 +6765,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DeregisterVolumeRequest,
     ) -> RusotoFuture<(), DeregisterVolumeError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DeregisterVolume");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6691,9 +6796,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DescribeAgentVersionsRequest,
     ) -> RusotoFuture<DescribeAgentVersionsResult, DescribeAgentVersionsError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DescribeAgentVersions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6719,9 +6829,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DescribeAppsRequest,
     ) -> RusotoFuture<DescribeAppsResult, DescribeAppsError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DescribeApps");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6748,9 +6863,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DescribeCommandsRequest,
     ) -> RusotoFuture<DescribeCommandsResult, DescribeCommandsError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DescribeCommands");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6777,9 +6897,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DescribeDeploymentsRequest,
     ) -> RusotoFuture<DescribeDeploymentsResult, DescribeDeploymentsError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DescribeDeployments");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6805,9 +6930,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DescribeEcsClustersRequest,
     ) -> RusotoFuture<DescribeEcsClustersResult, DescribeEcsClustersError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DescribeEcsClusters");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6833,9 +6963,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DescribeElasticIpsRequest,
     ) -> RusotoFuture<DescribeElasticIpsResult, DescribeElasticIpsError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DescribeElasticIps");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6862,9 +6997,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DescribeElasticLoadBalancersRequest,
     ) -> RusotoFuture<DescribeElasticLoadBalancersResult, DescribeElasticLoadBalancersError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OpsWorks_20130218.DescribeElasticLoadBalancers",
@@ -6891,9 +7031,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DescribeInstancesRequest,
     ) -> RusotoFuture<DescribeInstancesResult, DescribeInstancesError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DescribeInstances");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6920,9 +7065,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DescribeLayersRequest,
     ) -> RusotoFuture<DescribeLayersResult, DescribeLayersError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DescribeLayers");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6949,9 +7099,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DescribeLoadBasedAutoScalingRequest,
     ) -> RusotoFuture<DescribeLoadBasedAutoScalingResult, DescribeLoadBasedAutoScalingError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OpsWorks_20130218.DescribeLoadBasedAutoScaling",
@@ -6977,9 +7132,14 @@ impl OpsWorks for OpsWorksClient {
     fn describe_my_user_profile(
         &self,
     ) -> RusotoFuture<DescribeMyUserProfileResult, DescribeMyUserProfileError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DescribeMyUserProfile");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -7003,9 +7163,14 @@ impl OpsWorks for OpsWorksClient {
     fn describe_operating_systems(
         &self,
     ) -> RusotoFuture<DescribeOperatingSystemsResponse, DescribeOperatingSystemsError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DescribeOperatingSystems");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -7028,9 +7193,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DescribePermissionsRequest,
     ) -> RusotoFuture<DescribePermissionsResult, DescribePermissionsError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DescribePermissions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7056,9 +7226,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DescribeRaidArraysRequest,
     ) -> RusotoFuture<DescribeRaidArraysResult, DescribeRaidArraysError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DescribeRaidArrays");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7085,9 +7260,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DescribeRdsDbInstancesRequest,
     ) -> RusotoFuture<DescribeRdsDbInstancesResult, DescribeRdsDbInstancesError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DescribeRdsDbInstances");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7113,9 +7293,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DescribeServiceErrorsRequest,
     ) -> RusotoFuture<DescribeServiceErrorsResult, DescribeServiceErrorsError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DescribeServiceErrors");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7144,9 +7329,14 @@ impl OpsWorks for OpsWorksClient {
         DescribeStackProvisioningParametersResult,
         DescribeStackProvisioningParametersError,
     > {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OpsWorks_20130218.DescribeStackProvisioningParameters",
@@ -7175,9 +7365,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DescribeStackSummaryRequest,
     ) -> RusotoFuture<DescribeStackSummaryResult, DescribeStackSummaryError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DescribeStackSummary");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7203,9 +7398,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DescribeStacksRequest,
     ) -> RusotoFuture<DescribeStacksResult, DescribeStacksError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DescribeStacks");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7232,9 +7432,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DescribeTimeBasedAutoScalingRequest,
     ) -> RusotoFuture<DescribeTimeBasedAutoScalingResult, DescribeTimeBasedAutoScalingError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OpsWorks_20130218.DescribeTimeBasedAutoScaling",
@@ -7261,9 +7466,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DescribeUserProfilesRequest,
     ) -> RusotoFuture<DescribeUserProfilesResult, DescribeUserProfilesError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DescribeUserProfiles");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7289,9 +7499,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DescribeVolumesRequest,
     ) -> RusotoFuture<DescribeVolumesResult, DescribeVolumesError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DescribeVolumes");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7318,9 +7533,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DetachElasticLoadBalancerRequest,
     ) -> RusotoFuture<(), DetachElasticLoadBalancerError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OpsWorks_20130218.DetachElasticLoadBalancer",
@@ -7344,9 +7564,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: DisassociateElasticIpRequest,
     ) -> RusotoFuture<(), DisassociateElasticIpError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.DisassociateElasticIp");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7369,9 +7594,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: GetHostnameSuggestionRequest,
     ) -> RusotoFuture<GetHostnameSuggestionResult, GetHostnameSuggestionError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.GetHostnameSuggestion");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7397,9 +7627,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: GrantAccessRequest,
     ) -> RusotoFuture<GrantAccessResult, GrantAccessError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.GrantAccess");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7423,9 +7658,14 @@ impl OpsWorks for OpsWorksClient {
 
     /// <p>Returns a list of tags that are applied to the specified stack or layer.</p>
     fn list_tags(&self, input: ListTagsRequest) -> RusotoFuture<ListTagsResult, ListTagsError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.ListTags");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7451,9 +7691,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: RebootInstanceRequest,
     ) -> RusotoFuture<(), RebootInstanceError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.RebootInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7477,9 +7722,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: RegisterEcsClusterRequest,
     ) -> RusotoFuture<RegisterEcsClusterResult, RegisterEcsClusterError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.RegisterEcsCluster");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7506,9 +7756,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: RegisterElasticIpRequest,
     ) -> RusotoFuture<RegisterElasticIpResult, RegisterElasticIpError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.RegisterElasticIp");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7535,9 +7790,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: RegisterInstanceRequest,
     ) -> RusotoFuture<RegisterInstanceResult, RegisterInstanceError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.RegisterInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7564,9 +7824,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: RegisterRdsDbInstanceRequest,
     ) -> RusotoFuture<(), RegisterRdsDbInstanceError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.RegisterRdsDbInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7589,9 +7854,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: RegisterVolumeRequest,
     ) -> RusotoFuture<RegisterVolumeResult, RegisterVolumeError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.RegisterVolume");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7618,9 +7888,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: SetLoadBasedAutoScalingRequest,
     ) -> RusotoFuture<(), SetLoadBasedAutoScalingError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.SetLoadBasedAutoScaling");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7638,9 +7913,14 @@ impl OpsWorks for OpsWorksClient {
 
     /// <p>Specifies a user's permissions. For more information, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/workingsecurity.html">Security and Permissions</a>.</p> <p> <b>Required Permissions</b>: To use this action, an IAM user must have a Manage permissions level for the stack, or an attached policy that explicitly grants permissions. For more information on user permissions, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html">Managing User Permissions</a>.</p>
     fn set_permission(&self, input: SetPermissionRequest) -> RusotoFuture<(), SetPermissionError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.SetPermission");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7664,9 +7944,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: SetTimeBasedAutoScalingRequest,
     ) -> RusotoFuture<(), SetTimeBasedAutoScalingError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.SetTimeBasedAutoScaling");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7684,9 +7969,14 @@ impl OpsWorks for OpsWorksClient {
 
     /// <p>Starts a specified instance. For more information, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/workinginstances-starting.html">Starting, Stopping, and Rebooting Instances</a>.</p> <p> <b>Required Permissions</b>: To use this action, an IAM user must have a Manage permissions level for the stack, or an attached policy that explicitly grants permissions. For more information on user permissions, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html">Managing User Permissions</a>.</p>
     fn start_instance(&self, input: StartInstanceRequest) -> RusotoFuture<(), StartInstanceError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.StartInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7707,9 +7997,14 @@ impl OpsWorks for OpsWorksClient {
 
     /// <p>Starts a stack's instances.</p> <p> <b>Required Permissions</b>: To use this action, an IAM user must have a Manage permissions level for the stack, or an attached policy that explicitly grants permissions. For more information on user permissions, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html">Managing User Permissions</a>.</p>
     fn start_stack(&self, input: StartStackRequest) -> RusotoFuture<(), StartStackError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.StartStack");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7730,9 +8025,14 @@ impl OpsWorks for OpsWorksClient {
 
     /// <p>Stops a specified instance. When you stop a standard instance, the data disappears and must be reinstalled when you restart the instance. You can stop an Amazon EBS-backed instance without losing data. For more information, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/workinginstances-starting.html">Starting, Stopping, and Rebooting Instances</a>.</p> <p> <b>Required Permissions</b>: To use this action, an IAM user must have a Manage permissions level for the stack, or an attached policy that explicitly grants permissions. For more information on user permissions, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html">Managing User Permissions</a>.</p>
     fn stop_instance(&self, input: StopInstanceRequest) -> RusotoFuture<(), StopInstanceError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.StopInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7753,9 +8053,14 @@ impl OpsWorks for OpsWorksClient {
 
     /// <p>Stops a specified stack.</p> <p> <b>Required Permissions</b>: To use this action, an IAM user must have a Manage permissions level for the stack, or an attached policy that explicitly grants permissions. For more information on user permissions, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html">Managing User Permissions</a>.</p>
     fn stop_stack(&self, input: StopStackRequest) -> RusotoFuture<(), StopStackError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.StopStack");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7776,9 +8081,14 @@ impl OpsWorks for OpsWorksClient {
 
     /// <p>Apply cost-allocation tags to a specified stack or layer in AWS OpsWorks Stacks. For more information about how tagging works, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/tagging.html">Tags</a> in the AWS OpsWorks User Guide.</p>
     fn tag_resource(&self, input: TagResourceRequest) -> RusotoFuture<(), TagResourceError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.TagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7802,9 +8112,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: UnassignInstanceRequest,
     ) -> RusotoFuture<(), UnassignInstanceError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.UnassignInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7828,9 +8143,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: UnassignVolumeRequest,
     ) -> RusotoFuture<(), UnassignVolumeError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.UnassignVolume");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7851,9 +8171,14 @@ impl OpsWorks for OpsWorksClient {
 
     /// <p>Removes tags from a specified stack or layer.</p>
     fn untag_resource(&self, input: UntagResourceRequest) -> RusotoFuture<(), UntagResourceError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.UntagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7874,9 +8199,14 @@ impl OpsWorks for OpsWorksClient {
 
     /// <p>Updates a specified app.</p> <p> <b>Required Permissions</b>: To use this action, an IAM user must have a Deploy or Manage permissions level for the stack, or an attached policy that explicitly grants permissions. For more information on user permissions, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html">Managing User Permissions</a>.</p>
     fn update_app(&self, input: UpdateAppRequest) -> RusotoFuture<(), UpdateAppError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.UpdateApp");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7900,9 +8230,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: UpdateElasticIpRequest,
     ) -> RusotoFuture<(), UpdateElasticIpError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.UpdateElasticIp");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7926,9 +8261,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: UpdateInstanceRequest,
     ) -> RusotoFuture<(), UpdateInstanceError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.UpdateInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7949,9 +8289,14 @@ impl OpsWorks for OpsWorksClient {
 
     /// <p>Updates a specified layer.</p> <p> <b>Required Permissions</b>: To use this action, an IAM user must have a Manage permissions level for the stack, or an attached policy that explicitly grants permissions. For more information on user permissions, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html">Managing User Permissions</a>.</p>
     fn update_layer(&self, input: UpdateLayerRequest) -> RusotoFuture<(), UpdateLayerError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.UpdateLayer");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7975,9 +8320,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: UpdateMyUserProfileRequest,
     ) -> RusotoFuture<(), UpdateMyUserProfileError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.UpdateMyUserProfile");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8000,9 +8350,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: UpdateRdsDbInstanceRequest,
     ) -> RusotoFuture<(), UpdateRdsDbInstanceError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.UpdateRdsDbInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8022,9 +8377,14 @@ impl OpsWorks for OpsWorksClient {
 
     /// <p>Updates a specified stack.</p> <p> <b>Required Permissions</b>: To use this action, an IAM user must have a Manage permissions level for the stack, or an attached policy that explicitly grants permissions. For more information on user permissions, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html">Managing User Permissions</a>.</p>
     fn update_stack(&self, input: UpdateStackRequest) -> RusotoFuture<(), UpdateStackError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.UpdateStack");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8048,9 +8408,14 @@ impl OpsWorks for OpsWorksClient {
         &self,
         input: UpdateUserProfileRequest,
     ) -> RusotoFuture<(), UpdateUserProfileError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.UpdateUserProfile");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8071,9 +8436,14 @@ impl OpsWorks for OpsWorksClient {
 
     /// <p>Updates an Amazon EBS volume's name or mount point. For more information, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/resources.html">Resource Management</a>.</p> <p> <b>Required Permissions</b>: To use this action, an IAM user must have a Manage permissions level for the stack, or an attached policy that explicitly grants permissions. For more information on user permissions, see <a href="http://docs.aws.amazon.com/opsworks/latest/userguide/opsworks-security-users.html">Managing User Permissions</a>.</p>
     fn update_volume(&self, input: UpdateVolumeRequest) -> RusotoFuture<(), UpdateVolumeError> {
-        let mut request = SignedRequest::new("POST", "opsworks", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorks_20130218.UpdateVolume");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/opsworkscm/src/generated.rs
+++ b/rusoto/services/opsworkscm/src/generated.rs
@@ -1451,9 +1451,14 @@ impl OpsWorksCM for OpsWorksCMClient {
         &self,
         input: AssociateNodeRequest,
     ) -> RusotoFuture<AssociateNodeResponse, AssociateNodeError> {
-        let mut request = SignedRequest::new("POST", "opsworks-cm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks-cm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorksCM_V2016_11_01.AssociateNode");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1480,9 +1485,14 @@ impl OpsWorksCM for OpsWorksCMClient {
         &self,
         input: CreateBackupRequest,
     ) -> RusotoFuture<CreateBackupResponse, CreateBackupError> {
-        let mut request = SignedRequest::new("POST", "opsworks-cm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks-cm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorksCM_V2016_11_01.CreateBackup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1509,9 +1519,14 @@ impl OpsWorksCM for OpsWorksCMClient {
         &self,
         input: CreateServerRequest,
     ) -> RusotoFuture<CreateServerResponse, CreateServerError> {
-        let mut request = SignedRequest::new("POST", "opsworks-cm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks-cm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorksCM_V2016_11_01.CreateServer");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1538,9 +1553,14 @@ impl OpsWorksCM for OpsWorksCMClient {
         &self,
         input: DeleteBackupRequest,
     ) -> RusotoFuture<DeleteBackupResponse, DeleteBackupError> {
-        let mut request = SignedRequest::new("POST", "opsworks-cm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks-cm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorksCM_V2016_11_01.DeleteBackup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1567,9 +1587,14 @@ impl OpsWorksCM for OpsWorksCMClient {
         &self,
         input: DeleteServerRequest,
     ) -> RusotoFuture<DeleteServerResponse, DeleteServerError> {
-        let mut request = SignedRequest::new("POST", "opsworks-cm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks-cm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorksCM_V2016_11_01.DeleteServer");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1595,9 +1620,14 @@ impl OpsWorksCM for OpsWorksCMClient {
     fn describe_account_attributes(
         &self,
     ) -> RusotoFuture<DescribeAccountAttributesResponse, DescribeAccountAttributesError> {
-        let mut request = SignedRequest::new("POST", "opsworks-cm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks-cm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OpsWorksCM_V2016_11_01.DescribeAccountAttributes",
@@ -1623,9 +1653,14 @@ impl OpsWorksCM for OpsWorksCMClient {
         &self,
         input: DescribeBackupsRequest,
     ) -> RusotoFuture<DescribeBackupsResponse, DescribeBackupsError> {
-        let mut request = SignedRequest::new("POST", "opsworks-cm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks-cm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorksCM_V2016_11_01.DescribeBackups");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1652,9 +1687,14 @@ impl OpsWorksCM for OpsWorksCMClient {
         &self,
         input: DescribeEventsRequest,
     ) -> RusotoFuture<DescribeEventsResponse, DescribeEventsError> {
-        let mut request = SignedRequest::new("POST", "opsworks-cm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks-cm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorksCM_V2016_11_01.DescribeEvents");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1682,9 +1722,14 @@ impl OpsWorksCM for OpsWorksCMClient {
         input: DescribeNodeAssociationStatusRequest,
     ) -> RusotoFuture<DescribeNodeAssociationStatusResponse, DescribeNodeAssociationStatusError>
     {
-        let mut request = SignedRequest::new("POST", "opsworks-cm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks-cm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OpsWorksCM_V2016_11_01.DescribeNodeAssociationStatus",
@@ -1711,9 +1756,14 @@ impl OpsWorksCM for OpsWorksCMClient {
         &self,
         input: DescribeServersRequest,
     ) -> RusotoFuture<DescribeServersResponse, DescribeServersError> {
-        let mut request = SignedRequest::new("POST", "opsworks-cm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks-cm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorksCM_V2016_11_01.DescribeServers");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1740,9 +1790,14 @@ impl OpsWorksCM for OpsWorksCMClient {
         &self,
         input: DisassociateNodeRequest,
     ) -> RusotoFuture<DisassociateNodeResponse, DisassociateNodeError> {
-        let mut request = SignedRequest::new("POST", "opsworks-cm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks-cm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorksCM_V2016_11_01.DisassociateNode");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1769,9 +1824,14 @@ impl OpsWorksCM for OpsWorksCMClient {
         &self,
         input: ExportServerEngineAttributeRequest,
     ) -> RusotoFuture<ExportServerEngineAttributeResponse, ExportServerEngineAttributeError> {
-        let mut request = SignedRequest::new("POST", "opsworks-cm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks-cm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OpsWorksCM_V2016_11_01.ExportServerEngineAttribute",
@@ -1798,9 +1858,14 @@ impl OpsWorksCM for OpsWorksCMClient {
         &self,
         input: RestoreServerRequest,
     ) -> RusotoFuture<RestoreServerResponse, RestoreServerError> {
-        let mut request = SignedRequest::new("POST", "opsworks-cm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks-cm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorksCM_V2016_11_01.RestoreServer");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1827,9 +1892,14 @@ impl OpsWorksCM for OpsWorksCMClient {
         &self,
         input: StartMaintenanceRequest,
     ) -> RusotoFuture<StartMaintenanceResponse, StartMaintenanceError> {
-        let mut request = SignedRequest::new("POST", "opsworks-cm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks-cm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorksCM_V2016_11_01.StartMaintenance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1856,9 +1926,14 @@ impl OpsWorksCM for OpsWorksCMClient {
         &self,
         input: UpdateServerRequest,
     ) -> RusotoFuture<UpdateServerResponse, UpdateServerError> {
-        let mut request = SignedRequest::new("POST", "opsworks-cm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks-cm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "OpsWorksCM_V2016_11_01.UpdateServer");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1885,9 +1960,14 @@ impl OpsWorksCM for OpsWorksCMClient {
         &self,
         input: UpdateServerEngineAttributesRequest,
     ) -> RusotoFuture<UpdateServerEngineAttributesResponse, UpdateServerEngineAttributesError> {
-        let mut request = SignedRequest::new("POST", "opsworks-cm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "opsworks-cm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "OpsWorksCM_V2016_11_01.UpdateServerEngineAttributes",

--- a/rusoto/services/organizations/src/generated.rs
+++ b/rusoto/services/organizations/src/generated.rs
@@ -4736,9 +4736,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: AcceptHandshakeRequest,
     ) -> RusotoFuture<AcceptHandshakeResponse, AcceptHandshakeError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSOrganizationsV20161128.AcceptHandshake");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4762,9 +4767,14 @@ impl Organizations for OrganizationsClient {
 
     /// <p>Attaches a policy to a root, an organizational unit (OU), or an individual account. How the policy affects accounts depends on the type of policy:</p> <ul> <li> <p> <b>Service control policy (SCP)</b> - An SCP specifies what permissions can be delegated to users in affected member accounts. The scope of influence for a policy depends on what you attach the policy to:</p> <ul> <li> <p>If you attach an SCP to a root, it affects all accounts in the organization.</p> </li> <li> <p>If you attach an SCP to an OU, it affects all accounts in that OU and in any child OUs.</p> </li> <li> <p>If you attach the policy directly to an account, then it affects only that account.</p> </li> </ul> <p>SCPs are JSON policies that specify the maximum permissions for an organization or organizational unit (OU). When you attach one SCP to a higher level root or OU, and you also attach a different SCP to a child OU or to an account, the child policy can further restrict only the permissions that pass through the parent filter and are available to the child. An SCP that is attached to a child cannot grant a permission that is not already granted by the parent. For example, imagine that the parent SCP allows permissions A, B, C, D, and E. The child SCP allows C, D, E, F, and G. The result is that the accounts affected by the child SCP are allowed to use only C, D, and E. They cannot use A or B because they were filtered out by the child OU. They also cannot use F and G because they were filtered out by the parent OU. They cannot be granted back by the child SCP; child SCPs can only filter the permissions they receive from the parent SCP.</p> <p>AWS Organizations attaches a default SCP named <code>"FullAWSAccess</code> to every root, OU, and account. This default SCP allows all services and actions, enabling any new child OU or account to inherit the permissions of the parent root or OU. If you detach the default policy, you must replace it with a policy that specifies the permissions that you want to allow in that OU or account.</p> <p>For more information about how Organizations policies permissions work, see <a href="https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scp.html">Using Service Control Policies</a> in the <i>AWS Organizations User Guide</i>.</p> </li> </ul> <p>This operation can be called only from the organization's master account.</p>
     fn attach_policy(&self, input: AttachPolicyRequest) -> RusotoFuture<(), AttachPolicyError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSOrganizationsV20161128.AttachPolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4788,9 +4798,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: CancelHandshakeRequest,
     ) -> RusotoFuture<CancelHandshakeResponse, CancelHandshakeError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSOrganizationsV20161128.CancelHandshake");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4817,9 +4832,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: CreateAccountRequest,
     ) -> RusotoFuture<CreateAccountResponse, CreateAccountError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSOrganizationsV20161128.CreateAccount");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4846,9 +4866,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: CreateOrganizationRequest,
     ) -> RusotoFuture<CreateOrganizationResponse, CreateOrganizationError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrganizationsV20161128.CreateOrganization",
@@ -4878,9 +4903,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: CreateOrganizationalUnitRequest,
     ) -> RusotoFuture<CreateOrganizationalUnitResponse, CreateOrganizationalUnitError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrganizationsV20161128.CreateOrganizationalUnit",
@@ -4907,9 +4937,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: CreatePolicyRequest,
     ) -> RusotoFuture<CreatePolicyResponse, CreatePolicyError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSOrganizationsV20161128.CreatePolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4936,9 +4971,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: DeclineHandshakeRequest,
     ) -> RusotoFuture<DeclineHandshakeResponse, DeclineHandshakeError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSOrganizationsV20161128.DeclineHandshake");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4962,9 +5002,14 @@ impl Organizations for OrganizationsClient {
 
     /// <p>Deletes the organization. You can delete an organization only by using credentials from the master account. The organization must be empty of member accounts.</p>
     fn delete_organization(&self) -> RusotoFuture<(), DeleteOrganizationError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrganizationsV20161128.DeleteOrganization",
@@ -4990,9 +5035,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: DeleteOrganizationalUnitRequest,
     ) -> RusotoFuture<(), DeleteOrganizationalUnitError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrganizationsV20161128.DeleteOrganizationalUnit",
@@ -5013,9 +5063,14 @@ impl Organizations for OrganizationsClient {
 
     /// <p>Deletes the specified policy from your organization. Before you perform this operation, you must first detach the policy from all organizational units (OUs), roots, and accounts.</p> <p>This operation can be called only from the organization's master account.</p>
     fn delete_policy(&self, input: DeletePolicyRequest) -> RusotoFuture<(), DeletePolicyError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSOrganizationsV20161128.DeletePolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5039,9 +5094,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: DescribeAccountRequest,
     ) -> RusotoFuture<DescribeAccountResponse, DescribeAccountError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSOrganizationsV20161128.DescribeAccount");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5068,9 +5128,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: DescribeCreateAccountStatusRequest,
     ) -> RusotoFuture<DescribeCreateAccountStatusResponse, DescribeCreateAccountStatusError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrganizationsV20161128.DescribeCreateAccountStatus",
@@ -5097,9 +5162,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: DescribeHandshakeRequest,
     ) -> RusotoFuture<DescribeHandshakeResponse, DescribeHandshakeError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrganizationsV20161128.DescribeHandshake",
@@ -5128,9 +5198,14 @@ impl Organizations for OrganizationsClient {
     fn describe_organization(
         &self,
     ) -> RusotoFuture<DescribeOrganizationResponse, DescribeOrganizationError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrganizationsV20161128.DescribeOrganization",
@@ -5158,9 +5233,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: DescribeOrganizationalUnitRequest,
     ) -> RusotoFuture<DescribeOrganizationalUnitResponse, DescribeOrganizationalUnitError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrganizationsV20161128.DescribeOrganizationalUnit",
@@ -5187,9 +5267,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: DescribePolicyRequest,
     ) -> RusotoFuture<DescribePolicyResponse, DescribePolicyError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSOrganizationsV20161128.DescribePolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5213,9 +5298,14 @@ impl Organizations for OrganizationsClient {
 
     /// <p>Detaches a policy from a target root, organizational unit (OU), or account. If the policy being detached is a service control policy (SCP), the changes to permissions for IAM users and roles in affected accounts are immediate.</p> <p> <b>Note:</b> Every root, OU, and account must have at least one SCP attached. If you want to replace the default <code>FullAWSAccess</code> policy with one that limits the permissions that can be delegated, then you must attach the replacement policy before you can remove the default one. This is the authorization strategy of <a href="https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_about-scps.html#orgs_policies_whitelist">whitelisting</a>. If you instead attach a second SCP and leave the <code>FullAWSAccess</code> SCP still attached, and specify <code>"Effect": "Deny"</code> in the second SCP to override the <code>"Effect": "Allow"</code> in the <code>FullAWSAccess</code> policy (or any other attached SCP), then you are using the authorization strategy of <a href="https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_about-scps.html#orgs_policies_blacklist">blacklisting</a>. </p> <p>This operation can be called only from the organization's master account.</p>
     fn detach_policy(&self, input: DetachPolicyRequest) -> RusotoFuture<(), DetachPolicyError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSOrganizationsV20161128.DetachPolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5239,9 +5329,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: DisableAWSServiceAccessRequest,
     ) -> RusotoFuture<(), DisableAWSServiceAccessError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrganizationsV20161128.DisableAWSServiceAccess",
@@ -5265,9 +5360,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: DisablePolicyTypeRequest,
     ) -> RusotoFuture<DisablePolicyTypeResponse, DisablePolicyTypeError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrganizationsV20161128.DisablePolicyType",
@@ -5297,9 +5397,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: EnableAWSServiceAccessRequest,
     ) -> RusotoFuture<(), EnableAWSServiceAccessError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrganizationsV20161128.EnableAWSServiceAccess",
@@ -5324,9 +5429,14 @@ impl Organizations for OrganizationsClient {
     fn enable_all_features(
         &self,
     ) -> RusotoFuture<EnableAllFeaturesResponse, EnableAllFeaturesError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrganizationsV20161128.EnableAllFeatures",
@@ -5355,9 +5465,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: EnablePolicyTypeRequest,
     ) -> RusotoFuture<EnablePolicyTypeResponse, EnablePolicyTypeError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSOrganizationsV20161128.EnablePolicyType");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5384,9 +5499,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: InviteAccountToOrganizationRequest,
     ) -> RusotoFuture<InviteAccountToOrganizationResponse, InviteAccountToOrganizationError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrganizationsV20161128.InviteAccountToOrganization",
@@ -5410,9 +5530,14 @@ impl Organizations for OrganizationsClient {
 
     /// <p><p>Removes a member account from its parent organization. This version of the operation is performed by the account that wants to leave. To remove a member account as a user in the master account, use <a>RemoveAccountFromOrganization</a> instead.</p> <p>This operation can be called only from a member account in the organization.</p> <important> <ul> <li> <p>The master account in an organization with all features enabled can set service control policies (SCPs) that can restrict what administrators of member accounts can do, including preventing them from successfully calling <code>LeaveOrganization</code> and leaving the organization. </p> </li> <li> <p>You can leave an organization as a member account only if the account is configured with the information required to operate as a standalone account. When you create an account in an organization using the AWS Organizations console, API, or CLI commands, the information required of standalone accounts is <i>not</i> automatically collected. For each account that you want to make standalone, you must accept the End User License Agreement (EULA), choose a support plan, provide and verify the required contact information, and provide a current payment method. AWS uses the payment method to charge for any billable (not free tier) AWS activity that occurs while the account is not attached to an organization. Follow the steps at <a href="http://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_remove.html#leave-without-all-info"> To leave an organization when all required account information has not yet been provided</a> in the <i>AWS Organizations User Guide</i>.</p> </li> <li> <p>You can leave an organization only after you enable IAM user access to billing in your account. For more information, see <a href="http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/grantaccess.html#ControllingAccessWebsite-Activate">Activating Access to the Billing and Cost Management Console</a> in the <i>AWS Billing and Cost Management User Guide</i>.</p> </li> </ul> </important></p>
     fn leave_organization(&self) -> RusotoFuture<(), LeaveOrganizationError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrganizationsV20161128.LeaveOrganization",
@@ -5441,9 +5566,14 @@ impl Organizations for OrganizationsClient {
         ListAWSServiceAccessForOrganizationResponse,
         ListAWSServiceAccessForOrganizationError,
     > {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrganizationsV20161128.ListAWSServiceAccessForOrganization",
@@ -5472,9 +5602,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: ListAccountsRequest,
     ) -> RusotoFuture<ListAccountsResponse, ListAccountsError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSOrganizationsV20161128.ListAccounts");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5501,9 +5636,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: ListAccountsForParentRequest,
     ) -> RusotoFuture<ListAccountsForParentResponse, ListAccountsForParentError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrganizationsV20161128.ListAccountsForParent",
@@ -5532,9 +5672,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: ListChildrenRequest,
     ) -> RusotoFuture<ListChildrenResponse, ListChildrenError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSOrganizationsV20161128.ListChildren");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5561,9 +5706,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: ListCreateAccountStatusRequest,
     ) -> RusotoFuture<ListCreateAccountStatusResponse, ListCreateAccountStatusError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrganizationsV20161128.ListCreateAccountStatus",
@@ -5590,9 +5740,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: ListHandshakesForAccountRequest,
     ) -> RusotoFuture<ListHandshakesForAccountResponse, ListHandshakesForAccountError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrganizationsV20161128.ListHandshakesForAccount",
@@ -5620,9 +5775,14 @@ impl Organizations for OrganizationsClient {
         input: ListHandshakesForOrganizationRequest,
     ) -> RusotoFuture<ListHandshakesForOrganizationResponse, ListHandshakesForOrganizationError>
     {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrganizationsV20161128.ListHandshakesForOrganization",
@@ -5650,9 +5810,14 @@ impl Organizations for OrganizationsClient {
         input: ListOrganizationalUnitsForParentRequest,
     ) -> RusotoFuture<ListOrganizationalUnitsForParentResponse, ListOrganizationalUnitsForParentError>
     {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrganizationsV20161128.ListOrganizationalUnitsForParent",
@@ -5681,9 +5846,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: ListParentsRequest,
     ) -> RusotoFuture<ListParentsResponse, ListParentsError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSOrganizationsV20161128.ListParents");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5710,9 +5880,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: ListPoliciesRequest,
     ) -> RusotoFuture<ListPoliciesResponse, ListPoliciesError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSOrganizationsV20161128.ListPolicies");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5739,9 +5914,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: ListPoliciesForTargetRequest,
     ) -> RusotoFuture<ListPoliciesForTargetResponse, ListPoliciesForTargetError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrganizationsV20161128.ListPoliciesForTarget",
@@ -5770,9 +5950,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: ListRootsRequest,
     ) -> RusotoFuture<ListRootsResponse, ListRootsError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSOrganizationsV20161128.ListRoots");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5799,9 +5984,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: ListTargetsForPolicyRequest,
     ) -> RusotoFuture<ListTargetsForPolicyResponse, ListTargetsForPolicyError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrganizationsV20161128.ListTargetsForPolicy",
@@ -5827,9 +6017,14 @@ impl Organizations for OrganizationsClient {
 
     /// <p>Moves an account from its current source parent root or organizational unit (OU) to the specified destination parent root or OU.</p> <p>This operation can be called only from the organization's master account.</p>
     fn move_account(&self, input: MoveAccountRequest) -> RusotoFuture<(), MoveAccountError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSOrganizationsV20161128.MoveAccount");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5853,9 +6048,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: RemoveAccountFromOrganizationRequest,
     ) -> RusotoFuture<(), RemoveAccountFromOrganizationError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrganizationsV20161128.RemoveAccountFromOrganization",
@@ -5879,9 +6079,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: UpdateOrganizationalUnitRequest,
     ) -> RusotoFuture<UpdateOrganizationalUnitResponse, UpdateOrganizationalUnitError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSOrganizationsV20161128.UpdateOrganizationalUnit",
@@ -5908,9 +6113,14 @@ impl Organizations for OrganizationsClient {
         &self,
         input: UpdatePolicyRequest,
     ) -> RusotoFuture<UpdatePolicyResponse, UpdatePolicyError> {
-        let mut request = SignedRequest::new("POST", "organizations", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "organizations",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSOrganizationsV20161128.UpdatePolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/pi/src/generated.rs
+++ b/rusoto/services/pi/src/generated.rs
@@ -397,9 +397,14 @@ impl PerformanceInsights for PerformanceInsightsClient {
         &self,
         input: DescribeDimensionKeysRequest,
     ) -> RusotoFuture<DescribeDimensionKeysResponse, DescribeDimensionKeysError> {
-        let mut request = SignedRequest::new("POST", "pi", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "pi",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "PerformanceInsightsv20180227.DescribeDimensionKeys",
@@ -428,9 +433,14 @@ impl PerformanceInsights for PerformanceInsightsClient {
         &self,
         input: GetResourceMetricsRequest,
     ) -> RusotoFuture<GetResourceMetricsResponse, GetResourceMetricsError> {
-        let mut request = SignedRequest::new("POST", "pi", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "pi",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "PerformanceInsightsv20180227.GetResourceMetrics",

--- a/rusoto/services/pricing/src/generated.rs
+++ b/rusoto/services/pricing/src/generated.rs
@@ -404,9 +404,14 @@ impl Pricing for PricingClient {
         &self,
         input: DescribeServicesRequest,
     ) -> RusotoFuture<DescribeServicesResponse, DescribeServicesError> {
-        let mut request = SignedRequest::new("POST", "pricing", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "pricing",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.pricing".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSPriceListService.DescribeServices");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -433,9 +438,14 @@ impl Pricing for PricingClient {
         &self,
         input: GetAttributeValuesRequest,
     ) -> RusotoFuture<GetAttributeValuesResponse, GetAttributeValuesError> {
-        let mut request = SignedRequest::new("POST", "pricing", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "pricing",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.pricing".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSPriceListService.GetAttributeValues");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -462,9 +472,14 @@ impl Pricing for PricingClient {
         &self,
         input: GetProductsRequest,
     ) -> RusotoFuture<GetProductsResponse, GetProductsError> {
-        let mut request = SignedRequest::new("POST", "pricing", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "pricing",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.pricing".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSPriceListService.GetProducts");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/rekognition/src/generated.rs
+++ b/rusoto/services/rekognition/src/generated.rs
@@ -4806,9 +4806,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: CompareFacesRequest,
     ) -> RusotoFuture<CompareFacesResponse, CompareFacesError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.CompareFaces");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4835,9 +4840,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: CreateCollectionRequest,
     ) -> RusotoFuture<CreateCollectionResponse, CreateCollectionError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.CreateCollection");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4864,9 +4874,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: CreateStreamProcessorRequest,
     ) -> RusotoFuture<CreateStreamProcessorResponse, CreateStreamProcessorError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.CreateStreamProcessor");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4892,9 +4907,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: DeleteCollectionRequest,
     ) -> RusotoFuture<DeleteCollectionResponse, DeleteCollectionError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.DeleteCollection");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4921,9 +4941,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: DeleteFacesRequest,
     ) -> RusotoFuture<DeleteFacesResponse, DeleteFacesError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.DeleteFaces");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4950,9 +4975,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: DeleteStreamProcessorRequest,
     ) -> RusotoFuture<DeleteStreamProcessorResponse, DeleteStreamProcessorError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.DeleteStreamProcessor");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4978,9 +5008,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: DescribeCollectionRequest,
     ) -> RusotoFuture<DescribeCollectionResponse, DescribeCollectionError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.DescribeCollection");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5007,9 +5042,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: DescribeStreamProcessorRequest,
     ) -> RusotoFuture<DescribeStreamProcessorResponse, DescribeStreamProcessorError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.DescribeStreamProcessor");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5033,9 +5073,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: DetectFacesRequest,
     ) -> RusotoFuture<DetectFacesResponse, DetectFacesError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.DetectFaces");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5062,9 +5107,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: DetectLabelsRequest,
     ) -> RusotoFuture<DetectLabelsResponse, DetectLabelsError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.DetectLabels");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5091,9 +5141,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: DetectModerationLabelsRequest,
     ) -> RusotoFuture<DetectModerationLabelsResponse, DetectModerationLabelsError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.DetectModerationLabels");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5119,9 +5174,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: DetectTextRequest,
     ) -> RusotoFuture<DetectTextResponse, DetectTextError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.DetectText");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5148,9 +5208,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: GetCelebrityInfoRequest,
     ) -> RusotoFuture<GetCelebrityInfoResponse, GetCelebrityInfoError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.GetCelebrityInfo");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5177,9 +5242,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: GetCelebrityRecognitionRequest,
     ) -> RusotoFuture<GetCelebrityRecognitionResponse, GetCelebrityRecognitionError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.GetCelebrityRecognition");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5203,9 +5273,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: GetContentModerationRequest,
     ) -> RusotoFuture<GetContentModerationResponse, GetContentModerationError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.GetContentModeration");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5231,9 +5306,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: GetFaceDetectionRequest,
     ) -> RusotoFuture<GetFaceDetectionResponse, GetFaceDetectionError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.GetFaceDetection");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5260,9 +5340,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: GetFaceSearchRequest,
     ) -> RusotoFuture<GetFaceSearchResponse, GetFaceSearchError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.GetFaceSearch");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5289,9 +5374,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: GetLabelDetectionRequest,
     ) -> RusotoFuture<GetLabelDetectionResponse, GetLabelDetectionError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.GetLabelDetection");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5318,9 +5408,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: GetPersonTrackingRequest,
     ) -> RusotoFuture<GetPersonTrackingResponse, GetPersonTrackingError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.GetPersonTracking");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5347,9 +5442,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: IndexFacesRequest,
     ) -> RusotoFuture<IndexFacesResponse, IndexFacesError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.IndexFaces");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5376,9 +5476,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: ListCollectionsRequest,
     ) -> RusotoFuture<ListCollectionsResponse, ListCollectionsError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.ListCollections");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5405,9 +5510,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: ListFacesRequest,
     ) -> RusotoFuture<ListFacesResponse, ListFacesError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.ListFaces");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5434,9 +5544,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: ListStreamProcessorsRequest,
     ) -> RusotoFuture<ListStreamProcessorsResponse, ListStreamProcessorsError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.ListStreamProcessors");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5462,9 +5577,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: RecognizeCelebritiesRequest,
     ) -> RusotoFuture<RecognizeCelebritiesResponse, RecognizeCelebritiesError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.RecognizeCelebrities");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5490,9 +5610,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: SearchFacesRequest,
     ) -> RusotoFuture<SearchFacesResponse, SearchFacesError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.SearchFaces");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5519,9 +5644,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: SearchFacesByImageRequest,
     ) -> RusotoFuture<SearchFacesByImageResponse, SearchFacesByImageError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.SearchFacesByImage");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5548,9 +5678,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: StartCelebrityRecognitionRequest,
     ) -> RusotoFuture<StartCelebrityRecognitionResponse, StartCelebrityRecognitionError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "RekognitionService.StartCelebrityRecognition",
@@ -5577,9 +5712,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: StartContentModerationRequest,
     ) -> RusotoFuture<StartContentModerationResponse, StartContentModerationError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.StartContentModeration");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5605,9 +5745,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: StartFaceDetectionRequest,
     ) -> RusotoFuture<StartFaceDetectionResponse, StartFaceDetectionError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.StartFaceDetection");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5634,9 +5779,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: StartFaceSearchRequest,
     ) -> RusotoFuture<StartFaceSearchResponse, StartFaceSearchError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.StartFaceSearch");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5663,9 +5813,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: StartLabelDetectionRequest,
     ) -> RusotoFuture<StartLabelDetectionResponse, StartLabelDetectionError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.StartLabelDetection");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5691,9 +5846,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: StartPersonTrackingRequest,
     ) -> RusotoFuture<StartPersonTrackingResponse, StartPersonTrackingError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.StartPersonTracking");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5719,9 +5879,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: StartStreamProcessorRequest,
     ) -> RusotoFuture<StartStreamProcessorResponse, StartStreamProcessorError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.StartStreamProcessor");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5747,9 +5912,14 @@ impl Rekognition for RekognitionClient {
         &self,
         input: StopStreamProcessorRequest,
     ) -> RusotoFuture<StopStreamProcessorResponse, StopStreamProcessorError> {
-        let mut request = SignedRequest::new("POST", "rekognition", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "rekognition",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "RekognitionService.StopStreamProcessor");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/resourcegroupstaggingapi/src/generated.rs
+++ b/rusoto/services/resourcegroupstaggingapi/src/generated.rs
@@ -518,9 +518,14 @@ impl ResourceGroupsTaggingApi for ResourceGroupsTaggingApiClient {
         &self,
         input: GetResourcesInput,
     ) -> RusotoFuture<GetResourcesOutput, GetResourcesError> {
-        let mut request = SignedRequest::new("POST", "tagging", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "tagging",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "ResourceGroupsTaggingAPI_20170126.GetResources",
@@ -550,9 +555,14 @@ impl ResourceGroupsTaggingApi for ResourceGroupsTaggingApiClient {
         &self,
         input: GetTagKeysInput,
     ) -> RusotoFuture<GetTagKeysOutput, GetTagKeysError> {
-        let mut request = SignedRequest::new("POST", "tagging", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "tagging",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "ResourceGroupsTaggingAPI_20170126.GetTagKeys",
@@ -582,9 +592,14 @@ impl ResourceGroupsTaggingApi for ResourceGroupsTaggingApiClient {
         &self,
         input: GetTagValuesInput,
     ) -> RusotoFuture<GetTagValuesOutput, GetTagValuesError> {
-        let mut request = SignedRequest::new("POST", "tagging", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "tagging",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "ResourceGroupsTaggingAPI_20170126.GetTagValues",
@@ -614,9 +629,14 @@ impl ResourceGroupsTaggingApi for ResourceGroupsTaggingApiClient {
         &self,
         input: TagResourcesInput,
     ) -> RusotoFuture<TagResourcesOutput, TagResourcesError> {
-        let mut request = SignedRequest::new("POST", "tagging", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "tagging",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "ResourceGroupsTaggingAPI_20170126.TagResources",
@@ -646,9 +666,14 @@ impl ResourceGroupsTaggingApi for ResourceGroupsTaggingApiClient {
         &self,
         input: UntagResourcesInput,
     ) -> RusotoFuture<UntagResourcesOutput, UntagResourcesError> {
-        let mut request = SignedRequest::new("POST", "tagging", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "tagging",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "ResourceGroupsTaggingAPI_20170126.UntagResources",

--- a/rusoto/services/route53domains/src/generated.rs
+++ b/rusoto/services/route53domains/src/generated.rs
@@ -2253,9 +2253,14 @@ impl Route53Domains for Route53DomainsClient {
         &self,
         input: CheckDomainAvailabilityRequest,
     ) -> RusotoFuture<CheckDomainAvailabilityResponse, CheckDomainAvailabilityError> {
-        let mut request = SignedRequest::new("POST", "route53domains", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "route53domains",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53Domains_v20140515.CheckDomainAvailability",
@@ -2282,9 +2287,14 @@ impl Route53Domains for Route53DomainsClient {
         &self,
         input: CheckDomainTransferabilityRequest,
     ) -> RusotoFuture<CheckDomainTransferabilityResponse, CheckDomainTransferabilityError> {
-        let mut request = SignedRequest::new("POST", "route53domains", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "route53domains",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53Domains_v20140515.CheckDomainTransferability",
@@ -2311,9 +2321,14 @@ impl Route53Domains for Route53DomainsClient {
         &self,
         input: DeleteTagsForDomainRequest,
     ) -> RusotoFuture<DeleteTagsForDomainResponse, DeleteTagsForDomainError> {
-        let mut request = SignedRequest::new("POST", "route53domains", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "route53domains",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53Domains_v20140515.DeleteTagsForDomain",
@@ -2342,9 +2357,14 @@ impl Route53Domains for Route53DomainsClient {
         &self,
         input: DisableDomainAutoRenewRequest,
     ) -> RusotoFuture<DisableDomainAutoRenewResponse, DisableDomainAutoRenewError> {
-        let mut request = SignedRequest::new("POST", "route53domains", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "route53domains",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53Domains_v20140515.DisableDomainAutoRenew",
@@ -2373,9 +2393,14 @@ impl Route53Domains for Route53DomainsClient {
         &self,
         input: DisableDomainTransferLockRequest,
     ) -> RusotoFuture<DisableDomainTransferLockResponse, DisableDomainTransferLockError> {
-        let mut request = SignedRequest::new("POST", "route53domains", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "route53domains",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53Domains_v20140515.DisableDomainTransferLock",
@@ -2402,9 +2427,14 @@ impl Route53Domains for Route53DomainsClient {
         &self,
         input: EnableDomainAutoRenewRequest,
     ) -> RusotoFuture<EnableDomainAutoRenewResponse, EnableDomainAutoRenewError> {
-        let mut request = SignedRequest::new("POST", "route53domains", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "route53domains",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53Domains_v20140515.EnableDomainAutoRenew",
@@ -2433,9 +2463,14 @@ impl Route53Domains for Route53DomainsClient {
         &self,
         input: EnableDomainTransferLockRequest,
     ) -> RusotoFuture<EnableDomainTransferLockResponse, EnableDomainTransferLockError> {
-        let mut request = SignedRequest::new("POST", "route53domains", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "route53domains",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53Domains_v20140515.EnableDomainTransferLock",
@@ -2462,9 +2497,14 @@ impl Route53Domains for Route53DomainsClient {
         &self,
         input: GetContactReachabilityStatusRequest,
     ) -> RusotoFuture<GetContactReachabilityStatusResponse, GetContactReachabilityStatusError> {
-        let mut request = SignedRequest::new("POST", "route53domains", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "route53domains",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53Domains_v20140515.GetContactReachabilityStatus",
@@ -2491,9 +2531,14 @@ impl Route53Domains for Route53DomainsClient {
         &self,
         input: GetDomainDetailRequest,
     ) -> RusotoFuture<GetDomainDetailResponse, GetDomainDetailError> {
-        let mut request = SignedRequest::new("POST", "route53domains", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "route53domains",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Route53Domains_v20140515.GetDomainDetail");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2520,9 +2565,14 @@ impl Route53Domains for Route53DomainsClient {
         &self,
         input: GetDomainSuggestionsRequest,
     ) -> RusotoFuture<GetDomainSuggestionsResponse, GetDomainSuggestionsError> {
-        let mut request = SignedRequest::new("POST", "route53domains", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "route53domains",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53Domains_v20140515.GetDomainSuggestions",
@@ -2551,9 +2601,14 @@ impl Route53Domains for Route53DomainsClient {
         &self,
         input: GetOperationDetailRequest,
     ) -> RusotoFuture<GetOperationDetailResponse, GetOperationDetailError> {
-        let mut request = SignedRequest::new("POST", "route53domains", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "route53domains",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53Domains_v20140515.GetOperationDetail",
@@ -2583,9 +2638,14 @@ impl Route53Domains for Route53DomainsClient {
         &self,
         input: ListDomainsRequest,
     ) -> RusotoFuture<ListDomainsResponse, ListDomainsError> {
-        let mut request = SignedRequest::new("POST", "route53domains", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "route53domains",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Route53Domains_v20140515.ListDomains");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2612,9 +2672,14 @@ impl Route53Domains for Route53DomainsClient {
         &self,
         input: ListOperationsRequest,
     ) -> RusotoFuture<ListOperationsResponse, ListOperationsError> {
-        let mut request = SignedRequest::new("POST", "route53domains", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "route53domains",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Route53Domains_v20140515.ListOperations");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2641,9 +2706,14 @@ impl Route53Domains for Route53DomainsClient {
         &self,
         input: ListTagsForDomainRequest,
     ) -> RusotoFuture<ListTagsForDomainResponse, ListTagsForDomainError> {
-        let mut request = SignedRequest::new("POST", "route53domains", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "route53domains",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Route53Domains_v20140515.ListTagsForDomain");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2670,9 +2740,14 @@ impl Route53Domains for Route53DomainsClient {
         &self,
         input: RegisterDomainRequest,
     ) -> RusotoFuture<RegisterDomainResponse, RegisterDomainError> {
-        let mut request = SignedRequest::new("POST", "route53domains", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "route53domains",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Route53Domains_v20140515.RegisterDomain");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2699,9 +2774,14 @@ impl Route53Domains for Route53DomainsClient {
         &self,
         input: RenewDomainRequest,
     ) -> RusotoFuture<RenewDomainResponse, RenewDomainError> {
-        let mut request = SignedRequest::new("POST", "route53domains", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "route53domains",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Route53Domains_v20140515.RenewDomain");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2729,9 +2809,14 @@ impl Route53Domains for Route53DomainsClient {
         input: ResendContactReachabilityEmailRequest,
     ) -> RusotoFuture<ResendContactReachabilityEmailResponse, ResendContactReachabilityEmailError>
     {
-        let mut request = SignedRequest::new("POST", "route53domains", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "route53domains",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53Domains_v20140515.ResendContactReachabilityEmail",
@@ -2758,9 +2843,14 @@ impl Route53Domains for Route53DomainsClient {
         &self,
         input: RetrieveDomainAuthCodeRequest,
     ) -> RusotoFuture<RetrieveDomainAuthCodeResponse, RetrieveDomainAuthCodeError> {
-        let mut request = SignedRequest::new("POST", "route53domains", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "route53domains",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53Domains_v20140515.RetrieveDomainAuthCode",
@@ -2789,9 +2879,14 @@ impl Route53Domains for Route53DomainsClient {
         &self,
         input: TransferDomainRequest,
     ) -> RusotoFuture<TransferDomainResponse, TransferDomainError> {
-        let mut request = SignedRequest::new("POST", "route53domains", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "route53domains",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Route53Domains_v20140515.TransferDomain");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2818,9 +2913,14 @@ impl Route53Domains for Route53DomainsClient {
         &self,
         input: UpdateDomainContactRequest,
     ) -> RusotoFuture<UpdateDomainContactResponse, UpdateDomainContactError> {
-        let mut request = SignedRequest::new("POST", "route53domains", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "route53domains",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53Domains_v20140515.UpdateDomainContact",
@@ -2849,9 +2949,14 @@ impl Route53Domains for Route53DomainsClient {
         &self,
         input: UpdateDomainContactPrivacyRequest,
     ) -> RusotoFuture<UpdateDomainContactPrivacyResponse, UpdateDomainContactPrivacyError> {
-        let mut request = SignedRequest::new("POST", "route53domains", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "route53domains",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53Domains_v20140515.UpdateDomainContactPrivacy",
@@ -2878,9 +2983,14 @@ impl Route53Domains for Route53DomainsClient {
         &self,
         input: UpdateDomainNameserversRequest,
     ) -> RusotoFuture<UpdateDomainNameserversResponse, UpdateDomainNameserversError> {
-        let mut request = SignedRequest::new("POST", "route53domains", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "route53domains",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53Domains_v20140515.UpdateDomainNameservers",
@@ -2907,9 +3017,14 @@ impl Route53Domains for Route53DomainsClient {
         &self,
         input: UpdateTagsForDomainRequest,
     ) -> RusotoFuture<UpdateTagsForDomainResponse, UpdateTagsForDomainError> {
-        let mut request = SignedRequest::new("POST", "route53domains", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "route53domains",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53Domains_v20140515.UpdateTagsForDomain",
@@ -2938,9 +3053,14 @@ impl Route53Domains for Route53DomainsClient {
         &self,
         input: ViewBillingRequest,
     ) -> RusotoFuture<ViewBillingResponse, ViewBillingError> {
-        let mut request = SignedRequest::new("POST", "route53domains", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "route53domains",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Route53Domains_v20140515.ViewBilling");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/sagemaker/src/generated.rs
+++ b/rusoto/services/sagemaker/src/generated.rs
@@ -7258,9 +7258,14 @@ impl SageMakerClient {
 impl SageMaker for SageMakerClient {
     /// <p><p>Adds or overwrites one or more tags for the specified Amazon SageMaker resource. You can add tags to notebook instances, training jobs, hyperparameter tuning jobs, models, endpoint configurations, and endpoints.</p> <p>Each tag consists of a key and an optional value. Tag keys must be unique per resource. For more information about tags, see For more information, see <a href="https://aws.amazon.com/answers/account-management/aws-tagging-strategies/">AWS Tagging Strategies</a>.</p> <note> <p>Tags that you add to a hyperparameter tuning job by calling this API are also added to any training jobs that the hyperparameter tuning job launches after you call this API, but not to training jobs that the hyperparameter tuning job launched before you called this API. To make sure that the tags associated with a hyperparameter tuning job are also added to all training jobs that the hyperparameter tuning job launches, add the tags when you first create the tuning job by specifying them in the <code>Tags</code> parameter of <a>CreateHyperParameterTuningJob</a> </p> </note></p>
     fn add_tags(&self, input: AddTagsInput) -> RusotoFuture<AddTagsOutput, AddTagsError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.AddTags");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7286,9 +7291,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: CreateAlgorithmInput,
     ) -> RusotoFuture<CreateAlgorithmOutput, CreateAlgorithmError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.CreateAlgorithm");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7315,9 +7325,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: CreateCodeRepositoryInput,
     ) -> RusotoFuture<CreateCodeRepositoryOutput, CreateCodeRepositoryError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.CreateCodeRepository");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7343,9 +7358,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: CreateCompilationJobRequest,
     ) -> RusotoFuture<CreateCompilationJobResponse, CreateCompilationJobError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.CreateCompilationJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7371,9 +7391,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: CreateEndpointInput,
     ) -> RusotoFuture<CreateEndpointOutput, CreateEndpointError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.CreateEndpoint");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7400,9 +7425,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: CreateEndpointConfigInput,
     ) -> RusotoFuture<CreateEndpointConfigOutput, CreateEndpointConfigError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.CreateEndpointConfig");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7429,9 +7459,14 @@ impl SageMaker for SageMakerClient {
         input: CreateHyperParameterTuningJobRequest,
     ) -> RusotoFuture<CreateHyperParameterTuningJobResponse, CreateHyperParameterTuningJobError>
     {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.CreateHyperParameterTuningJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7455,9 +7490,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: CreateLabelingJobRequest,
     ) -> RusotoFuture<CreateLabelingJobResponse, CreateLabelingJobError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.CreateLabelingJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7484,9 +7524,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: CreateModelInput,
     ) -> RusotoFuture<CreateModelOutput, CreateModelError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.CreateModel");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7513,9 +7558,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: CreateModelPackageInput,
     ) -> RusotoFuture<CreateModelPackageOutput, CreateModelPackageError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.CreateModelPackage");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7542,9 +7592,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: CreateNotebookInstanceInput,
     ) -> RusotoFuture<CreateNotebookInstanceOutput, CreateNotebookInstanceError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.CreateNotebookInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7573,9 +7628,14 @@ impl SageMaker for SageMakerClient {
         CreateNotebookInstanceLifecycleConfigOutput,
         CreateNotebookInstanceLifecycleConfigError,
     > {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "SageMaker.CreateNotebookInstanceLifecycleConfig",
@@ -7607,9 +7667,14 @@ impl SageMaker for SageMakerClient {
         CreatePresignedNotebookInstanceUrlOutput,
         CreatePresignedNotebookInstanceUrlError,
     > {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "SageMaker.CreatePresignedNotebookInstanceUrl",
@@ -7638,9 +7703,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: CreateTrainingJobRequest,
     ) -> RusotoFuture<CreateTrainingJobResponse, CreateTrainingJobError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.CreateTrainingJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7667,9 +7737,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: CreateTransformJobRequest,
     ) -> RusotoFuture<CreateTransformJobResponse, CreateTransformJobError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.CreateTransformJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7696,9 +7771,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: CreateWorkteamRequest,
     ) -> RusotoFuture<CreateWorkteamResponse, CreateWorkteamError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.CreateWorkteam");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7725,9 +7805,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: DeleteAlgorithmInput,
     ) -> RusotoFuture<(), DeleteAlgorithmError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.DeleteAlgorithm");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7751,9 +7836,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: DeleteCodeRepositoryInput,
     ) -> RusotoFuture<(), DeleteCodeRepositoryError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.DeleteCodeRepository");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7773,9 +7863,14 @@ impl SageMaker for SageMakerClient {
 
     /// <p>Deletes an endpoint. Amazon SageMaker frees up all of the resources that were deployed when the endpoint was created. </p> <p>Amazon SageMaker retires any custom KMS key grants associated with the endpoint, meaning you don't need to use the <a href="http://docs.aws.amazon.com/kms/latest/APIReference/API_RevokeGrant.html">RevokeGrant</a> API call.</p>
     fn delete_endpoint(&self, input: DeleteEndpointInput) -> RusotoFuture<(), DeleteEndpointError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.DeleteEndpoint");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7799,9 +7894,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: DeleteEndpointConfigInput,
     ) -> RusotoFuture<(), DeleteEndpointConfigError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.DeleteEndpointConfig");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7821,9 +7921,14 @@ impl SageMaker for SageMakerClient {
 
     /// <p>Deletes a model. The <code>DeleteModel</code> API deletes only the model entry that was created in Amazon SageMaker when you called the <a href="http://docs.aws.amazon.com/sagemaker/latest/dg/API_CreateModel.html">CreateModel</a> API. It does not delete model artifacts, inference code, or the IAM role that you specified when creating the model. </p>
     fn delete_model(&self, input: DeleteModelInput) -> RusotoFuture<(), DeleteModelError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.DeleteModel");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7847,9 +7952,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: DeleteModelPackageInput,
     ) -> RusotoFuture<(), DeleteModelPackageError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.DeleteModelPackage");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7873,9 +7983,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: DeleteNotebookInstanceInput,
     ) -> RusotoFuture<(), DeleteNotebookInstanceError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.DeleteNotebookInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7898,9 +8013,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: DeleteNotebookInstanceLifecycleConfigInput,
     ) -> RusotoFuture<(), DeleteNotebookInstanceLifecycleConfigError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "SageMaker.DeleteNotebookInstanceLifecycleConfig",
@@ -7926,9 +8046,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: DeleteTagsInput,
     ) -> RusotoFuture<DeleteTagsOutput, DeleteTagsError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.DeleteTags");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7955,9 +8080,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: DeleteWorkteamRequest,
     ) -> RusotoFuture<DeleteWorkteamResponse, DeleteWorkteamError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.DeleteWorkteam");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7984,9 +8114,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: DescribeAlgorithmInput,
     ) -> RusotoFuture<DescribeAlgorithmOutput, DescribeAlgorithmError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.DescribeAlgorithm");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8013,9 +8148,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: DescribeCodeRepositoryInput,
     ) -> RusotoFuture<DescribeCodeRepositoryOutput, DescribeCodeRepositoryError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.DescribeCodeRepository");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8041,9 +8181,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: DescribeCompilationJobRequest,
     ) -> RusotoFuture<DescribeCompilationJobResponse, DescribeCompilationJobError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.DescribeCompilationJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8069,9 +8214,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: DescribeEndpointInput,
     ) -> RusotoFuture<DescribeEndpointOutput, DescribeEndpointError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.DescribeEndpoint");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8098,9 +8248,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: DescribeEndpointConfigInput,
     ) -> RusotoFuture<DescribeEndpointConfigOutput, DescribeEndpointConfigError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.DescribeEndpointConfig");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8127,9 +8282,14 @@ impl SageMaker for SageMakerClient {
         input: DescribeHyperParameterTuningJobRequest,
     ) -> RusotoFuture<DescribeHyperParameterTuningJobResponse, DescribeHyperParameterTuningJobError>
     {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.DescribeHyperParameterTuningJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8155,9 +8315,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: DescribeLabelingJobRequest,
     ) -> RusotoFuture<DescribeLabelingJobResponse, DescribeLabelingJobError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.DescribeLabelingJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8183,9 +8348,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: DescribeModelInput,
     ) -> RusotoFuture<DescribeModelOutput, DescribeModelError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.DescribeModel");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8212,9 +8382,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: DescribeModelPackageInput,
     ) -> RusotoFuture<DescribeModelPackageOutput, DescribeModelPackageError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.DescribeModelPackage");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8240,9 +8415,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: DescribeNotebookInstanceInput,
     ) -> RusotoFuture<DescribeNotebookInstanceOutput, DescribeNotebookInstanceError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.DescribeNotebookInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8269,9 +8449,14 @@ impl SageMaker for SageMakerClient {
         DescribeNotebookInstanceLifecycleConfigOutput,
         DescribeNotebookInstanceLifecycleConfigError,
     > {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "SageMaker.DescribeNotebookInstanceLifecycleConfig",
@@ -8300,9 +8485,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: DescribeSubscribedWorkteamRequest,
     ) -> RusotoFuture<DescribeSubscribedWorkteamResponse, DescribeSubscribedWorkteamError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.DescribeSubscribedWorkteam");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8326,9 +8516,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: DescribeTrainingJobRequest,
     ) -> RusotoFuture<DescribeTrainingJobResponse, DescribeTrainingJobError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.DescribeTrainingJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8354,9 +8549,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: DescribeTransformJobRequest,
     ) -> RusotoFuture<DescribeTransformJobResponse, DescribeTransformJobError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.DescribeTransformJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8382,9 +8582,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: DescribeWorkteamRequest,
     ) -> RusotoFuture<DescribeWorkteamResponse, DescribeWorkteamError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.DescribeWorkteam");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8411,9 +8616,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: GetSearchSuggestionsRequest,
     ) -> RusotoFuture<GetSearchSuggestionsResponse, GetSearchSuggestionsError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.GetSearchSuggestions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8439,9 +8649,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: ListAlgorithmsInput,
     ) -> RusotoFuture<ListAlgorithmsOutput, ListAlgorithmsError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.ListAlgorithms");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8468,9 +8683,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: ListCodeRepositoriesInput,
     ) -> RusotoFuture<ListCodeRepositoriesOutput, ListCodeRepositoriesError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.ListCodeRepositories");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8496,9 +8716,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: ListCompilationJobsRequest,
     ) -> RusotoFuture<ListCompilationJobsResponse, ListCompilationJobsError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.ListCompilationJobs");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8524,9 +8749,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: ListEndpointConfigsInput,
     ) -> RusotoFuture<ListEndpointConfigsOutput, ListEndpointConfigsError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.ListEndpointConfigs");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8552,9 +8782,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: ListEndpointsInput,
     ) -> RusotoFuture<ListEndpointsOutput, ListEndpointsError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.ListEndpoints");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8581,9 +8816,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: ListHyperParameterTuningJobsRequest,
     ) -> RusotoFuture<ListHyperParameterTuningJobsResponse, ListHyperParameterTuningJobsError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.ListHyperParameterTuningJobs");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8607,9 +8847,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: ListLabelingJobsRequest,
     ) -> RusotoFuture<ListLabelingJobsResponse, ListLabelingJobsError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.ListLabelingJobs");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8636,9 +8881,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: ListLabelingJobsForWorkteamRequest,
     ) -> RusotoFuture<ListLabelingJobsForWorkteamResponse, ListLabelingJobsForWorkteamError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.ListLabelingJobsForWorkteam");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8662,9 +8912,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: ListModelPackagesInput,
     ) -> RusotoFuture<ListModelPackagesOutput, ListModelPackagesError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.ListModelPackages");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8691,9 +8946,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: ListModelsInput,
     ) -> RusotoFuture<ListModelsOutput, ListModelsError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.ListModels");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8723,9 +8983,14 @@ impl SageMaker for SageMakerClient {
         ListNotebookInstanceLifecycleConfigsOutput,
         ListNotebookInstanceLifecycleConfigsError,
     > {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "SageMaker.ListNotebookInstanceLifecycleConfigs",
@@ -8754,9 +9019,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: ListNotebookInstancesInput,
     ) -> RusotoFuture<ListNotebookInstancesOutput, ListNotebookInstancesError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.ListNotebookInstances");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8782,9 +9052,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: ListSubscribedWorkteamsRequest,
     ) -> RusotoFuture<ListSubscribedWorkteamsResponse, ListSubscribedWorkteamsError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.ListSubscribedWorkteams");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8805,9 +9080,14 @@ impl SageMaker for SageMakerClient {
 
     /// <p>Returns the tags for the specified Amazon SageMaker resource.</p>
     fn list_tags(&self, input: ListTagsInput) -> RusotoFuture<ListTagsOutput, ListTagsError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.ListTags");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8833,9 +9113,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: ListTrainingJobsRequest,
     ) -> RusotoFuture<ListTrainingJobsResponse, ListTrainingJobsError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.ListTrainingJobs");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8865,9 +9150,14 @@ impl SageMaker for SageMakerClient {
         ListTrainingJobsForHyperParameterTuningJobResponse,
         ListTrainingJobsForHyperParameterTuningJobError,
     > {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "SageMaker.ListTrainingJobsForHyperParameterTuningJob",
@@ -8894,9 +9184,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: ListTransformJobsRequest,
     ) -> RusotoFuture<ListTransformJobsResponse, ListTransformJobsError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.ListTransformJobs");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8923,9 +9218,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: ListWorkteamsRequest,
     ) -> RusotoFuture<ListWorkteamsResponse, ListWorkteamsError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.ListWorkteams");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8952,9 +9252,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: RenderUiTemplateRequest,
     ) -> RusotoFuture<RenderUiTemplateResponse, RenderUiTemplateError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.RenderUiTemplate");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8978,9 +9283,14 @@ impl SageMaker for SageMakerClient {
 
     /// <p>Finds Amazon SageMaker resources that match a search query. Matching resource objects are returned as a list of <code>SearchResult</code> objects in the response. You can sort the search results by any resource property in a ascending or descending order.</p> <p>You can query against the following value types: numerical, text, Booleans, and timestamps.</p>
     fn search(&self, input: SearchRequest) -> RusotoFuture<SearchResponse, SearchError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.Search");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9006,9 +9316,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: StartNotebookInstanceInput,
     ) -> RusotoFuture<(), StartNotebookInstanceError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.StartNotebookInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9031,9 +9346,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: StopCompilationJobRequest,
     ) -> RusotoFuture<(), StopCompilationJobError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.StopCompilationJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9057,9 +9377,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: StopHyperParameterTuningJobRequest,
     ) -> RusotoFuture<(), StopHyperParameterTuningJobError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.StopHyperParameterTuningJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9080,9 +9405,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: StopLabelingJobRequest,
     ) -> RusotoFuture<(), StopLabelingJobError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.StopLabelingJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9106,9 +9436,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: StopNotebookInstanceInput,
     ) -> RusotoFuture<(), StopNotebookInstanceError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.StopNotebookInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9131,9 +9466,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: StopTrainingJobRequest,
     ) -> RusotoFuture<(), StopTrainingJobError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.StopTrainingJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9157,9 +9497,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: StopTransformJobRequest,
     ) -> RusotoFuture<(), StopTransformJobError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.StopTransformJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9183,9 +9528,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: UpdateCodeRepositoryInput,
     ) -> RusotoFuture<UpdateCodeRepositoryOutput, UpdateCodeRepositoryError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.UpdateCodeRepository");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9211,9 +9561,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: UpdateEndpointInput,
     ) -> RusotoFuture<UpdateEndpointOutput, UpdateEndpointError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.UpdateEndpoint");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9243,9 +9598,14 @@ impl SageMaker for SageMakerClient {
         UpdateEndpointWeightsAndCapacitiesOutput,
         UpdateEndpointWeightsAndCapacitiesError,
     > {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "SageMaker.UpdateEndpointWeightsAndCapacities",
@@ -9274,9 +9634,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: UpdateNotebookInstanceInput,
     ) -> RusotoFuture<UpdateNotebookInstanceOutput, UpdateNotebookInstanceError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.UpdateNotebookInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9305,9 +9670,14 @@ impl SageMaker for SageMakerClient {
         UpdateNotebookInstanceLifecycleConfigOutput,
         UpdateNotebookInstanceLifecycleConfigError,
     > {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "SageMaker.UpdateNotebookInstanceLifecycleConfig",
@@ -9336,9 +9706,14 @@ impl SageMaker for SageMakerClient {
         &self,
         input: UpdateWorkteamRequest,
     ) -> RusotoFuture<UpdateWorkteamResponse, UpdateWorkteamError> {
-        let mut request = SignedRequest::new("POST", "sagemaker", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sagemaker",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
         request.set_endpoint_prefix("api.sagemaker".to_string());
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "SageMaker.UpdateWorkteam");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/secretsmanager/src/generated.rs
+++ b/rusoto/services/secretsmanager/src/generated.rs
@@ -1886,9 +1886,14 @@ impl SecretsManager for SecretsManagerClient {
         &self,
         input: CancelRotateSecretRequest,
     ) -> RusotoFuture<CancelRotateSecretResponse, CancelRotateSecretError> {
-        let mut request = SignedRequest::new("POST", "secretsmanager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "secretsmanager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "secretsmanager.CancelRotateSecret");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1915,9 +1920,14 @@ impl SecretsManager for SecretsManagerClient {
         &self,
         input: CreateSecretRequest,
     ) -> RusotoFuture<CreateSecretResponse, CreateSecretError> {
-        let mut request = SignedRequest::new("POST", "secretsmanager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "secretsmanager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "secretsmanager.CreateSecret");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1944,9 +1954,14 @@ impl SecretsManager for SecretsManagerClient {
         &self,
         input: DeleteResourcePolicyRequest,
     ) -> RusotoFuture<DeleteResourcePolicyResponse, DeleteResourcePolicyError> {
-        let mut request = SignedRequest::new("POST", "secretsmanager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "secretsmanager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "secretsmanager.DeleteResourcePolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1972,9 +1987,14 @@ impl SecretsManager for SecretsManagerClient {
         &self,
         input: DeleteSecretRequest,
     ) -> RusotoFuture<DeleteSecretResponse, DeleteSecretError> {
-        let mut request = SignedRequest::new("POST", "secretsmanager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "secretsmanager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "secretsmanager.DeleteSecret");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2001,9 +2021,14 @@ impl SecretsManager for SecretsManagerClient {
         &self,
         input: DescribeSecretRequest,
     ) -> RusotoFuture<DescribeSecretResponse, DescribeSecretError> {
-        let mut request = SignedRequest::new("POST", "secretsmanager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "secretsmanager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "secretsmanager.DescribeSecret");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2030,9 +2055,14 @@ impl SecretsManager for SecretsManagerClient {
         &self,
         input: GetRandomPasswordRequest,
     ) -> RusotoFuture<GetRandomPasswordResponse, GetRandomPasswordError> {
-        let mut request = SignedRequest::new("POST", "secretsmanager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "secretsmanager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "secretsmanager.GetRandomPassword");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2059,9 +2089,14 @@ impl SecretsManager for SecretsManagerClient {
         &self,
         input: GetResourcePolicyRequest,
     ) -> RusotoFuture<GetResourcePolicyResponse, GetResourcePolicyError> {
-        let mut request = SignedRequest::new("POST", "secretsmanager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "secretsmanager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "secretsmanager.GetResourcePolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2088,9 +2123,14 @@ impl SecretsManager for SecretsManagerClient {
         &self,
         input: GetSecretValueRequest,
     ) -> RusotoFuture<GetSecretValueResponse, GetSecretValueError> {
-        let mut request = SignedRequest::new("POST", "secretsmanager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "secretsmanager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "secretsmanager.GetSecretValue");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2117,9 +2157,14 @@ impl SecretsManager for SecretsManagerClient {
         &self,
         input: ListSecretVersionIdsRequest,
     ) -> RusotoFuture<ListSecretVersionIdsResponse, ListSecretVersionIdsError> {
-        let mut request = SignedRequest::new("POST", "secretsmanager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "secretsmanager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "secretsmanager.ListSecretVersionIds");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2145,9 +2190,14 @@ impl SecretsManager for SecretsManagerClient {
         &self,
         input: ListSecretsRequest,
     ) -> RusotoFuture<ListSecretsResponse, ListSecretsError> {
-        let mut request = SignedRequest::new("POST", "secretsmanager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "secretsmanager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "secretsmanager.ListSecrets");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2174,9 +2224,14 @@ impl SecretsManager for SecretsManagerClient {
         &self,
         input: PutResourcePolicyRequest,
     ) -> RusotoFuture<PutResourcePolicyResponse, PutResourcePolicyError> {
-        let mut request = SignedRequest::new("POST", "secretsmanager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "secretsmanager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "secretsmanager.PutResourcePolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2203,9 +2258,14 @@ impl SecretsManager for SecretsManagerClient {
         &self,
         input: PutSecretValueRequest,
     ) -> RusotoFuture<PutSecretValueResponse, PutSecretValueError> {
-        let mut request = SignedRequest::new("POST", "secretsmanager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "secretsmanager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "secretsmanager.PutSecretValue");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2232,9 +2292,14 @@ impl SecretsManager for SecretsManagerClient {
         &self,
         input: RestoreSecretRequest,
     ) -> RusotoFuture<RestoreSecretResponse, RestoreSecretError> {
-        let mut request = SignedRequest::new("POST", "secretsmanager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "secretsmanager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "secretsmanager.RestoreSecret");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2261,9 +2326,14 @@ impl SecretsManager for SecretsManagerClient {
         &self,
         input: RotateSecretRequest,
     ) -> RusotoFuture<RotateSecretResponse, RotateSecretError> {
-        let mut request = SignedRequest::new("POST", "secretsmanager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "secretsmanager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "secretsmanager.RotateSecret");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2287,9 +2357,14 @@ impl SecretsManager for SecretsManagerClient {
 
     /// <p><p>Attaches one or more tags, each consisting of a key name and a value, to the specified secret. Tags are part of the secret&#39;s overall metadata, and are not associated with any specific version of the secret. This operation only appends tags to the existing list of tags. To remove tags, you must use <a>UntagResource</a>.</p> <p>The following basic restrictions apply to tags:</p> <ul> <li> <p>Maximum number of tags per secret—50</p> </li> <li> <p>Maximum key length—127 Unicode characters in UTF-8</p> </li> <li> <p>Maximum value length—255 Unicode characters in UTF-8</p> </li> <li> <p>Tag keys and values are case sensitive.</p> </li> <li> <p>Do not use the <code>aws:</code> prefix in your tag names or values because it is reserved for AWS use. You can&#39;t edit or delete tag names or values with this prefix. Tags with this prefix do not count against your tags per secret limit.</p> </li> <li> <p>If your tagging schema will be used across multiple services and resources, remember that other services might have restrictions on allowed characters. Generally allowed characters are: letters, spaces, and numbers representable in UTF-8, plus the following special characters: + - = . _ : / @.</p> </li> </ul> <important> <p>If you use tags as part of your security strategy, then adding or removing a tag can change permissions. If successfully completing this operation would result in you losing your permissions for this secret, then the operation is blocked and returns an Access Denied error.</p> </important> <p> <b>Minimum permissions</b> </p> <p>To run this command, you must have the following permissions:</p> <ul> <li> <p>secretsmanager:TagResource</p> </li> </ul> <p> <b>Related operations</b> </p> <ul> <li> <p>To remove one or more tags from the collection attached to a secret, use <a>UntagResource</a>.</p> </li> <li> <p>To view the list of tags attached to a secret, use <a>DescribeSecret</a>.</p> </li> </ul></p>
     fn tag_resource(&self, input: TagResourceRequest) -> RusotoFuture<(), TagResourceError> {
-        let mut request = SignedRequest::new("POST", "secretsmanager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "secretsmanager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "secretsmanager.TagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2310,9 +2385,14 @@ impl SecretsManager for SecretsManagerClient {
 
     /// <p><p>Removes one or more tags from the specified secret.</p> <p>This operation is idempotent. If a requested tag is not attached to the secret, no error is returned and the secret metadata is unchanged.</p> <important> <p>If you use tags as part of your security strategy, then removing a tag can change permissions. If successfully completing this operation would result in you losing your permissions for this secret, then the operation is blocked and returns an Access Denied error.</p> </important> <p> <b>Minimum permissions</b> </p> <p>To run this command, you must have the following permissions:</p> <ul> <li> <p>secretsmanager:UntagResource</p> </li> </ul> <p> <b>Related operations</b> </p> <ul> <li> <p>To add one or more tags to the collection attached to a secret, use <a>TagResource</a>.</p> </li> <li> <p>To view the list of tags attached to a secret, use <a>DescribeSecret</a>.</p> </li> </ul></p>
     fn untag_resource(&self, input: UntagResourceRequest) -> RusotoFuture<(), UntagResourceError> {
-        let mut request = SignedRequest::new("POST", "secretsmanager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "secretsmanager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "secretsmanager.UntagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2336,9 +2416,14 @@ impl SecretsManager for SecretsManagerClient {
         &self,
         input: UpdateSecretRequest,
     ) -> RusotoFuture<UpdateSecretResponse, UpdateSecretError> {
-        let mut request = SignedRequest::new("POST", "secretsmanager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "secretsmanager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "secretsmanager.UpdateSecret");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2365,9 +2450,14 @@ impl SecretsManager for SecretsManagerClient {
         &self,
         input: UpdateSecretVersionStageRequest,
     ) -> RusotoFuture<UpdateSecretVersionStageResponse, UpdateSecretVersionStageError> {
-        let mut request = SignedRequest::new("POST", "secretsmanager", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "secretsmanager",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "secretsmanager.UpdateSecretVersionStage");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/servicecatalog/src/generated.rs
+++ b/rusoto/services/servicecatalog/src/generated.rs
@@ -7333,9 +7333,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: AcceptPortfolioShareInput,
     ) -> RusotoFuture<AcceptPortfolioShareOutput, AcceptPortfolioShareError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.AcceptPortfolioShare",
@@ -7365,9 +7370,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         input: AssociatePrincipalWithPortfolioInput,
     ) -> RusotoFuture<AssociatePrincipalWithPortfolioOutput, AssociatePrincipalWithPortfolioError>
     {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.AssociatePrincipalWithPortfolio",
@@ -7396,9 +7406,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: AssociateProductWithPortfolioInput,
     ) -> RusotoFuture<AssociateProductWithPortfolioOutput, AssociateProductWithPortfolioError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.AssociateProductWithPortfolio",
@@ -7428,9 +7443,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         AssociateServiceActionWithProvisioningArtifactOutput,
         AssociateServiceActionWithProvisioningArtifactError,
     > {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.AssociateServiceActionWithProvisioningArtifact",
@@ -7457,9 +7477,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         input: AssociateTagOptionWithResourceInput,
     ) -> RusotoFuture<AssociateTagOptionWithResourceOutput, AssociateTagOptionWithResourceError>
     {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.AssociateTagOptionWithResource",
@@ -7489,9 +7514,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         BatchAssociateServiceActionWithProvisioningArtifactOutput,
         BatchAssociateServiceActionWithProvisioningArtifactError,
     > {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.BatchAssociateServiceActionWithProvisioningArtifact",
@@ -7520,9 +7550,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         BatchDisassociateServiceActionFromProvisioningArtifactOutput,
         BatchDisassociateServiceActionFromProvisioningArtifactError,
     > {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.BatchDisassociateServiceActionFromProvisioningArtifact",
@@ -7548,9 +7583,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: CopyProductInput,
     ) -> RusotoFuture<CopyProductOutput, CopyProductError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWS242ServiceCatalogService.CopyProduct");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7577,9 +7617,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: CreateConstraintInput,
     ) -> RusotoFuture<CreateConstraintOutput, CreateConstraintError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.CreateConstraint",
@@ -7609,9 +7654,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: CreatePortfolioInput,
     ) -> RusotoFuture<CreatePortfolioOutput, CreatePortfolioError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.CreatePortfolio",
@@ -7641,9 +7691,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: CreatePortfolioShareInput,
     ) -> RusotoFuture<CreatePortfolioShareOutput, CreatePortfolioShareError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.CreatePortfolioShare",
@@ -7672,9 +7727,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: CreateProductInput,
     ) -> RusotoFuture<CreateProductOutput, CreateProductError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWS242ServiceCatalogService.CreateProduct");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7701,9 +7761,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: CreateProvisionedProductPlanInput,
     ) -> RusotoFuture<CreateProvisionedProductPlanOutput, CreateProvisionedProductPlanError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.CreateProvisionedProductPlan",
@@ -7730,9 +7795,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: CreateProvisioningArtifactInput,
     ) -> RusotoFuture<CreateProvisioningArtifactOutput, CreateProvisioningArtifactError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.CreateProvisioningArtifact",
@@ -7759,9 +7829,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: CreateServiceActionInput,
     ) -> RusotoFuture<CreateServiceActionOutput, CreateServiceActionError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.CreateServiceAction",
@@ -7790,9 +7865,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: CreateTagOptionInput,
     ) -> RusotoFuture<CreateTagOptionOutput, CreateTagOptionError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.CreateTagOption",
@@ -7822,9 +7902,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: DeleteConstraintInput,
     ) -> RusotoFuture<DeleteConstraintOutput, DeleteConstraintError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DeleteConstraint",
@@ -7854,9 +7939,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: DeletePortfolioInput,
     ) -> RusotoFuture<DeletePortfolioOutput, DeletePortfolioError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DeletePortfolio",
@@ -7886,9 +7976,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: DeletePortfolioShareInput,
     ) -> RusotoFuture<DeletePortfolioShareOutput, DeletePortfolioShareError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DeletePortfolioShare",
@@ -7917,9 +8012,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: DeleteProductInput,
     ) -> RusotoFuture<DeleteProductOutput, DeleteProductError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWS242ServiceCatalogService.DeleteProduct");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7946,9 +8046,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: DeleteProvisionedProductPlanInput,
     ) -> RusotoFuture<DeleteProvisionedProductPlanOutput, DeleteProvisionedProductPlanError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DeleteProvisionedProductPlan",
@@ -7975,9 +8080,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: DeleteProvisioningArtifactInput,
     ) -> RusotoFuture<DeleteProvisioningArtifactOutput, DeleteProvisioningArtifactError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DeleteProvisioningArtifact",
@@ -8004,9 +8114,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: DeleteServiceActionInput,
     ) -> RusotoFuture<DeleteServiceActionOutput, DeleteServiceActionError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DeleteServiceAction",
@@ -8035,9 +8150,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: DeleteTagOptionInput,
     ) -> RusotoFuture<DeleteTagOptionOutput, DeleteTagOptionError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DeleteTagOption",
@@ -8067,9 +8187,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: DescribeConstraintInput,
     ) -> RusotoFuture<DescribeConstraintOutput, DescribeConstraintError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DescribeConstraint",
@@ -8099,9 +8224,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: DescribeCopyProductStatusInput,
     ) -> RusotoFuture<DescribeCopyProductStatusOutput, DescribeCopyProductStatusError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DescribeCopyProductStatus",
@@ -8128,9 +8258,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: DescribePortfolioInput,
     ) -> RusotoFuture<DescribePortfolioOutput, DescribePortfolioError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DescribePortfolio",
@@ -8160,9 +8295,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: DescribePortfolioShareStatusInput,
     ) -> RusotoFuture<DescribePortfolioShareStatusOutput, DescribePortfolioShareStatusError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DescribePortfolioShareStatus",
@@ -8189,9 +8329,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: DescribeProductInput,
     ) -> RusotoFuture<DescribeProductOutput, DescribeProductError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DescribeProduct",
@@ -8221,9 +8366,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: DescribeProductAsAdminInput,
     ) -> RusotoFuture<DescribeProductAsAdminOutput, DescribeProductAsAdminError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DescribeProductAsAdmin",
@@ -8252,9 +8402,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: DescribeProductViewInput,
     ) -> RusotoFuture<DescribeProductViewOutput, DescribeProductViewError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DescribeProductView",
@@ -8283,9 +8438,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: DescribeProvisionedProductInput,
     ) -> RusotoFuture<DescribeProvisionedProductOutput, DescribeProvisionedProductError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DescribeProvisionedProduct",
@@ -8313,9 +8473,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         input: DescribeProvisionedProductPlanInput,
     ) -> RusotoFuture<DescribeProvisionedProductPlanOutput, DescribeProvisionedProductPlanError>
     {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DescribeProvisionedProductPlan",
@@ -8342,9 +8507,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: DescribeProvisioningArtifactInput,
     ) -> RusotoFuture<DescribeProvisioningArtifactOutput, DescribeProvisioningArtifactError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DescribeProvisioningArtifact",
@@ -8372,9 +8542,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         input: DescribeProvisioningParametersInput,
     ) -> RusotoFuture<DescribeProvisioningParametersOutput, DescribeProvisioningParametersError>
     {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DescribeProvisioningParameters",
@@ -8401,9 +8576,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: DescribeRecordInput,
     ) -> RusotoFuture<DescribeRecordOutput, DescribeRecordError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWS242ServiceCatalogService.DescribeRecord");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8430,9 +8610,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: DescribeServiceActionInput,
     ) -> RusotoFuture<DescribeServiceActionOutput, DescribeServiceActionError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DescribeServiceAction",
@@ -8461,9 +8646,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: DescribeTagOptionInput,
     ) -> RusotoFuture<DescribeTagOptionOutput, DescribeTagOptionError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DescribeTagOption",
@@ -8492,9 +8682,14 @@ impl ServiceCatalog for ServiceCatalogClient {
     fn disable_aws_organizations_access(
         &self,
     ) -> RusotoFuture<DisableAWSOrganizationsAccessOutput, DisableAWSOrganizationsAccessError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DisableAWSOrganizationsAccess",
@@ -8523,9 +8718,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         DisassociatePrincipalFromPortfolioOutput,
         DisassociatePrincipalFromPortfolioError,
     > {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DisassociatePrincipalFromPortfolio",
@@ -8555,9 +8755,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         input: DisassociateProductFromPortfolioInput,
     ) -> RusotoFuture<DisassociateProductFromPortfolioOutput, DisassociateProductFromPortfolioError>
     {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DisassociateProductFromPortfolio",
@@ -8589,9 +8794,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         DisassociateServiceActionFromProvisioningArtifactOutput,
         DisassociateServiceActionFromProvisioningArtifactError,
     > {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DisassociateServiceActionFromProvisioningArtifact",
@@ -8618,9 +8828,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         input: DisassociateTagOptionFromResourceInput,
     ) -> RusotoFuture<DisassociateTagOptionFromResourceOutput, DisassociateTagOptionFromResourceError>
     {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.DisassociateTagOptionFromResource",
@@ -8648,9 +8863,14 @@ impl ServiceCatalog for ServiceCatalogClient {
     fn enable_aws_organizations_access(
         &self,
     ) -> RusotoFuture<EnableAWSOrganizationsAccessOutput, EnableAWSOrganizationsAccessError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.EnableAWSOrganizationsAccess",
@@ -8676,9 +8896,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: ExecuteProvisionedProductPlanInput,
     ) -> RusotoFuture<ExecuteProvisionedProductPlanOutput, ExecuteProvisionedProductPlanError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.ExecuteProvisionedProductPlan",
@@ -8708,9 +8933,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         ExecuteProvisionedProductServiceActionOutput,
         ExecuteProvisionedProductServiceActionError,
     > {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.ExecuteProvisionedProductServiceAction",
@@ -8739,9 +8969,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
     ) -> RusotoFuture<GetAWSOrganizationsAccessStatusOutput, GetAWSOrganizationsAccessStatusError>
     {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.GetAWSOrganizationsAccessStatus",
@@ -8769,9 +9004,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: ListAcceptedPortfolioSharesInput,
     ) -> RusotoFuture<ListAcceptedPortfolioSharesOutput, ListAcceptedPortfolioSharesError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.ListAcceptedPortfolioShares",
@@ -8798,9 +9038,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: ListConstraintsForPortfolioInput,
     ) -> RusotoFuture<ListConstraintsForPortfolioOutput, ListConstraintsForPortfolioError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.ListConstraintsForPortfolio",
@@ -8827,9 +9072,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: ListLaunchPathsInput,
     ) -> RusotoFuture<ListLaunchPathsOutput, ListLaunchPathsError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.ListLaunchPaths",
@@ -8860,9 +9110,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         input: ListOrganizationPortfolioAccessInput,
     ) -> RusotoFuture<ListOrganizationPortfolioAccessOutput, ListOrganizationPortfolioAccessError>
     {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.ListOrganizationPortfolioAccess",
@@ -8891,9 +9146,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: ListPortfolioAccessInput,
     ) -> RusotoFuture<ListPortfolioAccessOutput, ListPortfolioAccessError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.ListPortfolioAccess",
@@ -8922,9 +9182,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: ListPortfoliosInput,
     ) -> RusotoFuture<ListPortfoliosOutput, ListPortfoliosError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWS242ServiceCatalogService.ListPortfolios");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8951,9 +9216,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: ListPortfoliosForProductInput,
     ) -> RusotoFuture<ListPortfoliosForProductOutput, ListPortfoliosForProductError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.ListPortfoliosForProduct",
@@ -8980,9 +9250,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: ListPrincipalsForPortfolioInput,
     ) -> RusotoFuture<ListPrincipalsForPortfolioOutput, ListPrincipalsForPortfolioError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.ListPrincipalsForPortfolio",
@@ -9009,9 +9284,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: ListProvisionedProductPlansInput,
     ) -> RusotoFuture<ListProvisionedProductPlansOutput, ListProvisionedProductPlansError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.ListProvisionedProductPlans",
@@ -9038,9 +9318,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: ListProvisioningArtifactsInput,
     ) -> RusotoFuture<ListProvisioningArtifactsOutput, ListProvisioningArtifactsError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.ListProvisioningArtifacts",
@@ -9070,9 +9355,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         ListProvisioningArtifactsForServiceActionOutput,
         ListProvisioningArtifactsForServiceActionError,
     > {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.ListProvisioningArtifactsForServiceAction",
@@ -9099,9 +9389,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: ListRecordHistoryInput,
     ) -> RusotoFuture<ListRecordHistoryOutput, ListRecordHistoryError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.ListRecordHistory",
@@ -9131,9 +9426,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: ListResourcesForTagOptionInput,
     ) -> RusotoFuture<ListResourcesForTagOptionOutput, ListResourcesForTagOptionError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.ListResourcesForTagOption",
@@ -9160,9 +9460,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: ListServiceActionsInput,
     ) -> RusotoFuture<ListServiceActionsOutput, ListServiceActionsError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.ListServiceActions",
@@ -9195,9 +9500,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         ListServiceActionsForProvisioningArtifactOutput,
         ListServiceActionsForProvisioningArtifactError,
     > {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.ListServiceActionsForProvisioningArtifact",
@@ -9224,9 +9534,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: ListTagOptionsInput,
     ) -> RusotoFuture<ListTagOptionsOutput, ListTagOptionsError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWS242ServiceCatalogService.ListTagOptions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9253,9 +9568,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: ProvisionProductInput,
     ) -> RusotoFuture<ProvisionProductOutput, ProvisionProductError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.ProvisionProduct",
@@ -9285,9 +9605,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: RejectPortfolioShareInput,
     ) -> RusotoFuture<RejectPortfolioShareOutput, RejectPortfolioShareError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.RejectPortfolioShare",
@@ -9316,9 +9641,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: ScanProvisionedProductsInput,
     ) -> RusotoFuture<ScanProvisionedProductsOutput, ScanProvisionedProductsError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.ScanProvisionedProducts",
@@ -9345,9 +9675,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: SearchProductsInput,
     ) -> RusotoFuture<SearchProductsOutput, SearchProductsError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWS242ServiceCatalogService.SearchProducts");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9374,9 +9709,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: SearchProductsAsAdminInput,
     ) -> RusotoFuture<SearchProductsAsAdminOutput, SearchProductsAsAdminError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.SearchProductsAsAdmin",
@@ -9405,9 +9745,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: SearchProvisionedProductsInput,
     ) -> RusotoFuture<SearchProvisionedProductsOutput, SearchProvisionedProductsError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.SearchProvisionedProducts",
@@ -9434,9 +9779,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: TerminateProvisionedProductInput,
     ) -> RusotoFuture<TerminateProvisionedProductOutput, TerminateProvisionedProductError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.TerminateProvisionedProduct",
@@ -9463,9 +9813,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: UpdateConstraintInput,
     ) -> RusotoFuture<UpdateConstraintOutput, UpdateConstraintError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.UpdateConstraint",
@@ -9495,9 +9850,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: UpdatePortfolioInput,
     ) -> RusotoFuture<UpdatePortfolioOutput, UpdatePortfolioError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.UpdatePortfolio",
@@ -9527,9 +9887,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: UpdateProductInput,
     ) -> RusotoFuture<UpdateProductOutput, UpdateProductError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWS242ServiceCatalogService.UpdateProduct");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9556,9 +9921,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: UpdateProvisionedProductInput,
     ) -> RusotoFuture<UpdateProvisionedProductOutput, UpdateProvisionedProductError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.UpdateProvisionedProduct",
@@ -9585,9 +9955,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: UpdateProvisioningArtifactInput,
     ) -> RusotoFuture<UpdateProvisioningArtifactOutput, UpdateProvisioningArtifactError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.UpdateProvisioningArtifact",
@@ -9614,9 +9989,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: UpdateServiceActionInput,
     ) -> RusotoFuture<UpdateServiceActionOutput, UpdateServiceActionError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.UpdateServiceAction",
@@ -9645,9 +10025,14 @@ impl ServiceCatalog for ServiceCatalogClient {
         &self,
         input: UpdateTagOptionInput,
     ) -> RusotoFuture<UpdateTagOptionOutput, UpdateTagOptionError> {
-        let mut request = SignedRequest::new("POST", "servicecatalog", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicecatalog",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWS242ServiceCatalogService.UpdateTagOption",

--- a/rusoto/services/servicediscovery/src/generated.rs
+++ b/rusoto/services/servicediscovery/src/generated.rs
@@ -2019,9 +2019,14 @@ impl ServiceDiscovery for ServiceDiscoveryClient {
         &self,
         input: CreateHttpNamespaceRequest,
     ) -> RusotoFuture<CreateHttpNamespaceResponse, CreateHttpNamespaceError> {
-        let mut request = SignedRequest::new("POST", "servicediscovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicediscovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53AutoNaming_v20170314.CreateHttpNamespace",
@@ -2050,9 +2055,14 @@ impl ServiceDiscovery for ServiceDiscoveryClient {
         &self,
         input: CreatePrivateDnsNamespaceRequest,
     ) -> RusotoFuture<CreatePrivateDnsNamespaceResponse, CreatePrivateDnsNamespaceError> {
-        let mut request = SignedRequest::new("POST", "servicediscovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicediscovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53AutoNaming_v20170314.CreatePrivateDnsNamespace",
@@ -2079,9 +2089,14 @@ impl ServiceDiscovery for ServiceDiscoveryClient {
         &self,
         input: CreatePublicDnsNamespaceRequest,
     ) -> RusotoFuture<CreatePublicDnsNamespaceResponse, CreatePublicDnsNamespaceError> {
-        let mut request = SignedRequest::new("POST", "servicediscovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicediscovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53AutoNaming_v20170314.CreatePublicDnsNamespace",
@@ -2108,9 +2123,14 @@ impl ServiceDiscovery for ServiceDiscoveryClient {
         &self,
         input: CreateServiceRequest,
     ) -> RusotoFuture<CreateServiceResponse, CreateServiceError> {
-        let mut request = SignedRequest::new("POST", "servicediscovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicediscovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Route53AutoNaming_v20170314.CreateService");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2137,9 +2157,14 @@ impl ServiceDiscovery for ServiceDiscoveryClient {
         &self,
         input: DeleteNamespaceRequest,
     ) -> RusotoFuture<DeleteNamespaceResponse, DeleteNamespaceError> {
-        let mut request = SignedRequest::new("POST", "servicediscovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicediscovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53AutoNaming_v20170314.DeleteNamespace",
@@ -2169,9 +2194,14 @@ impl ServiceDiscovery for ServiceDiscoveryClient {
         &self,
         input: DeleteServiceRequest,
     ) -> RusotoFuture<DeleteServiceResponse, DeleteServiceError> {
-        let mut request = SignedRequest::new("POST", "servicediscovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicediscovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Route53AutoNaming_v20170314.DeleteService");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2198,9 +2228,14 @@ impl ServiceDiscovery for ServiceDiscoveryClient {
         &self,
         input: DeregisterInstanceRequest,
     ) -> RusotoFuture<DeregisterInstanceResponse, DeregisterInstanceError> {
-        let mut request = SignedRequest::new("POST", "servicediscovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicediscovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53AutoNaming_v20170314.DeregisterInstance",
@@ -2230,9 +2265,14 @@ impl ServiceDiscovery for ServiceDiscoveryClient {
         &self,
         input: DiscoverInstancesRequest,
     ) -> RusotoFuture<DiscoverInstancesResponse, DiscoverInstancesError> {
-        let mut request = SignedRequest::new("POST", "servicediscovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicediscovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53AutoNaming_v20170314.DiscoverInstances",
@@ -2262,9 +2302,14 @@ impl ServiceDiscovery for ServiceDiscoveryClient {
         &self,
         input: GetInstanceRequest,
     ) -> RusotoFuture<GetInstanceResponse, GetInstanceError> {
-        let mut request = SignedRequest::new("POST", "servicediscovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicediscovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Route53AutoNaming_v20170314.GetInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2291,9 +2336,14 @@ impl ServiceDiscovery for ServiceDiscoveryClient {
         &self,
         input: GetInstancesHealthStatusRequest,
     ) -> RusotoFuture<GetInstancesHealthStatusResponse, GetInstancesHealthStatusError> {
-        let mut request = SignedRequest::new("POST", "servicediscovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicediscovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53AutoNaming_v20170314.GetInstancesHealthStatus",
@@ -2320,9 +2370,14 @@ impl ServiceDiscovery for ServiceDiscoveryClient {
         &self,
         input: GetNamespaceRequest,
     ) -> RusotoFuture<GetNamespaceResponse, GetNamespaceError> {
-        let mut request = SignedRequest::new("POST", "servicediscovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicediscovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Route53AutoNaming_v20170314.GetNamespace");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2349,9 +2404,14 @@ impl ServiceDiscovery for ServiceDiscoveryClient {
         &self,
         input: GetOperationRequest,
     ) -> RusotoFuture<GetOperationResponse, GetOperationError> {
-        let mut request = SignedRequest::new("POST", "servicediscovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicediscovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Route53AutoNaming_v20170314.GetOperation");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2378,9 +2438,14 @@ impl ServiceDiscovery for ServiceDiscoveryClient {
         &self,
         input: GetServiceRequest,
     ) -> RusotoFuture<GetServiceResponse, GetServiceError> {
-        let mut request = SignedRequest::new("POST", "servicediscovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicediscovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Route53AutoNaming_v20170314.GetService");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2407,9 +2472,14 @@ impl ServiceDiscovery for ServiceDiscoveryClient {
         &self,
         input: ListInstancesRequest,
     ) -> RusotoFuture<ListInstancesResponse, ListInstancesError> {
-        let mut request = SignedRequest::new("POST", "servicediscovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicediscovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Route53AutoNaming_v20170314.ListInstances");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2436,9 +2506,14 @@ impl ServiceDiscovery for ServiceDiscoveryClient {
         &self,
         input: ListNamespacesRequest,
     ) -> RusotoFuture<ListNamespacesResponse, ListNamespacesError> {
-        let mut request = SignedRequest::new("POST", "servicediscovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicediscovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Route53AutoNaming_v20170314.ListNamespaces");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2465,9 +2540,14 @@ impl ServiceDiscovery for ServiceDiscoveryClient {
         &self,
         input: ListOperationsRequest,
     ) -> RusotoFuture<ListOperationsResponse, ListOperationsError> {
-        let mut request = SignedRequest::new("POST", "servicediscovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicediscovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Route53AutoNaming_v20170314.ListOperations");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2494,9 +2574,14 @@ impl ServiceDiscovery for ServiceDiscoveryClient {
         &self,
         input: ListServicesRequest,
     ) -> RusotoFuture<ListServicesResponse, ListServicesError> {
-        let mut request = SignedRequest::new("POST", "servicediscovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicediscovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Route53AutoNaming_v20170314.ListServices");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2523,9 +2608,14 @@ impl ServiceDiscovery for ServiceDiscoveryClient {
         &self,
         input: RegisterInstanceRequest,
     ) -> RusotoFuture<RegisterInstanceResponse, RegisterInstanceError> {
-        let mut request = SignedRequest::new("POST", "servicediscovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicediscovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53AutoNaming_v20170314.RegisterInstance",
@@ -2555,9 +2645,14 @@ impl ServiceDiscovery for ServiceDiscoveryClient {
         &self,
         input: UpdateInstanceCustomHealthStatusRequest,
     ) -> RusotoFuture<(), UpdateInstanceCustomHealthStatusError> {
-        let mut request = SignedRequest::new("POST", "servicediscovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicediscovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "Route53AutoNaming_v20170314.UpdateInstanceCustomHealthStatus",
@@ -2583,9 +2678,14 @@ impl ServiceDiscovery for ServiceDiscoveryClient {
         &self,
         input: UpdateServiceRequest,
     ) -> RusotoFuture<UpdateServiceResponse, UpdateServiceError> {
-        let mut request = SignedRequest::new("POST", "servicediscovery", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "servicediscovery",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Route53AutoNaming_v20170314.UpdateService");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/shield/src/generated.rs
+++ b/rusoto/services/shield/src/generated.rs
@@ -1636,9 +1636,14 @@ impl Shield for ShieldClient {
         &self,
         input: AssociateDRTLogBucketRequest,
     ) -> RusotoFuture<AssociateDRTLogBucketResponse, AssociateDRTLogBucketError> {
-        let mut request = SignedRequest::new("POST", "shield", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "shield",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSShield_20160616.AssociateDRTLogBucket");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1664,9 +1669,14 @@ impl Shield for ShieldClient {
         &self,
         input: AssociateDRTRoleRequest,
     ) -> RusotoFuture<AssociateDRTRoleResponse, AssociateDRTRoleError> {
-        let mut request = SignedRequest::new("POST", "shield", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "shield",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSShield_20160616.AssociateDRTRole");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1693,9 +1703,14 @@ impl Shield for ShieldClient {
         &self,
         input: CreateProtectionRequest,
     ) -> RusotoFuture<CreateProtectionResponse, CreateProtectionError> {
-        let mut request = SignedRequest::new("POST", "shield", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "shield",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSShield_20160616.CreateProtection");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1721,9 +1736,14 @@ impl Shield for ShieldClient {
     fn create_subscription(
         &self,
     ) -> RusotoFuture<CreateSubscriptionResponse, CreateSubscriptionError> {
-        let mut request = SignedRequest::new("POST", "shield", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "shield",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSShield_20160616.CreateSubscription");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -1749,9 +1769,14 @@ impl Shield for ShieldClient {
         &self,
         input: DeleteProtectionRequest,
     ) -> RusotoFuture<DeleteProtectionResponse, DeleteProtectionError> {
-        let mut request = SignedRequest::new("POST", "shield", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "shield",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSShield_20160616.DeleteProtection");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1777,9 +1802,14 @@ impl Shield for ShieldClient {
     fn delete_subscription(
         &self,
     ) -> RusotoFuture<DeleteSubscriptionResponse, DeleteSubscriptionError> {
-        let mut request = SignedRequest::new("POST", "shield", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "shield",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSShield_20160616.DeleteSubscription");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -1805,9 +1835,14 @@ impl Shield for ShieldClient {
         &self,
         input: DescribeAttackRequest,
     ) -> RusotoFuture<DescribeAttackResponse, DescribeAttackError> {
-        let mut request = SignedRequest::new("POST", "shield", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "shield",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSShield_20160616.DescribeAttack");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1833,9 +1868,14 @@ impl Shield for ShieldClient {
     fn describe_drt_access(
         &self,
     ) -> RusotoFuture<DescribeDRTAccessResponse, DescribeDRTAccessError> {
-        let mut request = SignedRequest::new("POST", "shield", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "shield",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSShield_20160616.DescribeDRTAccess");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -1861,9 +1901,14 @@ impl Shield for ShieldClient {
         &self,
     ) -> RusotoFuture<DescribeEmergencyContactSettingsResponse, DescribeEmergencyContactSettingsError>
     {
-        let mut request = SignedRequest::new("POST", "shield", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "shield",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSShield_20160616.DescribeEmergencyContactSettings",
@@ -1891,9 +1936,14 @@ impl Shield for ShieldClient {
         &self,
         input: DescribeProtectionRequest,
     ) -> RusotoFuture<DescribeProtectionResponse, DescribeProtectionError> {
-        let mut request = SignedRequest::new("POST", "shield", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "shield",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSShield_20160616.DescribeProtection");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1919,9 +1969,14 @@ impl Shield for ShieldClient {
     fn describe_subscription(
         &self,
     ) -> RusotoFuture<DescribeSubscriptionResponse, DescribeSubscriptionError> {
-        let mut request = SignedRequest::new("POST", "shield", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "shield",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSShield_20160616.DescribeSubscription");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -1946,9 +2001,14 @@ impl Shield for ShieldClient {
         &self,
         input: DisassociateDRTLogBucketRequest,
     ) -> RusotoFuture<DisassociateDRTLogBucketResponse, DisassociateDRTLogBucketError> {
-        let mut request = SignedRequest::new("POST", "shield", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "shield",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSShield_20160616.DisassociateDRTLogBucket",
@@ -1974,9 +2034,14 @@ impl Shield for ShieldClient {
     fn disassociate_drt_role(
         &self,
     ) -> RusotoFuture<DisassociateDRTRoleResponse, DisassociateDRTRoleError> {
-        let mut request = SignedRequest::new("POST", "shield", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "shield",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSShield_20160616.DisassociateDRTRole");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -2000,9 +2065,14 @@ impl Shield for ShieldClient {
     fn get_subscription_state(
         &self,
     ) -> RusotoFuture<GetSubscriptionStateResponse, GetSubscriptionStateError> {
-        let mut request = SignedRequest::new("POST", "shield", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "shield",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSShield_20160616.GetSubscriptionState");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -2027,9 +2097,14 @@ impl Shield for ShieldClient {
         &self,
         input: ListAttacksRequest,
     ) -> RusotoFuture<ListAttacksResponse, ListAttacksError> {
-        let mut request = SignedRequest::new("POST", "shield", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "shield",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSShield_20160616.ListAttacks");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2056,9 +2131,14 @@ impl Shield for ShieldClient {
         &self,
         input: ListProtectionsRequest,
     ) -> RusotoFuture<ListProtectionsResponse, ListProtectionsError> {
-        let mut request = SignedRequest::new("POST", "shield", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "shield",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSShield_20160616.ListProtections");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2086,9 +2166,14 @@ impl Shield for ShieldClient {
         input: UpdateEmergencyContactSettingsRequest,
     ) -> RusotoFuture<UpdateEmergencyContactSettingsResponse, UpdateEmergencyContactSettingsError>
     {
-        let mut request = SignedRequest::new("POST", "shield", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "shield",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSShield_20160616.UpdateEmergencyContactSettings",
@@ -2115,9 +2200,14 @@ impl Shield for ShieldClient {
         &self,
         input: UpdateSubscriptionRequest,
     ) -> RusotoFuture<UpdateSubscriptionResponse, UpdateSubscriptionError> {
-        let mut request = SignedRequest::new("POST", "shield", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "shield",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSShield_20160616.UpdateSubscription");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/sms/src/generated.rs
+++ b/rusoto/services/sms/src/generated.rs
@@ -3104,9 +3104,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
         &self,
         input: CreateAppRequest,
     ) -> RusotoFuture<CreateAppResponse, CreateAppError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.CreateApp",
@@ -3136,9 +3141,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
         &self,
         input: CreateReplicationJobRequest,
     ) -> RusotoFuture<CreateReplicationJobResponse, CreateReplicationJobError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.CreateReplicationJob",
@@ -3167,9 +3177,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
         &self,
         input: DeleteAppRequest,
     ) -> RusotoFuture<DeleteAppResponse, DeleteAppError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.DeleteApp",
@@ -3199,9 +3214,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
         &self,
         input: DeleteAppLaunchConfigurationRequest,
     ) -> RusotoFuture<DeleteAppLaunchConfigurationResponse, DeleteAppLaunchConfigurationError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.DeleteAppLaunchConfiguration",
@@ -3231,9 +3251,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
         DeleteAppReplicationConfigurationResponse,
         DeleteAppReplicationConfigurationError,
     > {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.DeleteAppReplicationConfiguration",
@@ -3262,9 +3287,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
         &self,
         input: DeleteReplicationJobRequest,
     ) -> RusotoFuture<DeleteReplicationJobResponse, DeleteReplicationJobError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.DeleteReplicationJob",
@@ -3292,9 +3322,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
     fn delete_server_catalog(
         &self,
     ) -> RusotoFuture<DeleteServerCatalogResponse, DeleteServerCatalogError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.DeleteServerCatalog",
@@ -3322,9 +3357,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
         &self,
         input: DisassociateConnectorRequest,
     ) -> RusotoFuture<DisassociateConnectorResponse, DisassociateConnectorError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.DisassociateConnector",
@@ -3353,9 +3393,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
         &self,
         input: GenerateChangeSetRequest,
     ) -> RusotoFuture<GenerateChangeSetResponse, GenerateChangeSetError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.GenerateChangeSet",
@@ -3385,9 +3430,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
         &self,
         input: GenerateTemplateRequest,
     ) -> RusotoFuture<GenerateTemplateResponse, GenerateTemplateError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.GenerateTemplate",
@@ -3414,9 +3464,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
 
     /// <p>Retrieve information about an application.</p>
     fn get_app(&self, input: GetAppRequest) -> RusotoFuture<GetAppResponse, GetAppError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.GetApp",
@@ -3445,9 +3500,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
         &self,
         input: GetAppLaunchConfigurationRequest,
     ) -> RusotoFuture<GetAppLaunchConfigurationResponse, GetAppLaunchConfigurationError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.GetAppLaunchConfiguration",
@@ -3475,9 +3535,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
         input: GetAppReplicationConfigurationRequest,
     ) -> RusotoFuture<GetAppReplicationConfigurationResponse, GetAppReplicationConfigurationError>
     {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.GetAppReplicationConfiguration",
@@ -3504,9 +3569,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
         &self,
         input: GetConnectorsRequest,
     ) -> RusotoFuture<GetConnectorsResponse, GetConnectorsError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.GetConnectors",
@@ -3536,9 +3606,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
         &self,
         input: GetReplicationJobsRequest,
     ) -> RusotoFuture<GetReplicationJobsResponse, GetReplicationJobsError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.GetReplicationJobs",
@@ -3568,9 +3643,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
         &self,
         input: GetReplicationRunsRequest,
     ) -> RusotoFuture<GetReplicationRunsResponse, GetReplicationRunsError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.GetReplicationRuns",
@@ -3600,9 +3680,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
         &self,
         input: GetServersRequest,
     ) -> RusotoFuture<GetServersResponse, GetServersError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.GetServers",
@@ -3631,9 +3716,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
     fn import_server_catalog(
         &self,
     ) -> RusotoFuture<ImportServerCatalogResponse, ImportServerCatalogError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.ImportServerCatalog",
@@ -3661,9 +3751,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
         &self,
         input: LaunchAppRequest,
     ) -> RusotoFuture<LaunchAppResponse, LaunchAppError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.LaunchApp",
@@ -3690,9 +3785,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
 
     /// <p>Returns a list of summaries for all applications.</p>
     fn list_apps(&self, input: ListAppsRequest) -> RusotoFuture<ListAppsResponse, ListAppsError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.ListApps",
@@ -3722,9 +3822,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
         &self,
         input: PutAppLaunchConfigurationRequest,
     ) -> RusotoFuture<PutAppLaunchConfigurationResponse, PutAppLaunchConfigurationError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.PutAppLaunchConfiguration",
@@ -3752,9 +3857,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
         input: PutAppReplicationConfigurationRequest,
     ) -> RusotoFuture<PutAppReplicationConfigurationResponse, PutAppReplicationConfigurationError>
     {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.PutAppReplicationConfiguration",
@@ -3781,9 +3891,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
         &self,
         input: StartAppReplicationRequest,
     ) -> RusotoFuture<StartAppReplicationResponse, StartAppReplicationError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.StartAppReplication",
@@ -3812,9 +3927,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
         &self,
         input: StartOnDemandReplicationRunRequest,
     ) -> RusotoFuture<StartOnDemandReplicationRunResponse, StartOnDemandReplicationRunError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.StartOnDemandReplicationRun",
@@ -3841,9 +3961,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
         &self,
         input: StopAppReplicationRequest,
     ) -> RusotoFuture<StopAppReplicationResponse, StopAppReplicationError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.StopAppReplication",
@@ -3873,9 +3998,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
         &self,
         input: TerminateAppRequest,
     ) -> RusotoFuture<TerminateAppResponse, TerminateAppError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.TerminateApp",
@@ -3905,9 +4035,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
         &self,
         input: UpdateAppRequest,
     ) -> RusotoFuture<UpdateAppResponse, UpdateAppError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.UpdateApp",
@@ -3937,9 +4072,14 @@ impl ServerMigrationService for ServerMigrationServiceClient {
         &self,
         input: UpdateReplicationJobRequest,
     ) -> RusotoFuture<UpdateReplicationJobResponse, UpdateReplicationJobError> {
-        let mut request = SignedRequest::new("POST", "sms", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "sms",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSServerMigrationService_V2016_10_24.UpdateReplicationJob",

--- a/rusoto/services/snowball/src/generated.rs
+++ b/rusoto/services/snowball/src/generated.rs
@@ -1797,9 +1797,14 @@ impl Snowball for SnowballClient {
         &self,
         input: CancelClusterRequest,
     ) -> RusotoFuture<CancelClusterResult, CancelClusterError> {
-        let mut request = SignedRequest::new("POST", "snowball", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "snowball",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSIESnowballJobManagementService.CancelCluster",
@@ -1826,9 +1831,14 @@ impl Snowball for SnowballClient {
 
     /// <p>Cancels the specified job. You can only cancel a job before its <code>JobState</code> value changes to <code>PreparingAppliance</code>. Requesting the <code>ListJobs</code> or <code>DescribeJob</code> action returns a job's <code>JobState</code> as part of the response element data returned.</p>
     fn cancel_job(&self, input: CancelJobRequest) -> RusotoFuture<CancelJobResult, CancelJobError> {
-        let mut request = SignedRequest::new("POST", "snowball", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "snowball",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSIESnowballJobManagementService.CancelJob",
@@ -1857,9 +1867,14 @@ impl Snowball for SnowballClient {
         &self,
         input: CreateAddressRequest,
     ) -> RusotoFuture<CreateAddressResult, CreateAddressError> {
-        let mut request = SignedRequest::new("POST", "snowball", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "snowball",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSIESnowballJobManagementService.CreateAddress",
@@ -1889,9 +1904,14 @@ impl Snowball for SnowballClient {
         &self,
         input: CreateClusterRequest,
     ) -> RusotoFuture<CreateClusterResult, CreateClusterError> {
-        let mut request = SignedRequest::new("POST", "snowball", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "snowball",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSIESnowballJobManagementService.CreateCluster",
@@ -1918,9 +1938,14 @@ impl Snowball for SnowballClient {
 
     /// <p>Creates a job to import or export data between Amazon S3 and your on-premises data center. Your AWS account must have the right trust policies and permissions in place to create a job for Snowball. If you're creating a job for a node in a cluster, you only need to provide the <code>clusterId</code> value; the other job attributes are inherited from the cluster. </p>
     fn create_job(&self, input: CreateJobRequest) -> RusotoFuture<CreateJobResult, CreateJobError> {
-        let mut request = SignedRequest::new("POST", "snowball", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "snowball",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSIESnowballJobManagementService.CreateJob",
@@ -1949,9 +1974,14 @@ impl Snowball for SnowballClient {
         &self,
         input: DescribeAddressRequest,
     ) -> RusotoFuture<DescribeAddressResult, DescribeAddressError> {
-        let mut request = SignedRequest::new("POST", "snowball", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "snowball",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSIESnowballJobManagementService.DescribeAddress",
@@ -1981,9 +2011,14 @@ impl Snowball for SnowballClient {
         &self,
         input: DescribeAddressesRequest,
     ) -> RusotoFuture<DescribeAddressesResult, DescribeAddressesError> {
-        let mut request = SignedRequest::new("POST", "snowball", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "snowball",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSIESnowballJobManagementService.DescribeAddresses",
@@ -2013,9 +2048,14 @@ impl Snowball for SnowballClient {
         &self,
         input: DescribeClusterRequest,
     ) -> RusotoFuture<DescribeClusterResult, DescribeClusterError> {
-        let mut request = SignedRequest::new("POST", "snowball", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "snowball",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSIESnowballJobManagementService.DescribeCluster",
@@ -2045,9 +2085,14 @@ impl Snowball for SnowballClient {
         &self,
         input: DescribeJobRequest,
     ) -> RusotoFuture<DescribeJobResult, DescribeJobError> {
-        let mut request = SignedRequest::new("POST", "snowball", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "snowball",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSIESnowballJobManagementService.DescribeJob",
@@ -2077,9 +2122,14 @@ impl Snowball for SnowballClient {
         &self,
         input: GetJobManifestRequest,
     ) -> RusotoFuture<GetJobManifestResult, GetJobManifestError> {
-        let mut request = SignedRequest::new("POST", "snowball", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "snowball",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSIESnowballJobManagementService.GetJobManifest",
@@ -2109,9 +2159,14 @@ impl Snowball for SnowballClient {
         &self,
         input: GetJobUnlockCodeRequest,
     ) -> RusotoFuture<GetJobUnlockCodeResult, GetJobUnlockCodeError> {
-        let mut request = SignedRequest::new("POST", "snowball", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "snowball",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSIESnowballJobManagementService.GetJobUnlockCode",
@@ -2138,9 +2193,14 @@ impl Snowball for SnowballClient {
 
     /// <p>Returns information about the Snowball service limit for your account, and also the number of Snowballs your account has in use.</p> <p>The default service limit for the number of Snowballs that you can have at one time is 1. If you want to increase your service limit, contact AWS Support.</p>
     fn get_snowball_usage(&self) -> RusotoFuture<GetSnowballUsageResult, GetSnowballUsageError> {
-        let mut request = SignedRequest::new("POST", "snowball", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "snowball",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSIESnowballJobManagementService.GetSnowballUsage",
@@ -2169,9 +2229,14 @@ impl Snowball for SnowballClient {
         &self,
         input: ListClusterJobsRequest,
     ) -> RusotoFuture<ListClusterJobsResult, ListClusterJobsError> {
-        let mut request = SignedRequest::new("POST", "snowball", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "snowball",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSIESnowballJobManagementService.ListClusterJobs",
@@ -2201,9 +2266,14 @@ impl Snowball for SnowballClient {
         &self,
         input: ListClustersRequest,
     ) -> RusotoFuture<ListClustersResult, ListClustersError> {
-        let mut request = SignedRequest::new("POST", "snowball", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "snowball",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSIESnowballJobManagementService.ListClusters",
@@ -2233,9 +2303,14 @@ impl Snowball for SnowballClient {
         &self,
         input: ListCompatibleImagesRequest,
     ) -> RusotoFuture<ListCompatibleImagesResult, ListCompatibleImagesError> {
-        let mut request = SignedRequest::new("POST", "snowball", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "snowball",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSIESnowballJobManagementService.ListCompatibleImages",
@@ -2261,9 +2336,14 @@ impl Snowball for SnowballClient {
 
     /// <p>Returns an array of <code>JobListEntry</code> objects of the specified length. Each <code>JobListEntry</code> object contains a job's state, a job's ID, and a value that indicates whether the job is a job part, in the case of export jobs. Calling this API action in one of the US regions will return jobs from the list of all jobs associated with this account in all US regions.</p>
     fn list_jobs(&self, input: ListJobsRequest) -> RusotoFuture<ListJobsResult, ListJobsError> {
-        let mut request = SignedRequest::new("POST", "snowball", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "snowball",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSIESnowballJobManagementService.ListJobs");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2289,9 +2369,14 @@ impl Snowball for SnowballClient {
         &self,
         input: UpdateClusterRequest,
     ) -> RusotoFuture<UpdateClusterResult, UpdateClusterError> {
-        let mut request = SignedRequest::new("POST", "snowball", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "snowball",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSIESnowballJobManagementService.UpdateCluster",
@@ -2318,9 +2403,14 @@ impl Snowball for SnowballClient {
 
     /// <p>While a job's <code>JobState</code> value is <code>New</code>, you can update some of the information associated with a job. Once the job changes to a different job state, usually within 60 minutes of the job being created, this action is no longer available.</p>
     fn update_job(&self, input: UpdateJobRequest) -> RusotoFuture<UpdateJobResult, UpdateJobError> {
-        let mut request = SignedRequest::new("POST", "snowball", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "snowball",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSIESnowballJobManagementService.UpdateJob",

--- a/rusoto/services/ssm/src/generated.rs
+++ b/rusoto/services/ssm/src/generated.rs
@@ -13846,9 +13846,14 @@ impl Ssm for SsmClient {
         &self,
         input: AddTagsToResourceRequest,
     ) -> RusotoFuture<AddTagsToResourceResult, AddTagsToResourceError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.AddTagsToResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13875,9 +13880,14 @@ impl Ssm for SsmClient {
         &self,
         input: CancelCommandRequest,
     ) -> RusotoFuture<CancelCommandResult, CancelCommandError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.CancelCommand");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13905,9 +13915,14 @@ impl Ssm for SsmClient {
         input: CancelMaintenanceWindowExecutionRequest,
     ) -> RusotoFuture<CancelMaintenanceWindowExecutionResult, CancelMaintenanceWindowExecutionError>
     {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.CancelMaintenanceWindowExecution");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13933,9 +13948,14 @@ impl Ssm for SsmClient {
         &self,
         input: CreateActivationRequest,
     ) -> RusotoFuture<CreateActivationResult, CreateActivationError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.CreateActivation");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13962,9 +13982,14 @@ impl Ssm for SsmClient {
         &self,
         input: CreateAssociationRequest,
     ) -> RusotoFuture<CreateAssociationResult, CreateAssociationError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.CreateAssociation");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -13991,9 +14016,14 @@ impl Ssm for SsmClient {
         &self,
         input: CreateAssociationBatchRequest,
     ) -> RusotoFuture<CreateAssociationBatchResult, CreateAssociationBatchError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.CreateAssociationBatch");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14019,9 +14049,14 @@ impl Ssm for SsmClient {
         &self,
         input: CreateDocumentRequest,
     ) -> RusotoFuture<CreateDocumentResult, CreateDocumentError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.CreateDocument");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14048,9 +14083,14 @@ impl Ssm for SsmClient {
         &self,
         input: CreateMaintenanceWindowRequest,
     ) -> RusotoFuture<CreateMaintenanceWindowResult, CreateMaintenanceWindowError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.CreateMaintenanceWindow");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14074,9 +14114,14 @@ impl Ssm for SsmClient {
         &self,
         input: CreatePatchBaselineRequest,
     ) -> RusotoFuture<CreatePatchBaselineResult, CreatePatchBaselineError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.CreatePatchBaseline");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14102,9 +14147,14 @@ impl Ssm for SsmClient {
         &self,
         input: CreateResourceDataSyncRequest,
     ) -> RusotoFuture<CreateResourceDataSyncResult, CreateResourceDataSyncError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.CreateResourceDataSync");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14130,9 +14180,14 @@ impl Ssm for SsmClient {
         &self,
         input: DeleteActivationRequest,
     ) -> RusotoFuture<DeleteActivationResult, DeleteActivationError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DeleteActivation");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14159,9 +14214,14 @@ impl Ssm for SsmClient {
         &self,
         input: DeleteAssociationRequest,
     ) -> RusotoFuture<DeleteAssociationResult, DeleteAssociationError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DeleteAssociation");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14188,9 +14248,14 @@ impl Ssm for SsmClient {
         &self,
         input: DeleteDocumentRequest,
     ) -> RusotoFuture<DeleteDocumentResult, DeleteDocumentError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DeleteDocument");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14217,9 +14282,14 @@ impl Ssm for SsmClient {
         &self,
         input: DeleteInventoryRequest,
     ) -> RusotoFuture<DeleteInventoryResult, DeleteInventoryError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DeleteInventory");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14246,9 +14316,14 @@ impl Ssm for SsmClient {
         &self,
         input: DeleteMaintenanceWindowRequest,
     ) -> RusotoFuture<DeleteMaintenanceWindowResult, DeleteMaintenanceWindowError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DeleteMaintenanceWindow");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14272,9 +14347,14 @@ impl Ssm for SsmClient {
         &self,
         input: DeleteParameterRequest,
     ) -> RusotoFuture<DeleteParameterResult, DeleteParameterError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DeleteParameter");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14301,9 +14381,14 @@ impl Ssm for SsmClient {
         &self,
         input: DeleteParametersRequest,
     ) -> RusotoFuture<DeleteParametersResult, DeleteParametersError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DeleteParameters");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14330,9 +14415,14 @@ impl Ssm for SsmClient {
         &self,
         input: DeletePatchBaselineRequest,
     ) -> RusotoFuture<DeletePatchBaselineResult, DeletePatchBaselineError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DeletePatchBaseline");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14358,9 +14448,14 @@ impl Ssm for SsmClient {
         &self,
         input: DeleteResourceDataSyncRequest,
     ) -> RusotoFuture<DeleteResourceDataSyncResult, DeleteResourceDataSyncError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DeleteResourceDataSync");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14386,9 +14481,14 @@ impl Ssm for SsmClient {
         &self,
         input: DeregisterManagedInstanceRequest,
     ) -> RusotoFuture<DeregisterManagedInstanceResult, DeregisterManagedInstanceError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DeregisterManagedInstance");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14415,9 +14515,14 @@ impl Ssm for SsmClient {
         DeregisterPatchBaselineForPatchGroupResult,
         DeregisterPatchBaselineForPatchGroupError,
     > {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonSSM.DeregisterPatchBaselineForPatchGroup",
@@ -14449,9 +14554,14 @@ impl Ssm for SsmClient {
         DeregisterTargetFromMaintenanceWindowResult,
         DeregisterTargetFromMaintenanceWindowError,
     > {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonSSM.DeregisterTargetFromMaintenanceWindow",
@@ -14483,9 +14593,14 @@ impl Ssm for SsmClient {
         DeregisterTaskFromMaintenanceWindowResult,
         DeregisterTaskFromMaintenanceWindowError,
     > {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonSSM.DeregisterTaskFromMaintenanceWindow",
@@ -14514,9 +14629,14 @@ impl Ssm for SsmClient {
         &self,
         input: DescribeActivationsRequest,
     ) -> RusotoFuture<DescribeActivationsResult, DescribeActivationsError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DescribeActivations");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14542,9 +14662,14 @@ impl Ssm for SsmClient {
         &self,
         input: DescribeAssociationRequest,
     ) -> RusotoFuture<DescribeAssociationResult, DescribeAssociationError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DescribeAssociation");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14573,9 +14698,14 @@ impl Ssm for SsmClient {
         DescribeAssociationExecutionTargetsResult,
         DescribeAssociationExecutionTargetsError,
     > {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonSSM.DescribeAssociationExecutionTargets",
@@ -14604,9 +14734,14 @@ impl Ssm for SsmClient {
         &self,
         input: DescribeAssociationExecutionsRequest,
     ) -> RusotoFuture<DescribeAssociationExecutionsResult, DescribeAssociationExecutionsError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DescribeAssociationExecutions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14630,9 +14765,14 @@ impl Ssm for SsmClient {
         &self,
         input: DescribeAutomationExecutionsRequest,
     ) -> RusotoFuture<DescribeAutomationExecutionsResult, DescribeAutomationExecutionsError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DescribeAutomationExecutions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14657,9 +14797,14 @@ impl Ssm for SsmClient {
         input: DescribeAutomationStepExecutionsRequest,
     ) -> RusotoFuture<DescribeAutomationStepExecutionsResult, DescribeAutomationStepExecutionsError>
     {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DescribeAutomationStepExecutions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14685,9 +14830,14 @@ impl Ssm for SsmClient {
         &self,
         input: DescribeAvailablePatchesRequest,
     ) -> RusotoFuture<DescribeAvailablePatchesResult, DescribeAvailablePatchesError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DescribeAvailablePatches");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14711,9 +14861,14 @@ impl Ssm for SsmClient {
         &self,
         input: DescribeDocumentRequest,
     ) -> RusotoFuture<DescribeDocumentResult, DescribeDocumentError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DescribeDocument");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14740,9 +14895,14 @@ impl Ssm for SsmClient {
         &self,
         input: DescribeDocumentPermissionRequest,
     ) -> RusotoFuture<DescribeDocumentPermissionResponse, DescribeDocumentPermissionError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DescribeDocumentPermission");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14769,9 +14929,14 @@ impl Ssm for SsmClient {
         DescribeEffectiveInstanceAssociationsResult,
         DescribeEffectiveInstanceAssociationsError,
     > {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonSSM.DescribeEffectiveInstanceAssociations",
@@ -14803,9 +14968,14 @@ impl Ssm for SsmClient {
         DescribeEffectivePatchesForPatchBaselineResult,
         DescribeEffectivePatchesForPatchBaselineError,
     > {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonSSM.DescribeEffectivePatchesForPatchBaseline",
@@ -14835,9 +15005,14 @@ impl Ssm for SsmClient {
         DescribeInstanceAssociationsStatusResult,
         DescribeInstanceAssociationsStatusError,
     > {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonSSM.DescribeInstanceAssociationsStatus",
@@ -14866,9 +15041,14 @@ impl Ssm for SsmClient {
         &self,
         input: DescribeInstanceInformationRequest,
     ) -> RusotoFuture<DescribeInstanceInformationResult, DescribeInstanceInformationError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DescribeInstanceInformation");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14892,9 +15072,14 @@ impl Ssm for SsmClient {
         &self,
         input: DescribeInstancePatchStatesRequest,
     ) -> RusotoFuture<DescribeInstancePatchStatesResult, DescribeInstancePatchStatesError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DescribeInstancePatchStates");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14921,9 +15106,14 @@ impl Ssm for SsmClient {
         DescribeInstancePatchStatesForPatchGroupResult,
         DescribeInstancePatchStatesForPatchGroupError,
     > {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonSSM.DescribeInstancePatchStatesForPatchGroup",
@@ -14950,9 +15140,14 @@ impl Ssm for SsmClient {
         &self,
         input: DescribeInstancePatchesRequest,
     ) -> RusotoFuture<DescribeInstancePatchesResult, DescribeInstancePatchesError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DescribeInstancePatches");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -14976,9 +15171,14 @@ impl Ssm for SsmClient {
         &self,
         input: DescribeInventoryDeletionsRequest,
     ) -> RusotoFuture<DescribeInventoryDeletionsResult, DescribeInventoryDeletionsError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DescribeInventoryDeletions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15005,9 +15205,14 @@ impl Ssm for SsmClient {
         DescribeMaintenanceWindowExecutionTaskInvocationsResult,
         DescribeMaintenanceWindowExecutionTaskInvocationsError,
     > {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonSSM.DescribeMaintenanceWindowExecutionTaskInvocations",
@@ -15036,9 +15241,14 @@ impl Ssm for SsmClient {
         DescribeMaintenanceWindowExecutionTasksResult,
         DescribeMaintenanceWindowExecutionTasksError,
     > {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonSSM.DescribeMaintenanceWindowExecutionTasks",
@@ -15070,9 +15280,14 @@ impl Ssm for SsmClient {
         DescribeMaintenanceWindowExecutionsResult,
         DescribeMaintenanceWindowExecutionsError,
     > {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonSSM.DescribeMaintenanceWindowExecutions",
@@ -15102,9 +15317,14 @@ impl Ssm for SsmClient {
         input: DescribeMaintenanceWindowScheduleRequest,
     ) -> RusotoFuture<DescribeMaintenanceWindowScheduleResult, DescribeMaintenanceWindowScheduleError>
     {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonSSM.DescribeMaintenanceWindowSchedule",
@@ -15134,9 +15354,14 @@ impl Ssm for SsmClient {
         input: DescribeMaintenanceWindowTargetsRequest,
     ) -> RusotoFuture<DescribeMaintenanceWindowTargetsResult, DescribeMaintenanceWindowTargetsError>
     {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DescribeMaintenanceWindowTargets");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15163,9 +15388,14 @@ impl Ssm for SsmClient {
         input: DescribeMaintenanceWindowTasksRequest,
     ) -> RusotoFuture<DescribeMaintenanceWindowTasksResult, DescribeMaintenanceWindowTasksError>
     {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DescribeMaintenanceWindowTasks");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15189,9 +15419,14 @@ impl Ssm for SsmClient {
         &self,
         input: DescribeMaintenanceWindowsRequest,
     ) -> RusotoFuture<DescribeMaintenanceWindowsResult, DescribeMaintenanceWindowsError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DescribeMaintenanceWindows");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15218,9 +15453,14 @@ impl Ssm for SsmClient {
         DescribeMaintenanceWindowsForTargetResult,
         DescribeMaintenanceWindowsForTargetError,
     > {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonSSM.DescribeMaintenanceWindowsForTarget",
@@ -15249,9 +15489,14 @@ impl Ssm for SsmClient {
         &self,
         input: DescribeParametersRequest,
     ) -> RusotoFuture<DescribeParametersResult, DescribeParametersError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DescribeParameters");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15278,9 +15523,14 @@ impl Ssm for SsmClient {
         &self,
         input: DescribePatchBaselinesRequest,
     ) -> RusotoFuture<DescribePatchBaselinesResult, DescribePatchBaselinesError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DescribePatchBaselines");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15306,9 +15556,14 @@ impl Ssm for SsmClient {
         &self,
         input: DescribePatchGroupStateRequest,
     ) -> RusotoFuture<DescribePatchGroupStateResult, DescribePatchGroupStateError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DescribePatchGroupState");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15332,9 +15587,14 @@ impl Ssm for SsmClient {
         &self,
         input: DescribePatchGroupsRequest,
     ) -> RusotoFuture<DescribePatchGroupsResult, DescribePatchGroupsError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DescribePatchGroups");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15360,9 +15620,14 @@ impl Ssm for SsmClient {
         &self,
         input: DescribeSessionsRequest,
     ) -> RusotoFuture<DescribeSessionsResponse, DescribeSessionsError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.DescribeSessions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15389,9 +15654,14 @@ impl Ssm for SsmClient {
         &self,
         input: GetAutomationExecutionRequest,
     ) -> RusotoFuture<GetAutomationExecutionResult, GetAutomationExecutionError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.GetAutomationExecution");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15417,9 +15687,14 @@ impl Ssm for SsmClient {
         &self,
         input: GetCommandInvocationRequest,
     ) -> RusotoFuture<GetCommandInvocationResult, GetCommandInvocationError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.GetCommandInvocation");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15445,9 +15720,14 @@ impl Ssm for SsmClient {
         &self,
         input: GetConnectionStatusRequest,
     ) -> RusotoFuture<GetConnectionStatusResponse, GetConnectionStatusError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.GetConnectionStatus");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15473,9 +15753,14 @@ impl Ssm for SsmClient {
         &self,
         input: GetDefaultPatchBaselineRequest,
     ) -> RusotoFuture<GetDefaultPatchBaselineResult, GetDefaultPatchBaselineError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.GetDefaultPatchBaseline");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15502,9 +15787,14 @@ impl Ssm for SsmClient {
         GetDeployablePatchSnapshotForInstanceResult,
         GetDeployablePatchSnapshotForInstanceError,
     > {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonSSM.GetDeployablePatchSnapshotForInstance",
@@ -15533,9 +15823,14 @@ impl Ssm for SsmClient {
         &self,
         input: GetDocumentRequest,
     ) -> RusotoFuture<GetDocumentResult, GetDocumentError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.GetDocument");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15562,9 +15857,14 @@ impl Ssm for SsmClient {
         &self,
         input: GetInventoryRequest,
     ) -> RusotoFuture<GetInventoryResult, GetInventoryError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.GetInventory");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15591,9 +15891,14 @@ impl Ssm for SsmClient {
         &self,
         input: GetInventorySchemaRequest,
     ) -> RusotoFuture<GetInventorySchemaResult, GetInventorySchemaError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.GetInventorySchema");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15620,9 +15925,14 @@ impl Ssm for SsmClient {
         &self,
         input: GetMaintenanceWindowRequest,
     ) -> RusotoFuture<GetMaintenanceWindowResult, GetMaintenanceWindowError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.GetMaintenanceWindow");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15648,9 +15958,14 @@ impl Ssm for SsmClient {
         &self,
         input: GetMaintenanceWindowExecutionRequest,
     ) -> RusotoFuture<GetMaintenanceWindowExecutionResult, GetMaintenanceWindowExecutionError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.GetMaintenanceWindowExecution");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15675,9 +15990,14 @@ impl Ssm for SsmClient {
         input: GetMaintenanceWindowExecutionTaskRequest,
     ) -> RusotoFuture<GetMaintenanceWindowExecutionTaskResult, GetMaintenanceWindowExecutionTaskError>
     {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonSSM.GetMaintenanceWindowExecutionTask",
@@ -15709,9 +16029,14 @@ impl Ssm for SsmClient {
         GetMaintenanceWindowExecutionTaskInvocationResult,
         GetMaintenanceWindowExecutionTaskInvocationError,
     > {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonSSM.GetMaintenanceWindowExecutionTaskInvocation",
@@ -15738,9 +16063,14 @@ impl Ssm for SsmClient {
         &self,
         input: GetMaintenanceWindowTaskRequest,
     ) -> RusotoFuture<GetMaintenanceWindowTaskResult, GetMaintenanceWindowTaskError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.GetMaintenanceWindowTask");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15764,9 +16094,14 @@ impl Ssm for SsmClient {
         &self,
         input: GetParameterRequest,
     ) -> RusotoFuture<GetParameterResult, GetParameterError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.GetParameter");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15793,9 +16128,14 @@ impl Ssm for SsmClient {
         &self,
         input: GetParameterHistoryRequest,
     ) -> RusotoFuture<GetParameterHistoryResult, GetParameterHistoryError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.GetParameterHistory");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15821,9 +16161,14 @@ impl Ssm for SsmClient {
         &self,
         input: GetParametersRequest,
     ) -> RusotoFuture<GetParametersResult, GetParametersError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.GetParameters");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15850,9 +16195,14 @@ impl Ssm for SsmClient {
         &self,
         input: GetParametersByPathRequest,
     ) -> RusotoFuture<GetParametersByPathResult, GetParametersByPathError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.GetParametersByPath");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15878,9 +16228,14 @@ impl Ssm for SsmClient {
         &self,
         input: GetPatchBaselineRequest,
     ) -> RusotoFuture<GetPatchBaselineResult, GetPatchBaselineError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.GetPatchBaseline");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15907,9 +16262,14 @@ impl Ssm for SsmClient {
         &self,
         input: GetPatchBaselineForPatchGroupRequest,
     ) -> RusotoFuture<GetPatchBaselineForPatchGroupResult, GetPatchBaselineForPatchGroupError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.GetPatchBaselineForPatchGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15933,9 +16293,14 @@ impl Ssm for SsmClient {
         &self,
         input: LabelParameterVersionRequest,
     ) -> RusotoFuture<LabelParameterVersionResult, LabelParameterVersionError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.LabelParameterVersion");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15961,9 +16326,14 @@ impl Ssm for SsmClient {
         &self,
         input: ListAssociationVersionsRequest,
     ) -> RusotoFuture<ListAssociationVersionsResult, ListAssociationVersionsError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.ListAssociationVersions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -15987,9 +16357,14 @@ impl Ssm for SsmClient {
         &self,
         input: ListAssociationsRequest,
     ) -> RusotoFuture<ListAssociationsResult, ListAssociationsError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.ListAssociations");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16016,9 +16391,14 @@ impl Ssm for SsmClient {
         &self,
         input: ListCommandInvocationsRequest,
     ) -> RusotoFuture<ListCommandInvocationsResult, ListCommandInvocationsError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.ListCommandInvocations");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16044,9 +16424,14 @@ impl Ssm for SsmClient {
         &self,
         input: ListCommandsRequest,
     ) -> RusotoFuture<ListCommandsResult, ListCommandsError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.ListCommands");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16073,9 +16458,14 @@ impl Ssm for SsmClient {
         &self,
         input: ListComplianceItemsRequest,
     ) -> RusotoFuture<ListComplianceItemsResult, ListComplianceItemsError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.ListComplianceItems");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16101,9 +16491,14 @@ impl Ssm for SsmClient {
         &self,
         input: ListComplianceSummariesRequest,
     ) -> RusotoFuture<ListComplianceSummariesResult, ListComplianceSummariesError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.ListComplianceSummaries");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16127,9 +16522,14 @@ impl Ssm for SsmClient {
         &self,
         input: ListDocumentVersionsRequest,
     ) -> RusotoFuture<ListDocumentVersionsResult, ListDocumentVersionsError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.ListDocumentVersions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16155,9 +16555,14 @@ impl Ssm for SsmClient {
         &self,
         input: ListDocumentsRequest,
     ) -> RusotoFuture<ListDocumentsResult, ListDocumentsError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.ListDocuments");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16184,9 +16589,14 @@ impl Ssm for SsmClient {
         &self,
         input: ListInventoryEntriesRequest,
     ) -> RusotoFuture<ListInventoryEntriesResult, ListInventoryEntriesError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.ListInventoryEntries");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16213,9 +16623,14 @@ impl Ssm for SsmClient {
         input: ListResourceComplianceSummariesRequest,
     ) -> RusotoFuture<ListResourceComplianceSummariesResult, ListResourceComplianceSummariesError>
     {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.ListResourceComplianceSummaries");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16241,9 +16656,14 @@ impl Ssm for SsmClient {
         &self,
         input: ListResourceDataSyncRequest,
     ) -> RusotoFuture<ListResourceDataSyncResult, ListResourceDataSyncError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.ListResourceDataSync");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16269,9 +16689,14 @@ impl Ssm for SsmClient {
         &self,
         input: ListTagsForResourceRequest,
     ) -> RusotoFuture<ListTagsForResourceResult, ListTagsForResourceError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.ListTagsForResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16297,9 +16722,14 @@ impl Ssm for SsmClient {
         &self,
         input: ModifyDocumentPermissionRequest,
     ) -> RusotoFuture<ModifyDocumentPermissionResponse, ModifyDocumentPermissionError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.ModifyDocumentPermission");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16323,9 +16753,14 @@ impl Ssm for SsmClient {
         &self,
         input: PutComplianceItemsRequest,
     ) -> RusotoFuture<PutComplianceItemsResult, PutComplianceItemsError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.PutComplianceItems");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16352,9 +16787,14 @@ impl Ssm for SsmClient {
         &self,
         input: PutInventoryRequest,
     ) -> RusotoFuture<PutInventoryResult, PutInventoryError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.PutInventory");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16381,9 +16821,14 @@ impl Ssm for SsmClient {
         &self,
         input: PutParameterRequest,
     ) -> RusotoFuture<PutParameterResult, PutParameterError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.PutParameter");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16410,9 +16855,14 @@ impl Ssm for SsmClient {
         &self,
         input: RegisterDefaultPatchBaselineRequest,
     ) -> RusotoFuture<RegisterDefaultPatchBaselineResult, RegisterDefaultPatchBaselineError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.RegisterDefaultPatchBaseline");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16439,9 +16889,14 @@ impl Ssm for SsmClient {
         RegisterPatchBaselineForPatchGroupResult,
         RegisterPatchBaselineForPatchGroupError,
     > {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonSSM.RegisterPatchBaselineForPatchGroup",
@@ -16473,9 +16928,14 @@ impl Ssm for SsmClient {
         RegisterTargetWithMaintenanceWindowResult,
         RegisterTargetWithMaintenanceWindowError,
     > {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonSSM.RegisterTargetWithMaintenanceWindow",
@@ -16505,9 +16965,14 @@ impl Ssm for SsmClient {
         input: RegisterTaskWithMaintenanceWindowRequest,
     ) -> RusotoFuture<RegisterTaskWithMaintenanceWindowResult, RegisterTaskWithMaintenanceWindowError>
     {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AmazonSSM.RegisterTaskWithMaintenanceWindow",
@@ -16536,9 +17001,14 @@ impl Ssm for SsmClient {
         &self,
         input: RemoveTagsFromResourceRequest,
     ) -> RusotoFuture<RemoveTagsFromResourceResult, RemoveTagsFromResourceError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.RemoveTagsFromResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16564,9 +17034,14 @@ impl Ssm for SsmClient {
         &self,
         input: ResumeSessionRequest,
     ) -> RusotoFuture<ResumeSessionResponse, ResumeSessionError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.ResumeSession");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16593,9 +17068,14 @@ impl Ssm for SsmClient {
         &self,
         input: SendAutomationSignalRequest,
     ) -> RusotoFuture<SendAutomationSignalResult, SendAutomationSignalError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.SendAutomationSignal");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16621,9 +17101,14 @@ impl Ssm for SsmClient {
         &self,
         input: SendCommandRequest,
     ) -> RusotoFuture<SendCommandResult, SendCommandError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.SendCommand");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16650,9 +17135,14 @@ impl Ssm for SsmClient {
         &self,
         input: StartAssociationsOnceRequest,
     ) -> RusotoFuture<StartAssociationsOnceResult, StartAssociationsOnceError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.StartAssociationsOnce");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16678,9 +17168,14 @@ impl Ssm for SsmClient {
         &self,
         input: StartAutomationExecutionRequest,
     ) -> RusotoFuture<StartAutomationExecutionResult, StartAutomationExecutionError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.StartAutomationExecution");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16704,9 +17199,14 @@ impl Ssm for SsmClient {
         &self,
         input: StartSessionRequest,
     ) -> RusotoFuture<StartSessionResponse, StartSessionError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.StartSession");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16733,9 +17233,14 @@ impl Ssm for SsmClient {
         &self,
         input: StopAutomationExecutionRequest,
     ) -> RusotoFuture<StopAutomationExecutionResult, StopAutomationExecutionError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.StopAutomationExecution");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16759,9 +17264,14 @@ impl Ssm for SsmClient {
         &self,
         input: TerminateSessionRequest,
     ) -> RusotoFuture<TerminateSessionResponse, TerminateSessionError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.TerminateSession");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16788,9 +17298,14 @@ impl Ssm for SsmClient {
         &self,
         input: UpdateAssociationRequest,
     ) -> RusotoFuture<UpdateAssociationResult, UpdateAssociationError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.UpdateAssociation");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16817,9 +17332,14 @@ impl Ssm for SsmClient {
         &self,
         input: UpdateAssociationStatusRequest,
     ) -> RusotoFuture<UpdateAssociationStatusResult, UpdateAssociationStatusError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.UpdateAssociationStatus");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16843,9 +17363,14 @@ impl Ssm for SsmClient {
         &self,
         input: UpdateDocumentRequest,
     ) -> RusotoFuture<UpdateDocumentResult, UpdateDocumentError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.UpdateDocument");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16872,9 +17397,14 @@ impl Ssm for SsmClient {
         &self,
         input: UpdateDocumentDefaultVersionRequest,
     ) -> RusotoFuture<UpdateDocumentDefaultVersionResult, UpdateDocumentDefaultVersionError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.UpdateDocumentDefaultVersion");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16898,9 +17428,14 @@ impl Ssm for SsmClient {
         &self,
         input: UpdateMaintenanceWindowRequest,
     ) -> RusotoFuture<UpdateMaintenanceWindowResult, UpdateMaintenanceWindowError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.UpdateMaintenanceWindow");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16924,9 +17459,14 @@ impl Ssm for SsmClient {
         &self,
         input: UpdateMaintenanceWindowTargetRequest,
     ) -> RusotoFuture<UpdateMaintenanceWindowTargetResult, UpdateMaintenanceWindowTargetError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.UpdateMaintenanceWindowTarget");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16950,9 +17490,14 @@ impl Ssm for SsmClient {
         &self,
         input: UpdateMaintenanceWindowTaskRequest,
     ) -> RusotoFuture<UpdateMaintenanceWindowTaskResult, UpdateMaintenanceWindowTaskError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.UpdateMaintenanceWindowTask");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -16976,9 +17521,14 @@ impl Ssm for SsmClient {
         &self,
         input: UpdateManagedInstanceRoleRequest,
     ) -> RusotoFuture<UpdateManagedInstanceRoleResult, UpdateManagedInstanceRoleError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.UpdateManagedInstanceRole");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -17002,9 +17552,14 @@ impl Ssm for SsmClient {
         &self,
         input: UpdatePatchBaselineRequest,
     ) -> RusotoFuture<UpdatePatchBaselineResult, UpdatePatchBaselineError> {
-        let mut request = SignedRequest::new("POST", "ssm", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "ssm",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AmazonSSM.UpdatePatchBaseline");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/stepfunctions/src/generated.rs
+++ b/rusoto/services/stepfunctions/src/generated.rs
@@ -2251,9 +2251,14 @@ impl StepFunctions for StepFunctionsClient {
         &self,
         input: CreateActivityInput,
     ) -> RusotoFuture<CreateActivityOutput, CreateActivityError> {
-        let mut request = SignedRequest::new("POST", "states", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "states",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "AWSStepFunctions.CreateActivity");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2280,9 +2285,14 @@ impl StepFunctions for StepFunctionsClient {
         &self,
         input: CreateStateMachineInput,
     ) -> RusotoFuture<CreateStateMachineOutput, CreateStateMachineError> {
-        let mut request = SignedRequest::new("POST", "states", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "states",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "AWSStepFunctions.CreateStateMachine");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2309,9 +2319,14 @@ impl StepFunctions for StepFunctionsClient {
         &self,
         input: DeleteActivityInput,
     ) -> RusotoFuture<DeleteActivityOutput, DeleteActivityError> {
-        let mut request = SignedRequest::new("POST", "states", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "states",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "AWSStepFunctions.DeleteActivity");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2338,9 +2353,14 @@ impl StepFunctions for StepFunctionsClient {
         &self,
         input: DeleteStateMachineInput,
     ) -> RusotoFuture<DeleteStateMachineOutput, DeleteStateMachineError> {
-        let mut request = SignedRequest::new("POST", "states", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "states",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "AWSStepFunctions.DeleteStateMachine");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2367,9 +2387,14 @@ impl StepFunctions for StepFunctionsClient {
         &self,
         input: DescribeActivityInput,
     ) -> RusotoFuture<DescribeActivityOutput, DescribeActivityError> {
-        let mut request = SignedRequest::new("POST", "states", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "states",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "AWSStepFunctions.DescribeActivity");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2396,9 +2421,14 @@ impl StepFunctions for StepFunctionsClient {
         &self,
         input: DescribeExecutionInput,
     ) -> RusotoFuture<DescribeExecutionOutput, DescribeExecutionError> {
-        let mut request = SignedRequest::new("POST", "states", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "states",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "AWSStepFunctions.DescribeExecution");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2425,9 +2455,14 @@ impl StepFunctions for StepFunctionsClient {
         &self,
         input: DescribeStateMachineInput,
     ) -> RusotoFuture<DescribeStateMachineOutput, DescribeStateMachineError> {
-        let mut request = SignedRequest::new("POST", "states", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "states",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "AWSStepFunctions.DescribeStateMachine");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2454,9 +2489,14 @@ impl StepFunctions for StepFunctionsClient {
         input: DescribeStateMachineForExecutionInput,
     ) -> RusotoFuture<DescribeStateMachineForExecutionOutput, DescribeStateMachineForExecutionError>
     {
-        let mut request = SignedRequest::new("POST", "states", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "states",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSStepFunctions.DescribeStateMachineForExecution",
@@ -2485,9 +2525,14 @@ impl StepFunctions for StepFunctionsClient {
         &self,
         input: GetActivityTaskInput,
     ) -> RusotoFuture<GetActivityTaskOutput, GetActivityTaskError> {
-        let mut request = SignedRequest::new("POST", "states", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "states",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "AWSStepFunctions.GetActivityTask");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2514,9 +2559,14 @@ impl StepFunctions for StepFunctionsClient {
         &self,
         input: GetExecutionHistoryInput,
     ) -> RusotoFuture<GetExecutionHistoryOutput, GetExecutionHistoryError> {
-        let mut request = SignedRequest::new("POST", "states", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "states",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "AWSStepFunctions.GetExecutionHistory");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2542,9 +2592,14 @@ impl StepFunctions for StepFunctionsClient {
         &self,
         input: ListActivitiesInput,
     ) -> RusotoFuture<ListActivitiesOutput, ListActivitiesError> {
-        let mut request = SignedRequest::new("POST", "states", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "states",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "AWSStepFunctions.ListActivities");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2571,9 +2626,14 @@ impl StepFunctions for StepFunctionsClient {
         &self,
         input: ListExecutionsInput,
     ) -> RusotoFuture<ListExecutionsOutput, ListExecutionsError> {
-        let mut request = SignedRequest::new("POST", "states", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "states",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "AWSStepFunctions.ListExecutions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2600,9 +2660,14 @@ impl StepFunctions for StepFunctionsClient {
         &self,
         input: ListStateMachinesInput,
     ) -> RusotoFuture<ListStateMachinesOutput, ListStateMachinesError> {
-        let mut request = SignedRequest::new("POST", "states", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "states",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "AWSStepFunctions.ListStateMachines");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2629,9 +2694,14 @@ impl StepFunctions for StepFunctionsClient {
         &self,
         input: ListTagsForResourceInput,
     ) -> RusotoFuture<ListTagsForResourceOutput, ListTagsForResourceError> {
-        let mut request = SignedRequest::new("POST", "states", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "states",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "AWSStepFunctions.ListTagsForResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2657,9 +2727,14 @@ impl StepFunctions for StepFunctionsClient {
         &self,
         input: SendTaskFailureInput,
     ) -> RusotoFuture<SendTaskFailureOutput, SendTaskFailureError> {
-        let mut request = SignedRequest::new("POST", "states", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "states",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "AWSStepFunctions.SendTaskFailure");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2686,9 +2761,14 @@ impl StepFunctions for StepFunctionsClient {
         &self,
         input: SendTaskHeartbeatInput,
     ) -> RusotoFuture<SendTaskHeartbeatOutput, SendTaskHeartbeatError> {
-        let mut request = SignedRequest::new("POST", "states", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "states",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "AWSStepFunctions.SendTaskHeartbeat");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2715,9 +2795,14 @@ impl StepFunctions for StepFunctionsClient {
         &self,
         input: SendTaskSuccessInput,
     ) -> RusotoFuture<SendTaskSuccessOutput, SendTaskSuccessError> {
-        let mut request = SignedRequest::new("POST", "states", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "states",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "AWSStepFunctions.SendTaskSuccess");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2744,9 +2829,14 @@ impl StepFunctions for StepFunctionsClient {
         &self,
         input: StartExecutionInput,
     ) -> RusotoFuture<StartExecutionOutput, StartExecutionError> {
-        let mut request = SignedRequest::new("POST", "states", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "states",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "AWSStepFunctions.StartExecution");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2773,9 +2863,14 @@ impl StepFunctions for StepFunctionsClient {
         &self,
         input: StopExecutionInput,
     ) -> RusotoFuture<StopExecutionOutput, StopExecutionError> {
-        let mut request = SignedRequest::new("POST", "states", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "states",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "AWSStepFunctions.StopExecution");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2802,9 +2897,14 @@ impl StepFunctions for StepFunctionsClient {
         &self,
         input: TagResourceInput,
     ) -> RusotoFuture<TagResourceOutput, TagResourceError> {
-        let mut request = SignedRequest::new("POST", "states", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "states",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "AWSStepFunctions.TagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2831,9 +2931,14 @@ impl StepFunctions for StepFunctionsClient {
         &self,
         input: UntagResourceInput,
     ) -> RusotoFuture<UntagResourceOutput, UntagResourceError> {
-        let mut request = SignedRequest::new("POST", "states", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "states",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "AWSStepFunctions.UntagResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2860,9 +2965,14 @@ impl StepFunctions for StepFunctionsClient {
         &self,
         input: UpdateStateMachineInput,
     ) -> RusotoFuture<UpdateStateMachineOutput, UpdateStateMachineError> {
-        let mut request = SignedRequest::new("POST", "states", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "states",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "AWSStepFunctions.UpdateStateMachine");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/storagegateway/src/generated.rs
+++ b/rusoto/services/storagegateway/src/generated.rs
@@ -6042,9 +6042,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: ActivateGatewayInput,
     ) -> RusotoFuture<ActivateGatewayOutput, ActivateGatewayError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.ActivateGateway");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6068,9 +6073,14 @@ impl StorageGateway for StorageGatewayClient {
 
     /// <p>Configures one or more gateway local disks as cache for a gateway. This operation is only supported in the cached volume, tape and file gateway type (see <a href="http://docs.aws.amazon.com/storagegateway/latest/userguide/StorageGatewayConcepts.html">Storage Gateway Concepts</a>).</p> <p>In the request, you specify the gateway Amazon Resource Name (ARN) to which you want to add cache, and one or more disk IDs that you want to configure as cache.</p>
     fn add_cache(&self, input: AddCacheInput) -> RusotoFuture<AddCacheOutput, AddCacheError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.AddCache");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6096,9 +6106,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: AddTagsToResourceInput,
     ) -> RusotoFuture<AddTagsToResourceOutput, AddTagsToResourceError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.AddTagsToResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6125,9 +6140,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: AddUploadBufferInput,
     ) -> RusotoFuture<AddUploadBufferOutput, AddUploadBufferError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.AddUploadBuffer");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6154,9 +6174,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: AddWorkingStorageInput,
     ) -> RusotoFuture<AddWorkingStorageOutput, AddWorkingStorageError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.AddWorkingStorage");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6183,9 +6208,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: AttachVolumeInput,
     ) -> RusotoFuture<AttachVolumeOutput, AttachVolumeError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.AttachVolume");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6212,9 +6242,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: CancelArchivalInput,
     ) -> RusotoFuture<CancelArchivalOutput, CancelArchivalError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.CancelArchival");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6241,9 +6276,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: CancelRetrievalInput,
     ) -> RusotoFuture<CancelRetrievalOutput, CancelRetrievalError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.CancelRetrieval");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6270,9 +6310,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: CreateCachediSCSIVolumeInput,
     ) -> RusotoFuture<CreateCachediSCSIVolumeOutput, CreateCachediSCSIVolumeError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.CreateCachediSCSIVolume",
@@ -6299,9 +6344,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: CreateNFSFileShareInput,
     ) -> RusotoFuture<CreateNFSFileShareOutput, CreateNFSFileShareError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.CreateNFSFileShare");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6328,9 +6378,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: CreateSMBFileShareInput,
     ) -> RusotoFuture<CreateSMBFileShareOutput, CreateSMBFileShareError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.CreateSMBFileShare");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6357,9 +6412,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: CreateSnapshotInput,
     ) -> RusotoFuture<CreateSnapshotOutput, CreateSnapshotError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.CreateSnapshot");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6389,9 +6449,14 @@ impl StorageGateway for StorageGatewayClient {
         CreateSnapshotFromVolumeRecoveryPointOutput,
         CreateSnapshotFromVolumeRecoveryPointError,
     > {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.CreateSnapshotFromVolumeRecoveryPoint",
@@ -6420,9 +6485,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: CreateStorediSCSIVolumeInput,
     ) -> RusotoFuture<CreateStorediSCSIVolumeOutput, CreateStorediSCSIVolumeError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.CreateStorediSCSIVolume",
@@ -6449,9 +6519,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: CreateTapeWithBarcodeInput,
     ) -> RusotoFuture<CreateTapeWithBarcodeOutput, CreateTapeWithBarcodeError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.CreateTapeWithBarcode",
@@ -6480,9 +6555,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: CreateTapesInput,
     ) -> RusotoFuture<CreateTapesOutput, CreateTapesError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.CreateTapes");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6509,9 +6589,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DeleteBandwidthRateLimitInput,
     ) -> RusotoFuture<DeleteBandwidthRateLimitOutput, DeleteBandwidthRateLimitError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.DeleteBandwidthRateLimit",
@@ -6538,9 +6623,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DeleteChapCredentialsInput,
     ) -> RusotoFuture<DeleteChapCredentialsOutput, DeleteChapCredentialsError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.DeleteChapCredentials",
@@ -6569,9 +6659,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DeleteFileShareInput,
     ) -> RusotoFuture<DeleteFileShareOutput, DeleteFileShareError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.DeleteFileShare");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6598,9 +6693,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DeleteGatewayInput,
     ) -> RusotoFuture<DeleteGatewayOutput, DeleteGatewayError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.DeleteGateway");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6627,9 +6727,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DeleteSnapshotScheduleInput,
     ) -> RusotoFuture<DeleteSnapshotScheduleOutput, DeleteSnapshotScheduleError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.DeleteSnapshotSchedule",
@@ -6658,9 +6763,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DeleteTapeInput,
     ) -> RusotoFuture<DeleteTapeOutput, DeleteTapeError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.DeleteTape");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6687,9 +6797,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DeleteTapeArchiveInput,
     ) -> RusotoFuture<DeleteTapeArchiveOutput, DeleteTapeArchiveError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.DeleteTapeArchive");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6716,9 +6831,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DeleteVolumeInput,
     ) -> RusotoFuture<DeleteVolumeOutput, DeleteVolumeError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.DeleteVolume");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6745,9 +6865,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DescribeBandwidthRateLimitInput,
     ) -> RusotoFuture<DescribeBandwidthRateLimitOutput, DescribeBandwidthRateLimitError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.DescribeBandwidthRateLimit",
@@ -6774,9 +6899,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DescribeCacheInput,
     ) -> RusotoFuture<DescribeCacheOutput, DescribeCacheError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.DescribeCache");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -6803,9 +6933,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DescribeCachediSCSIVolumesInput,
     ) -> RusotoFuture<DescribeCachediSCSIVolumesOutput, DescribeCachediSCSIVolumesError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.DescribeCachediSCSIVolumes",
@@ -6832,9 +6967,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DescribeChapCredentialsInput,
     ) -> RusotoFuture<DescribeChapCredentialsOutput, DescribeChapCredentialsError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.DescribeChapCredentials",
@@ -6861,9 +7001,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DescribeGatewayInformationInput,
     ) -> RusotoFuture<DescribeGatewayInformationOutput, DescribeGatewayInformationError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.DescribeGatewayInformation",
@@ -6890,9 +7035,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DescribeMaintenanceStartTimeInput,
     ) -> RusotoFuture<DescribeMaintenanceStartTimeOutput, DescribeMaintenanceStartTimeError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.DescribeMaintenanceStartTime",
@@ -6919,9 +7069,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DescribeNFSFileSharesInput,
     ) -> RusotoFuture<DescribeNFSFileSharesOutput, DescribeNFSFileSharesError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.DescribeNFSFileShares",
@@ -6950,9 +7105,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DescribeSMBFileSharesInput,
     ) -> RusotoFuture<DescribeSMBFileSharesOutput, DescribeSMBFileSharesError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.DescribeSMBFileShares",
@@ -6981,9 +7141,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DescribeSMBSettingsInput,
     ) -> RusotoFuture<DescribeSMBSettingsOutput, DescribeSMBSettingsError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.DescribeSMBSettings",
@@ -7012,9 +7177,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DescribeSnapshotScheduleInput,
     ) -> RusotoFuture<DescribeSnapshotScheduleOutput, DescribeSnapshotScheduleError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.DescribeSnapshotSchedule",
@@ -7041,9 +7211,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DescribeStorediSCSIVolumesInput,
     ) -> RusotoFuture<DescribeStorediSCSIVolumesOutput, DescribeStorediSCSIVolumesError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.DescribeStorediSCSIVolumes",
@@ -7070,9 +7245,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DescribeTapeArchivesInput,
     ) -> RusotoFuture<DescribeTapeArchivesOutput, DescribeTapeArchivesError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.DescribeTapeArchives",
@@ -7101,9 +7281,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DescribeTapeRecoveryPointsInput,
     ) -> RusotoFuture<DescribeTapeRecoveryPointsOutput, DescribeTapeRecoveryPointsError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.DescribeTapeRecoveryPoints",
@@ -7130,9 +7315,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DescribeTapesInput,
     ) -> RusotoFuture<DescribeTapesOutput, DescribeTapesError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.DescribeTapes");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7159,9 +7349,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DescribeUploadBufferInput,
     ) -> RusotoFuture<DescribeUploadBufferOutput, DescribeUploadBufferError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.DescribeUploadBuffer",
@@ -7190,9 +7385,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DescribeVTLDevicesInput,
     ) -> RusotoFuture<DescribeVTLDevicesOutput, DescribeVTLDevicesError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.DescribeVTLDevices");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7219,9 +7419,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DescribeWorkingStorageInput,
     ) -> RusotoFuture<DescribeWorkingStorageOutput, DescribeWorkingStorageError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.DescribeWorkingStorage",
@@ -7250,9 +7455,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DetachVolumeInput,
     ) -> RusotoFuture<DetachVolumeOutput, DetachVolumeError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.DetachVolume");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7279,9 +7489,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: DisableGatewayInput,
     ) -> RusotoFuture<DisableGatewayOutput, DisableGatewayError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.DisableGateway");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7308,9 +7523,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: JoinDomainInput,
     ) -> RusotoFuture<JoinDomainOutput, JoinDomainError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.JoinDomain");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7337,9 +7557,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: ListFileSharesInput,
     ) -> RusotoFuture<ListFileSharesOutput, ListFileSharesError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.ListFileShares");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7366,9 +7591,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: ListGatewaysInput,
     ) -> RusotoFuture<ListGatewaysOutput, ListGatewaysError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.ListGateways");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7395,9 +7625,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: ListLocalDisksInput,
     ) -> RusotoFuture<ListLocalDisksOutput, ListLocalDisksError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.ListLocalDisks");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7424,9 +7659,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: ListTagsForResourceInput,
     ) -> RusotoFuture<ListTagsForResourceOutput, ListTagsForResourceError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.ListTagsForResource",
@@ -7452,9 +7692,14 @@ impl StorageGateway for StorageGatewayClient {
 
     /// <p>Lists virtual tapes in your virtual tape library (VTL) and your virtual tape shelf (VTS). You specify the tapes to list by specifying one or more tape Amazon Resource Names (ARNs). If you don't specify a tape ARN, the operation lists all virtual tapes in both your VTL and VTS.</p> <p>This operation supports pagination. By default, the operation returns a maximum of up to 100 tapes. You can optionally specify the <code>Limit</code> parameter in the body to limit the number of tapes in the response. If the number of tapes returned in the response is truncated, the response includes a <code>Marker</code> element that you can use in your subsequent request to retrieve the next set of tapes. This operation is only supported in the tape gateway type.</p>
     fn list_tapes(&self, input: ListTapesInput) -> RusotoFuture<ListTapesOutput, ListTapesError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.ListTapes");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7480,9 +7725,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: ListVolumeInitiatorsInput,
     ) -> RusotoFuture<ListVolumeInitiatorsOutput, ListVolumeInitiatorsError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.ListVolumeInitiators",
@@ -7511,9 +7761,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: ListVolumeRecoveryPointsInput,
     ) -> RusotoFuture<ListVolumeRecoveryPointsOutput, ListVolumeRecoveryPointsError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.ListVolumeRecoveryPoints",
@@ -7540,9 +7795,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: ListVolumesInput,
     ) -> RusotoFuture<ListVolumesOutput, ListVolumesError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.ListVolumes");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7569,9 +7829,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: NotifyWhenUploadedInput,
     ) -> RusotoFuture<NotifyWhenUploadedOutput, NotifyWhenUploadedError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.NotifyWhenUploaded");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7598,9 +7863,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: RefreshCacheInput,
     ) -> RusotoFuture<RefreshCacheOutput, RefreshCacheError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.RefreshCache");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7627,9 +7897,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: RemoveTagsFromResourceInput,
     ) -> RusotoFuture<RemoveTagsFromResourceOutput, RemoveTagsFromResourceError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.RemoveTagsFromResource",
@@ -7658,9 +7933,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: ResetCacheInput,
     ) -> RusotoFuture<ResetCacheOutput, ResetCacheError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.ResetCache");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7687,9 +7967,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: RetrieveTapeArchiveInput,
     ) -> RusotoFuture<RetrieveTapeArchiveOutput, RetrieveTapeArchiveError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.RetrieveTapeArchive",
@@ -7718,9 +8003,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: RetrieveTapeRecoveryPointInput,
     ) -> RusotoFuture<RetrieveTapeRecoveryPointOutput, RetrieveTapeRecoveryPointError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.RetrieveTapeRecoveryPoint",
@@ -7747,9 +8037,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: SetLocalConsolePasswordInput,
     ) -> RusotoFuture<SetLocalConsolePasswordOutput, SetLocalConsolePasswordError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.SetLocalConsolePassword",
@@ -7776,9 +8071,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: SetSMBGuestPasswordInput,
     ) -> RusotoFuture<SetSMBGuestPasswordOutput, SetSMBGuestPasswordError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.SetSMBGuestPassword",
@@ -7807,9 +8107,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: ShutdownGatewayInput,
     ) -> RusotoFuture<ShutdownGatewayOutput, ShutdownGatewayError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.ShutdownGateway");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7836,9 +8141,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: StartGatewayInput,
     ) -> RusotoFuture<StartGatewayOutput, StartGatewayError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.StartGateway");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7865,9 +8175,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: UpdateBandwidthRateLimitInput,
     ) -> RusotoFuture<UpdateBandwidthRateLimitOutput, UpdateBandwidthRateLimitError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.UpdateBandwidthRateLimit",
@@ -7894,9 +8209,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: UpdateChapCredentialsInput,
     ) -> RusotoFuture<UpdateChapCredentialsOutput, UpdateChapCredentialsError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.UpdateChapCredentials",
@@ -7925,9 +8245,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: UpdateGatewayInformationInput,
     ) -> RusotoFuture<UpdateGatewayInformationOutput, UpdateGatewayInformationError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.UpdateGatewayInformation",
@@ -7954,9 +8279,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: UpdateGatewaySoftwareNowInput,
     ) -> RusotoFuture<UpdateGatewaySoftwareNowOutput, UpdateGatewaySoftwareNowError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.UpdateGatewaySoftwareNow",
@@ -7983,9 +8313,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: UpdateMaintenanceStartTimeInput,
     ) -> RusotoFuture<UpdateMaintenanceStartTimeOutput, UpdateMaintenanceStartTimeError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.UpdateMaintenanceStartTime",
@@ -8012,9 +8347,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: UpdateNFSFileShareInput,
     ) -> RusotoFuture<UpdateNFSFileShareOutput, UpdateNFSFileShareError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.UpdateNFSFileShare");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8041,9 +8381,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: UpdateSMBFileShareInput,
     ) -> RusotoFuture<UpdateSMBFileShareOutput, UpdateSMBFileShareError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "StorageGateway_20130630.UpdateSMBFileShare");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8070,9 +8415,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: UpdateSnapshotScheduleInput,
     ) -> RusotoFuture<UpdateSnapshotScheduleOutput, UpdateSnapshotScheduleError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.UpdateSnapshotSchedule",
@@ -8101,9 +8451,14 @@ impl StorageGateway for StorageGatewayClient {
         &self,
         input: UpdateVTLDeviceTypeInput,
     ) -> RusotoFuture<UpdateVTLDeviceTypeOutput, UpdateVTLDeviceTypeError> {
-        let mut request = SignedRequest::new("POST", "storagegateway", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "storagegateway",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "StorageGateway_20130630.UpdateVTLDeviceType",

--- a/rusoto/services/support/src/generated.rs
+++ b/rusoto/services/support/src/generated.rs
@@ -1459,9 +1459,14 @@ impl AWSSupport for AWSSupportClient {
         &self,
         input: AddAttachmentsToSetRequest,
     ) -> RusotoFuture<AddAttachmentsToSetResponse, AddAttachmentsToSetError> {
-        let mut request = SignedRequest::new("POST", "support", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "support",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSSupport_20130415.AddAttachmentsToSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1487,9 +1492,14 @@ impl AWSSupport for AWSSupportClient {
         &self,
         input: AddCommunicationToCaseRequest,
     ) -> RusotoFuture<AddCommunicationToCaseResponse, AddCommunicationToCaseError> {
-        let mut request = SignedRequest::new("POST", "support", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "support",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSSupport_20130415.AddCommunicationToCase");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1515,9 +1525,14 @@ impl AWSSupport for AWSSupportClient {
         &self,
         input: CreateCaseRequest,
     ) -> RusotoFuture<CreateCaseResponse, CreateCaseError> {
-        let mut request = SignedRequest::new("POST", "support", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "support",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSSupport_20130415.CreateCase");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1544,9 +1559,14 @@ impl AWSSupport for AWSSupportClient {
         &self,
         input: DescribeAttachmentRequest,
     ) -> RusotoFuture<DescribeAttachmentResponse, DescribeAttachmentError> {
-        let mut request = SignedRequest::new("POST", "support", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "support",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSSupport_20130415.DescribeAttachment");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1573,9 +1593,14 @@ impl AWSSupport for AWSSupportClient {
         &self,
         input: DescribeCasesRequest,
     ) -> RusotoFuture<DescribeCasesResponse, DescribeCasesError> {
-        let mut request = SignedRequest::new("POST", "support", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "support",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSSupport_20130415.DescribeCases");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1602,9 +1627,14 @@ impl AWSSupport for AWSSupportClient {
         &self,
         input: DescribeCommunicationsRequest,
     ) -> RusotoFuture<DescribeCommunicationsResponse, DescribeCommunicationsError> {
-        let mut request = SignedRequest::new("POST", "support", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "support",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSSupport_20130415.DescribeCommunications");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1630,9 +1660,14 @@ impl AWSSupport for AWSSupportClient {
         &self,
         input: DescribeServicesRequest,
     ) -> RusotoFuture<DescribeServicesResponse, DescribeServicesError> {
-        let mut request = SignedRequest::new("POST", "support", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "support",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSSupport_20130415.DescribeServices");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1659,9 +1694,14 @@ impl AWSSupport for AWSSupportClient {
         &self,
         input: DescribeSeverityLevelsRequest,
     ) -> RusotoFuture<DescribeSeverityLevelsResponse, DescribeSeverityLevelsError> {
-        let mut request = SignedRequest::new("POST", "support", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "support",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSSupport_20130415.DescribeSeverityLevels");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1690,9 +1730,14 @@ impl AWSSupport for AWSSupportClient {
         DescribeTrustedAdvisorCheckRefreshStatusesResponse,
         DescribeTrustedAdvisorCheckRefreshStatusesError,
     > {
-        let mut request = SignedRequest::new("POST", "support", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "support",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSSupport_20130415.DescribeTrustedAdvisorCheckRefreshStatuses",
@@ -1722,9 +1767,14 @@ impl AWSSupport for AWSSupportClient {
         DescribeTrustedAdvisorCheckResultResponse,
         DescribeTrustedAdvisorCheckResultError,
     > {
-        let mut request = SignedRequest::new("POST", "support", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "support",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSSupport_20130415.DescribeTrustedAdvisorCheckResult",
@@ -1756,9 +1806,14 @@ impl AWSSupport for AWSSupportClient {
         DescribeTrustedAdvisorCheckSummariesResponse,
         DescribeTrustedAdvisorCheckSummariesError,
     > {
-        let mut request = SignedRequest::new("POST", "support", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "support",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSSupport_20130415.DescribeTrustedAdvisorCheckSummaries",
@@ -1787,9 +1842,14 @@ impl AWSSupport for AWSSupportClient {
         &self,
         input: DescribeTrustedAdvisorChecksRequest,
     ) -> RusotoFuture<DescribeTrustedAdvisorChecksResponse, DescribeTrustedAdvisorChecksError> {
-        let mut request = SignedRequest::new("POST", "support", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "support",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSSupport_20130415.DescribeTrustedAdvisorChecks",
@@ -1816,9 +1876,14 @@ impl AWSSupport for AWSSupportClient {
         &self,
         input: RefreshTrustedAdvisorCheckRequest,
     ) -> RusotoFuture<RefreshTrustedAdvisorCheckResponse, RefreshTrustedAdvisorCheckError> {
-        let mut request = SignedRequest::new("POST", "support", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "support",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSSupport_20130415.RefreshTrustedAdvisorCheck",
@@ -1845,9 +1910,14 @@ impl AWSSupport for AWSSupportClient {
         &self,
         input: ResolveCaseRequest,
     ) -> RusotoFuture<ResolveCaseResponse, ResolveCaseError> {
-        let mut request = SignedRequest::new("POST", "support", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "support",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSSupport_20130415.ResolveCase");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/swf/src/generated.rs
+++ b/rusoto/services/swf/src/generated.rs
@@ -4494,9 +4494,14 @@ impl Swf for SwfClient {
         &self,
         input: CountClosedWorkflowExecutionsInput,
     ) -> RusotoFuture<WorkflowExecutionCount, CountClosedWorkflowExecutionsError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header(
             "x-amz-target",
             "SimpleWorkflowService.CountClosedWorkflowExecutions",
@@ -4523,9 +4528,14 @@ impl Swf for SwfClient {
         &self,
         input: CountOpenWorkflowExecutionsInput,
     ) -> RusotoFuture<WorkflowExecutionCount, CountOpenWorkflowExecutionsError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header(
             "x-amz-target",
             "SimpleWorkflowService.CountOpenWorkflowExecutions",
@@ -4552,9 +4562,14 @@ impl Swf for SwfClient {
         &self,
         input: CountPendingActivityTasksInput,
     ) -> RusotoFuture<PendingTaskCount, CountPendingActivityTasksError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header(
             "x-amz-target",
             "SimpleWorkflowService.CountPendingActivityTasks",
@@ -4581,9 +4596,14 @@ impl Swf for SwfClient {
         &self,
         input: CountPendingDecisionTasksInput,
     ) -> RusotoFuture<PendingTaskCount, CountPendingDecisionTasksError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header(
             "x-amz-target",
             "SimpleWorkflowService.CountPendingDecisionTasks",
@@ -4610,9 +4630,14 @@ impl Swf for SwfClient {
         &self,
         input: DeprecateActivityTypeInput,
     ) -> RusotoFuture<(), DeprecateActivityTypeError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header(
             "x-amz-target",
             "SimpleWorkflowService.DeprecateActivityType",
@@ -4638,9 +4663,14 @@ impl Swf for SwfClient {
         &self,
         input: DeprecateDomainInput,
     ) -> RusotoFuture<(), DeprecateDomainError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "SimpleWorkflowService.DeprecateDomain");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4664,9 +4694,14 @@ impl Swf for SwfClient {
         &self,
         input: DeprecateWorkflowTypeInput,
     ) -> RusotoFuture<(), DeprecateWorkflowTypeError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header(
             "x-amz-target",
             "SimpleWorkflowService.DeprecateWorkflowType",
@@ -4692,9 +4727,14 @@ impl Swf for SwfClient {
         &self,
         input: DescribeActivityTypeInput,
     ) -> RusotoFuture<ActivityTypeDetail, DescribeActivityTypeError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "SimpleWorkflowService.DescribeActivityType");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4720,9 +4760,14 @@ impl Swf for SwfClient {
         &self,
         input: DescribeDomainInput,
     ) -> RusotoFuture<DomainDetail, DescribeDomainError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "SimpleWorkflowService.DescribeDomain");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4748,9 +4793,14 @@ impl Swf for SwfClient {
         &self,
         input: DescribeWorkflowExecutionInput,
     ) -> RusotoFuture<WorkflowExecutionDetail, DescribeWorkflowExecutionError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header(
             "x-amz-target",
             "SimpleWorkflowService.DescribeWorkflowExecution",
@@ -4777,9 +4827,14 @@ impl Swf for SwfClient {
         &self,
         input: DescribeWorkflowTypeInput,
     ) -> RusotoFuture<WorkflowTypeDetail, DescribeWorkflowTypeError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "SimpleWorkflowService.DescribeWorkflowType");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4805,9 +4860,14 @@ impl Swf for SwfClient {
         &self,
         input: GetWorkflowExecutionHistoryInput,
     ) -> RusotoFuture<History, GetWorkflowExecutionHistoryError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header(
             "x-amz-target",
             "SimpleWorkflowService.GetWorkflowExecutionHistory",
@@ -4833,9 +4893,14 @@ impl Swf for SwfClient {
         &self,
         input: ListActivityTypesInput,
     ) -> RusotoFuture<ActivityTypeInfos, ListActivityTypesError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "SimpleWorkflowService.ListActivityTypes");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4862,9 +4927,14 @@ impl Swf for SwfClient {
         &self,
         input: ListClosedWorkflowExecutionsInput,
     ) -> RusotoFuture<WorkflowExecutionInfos, ListClosedWorkflowExecutionsError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header(
             "x-amz-target",
             "SimpleWorkflowService.ListClosedWorkflowExecutions",
@@ -4888,9 +4958,14 @@ impl Swf for SwfClient {
 
     /// <p>Returns the list of domains registered in the account. The results may be split into multiple pages. To retrieve subsequent pages, make the call again using the nextPageToken returned by the initial call.</p> <note> <p>This operation is eventually consistent. The results are best effort and may not exactly reflect recent updates and changes.</p> </note> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this action's access to Amazon SWF resources as follows:</p> <ul> <li> <p>Use a <code>Resource</code> element with the domain name to limit the action to only specified domains. The element must be set to <code>arn:aws:swf::AccountID:domain/*</code>, where <i>AccountID</i> is the account ID, with no dashes.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>You cannot use an IAM policy to constrain this action's parameters.</p> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>
     fn list_domains(&self, input: ListDomainsInput) -> RusotoFuture<DomainInfos, ListDomainsError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "SimpleWorkflowService.ListDomains");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4916,9 +4991,14 @@ impl Swf for SwfClient {
         &self,
         input: ListOpenWorkflowExecutionsInput,
     ) -> RusotoFuture<WorkflowExecutionInfos, ListOpenWorkflowExecutionsError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header(
             "x-amz-target",
             "SimpleWorkflowService.ListOpenWorkflowExecutions",
@@ -4945,9 +5025,14 @@ impl Swf for SwfClient {
         &self,
         input: ListWorkflowTypesInput,
     ) -> RusotoFuture<WorkflowTypeInfos, ListWorkflowTypesError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "SimpleWorkflowService.ListWorkflowTypes");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4974,9 +5059,14 @@ impl Swf for SwfClient {
         &self,
         input: PollForActivityTaskInput,
     ) -> RusotoFuture<ActivityTask, PollForActivityTaskError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "SimpleWorkflowService.PollForActivityTask");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5001,9 +5091,14 @@ impl Swf for SwfClient {
         &self,
         input: PollForDecisionTaskInput,
     ) -> RusotoFuture<DecisionTask, PollForDecisionTaskError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "SimpleWorkflowService.PollForDecisionTask");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5028,9 +5123,14 @@ impl Swf for SwfClient {
         &self,
         input: RecordActivityTaskHeartbeatInput,
     ) -> RusotoFuture<ActivityTaskStatus, RecordActivityTaskHeartbeatError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header(
             "x-amz-target",
             "SimpleWorkflowService.RecordActivityTaskHeartbeat",
@@ -5057,9 +5157,14 @@ impl Swf for SwfClient {
         &self,
         input: RegisterActivityTypeInput,
     ) -> RusotoFuture<(), RegisterActivityTypeError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "SimpleWorkflowService.RegisterActivityType");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5079,9 +5184,14 @@ impl Swf for SwfClient {
 
     /// <p>Registers a new domain.</p> <p> <b>Access Control</b> </p> <p>You can use IAM policies to control this action's access to Amazon SWF resources as follows:</p> <ul> <li> <p>You cannot use an IAM policy to control domain access for this action. The name of the domain being registered is available as the resource of this action.</p> </li> <li> <p>Use an <code>Action</code> element to allow or deny permission to call this action.</p> </li> <li> <p>You cannot use an IAM policy to constrain this action's parameters.</p> </li> </ul> <p>If the caller doesn't have sufficient permissions to invoke the action, or the parameter values fall outside the specified constraints, the action fails. The associated event attribute's <code>cause</code> parameter is set to <code>OPERATION_NOT_PERMITTED</code>. For details and example IAM policies, see <a href="http://docs.aws.amazon.com/amazonswf/latest/developerguide/swf-dev-iam.html">Using IAM to Manage Access to Amazon SWF Workflows</a> in the <i>Amazon SWF Developer Guide</i>.</p>
     fn register_domain(&self, input: RegisterDomainInput) -> RusotoFuture<(), RegisterDomainError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "SimpleWorkflowService.RegisterDomain");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5105,9 +5215,14 @@ impl Swf for SwfClient {
         &self,
         input: RegisterWorkflowTypeInput,
     ) -> RusotoFuture<(), RegisterWorkflowTypeError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header("x-amz-target", "SimpleWorkflowService.RegisterWorkflowType");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -5130,9 +5245,14 @@ impl Swf for SwfClient {
         &self,
         input: RequestCancelWorkflowExecutionInput,
     ) -> RusotoFuture<(), RequestCancelWorkflowExecutionError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header(
             "x-amz-target",
             "SimpleWorkflowService.RequestCancelWorkflowExecution",
@@ -5156,9 +5276,14 @@ impl Swf for SwfClient {
         &self,
         input: RespondActivityTaskCanceledInput,
     ) -> RusotoFuture<(), RespondActivityTaskCanceledError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header(
             "x-amz-target",
             "SimpleWorkflowService.RespondActivityTaskCanceled",
@@ -5182,9 +5307,14 @@ impl Swf for SwfClient {
         &self,
         input: RespondActivityTaskCompletedInput,
     ) -> RusotoFuture<(), RespondActivityTaskCompletedError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header(
             "x-amz-target",
             "SimpleWorkflowService.RespondActivityTaskCompleted",
@@ -5208,9 +5338,14 @@ impl Swf for SwfClient {
         &self,
         input: RespondActivityTaskFailedInput,
     ) -> RusotoFuture<(), RespondActivityTaskFailedError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header(
             "x-amz-target",
             "SimpleWorkflowService.RespondActivityTaskFailed",
@@ -5234,9 +5369,14 @@ impl Swf for SwfClient {
         &self,
         input: RespondDecisionTaskCompletedInput,
     ) -> RusotoFuture<(), RespondDecisionTaskCompletedError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header(
             "x-amz-target",
             "SimpleWorkflowService.RespondDecisionTaskCompleted",
@@ -5260,9 +5400,14 @@ impl Swf for SwfClient {
         &self,
         input: SignalWorkflowExecutionInput,
     ) -> RusotoFuture<(), SignalWorkflowExecutionError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header(
             "x-amz-target",
             "SimpleWorkflowService.SignalWorkflowExecution",
@@ -5286,9 +5431,14 @@ impl Swf for SwfClient {
         &self,
         input: StartWorkflowExecutionInput,
     ) -> RusotoFuture<Run, StartWorkflowExecutionError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header(
             "x-amz-target",
             "SimpleWorkflowService.StartWorkflowExecution",
@@ -5316,9 +5466,14 @@ impl Swf for SwfClient {
         &self,
         input: TerminateWorkflowExecutionInput,
     ) -> RusotoFuture<(), TerminateWorkflowExecutionError> {
-        let mut request = SignedRequest::new("POST", "swf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "swf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.0",
+        );
 
-        request.set_content_type("application/x-amz-json-1.0".to_owned());
         request.add_header(
             "x-amz-target",
             "SimpleWorkflowService.TerminateWorkflowExecution",

--- a/rusoto/services/transcribe/src/generated.rs
+++ b/rusoto/services/transcribe/src/generated.rs
@@ -972,9 +972,14 @@ impl Transcribe for TranscribeClient {
         &self,
         input: CreateVocabularyRequest,
     ) -> RusotoFuture<CreateVocabularyResponse, CreateVocabularyError> {
-        let mut request = SignedRequest::new("POST", "transcribe", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "transcribe",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Transcribe.CreateVocabulary");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1001,9 +1006,14 @@ impl Transcribe for TranscribeClient {
         &self,
         input: DeleteTranscriptionJobRequest,
     ) -> RusotoFuture<(), DeleteTranscriptionJobError> {
-        let mut request = SignedRequest::new("POST", "transcribe", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "transcribe",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Transcribe.DeleteTranscriptionJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1026,9 +1036,14 @@ impl Transcribe for TranscribeClient {
         &self,
         input: DeleteVocabularyRequest,
     ) -> RusotoFuture<(), DeleteVocabularyError> {
-        let mut request = SignedRequest::new("POST", "transcribe", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "transcribe",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Transcribe.DeleteVocabulary");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1052,9 +1067,14 @@ impl Transcribe for TranscribeClient {
         &self,
         input: GetTranscriptionJobRequest,
     ) -> RusotoFuture<GetTranscriptionJobResponse, GetTranscriptionJobError> {
-        let mut request = SignedRequest::new("POST", "transcribe", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "transcribe",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Transcribe.GetTranscriptionJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1080,9 +1100,14 @@ impl Transcribe for TranscribeClient {
         &self,
         input: GetVocabularyRequest,
     ) -> RusotoFuture<GetVocabularyResponse, GetVocabularyError> {
-        let mut request = SignedRequest::new("POST", "transcribe", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "transcribe",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Transcribe.GetVocabulary");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1109,9 +1134,14 @@ impl Transcribe for TranscribeClient {
         &self,
         input: ListTranscriptionJobsRequest,
     ) -> RusotoFuture<ListTranscriptionJobsResponse, ListTranscriptionJobsError> {
-        let mut request = SignedRequest::new("POST", "transcribe", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "transcribe",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Transcribe.ListTranscriptionJobs");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1137,9 +1167,14 @@ impl Transcribe for TranscribeClient {
         &self,
         input: ListVocabulariesRequest,
     ) -> RusotoFuture<ListVocabulariesResponse, ListVocabulariesError> {
-        let mut request = SignedRequest::new("POST", "transcribe", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "transcribe",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Transcribe.ListVocabularies");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1166,9 +1201,14 @@ impl Transcribe for TranscribeClient {
         &self,
         input: StartTranscriptionJobRequest,
     ) -> RusotoFuture<StartTranscriptionJobResponse, StartTranscriptionJobError> {
-        let mut request = SignedRequest::new("POST", "transcribe", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "transcribe",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Transcribe.StartTranscriptionJob");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -1194,9 +1234,14 @@ impl Transcribe for TranscribeClient {
         &self,
         input: UpdateVocabularyRequest,
     ) -> RusotoFuture<UpdateVocabularyResponse, UpdateVocabularyError> {
-        let mut request = SignedRequest::new("POST", "transcribe", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "transcribe",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "Transcribe.UpdateVocabulary");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/translate/src/generated.rs
+++ b/rusoto/services/translate/src/generated.rs
@@ -608,9 +608,14 @@ impl Translate for TranslateClient {
         &self,
         input: DeleteTerminologyRequest,
     ) -> RusotoFuture<(), DeleteTerminologyError> {
-        let mut request = SignedRequest::new("POST", "translate", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "translate",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSShineFrontendService_20170701.DeleteTerminology",
@@ -637,9 +642,14 @@ impl Translate for TranslateClient {
         &self,
         input: GetTerminologyRequest,
     ) -> RusotoFuture<GetTerminologyResponse, GetTerminologyError> {
-        let mut request = SignedRequest::new("POST", "translate", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "translate",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSShineFrontendService_20170701.GetTerminology",
@@ -669,9 +679,14 @@ impl Translate for TranslateClient {
         &self,
         input: ImportTerminologyRequest,
     ) -> RusotoFuture<ImportTerminologyResponse, ImportTerminologyError> {
-        let mut request = SignedRequest::new("POST", "translate", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "translate",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSShineFrontendService_20170701.ImportTerminology",
@@ -701,9 +716,14 @@ impl Translate for TranslateClient {
         &self,
         input: ListTerminologiesRequest,
     ) -> RusotoFuture<ListTerminologiesResponse, ListTerminologiesError> {
-        let mut request = SignedRequest::new("POST", "translate", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "translate",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSShineFrontendService_20170701.ListTerminologies",
@@ -733,9 +753,14 @@ impl Translate for TranslateClient {
         &self,
         input: TranslateTextRequest,
     ) -> RusotoFuture<TranslateTextResponse, TranslateTextError> {
-        let mut request = SignedRequest::new("POST", "translate", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "translate",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSShineFrontendService_20170701.TranslateText",

--- a/rusoto/services/waf-regional/src/generated.rs
+++ b/rusoto/services/waf-regional/src/generated.rs
@@ -7434,9 +7434,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: AssociateWebACLRequest,
     ) -> RusotoFuture<AssociateWebACLResponse, AssociateWebACLError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.AssociateWebACL");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7463,9 +7468,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: CreateByteMatchSetRequest,
     ) -> RusotoFuture<CreateByteMatchSetResponse, CreateByteMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.CreateByteMatchSet",
@@ -7495,9 +7505,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: CreateGeoMatchSetRequest,
     ) -> RusotoFuture<CreateGeoMatchSetResponse, CreateGeoMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.CreateGeoMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7524,9 +7539,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: CreateIPSetRequest,
     ) -> RusotoFuture<CreateIPSetResponse, CreateIPSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.CreateIPSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7553,9 +7573,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: CreateRateBasedRuleRequest,
     ) -> RusotoFuture<CreateRateBasedRuleResponse, CreateRateBasedRuleError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.CreateRateBasedRule",
@@ -7584,9 +7609,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: CreateRegexMatchSetRequest,
     ) -> RusotoFuture<CreateRegexMatchSetResponse, CreateRegexMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.CreateRegexMatchSet",
@@ -7615,9 +7645,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: CreateRegexPatternSetRequest,
     ) -> RusotoFuture<CreateRegexPatternSetResponse, CreateRegexPatternSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.CreateRegexPatternSet",
@@ -7646,9 +7681,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: CreateRuleRequest,
     ) -> RusotoFuture<CreateRuleResponse, CreateRuleError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.CreateRule");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7675,9 +7715,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: CreateRuleGroupRequest,
     ) -> RusotoFuture<CreateRuleGroupResponse, CreateRuleGroupError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.CreateRuleGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7704,9 +7749,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: CreateSizeConstraintSetRequest,
     ) -> RusotoFuture<CreateSizeConstraintSetResponse, CreateSizeConstraintSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.CreateSizeConstraintSet",
@@ -7733,9 +7783,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: CreateSqlInjectionMatchSetRequest,
     ) -> RusotoFuture<CreateSqlInjectionMatchSetResponse, CreateSqlInjectionMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.CreateSqlInjectionMatchSet",
@@ -7762,9 +7817,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: CreateWebACLRequest,
     ) -> RusotoFuture<CreateWebACLResponse, CreateWebACLError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.CreateWebACL");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7791,9 +7851,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: CreateXssMatchSetRequest,
     ) -> RusotoFuture<CreateXssMatchSetResponse, CreateXssMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.CreateXssMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7820,9 +7885,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: DeleteByteMatchSetRequest,
     ) -> RusotoFuture<DeleteByteMatchSetResponse, DeleteByteMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.DeleteByteMatchSet",
@@ -7852,9 +7922,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: DeleteGeoMatchSetRequest,
     ) -> RusotoFuture<DeleteGeoMatchSetResponse, DeleteGeoMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.DeleteGeoMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7881,9 +7956,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: DeleteIPSetRequest,
     ) -> RusotoFuture<DeleteIPSetResponse, DeleteIPSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.DeleteIPSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7910,9 +7990,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: DeleteLoggingConfigurationRequest,
     ) -> RusotoFuture<DeleteLoggingConfigurationResponse, DeleteLoggingConfigurationError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.DeleteLoggingConfiguration",
@@ -7939,9 +8024,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: DeletePermissionPolicyRequest,
     ) -> RusotoFuture<DeletePermissionPolicyResponse, DeletePermissionPolicyError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.DeletePermissionPolicy",
@@ -7970,9 +8060,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: DeleteRateBasedRuleRequest,
     ) -> RusotoFuture<DeleteRateBasedRuleResponse, DeleteRateBasedRuleError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.DeleteRateBasedRule",
@@ -8001,9 +8096,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: DeleteRegexMatchSetRequest,
     ) -> RusotoFuture<DeleteRegexMatchSetResponse, DeleteRegexMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.DeleteRegexMatchSet",
@@ -8032,9 +8132,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: DeleteRegexPatternSetRequest,
     ) -> RusotoFuture<DeleteRegexPatternSetResponse, DeleteRegexPatternSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.DeleteRegexPatternSet",
@@ -8063,9 +8168,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: DeleteRuleRequest,
     ) -> RusotoFuture<DeleteRuleResponse, DeleteRuleError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.DeleteRule");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8092,9 +8202,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: DeleteRuleGroupRequest,
     ) -> RusotoFuture<DeleteRuleGroupResponse, DeleteRuleGroupError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.DeleteRuleGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8121,9 +8236,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: DeleteSizeConstraintSetRequest,
     ) -> RusotoFuture<DeleteSizeConstraintSetResponse, DeleteSizeConstraintSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.DeleteSizeConstraintSet",
@@ -8150,9 +8270,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: DeleteSqlInjectionMatchSetRequest,
     ) -> RusotoFuture<DeleteSqlInjectionMatchSetResponse, DeleteSqlInjectionMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.DeleteSqlInjectionMatchSet",
@@ -8179,9 +8304,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: DeleteWebACLRequest,
     ) -> RusotoFuture<DeleteWebACLResponse, DeleteWebACLError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.DeleteWebACL");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8208,9 +8338,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: DeleteXssMatchSetRequest,
     ) -> RusotoFuture<DeleteXssMatchSetResponse, DeleteXssMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.DeleteXssMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8237,9 +8372,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: DisassociateWebACLRequest,
     ) -> RusotoFuture<DisassociateWebACLResponse, DisassociateWebACLError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.DisassociateWebACL",
@@ -8269,9 +8409,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: GetByteMatchSetRequest,
     ) -> RusotoFuture<GetByteMatchSetResponse, GetByteMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.GetByteMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8295,9 +8440,14 @@ impl WAFRegional for WAFRegionalClient {
 
     /// <p>When you want to create, update, or delete AWS WAF objects, get a change token and include the change token in the create, update, or delete request. Change tokens ensure that your application doesn't submit conflicting requests to AWS WAF.</p> <p>Each create, update, or delete request must use a unique change token. If your application submits a <code>GetChangeToken</code> request and then submits a second <code>GetChangeToken</code> request before submitting a create, update, or delete request, the second <code>GetChangeToken</code> request returns the same value as the first <code>GetChangeToken</code> request.</p> <p>When you use a change token in a create, update, or delete request, the status of the change token changes to <code>PENDING</code>, which indicates that AWS WAF is propagating the change to all AWS WAF servers. Use <code>GetChangeTokenStatus</code> to determine the status of your change token.</p>
     fn get_change_token(&self) -> RusotoFuture<GetChangeTokenResponse, GetChangeTokenError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.GetChangeToken");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -8323,9 +8473,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: GetChangeTokenStatusRequest,
     ) -> RusotoFuture<GetChangeTokenStatusResponse, GetChangeTokenStatusError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.GetChangeTokenStatus",
@@ -8354,9 +8509,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: GetGeoMatchSetRequest,
     ) -> RusotoFuture<GetGeoMatchSetResponse, GetGeoMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.GetGeoMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8380,9 +8540,14 @@ impl WAFRegional for WAFRegionalClient {
 
     /// <p>Returns the <a>IPSet</a> that is specified by <code>IPSetId</code>.</p>
     fn get_ip_set(&self, input: GetIPSetRequest) -> RusotoFuture<GetIPSetResponse, GetIPSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.GetIPSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8409,9 +8574,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: GetLoggingConfigurationRequest,
     ) -> RusotoFuture<GetLoggingConfigurationResponse, GetLoggingConfigurationError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.GetLoggingConfiguration",
@@ -8438,9 +8608,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: GetPermissionPolicyRequest,
     ) -> RusotoFuture<GetPermissionPolicyResponse, GetPermissionPolicyError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.GetPermissionPolicy",
@@ -8469,9 +8644,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: GetRateBasedRuleRequest,
     ) -> RusotoFuture<GetRateBasedRuleResponse, GetRateBasedRuleError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.GetRateBasedRule");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8498,9 +8678,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: GetRateBasedRuleManagedKeysRequest,
     ) -> RusotoFuture<GetRateBasedRuleManagedKeysResponse, GetRateBasedRuleManagedKeysError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.GetRateBasedRuleManagedKeys",
@@ -8527,9 +8712,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: GetRegexMatchSetRequest,
     ) -> RusotoFuture<GetRegexMatchSetResponse, GetRegexMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.GetRegexMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8556,9 +8746,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: GetRegexPatternSetRequest,
     ) -> RusotoFuture<GetRegexPatternSetResponse, GetRegexPatternSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.GetRegexPatternSet",
@@ -8585,9 +8780,14 @@ impl WAFRegional for WAFRegionalClient {
 
     /// <p>Returns the <a>Rule</a> that is specified by the <code>RuleId</code> that you included in the <code>GetRule</code> request.</p>
     fn get_rule(&self, input: GetRuleRequest) -> RusotoFuture<GetRuleResponse, GetRuleError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.GetRule");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8613,9 +8813,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: GetRuleGroupRequest,
     ) -> RusotoFuture<GetRuleGroupResponse, GetRuleGroupError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.GetRuleGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8642,9 +8847,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: GetSampledRequestsRequest,
     ) -> RusotoFuture<GetSampledRequestsResponse, GetSampledRequestsError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.GetSampledRequests",
@@ -8674,9 +8884,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: GetSizeConstraintSetRequest,
     ) -> RusotoFuture<GetSizeConstraintSetResponse, GetSizeConstraintSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.GetSizeConstraintSet",
@@ -8705,9 +8920,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: GetSqlInjectionMatchSetRequest,
     ) -> RusotoFuture<GetSqlInjectionMatchSetResponse, GetSqlInjectionMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.GetSqlInjectionMatchSet",
@@ -8734,9 +8954,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: GetWebACLRequest,
     ) -> RusotoFuture<GetWebACLResponse, GetWebACLError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.GetWebACL");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8763,9 +8988,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: GetWebACLForResourceRequest,
     ) -> RusotoFuture<GetWebACLForResourceResponse, GetWebACLForResourceError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.GetWebACLForResource",
@@ -8794,9 +9024,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: GetXssMatchSetRequest,
     ) -> RusotoFuture<GetXssMatchSetResponse, GetXssMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.GetXssMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8824,9 +9059,14 @@ impl WAFRegional for WAFRegionalClient {
         input: ListActivatedRulesInRuleGroupRequest,
     ) -> RusotoFuture<ListActivatedRulesInRuleGroupResponse, ListActivatedRulesInRuleGroupError>
     {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.ListActivatedRulesInRuleGroup",
@@ -8853,9 +9093,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: ListByteMatchSetsRequest,
     ) -> RusotoFuture<ListByteMatchSetsResponse, ListByteMatchSetsError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.ListByteMatchSets");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8882,9 +9127,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: ListGeoMatchSetsRequest,
     ) -> RusotoFuture<ListGeoMatchSetsResponse, ListGeoMatchSetsError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.ListGeoMatchSets");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8911,9 +9161,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: ListIPSetsRequest,
     ) -> RusotoFuture<ListIPSetsResponse, ListIPSetsError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.ListIPSets");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8940,9 +9195,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: ListLoggingConfigurationsRequest,
     ) -> RusotoFuture<ListLoggingConfigurationsResponse, ListLoggingConfigurationsError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.ListLoggingConfigurations",
@@ -8969,9 +9229,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: ListRateBasedRulesRequest,
     ) -> RusotoFuture<ListRateBasedRulesResponse, ListRateBasedRulesError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.ListRateBasedRules",
@@ -9001,9 +9266,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: ListRegexMatchSetsRequest,
     ) -> RusotoFuture<ListRegexMatchSetsResponse, ListRegexMatchSetsError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.ListRegexMatchSets",
@@ -9033,9 +9303,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: ListRegexPatternSetsRequest,
     ) -> RusotoFuture<ListRegexPatternSetsResponse, ListRegexPatternSetsError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.ListRegexPatternSets",
@@ -9064,9 +9339,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: ListResourcesForWebACLRequest,
     ) -> RusotoFuture<ListResourcesForWebACLResponse, ListResourcesForWebACLError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.ListResourcesForWebACL",
@@ -9095,9 +9375,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: ListRuleGroupsRequest,
     ) -> RusotoFuture<ListRuleGroupsResponse, ListRuleGroupsError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.ListRuleGroups");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9124,9 +9409,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: ListRulesRequest,
     ) -> RusotoFuture<ListRulesResponse, ListRulesError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.ListRules");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9153,9 +9443,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: ListSizeConstraintSetsRequest,
     ) -> RusotoFuture<ListSizeConstraintSetsResponse, ListSizeConstraintSetsError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.ListSizeConstraintSets",
@@ -9184,9 +9479,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: ListSqlInjectionMatchSetsRequest,
     ) -> RusotoFuture<ListSqlInjectionMatchSetsResponse, ListSqlInjectionMatchSetsError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.ListSqlInjectionMatchSets",
@@ -9213,9 +9513,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: ListSubscribedRuleGroupsRequest,
     ) -> RusotoFuture<ListSubscribedRuleGroupsResponse, ListSubscribedRuleGroupsError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.ListSubscribedRuleGroups",
@@ -9242,9 +9547,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: ListWebACLsRequest,
     ) -> RusotoFuture<ListWebACLsResponse, ListWebACLsError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.ListWebACLs");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9271,9 +9581,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: ListXssMatchSetsRequest,
     ) -> RusotoFuture<ListXssMatchSetsResponse, ListXssMatchSetsError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.ListXssMatchSets");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9300,9 +9615,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: PutLoggingConfigurationRequest,
     ) -> RusotoFuture<PutLoggingConfigurationResponse, PutLoggingConfigurationError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.PutLoggingConfiguration",
@@ -9329,9 +9649,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: PutPermissionPolicyRequest,
     ) -> RusotoFuture<PutPermissionPolicyResponse, PutPermissionPolicyError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.PutPermissionPolicy",
@@ -9360,9 +9685,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: UpdateByteMatchSetRequest,
     ) -> RusotoFuture<UpdateByteMatchSetResponse, UpdateByteMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.UpdateByteMatchSet",
@@ -9392,9 +9722,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: UpdateGeoMatchSetRequest,
     ) -> RusotoFuture<UpdateGeoMatchSetResponse, UpdateGeoMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.UpdateGeoMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9421,9 +9756,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: UpdateIPSetRequest,
     ) -> RusotoFuture<UpdateIPSetResponse, UpdateIPSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.UpdateIPSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9450,9 +9790,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: UpdateRateBasedRuleRequest,
     ) -> RusotoFuture<UpdateRateBasedRuleResponse, UpdateRateBasedRuleError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.UpdateRateBasedRule",
@@ -9481,9 +9826,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: UpdateRegexMatchSetRequest,
     ) -> RusotoFuture<UpdateRegexMatchSetResponse, UpdateRegexMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.UpdateRegexMatchSet",
@@ -9512,9 +9862,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: UpdateRegexPatternSetRequest,
     ) -> RusotoFuture<UpdateRegexPatternSetResponse, UpdateRegexPatternSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.UpdateRegexPatternSet",
@@ -9543,9 +9898,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: UpdateRuleRequest,
     ) -> RusotoFuture<UpdateRuleResponse, UpdateRuleError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.UpdateRule");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9572,9 +9932,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: UpdateRuleGroupRequest,
     ) -> RusotoFuture<UpdateRuleGroupResponse, UpdateRuleGroupError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.UpdateRuleGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9601,9 +9966,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: UpdateSizeConstraintSetRequest,
     ) -> RusotoFuture<UpdateSizeConstraintSetResponse, UpdateSizeConstraintSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.UpdateSizeConstraintSet",
@@ -9630,9 +10000,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: UpdateSqlInjectionMatchSetRequest,
     ) -> RusotoFuture<UpdateSqlInjectionMatchSetResponse, UpdateSqlInjectionMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_Regional_20161128.UpdateSqlInjectionMatchSet",
@@ -9659,9 +10034,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: UpdateWebACLRequest,
     ) -> RusotoFuture<UpdateWebACLResponse, UpdateWebACLError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.UpdateWebACL");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9688,9 +10068,14 @@ impl WAFRegional for WAFRegionalClient {
         &self,
         input: UpdateXssMatchSetRequest,
     ) -> RusotoFuture<UpdateXssMatchSetResponse, UpdateXssMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf-regional", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf-regional",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_Regional_20161128.UpdateXssMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/waf/src/generated.rs
+++ b/rusoto/services/waf/src/generated.rs
@@ -7107,9 +7107,14 @@ impl Waf for WafClient {
         &self,
         input: CreateByteMatchSetRequest,
     ) -> RusotoFuture<CreateByteMatchSetResponse, CreateByteMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.CreateByteMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7136,9 +7141,14 @@ impl Waf for WafClient {
         &self,
         input: CreateGeoMatchSetRequest,
     ) -> RusotoFuture<CreateGeoMatchSetResponse, CreateGeoMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.CreateGeoMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7165,9 +7175,14 @@ impl Waf for WafClient {
         &self,
         input: CreateIPSetRequest,
     ) -> RusotoFuture<CreateIPSetResponse, CreateIPSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.CreateIPSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7194,9 +7209,14 @@ impl Waf for WafClient {
         &self,
         input: CreateRateBasedRuleRequest,
     ) -> RusotoFuture<CreateRateBasedRuleResponse, CreateRateBasedRuleError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.CreateRateBasedRule");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7222,9 +7242,14 @@ impl Waf for WafClient {
         &self,
         input: CreateRegexMatchSetRequest,
     ) -> RusotoFuture<CreateRegexMatchSetResponse, CreateRegexMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.CreateRegexMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7250,9 +7275,14 @@ impl Waf for WafClient {
         &self,
         input: CreateRegexPatternSetRequest,
     ) -> RusotoFuture<CreateRegexPatternSetResponse, CreateRegexPatternSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.CreateRegexPatternSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7278,9 +7308,14 @@ impl Waf for WafClient {
         &self,
         input: CreateRuleRequest,
     ) -> RusotoFuture<CreateRuleResponse, CreateRuleError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.CreateRule");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7307,9 +7342,14 @@ impl Waf for WafClient {
         &self,
         input: CreateRuleGroupRequest,
     ) -> RusotoFuture<CreateRuleGroupResponse, CreateRuleGroupError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.CreateRuleGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7336,9 +7376,14 @@ impl Waf for WafClient {
         &self,
         input: CreateSizeConstraintSetRequest,
     ) -> RusotoFuture<CreateSizeConstraintSetResponse, CreateSizeConstraintSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.CreateSizeConstraintSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7362,9 +7407,14 @@ impl Waf for WafClient {
         &self,
         input: CreateSqlInjectionMatchSetRequest,
     ) -> RusotoFuture<CreateSqlInjectionMatchSetResponse, CreateSqlInjectionMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.CreateSqlInjectionMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7388,9 +7438,14 @@ impl Waf for WafClient {
         &self,
         input: CreateWebACLRequest,
     ) -> RusotoFuture<CreateWebACLResponse, CreateWebACLError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.CreateWebACL");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7417,9 +7472,14 @@ impl Waf for WafClient {
         &self,
         input: CreateXssMatchSetRequest,
     ) -> RusotoFuture<CreateXssMatchSetResponse, CreateXssMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.CreateXssMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7446,9 +7506,14 @@ impl Waf for WafClient {
         &self,
         input: DeleteByteMatchSetRequest,
     ) -> RusotoFuture<DeleteByteMatchSetResponse, DeleteByteMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.DeleteByteMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7475,9 +7540,14 @@ impl Waf for WafClient {
         &self,
         input: DeleteGeoMatchSetRequest,
     ) -> RusotoFuture<DeleteGeoMatchSetResponse, DeleteGeoMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.DeleteGeoMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7504,9 +7574,14 @@ impl Waf for WafClient {
         &self,
         input: DeleteIPSetRequest,
     ) -> RusotoFuture<DeleteIPSetResponse, DeleteIPSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.DeleteIPSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7533,9 +7608,14 @@ impl Waf for WafClient {
         &self,
         input: DeleteLoggingConfigurationRequest,
     ) -> RusotoFuture<DeleteLoggingConfigurationResponse, DeleteLoggingConfigurationError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.DeleteLoggingConfiguration");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7559,9 +7639,14 @@ impl Waf for WafClient {
         &self,
         input: DeletePermissionPolicyRequest,
     ) -> RusotoFuture<DeletePermissionPolicyResponse, DeletePermissionPolicyError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.DeletePermissionPolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7587,9 +7672,14 @@ impl Waf for WafClient {
         &self,
         input: DeleteRateBasedRuleRequest,
     ) -> RusotoFuture<DeleteRateBasedRuleResponse, DeleteRateBasedRuleError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.DeleteRateBasedRule");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7615,9 +7705,14 @@ impl Waf for WafClient {
         &self,
         input: DeleteRegexMatchSetRequest,
     ) -> RusotoFuture<DeleteRegexMatchSetResponse, DeleteRegexMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.DeleteRegexMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7643,9 +7738,14 @@ impl Waf for WafClient {
         &self,
         input: DeleteRegexPatternSetRequest,
     ) -> RusotoFuture<DeleteRegexPatternSetResponse, DeleteRegexPatternSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.DeleteRegexPatternSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7671,9 +7771,14 @@ impl Waf for WafClient {
         &self,
         input: DeleteRuleRequest,
     ) -> RusotoFuture<DeleteRuleResponse, DeleteRuleError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.DeleteRule");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7700,9 +7805,14 @@ impl Waf for WafClient {
         &self,
         input: DeleteRuleGroupRequest,
     ) -> RusotoFuture<DeleteRuleGroupResponse, DeleteRuleGroupError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.DeleteRuleGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7729,9 +7839,14 @@ impl Waf for WafClient {
         &self,
         input: DeleteSizeConstraintSetRequest,
     ) -> RusotoFuture<DeleteSizeConstraintSetResponse, DeleteSizeConstraintSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.DeleteSizeConstraintSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7755,9 +7870,14 @@ impl Waf for WafClient {
         &self,
         input: DeleteSqlInjectionMatchSetRequest,
     ) -> RusotoFuture<DeleteSqlInjectionMatchSetResponse, DeleteSqlInjectionMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.DeleteSqlInjectionMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7781,9 +7901,14 @@ impl Waf for WafClient {
         &self,
         input: DeleteWebACLRequest,
     ) -> RusotoFuture<DeleteWebACLResponse, DeleteWebACLError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.DeleteWebACL");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7810,9 +7935,14 @@ impl Waf for WafClient {
         &self,
         input: DeleteXssMatchSetRequest,
     ) -> RusotoFuture<DeleteXssMatchSetResponse, DeleteXssMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.DeleteXssMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7839,9 +7969,14 @@ impl Waf for WafClient {
         &self,
         input: GetByteMatchSetRequest,
     ) -> RusotoFuture<GetByteMatchSetResponse, GetByteMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.GetByteMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7865,9 +8000,14 @@ impl Waf for WafClient {
 
     /// <p>When you want to create, update, or delete AWS WAF objects, get a change token and include the change token in the create, update, or delete request. Change tokens ensure that your application doesn't submit conflicting requests to AWS WAF.</p> <p>Each create, update, or delete request must use a unique change token. If your application submits a <code>GetChangeToken</code> request and then submits a second <code>GetChangeToken</code> request before submitting a create, update, or delete request, the second <code>GetChangeToken</code> request returns the same value as the first <code>GetChangeToken</code> request.</p> <p>When you use a change token in a create, update, or delete request, the status of the change token changes to <code>PENDING</code>, which indicates that AWS WAF is propagating the change to all AWS WAF servers. Use <code>GetChangeTokenStatus</code> to determine the status of your change token.</p>
     fn get_change_token(&self) -> RusotoFuture<GetChangeTokenResponse, GetChangeTokenError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.GetChangeToken");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -7893,9 +8033,14 @@ impl Waf for WafClient {
         &self,
         input: GetChangeTokenStatusRequest,
     ) -> RusotoFuture<GetChangeTokenStatusResponse, GetChangeTokenStatusError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.GetChangeTokenStatus");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7921,9 +8066,14 @@ impl Waf for WafClient {
         &self,
         input: GetGeoMatchSetRequest,
     ) -> RusotoFuture<GetGeoMatchSetResponse, GetGeoMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.GetGeoMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7947,9 +8097,14 @@ impl Waf for WafClient {
 
     /// <p>Returns the <a>IPSet</a> that is specified by <code>IPSetId</code>.</p>
     fn get_ip_set(&self, input: GetIPSetRequest) -> RusotoFuture<GetIPSetResponse, GetIPSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.GetIPSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -7976,9 +8131,14 @@ impl Waf for WafClient {
         &self,
         input: GetLoggingConfigurationRequest,
     ) -> RusotoFuture<GetLoggingConfigurationResponse, GetLoggingConfigurationError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.GetLoggingConfiguration");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8002,9 +8162,14 @@ impl Waf for WafClient {
         &self,
         input: GetPermissionPolicyRequest,
     ) -> RusotoFuture<GetPermissionPolicyResponse, GetPermissionPolicyError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.GetPermissionPolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8030,9 +8195,14 @@ impl Waf for WafClient {
         &self,
         input: GetRateBasedRuleRequest,
     ) -> RusotoFuture<GetRateBasedRuleResponse, GetRateBasedRuleError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.GetRateBasedRule");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8059,9 +8229,14 @@ impl Waf for WafClient {
         &self,
         input: GetRateBasedRuleManagedKeysRequest,
     ) -> RusotoFuture<GetRateBasedRuleManagedKeysResponse, GetRateBasedRuleManagedKeysError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_20150824.GetRateBasedRuleManagedKeys",
@@ -8088,9 +8263,14 @@ impl Waf for WafClient {
         &self,
         input: GetRegexMatchSetRequest,
     ) -> RusotoFuture<GetRegexMatchSetResponse, GetRegexMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.GetRegexMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8117,9 +8297,14 @@ impl Waf for WafClient {
         &self,
         input: GetRegexPatternSetRequest,
     ) -> RusotoFuture<GetRegexPatternSetResponse, GetRegexPatternSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.GetRegexPatternSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8143,9 +8328,14 @@ impl Waf for WafClient {
 
     /// <p>Returns the <a>Rule</a> that is specified by the <code>RuleId</code> that you included in the <code>GetRule</code> request.</p>
     fn get_rule(&self, input: GetRuleRequest) -> RusotoFuture<GetRuleResponse, GetRuleError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.GetRule");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8171,9 +8361,14 @@ impl Waf for WafClient {
         &self,
         input: GetRuleGroupRequest,
     ) -> RusotoFuture<GetRuleGroupResponse, GetRuleGroupError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.GetRuleGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8200,9 +8395,14 @@ impl Waf for WafClient {
         &self,
         input: GetSampledRequestsRequest,
     ) -> RusotoFuture<GetSampledRequestsResponse, GetSampledRequestsError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.GetSampledRequests");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8229,9 +8429,14 @@ impl Waf for WafClient {
         &self,
         input: GetSizeConstraintSetRequest,
     ) -> RusotoFuture<GetSizeConstraintSetResponse, GetSizeConstraintSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.GetSizeConstraintSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8257,9 +8462,14 @@ impl Waf for WafClient {
         &self,
         input: GetSqlInjectionMatchSetRequest,
     ) -> RusotoFuture<GetSqlInjectionMatchSetResponse, GetSqlInjectionMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.GetSqlInjectionMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8283,9 +8493,14 @@ impl Waf for WafClient {
         &self,
         input: GetWebACLRequest,
     ) -> RusotoFuture<GetWebACLResponse, GetWebACLError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.GetWebACL");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8312,9 +8527,14 @@ impl Waf for WafClient {
         &self,
         input: GetXssMatchSetRequest,
     ) -> RusotoFuture<GetXssMatchSetResponse, GetXssMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.GetXssMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8342,9 +8562,14 @@ impl Waf for WafClient {
         input: ListActivatedRulesInRuleGroupRequest,
     ) -> RusotoFuture<ListActivatedRulesInRuleGroupResponse, ListActivatedRulesInRuleGroupError>
     {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "AWSWAF_20150824.ListActivatedRulesInRuleGroup",
@@ -8371,9 +8596,14 @@ impl Waf for WafClient {
         &self,
         input: ListByteMatchSetsRequest,
     ) -> RusotoFuture<ListByteMatchSetsResponse, ListByteMatchSetsError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.ListByteMatchSets");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8400,9 +8630,14 @@ impl Waf for WafClient {
         &self,
         input: ListGeoMatchSetsRequest,
     ) -> RusotoFuture<ListGeoMatchSetsResponse, ListGeoMatchSetsError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.ListGeoMatchSets");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8429,9 +8664,14 @@ impl Waf for WafClient {
         &self,
         input: ListIPSetsRequest,
     ) -> RusotoFuture<ListIPSetsResponse, ListIPSetsError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.ListIPSets");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8458,9 +8698,14 @@ impl Waf for WafClient {
         &self,
         input: ListLoggingConfigurationsRequest,
     ) -> RusotoFuture<ListLoggingConfigurationsResponse, ListLoggingConfigurationsError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.ListLoggingConfigurations");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8484,9 +8729,14 @@ impl Waf for WafClient {
         &self,
         input: ListRateBasedRulesRequest,
     ) -> RusotoFuture<ListRateBasedRulesResponse, ListRateBasedRulesError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.ListRateBasedRules");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8513,9 +8763,14 @@ impl Waf for WafClient {
         &self,
         input: ListRegexMatchSetsRequest,
     ) -> RusotoFuture<ListRegexMatchSetsResponse, ListRegexMatchSetsError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.ListRegexMatchSets");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8542,9 +8797,14 @@ impl Waf for WafClient {
         &self,
         input: ListRegexPatternSetsRequest,
     ) -> RusotoFuture<ListRegexPatternSetsResponse, ListRegexPatternSetsError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.ListRegexPatternSets");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8570,9 +8830,14 @@ impl Waf for WafClient {
         &self,
         input: ListRuleGroupsRequest,
     ) -> RusotoFuture<ListRuleGroupsResponse, ListRuleGroupsError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.ListRuleGroups");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8599,9 +8864,14 @@ impl Waf for WafClient {
         &self,
         input: ListRulesRequest,
     ) -> RusotoFuture<ListRulesResponse, ListRulesError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.ListRules");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8628,9 +8898,14 @@ impl Waf for WafClient {
         &self,
         input: ListSizeConstraintSetsRequest,
     ) -> RusotoFuture<ListSizeConstraintSetsResponse, ListSizeConstraintSetsError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.ListSizeConstraintSets");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8656,9 +8931,14 @@ impl Waf for WafClient {
         &self,
         input: ListSqlInjectionMatchSetsRequest,
     ) -> RusotoFuture<ListSqlInjectionMatchSetsResponse, ListSqlInjectionMatchSetsError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.ListSqlInjectionMatchSets");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8682,9 +8962,14 @@ impl Waf for WafClient {
         &self,
         input: ListSubscribedRuleGroupsRequest,
     ) -> RusotoFuture<ListSubscribedRuleGroupsResponse, ListSubscribedRuleGroupsError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.ListSubscribedRuleGroups");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8708,9 +8993,14 @@ impl Waf for WafClient {
         &self,
         input: ListWebACLsRequest,
     ) -> RusotoFuture<ListWebACLsResponse, ListWebACLsError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.ListWebACLs");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8737,9 +9027,14 @@ impl Waf for WafClient {
         &self,
         input: ListXssMatchSetsRequest,
     ) -> RusotoFuture<ListXssMatchSetsResponse, ListXssMatchSetsError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.ListXssMatchSets");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8766,9 +9061,14 @@ impl Waf for WafClient {
         &self,
         input: PutLoggingConfigurationRequest,
     ) -> RusotoFuture<PutLoggingConfigurationResponse, PutLoggingConfigurationError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.PutLoggingConfiguration");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8792,9 +9092,14 @@ impl Waf for WafClient {
         &self,
         input: PutPermissionPolicyRequest,
     ) -> RusotoFuture<PutPermissionPolicyResponse, PutPermissionPolicyError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.PutPermissionPolicy");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8820,9 +9125,14 @@ impl Waf for WafClient {
         &self,
         input: UpdateByteMatchSetRequest,
     ) -> RusotoFuture<UpdateByteMatchSetResponse, UpdateByteMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.UpdateByteMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8849,9 +9159,14 @@ impl Waf for WafClient {
         &self,
         input: UpdateGeoMatchSetRequest,
     ) -> RusotoFuture<UpdateGeoMatchSetResponse, UpdateGeoMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.UpdateGeoMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8878,9 +9193,14 @@ impl Waf for WafClient {
         &self,
         input: UpdateIPSetRequest,
     ) -> RusotoFuture<UpdateIPSetResponse, UpdateIPSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.UpdateIPSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8907,9 +9227,14 @@ impl Waf for WafClient {
         &self,
         input: UpdateRateBasedRuleRequest,
     ) -> RusotoFuture<UpdateRateBasedRuleResponse, UpdateRateBasedRuleError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.UpdateRateBasedRule");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8935,9 +9260,14 @@ impl Waf for WafClient {
         &self,
         input: UpdateRegexMatchSetRequest,
     ) -> RusotoFuture<UpdateRegexMatchSetResponse, UpdateRegexMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.UpdateRegexMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8963,9 +9293,14 @@ impl Waf for WafClient {
         &self,
         input: UpdateRegexPatternSetRequest,
     ) -> RusotoFuture<UpdateRegexPatternSetResponse, UpdateRegexPatternSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.UpdateRegexPatternSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -8991,9 +9326,14 @@ impl Waf for WafClient {
         &self,
         input: UpdateRuleRequest,
     ) -> RusotoFuture<UpdateRuleResponse, UpdateRuleError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.UpdateRule");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9020,9 +9360,14 @@ impl Waf for WafClient {
         &self,
         input: UpdateRuleGroupRequest,
     ) -> RusotoFuture<UpdateRuleGroupResponse, UpdateRuleGroupError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.UpdateRuleGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9049,9 +9394,14 @@ impl Waf for WafClient {
         &self,
         input: UpdateSizeConstraintSetRequest,
     ) -> RusotoFuture<UpdateSizeConstraintSetResponse, UpdateSizeConstraintSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.UpdateSizeConstraintSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9075,9 +9425,14 @@ impl Waf for WafClient {
         &self,
         input: UpdateSqlInjectionMatchSetRequest,
     ) -> RusotoFuture<UpdateSqlInjectionMatchSetResponse, UpdateSqlInjectionMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.UpdateSqlInjectionMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9101,9 +9456,14 @@ impl Waf for WafClient {
         &self,
         input: UpdateWebACLRequest,
     ) -> RusotoFuture<UpdateWebACLResponse, UpdateWebACLError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.UpdateWebACL");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -9130,9 +9490,14 @@ impl Waf for WafClient {
         &self,
         input: UpdateXssMatchSetRequest,
     ) -> RusotoFuture<UpdateXssMatchSetResponse, UpdateXssMatchSetError> {
-        let mut request = SignedRequest::new("POST", "waf", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "waf",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "AWSWAF_20150824.UpdateXssMatchSet");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/workmail/src/generated.rs
+++ b/rusoto/services/workmail/src/generated.rs
@@ -3281,9 +3281,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: AssociateDelegateToResourceRequest,
     ) -> RusotoFuture<AssociateDelegateToResourceResponse, AssociateDelegateToResourceError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "WorkMailService.AssociateDelegateToResource",
@@ -3310,9 +3315,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: AssociateMemberToGroupRequest,
     ) -> RusotoFuture<AssociateMemberToGroupResponse, AssociateMemberToGroupError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.AssociateMemberToGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3338,9 +3348,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: CreateAliasRequest,
     ) -> RusotoFuture<CreateAliasResponse, CreateAliasError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.CreateAlias");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3367,9 +3382,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: CreateGroupRequest,
     ) -> RusotoFuture<CreateGroupResponse, CreateGroupError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.CreateGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3396,9 +3416,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: CreateResourceRequest,
     ) -> RusotoFuture<CreateResourceResponse, CreateResourceError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.CreateResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3425,9 +3450,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: CreateUserRequest,
     ) -> RusotoFuture<CreateUserResponse, CreateUserError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.CreateUser");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3454,9 +3484,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: DeleteAliasRequest,
     ) -> RusotoFuture<DeleteAliasResponse, DeleteAliasError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.DeleteAlias");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3483,9 +3518,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: DeleteGroupRequest,
     ) -> RusotoFuture<DeleteGroupResponse, DeleteGroupError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.DeleteGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3512,9 +3552,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: DeleteMailboxPermissionsRequest,
     ) -> RusotoFuture<DeleteMailboxPermissionsResponse, DeleteMailboxPermissionsError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.DeleteMailboxPermissions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3538,9 +3583,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: DeleteResourceRequest,
     ) -> RusotoFuture<DeleteResourceResponse, DeleteResourceError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.DeleteResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3567,9 +3617,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: DeleteUserRequest,
     ) -> RusotoFuture<DeleteUserResponse, DeleteUserError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.DeleteUser");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3596,9 +3651,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: DeregisterFromWorkMailRequest,
     ) -> RusotoFuture<DeregisterFromWorkMailResponse, DeregisterFromWorkMailError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.DeregisterFromWorkMail");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3624,9 +3684,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: DescribeGroupRequest,
     ) -> RusotoFuture<DescribeGroupResponse, DescribeGroupError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.DescribeGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3653,9 +3718,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: DescribeOrganizationRequest,
     ) -> RusotoFuture<DescribeOrganizationResponse, DescribeOrganizationError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.DescribeOrganization");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3681,9 +3751,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: DescribeResourceRequest,
     ) -> RusotoFuture<DescribeResourceResponse, DescribeResourceError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.DescribeResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3710,9 +3785,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: DescribeUserRequest,
     ) -> RusotoFuture<DescribeUserResponse, DescribeUserError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.DescribeUser");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3740,9 +3820,14 @@ impl Workmail for WorkmailClient {
         input: DisassociateDelegateFromResourceRequest,
     ) -> RusotoFuture<DisassociateDelegateFromResourceResponse, DisassociateDelegateFromResourceError>
     {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "WorkMailService.DisassociateDelegateFromResource",
@@ -3771,9 +3856,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: DisassociateMemberFromGroupRequest,
     ) -> RusotoFuture<DisassociateMemberFromGroupResponse, DisassociateMemberFromGroupError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "WorkMailService.DisassociateMemberFromGroup",
@@ -3800,9 +3890,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: ListAliasesRequest,
     ) -> RusotoFuture<ListAliasesResponse, ListAliasesError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.ListAliases");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3829,9 +3924,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: ListGroupMembersRequest,
     ) -> RusotoFuture<ListGroupMembersResponse, ListGroupMembersError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.ListGroupMembers");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3858,9 +3958,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: ListGroupsRequest,
     ) -> RusotoFuture<ListGroupsResponse, ListGroupsError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.ListGroups");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3887,9 +3992,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: ListMailboxPermissionsRequest,
     ) -> RusotoFuture<ListMailboxPermissionsResponse, ListMailboxPermissionsError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.ListMailboxPermissions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3915,9 +4025,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: ListOrganizationsRequest,
     ) -> RusotoFuture<ListOrganizationsResponse, ListOrganizationsError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.ListOrganizations");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3944,9 +4059,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: ListResourceDelegatesRequest,
     ) -> RusotoFuture<ListResourceDelegatesResponse, ListResourceDelegatesError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.ListResourceDelegates");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3972,9 +4092,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: ListResourcesRequest,
     ) -> RusotoFuture<ListResourcesResponse, ListResourcesError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.ListResources");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4001,9 +4126,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: ListUsersRequest,
     ) -> RusotoFuture<ListUsersResponse, ListUsersError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.ListUsers");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4030,9 +4160,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: PutMailboxPermissionsRequest,
     ) -> RusotoFuture<PutMailboxPermissionsResponse, PutMailboxPermissionsError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.PutMailboxPermissions");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4058,9 +4193,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: RegisterToWorkMailRequest,
     ) -> RusotoFuture<RegisterToWorkMailResponse, RegisterToWorkMailError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.RegisterToWorkMail");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4087,9 +4227,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: ResetPasswordRequest,
     ) -> RusotoFuture<ResetPasswordResponse, ResetPasswordError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.ResetPassword");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4116,9 +4261,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: UpdatePrimaryEmailAddressRequest,
     ) -> RusotoFuture<UpdatePrimaryEmailAddressResponse, UpdatePrimaryEmailAddressError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.UpdatePrimaryEmailAddress");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -4142,9 +4292,14 @@ impl Workmail for WorkmailClient {
         &self,
         input: UpdateResourceRequest,
     ) -> RusotoFuture<UpdateResourceResponse, UpdateResourceError> {
-        let mut request = SignedRequest::new("POST", "workmail", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workmail",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkMailService.UpdateResource");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/rusoto/services/workspaces/src/generated.rs
+++ b/rusoto/services/workspaces/src/generated.rs
@@ -2855,9 +2855,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: AssociateIpGroupsRequest,
     ) -> RusotoFuture<AssociateIpGroupsResult, AssociateIpGroupsError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.AssociateIpGroups");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2884,9 +2889,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: AuthorizeIpRulesRequest,
     ) -> RusotoFuture<AuthorizeIpRulesResult, AuthorizeIpRulesError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.AuthorizeIpRules");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2913,9 +2923,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: CreateIpGroupRequest,
     ) -> RusotoFuture<CreateIpGroupResult, CreateIpGroupError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.CreateIpGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2942,9 +2957,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: CreateTagsRequest,
     ) -> RusotoFuture<CreateTagsResult, CreateTagsError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.CreateTags");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -2971,9 +2991,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: CreateWorkspacesRequest,
     ) -> RusotoFuture<CreateWorkspacesResult, CreateWorkspacesError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.CreateWorkspaces");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3000,9 +3025,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: DeleteIpGroupRequest,
     ) -> RusotoFuture<DeleteIpGroupResult, DeleteIpGroupError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.DeleteIpGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3029,9 +3059,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: DeleteTagsRequest,
     ) -> RusotoFuture<DeleteTagsResult, DeleteTagsError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.DeleteTags");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3058,9 +3093,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: DeleteWorkspaceImageRequest,
     ) -> RusotoFuture<DeleteWorkspaceImageResult, DeleteWorkspaceImageError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.DeleteWorkspaceImage");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3083,9 +3123,14 @@ impl Workspaces for WorkspacesClient {
 
     /// <p>Retrieves a list that describes the configuration of bring your own license (BYOL) for the specified account.</p>
     fn describe_account(&self) -> RusotoFuture<DescribeAccountResult, DescribeAccountError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.DescribeAccount");
         request.set_payload(Some(bytes::Bytes::from_static(b"{}")));
 
@@ -3111,9 +3156,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: DescribeAccountModificationsRequest,
     ) -> RusotoFuture<DescribeAccountModificationsResult, DescribeAccountModificationsError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "WorkspacesService.DescribeAccountModifications",
@@ -3140,9 +3190,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: DescribeClientPropertiesRequest,
     ) -> RusotoFuture<DescribeClientPropertiesResult, DescribeClientPropertiesError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.DescribeClientProperties");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3166,9 +3221,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: DescribeIpGroupsRequest,
     ) -> RusotoFuture<DescribeIpGroupsResult, DescribeIpGroupsError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.DescribeIpGroups");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3195,9 +3255,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: DescribeTagsRequest,
     ) -> RusotoFuture<DescribeTagsResult, DescribeTagsError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.DescribeTags");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3224,9 +3289,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: DescribeWorkspaceBundlesRequest,
     ) -> RusotoFuture<DescribeWorkspaceBundlesResult, DescribeWorkspaceBundlesError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.DescribeWorkspaceBundles");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3250,9 +3320,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: DescribeWorkspaceDirectoriesRequest,
     ) -> RusotoFuture<DescribeWorkspaceDirectoriesResult, DescribeWorkspaceDirectoriesError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "WorkspacesService.DescribeWorkspaceDirectories",
@@ -3279,9 +3354,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: DescribeWorkspaceImagesRequest,
     ) -> RusotoFuture<DescribeWorkspaceImagesResult, DescribeWorkspaceImagesError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.DescribeWorkspaceImages");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3305,9 +3385,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: DescribeWorkspacesRequest,
     ) -> RusotoFuture<DescribeWorkspacesResult, DescribeWorkspacesError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.DescribeWorkspaces");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3337,9 +3422,14 @@ impl Workspaces for WorkspacesClient {
         DescribeWorkspacesConnectionStatusResult,
         DescribeWorkspacesConnectionStatusError,
     > {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "WorkspacesService.DescribeWorkspacesConnectionStatus",
@@ -3368,9 +3458,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: DisassociateIpGroupsRequest,
     ) -> RusotoFuture<DisassociateIpGroupsResult, DisassociateIpGroupsError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.DisassociateIpGroups");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3396,9 +3491,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: ImportWorkspaceImageRequest,
     ) -> RusotoFuture<ImportWorkspaceImageResult, ImportWorkspaceImageError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.ImportWorkspaceImage");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3425,9 +3525,14 @@ impl Workspaces for WorkspacesClient {
         input: ListAvailableManagementCidrRangesRequest,
     ) -> RusotoFuture<ListAvailableManagementCidrRangesResult, ListAvailableManagementCidrRangesError>
     {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "WorkspacesService.ListAvailableManagementCidrRanges",
@@ -3456,9 +3561,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: ModifyAccountRequest,
     ) -> RusotoFuture<ModifyAccountResult, ModifyAccountError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.ModifyAccount");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3485,9 +3595,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: ModifyClientPropertiesRequest,
     ) -> RusotoFuture<ModifyClientPropertiesResult, ModifyClientPropertiesError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.ModifyClientProperties");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3513,9 +3628,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: ModifyWorkspacePropertiesRequest,
     ) -> RusotoFuture<ModifyWorkspacePropertiesResult, ModifyWorkspacePropertiesError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header(
             "x-amz-target",
             "WorkspacesService.ModifyWorkspaceProperties",
@@ -3542,9 +3662,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: ModifyWorkspaceStateRequest,
     ) -> RusotoFuture<ModifyWorkspaceStateResult, ModifyWorkspaceStateError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.ModifyWorkspaceState");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3570,9 +3695,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: RebootWorkspacesRequest,
     ) -> RusotoFuture<RebootWorkspacesResult, RebootWorkspacesError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.RebootWorkspaces");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3599,9 +3729,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: RebuildWorkspacesRequest,
     ) -> RusotoFuture<RebuildWorkspacesResult, RebuildWorkspacesError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.RebuildWorkspaces");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3628,9 +3763,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: RevokeIpRulesRequest,
     ) -> RusotoFuture<RevokeIpRulesResult, RevokeIpRulesError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.RevokeIpRules");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3657,9 +3797,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: StartWorkspacesRequest,
     ) -> RusotoFuture<StartWorkspacesResult, StartWorkspacesError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.StartWorkspaces");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3686,9 +3831,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: StopWorkspacesRequest,
     ) -> RusotoFuture<StopWorkspacesResult, StopWorkspacesError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.StopWorkspaces");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3715,9 +3865,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: TerminateWorkspacesRequest,
     ) -> RusotoFuture<TerminateWorkspacesResult, TerminateWorkspacesError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.TerminateWorkspaces");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));
@@ -3743,9 +3898,14 @@ impl Workspaces for WorkspacesClient {
         &self,
         input: UpdateRulesOfIpGroupRequest,
     ) -> RusotoFuture<UpdateRulesOfIpGroupResult, UpdateRulesOfIpGroupError> {
-        let mut request = SignedRequest::new("POST", "workspaces", &self.region, "/");
+        let mut request = SignedRequest::new_with_content_type(
+            "POST",
+            "workspaces",
+            &self.region,
+            "/",
+            "application/x-amz-json-1.1",
+        );
 
-        request.set_content_type("application/x-amz-json-1.1".to_owned());
         request.add_header("x-amz-target", "WorkspacesService.UpdateRulesOfIpGroup");
         let encoded = serde_json::to_string(&input).unwrap();
         request.set_payload(Some(encoded));

--- a/service_crategen/src/commands/generate/codegen/json.rs
+++ b/service_crategen/src/commands/generate/codegen/json.rs
@@ -35,9 +35,8 @@ impl GenerateProtocol for JsonGenerator {
                      "
                 {documentation}
                 {method_signature} -> RusotoFuture<{output_type}, {error_type}> {{
-                    let mut request = SignedRequest::new(\"{http_method}\", \"{signing_name}\", &self.region, \"{request_uri}\");
+                    let mut request = SignedRequest::new_with_content_type(\"{http_method}\", \"{signing_name}\", &self.region, \"{request_uri}\", \"application/x-amz-json-{json_version}\");
                     {modify_endpoint_prefix}
-                    request.set_content_type(\"application/x-amz-json-{json_version}\".to_owned());
                     request.add_header(\"x-amz-target\", \"{target_prefix}.{name}\");
                     {payload}
 


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Add new constructor to SignedRequest to reduce number of function calls made in generated code.

An attempt to reduce the amount of code each crate generates. While the total number of lines of code increased, that's due to `rustfmt` changes. Each affected crate has tens or hundreds of function calls in it replaced by a single function call in `rusoto_core`.

Not sure how to test if this improves compilation speed or crate size. Any thoughts?