### PR TITLE
Update build badges for Azure Pipelines.

### DIFF
--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -18,6 +18,10 @@ categories = [
 ]
 edition = "2018"
 
+[badges]
+appveyor = { repository = "rusoto/rusoto", branch = "master" }
+azure-devops = { project = "Rusoto", pipeline = "rusoto.rusoto", build="1" }
+
 [dependencies]
 chrono = "0.4.0"
 futures = "0.1.16"

--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -19,8 +19,8 @@ exclude = ["test_resources/*"]
 edition = "2018"
 
 [badges]
-travis-ci = { repository = "rusoto/rusoto", branch = "master" }
 appveyor = { repository = "rusoto/rusoto", branch = "master" }
+azure-devops = { project = "Rusoto", pipeline = "rusoto.rusoto", build="1" }
 
 [build-dependencies]
 rustc_version = "0.2.1"

--- a/rusoto/core/README.md
+++ b/rusoto/core/README.md
@@ -3,7 +3,7 @@
 <table>
     <tr>
         <td><strong>Linux / OS X</strong></td>
-        <td><a href="https://travis-ci.org/rusoto/rusoto" title="Travis Build Status"><img src="https://travis-ci.org/rusoto/rusoto.svg?branch=master" alt="travis-badge"></img></a></td>
+        <td><a href="https://dev.azure.com/matthewkmayer/Rusoto/_build?definitionId=1" title="Pipelines Build Status"><img src="https://dev.azure.com/matthewkmayer/Rusoto/_apis/build/status/rusoto.rusoto?branchName=master" alt="pipelines-badge"></img></a></td>
     </tr>
     <tr>
         <td><strong>Windows</strong></td>

--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -14,6 +14,10 @@ version = "0.39.0"
 exclude = ["tests/sample-data/*"]
 edition = "2018"
 
+[badges]
+appveyor = { repository = "rusoto/rusoto", branch = "master" }
+azure-devops = { project = "Rusoto", pipeline = "rusoto.rusoto", build="1" }
+
 [dependencies]
 chrono = { version = "0.4.0", features = ["serde"] }
 dirs = "1.0.2"


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Update build badge locations to Pipelines.

Fixes https://github.com/rusoto/rusoto/issues/1344 .