### PR TITLE
Move API documentation links to docs.rs.

### DIFF
--- a/AWS-CREDENTIALS.md
+++ b/AWS-CREDENTIALS.md
@@ -62,7 +62,7 @@ Current implementation is not using the cached token returned by the AssumeRole 
 
 This will affect the performance as well as the billing of AWS.
 
-- https://rusoto.github.io/rusoto/rusoto_credential/index.html
+- https://docs.rs/rusoto_credential
 - https://crates.io/crates/rusoto_credential
 ```
 let provider = StsAssumeRoleSessionCredentialsProvider::new(

--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ See [CONTRIBUTING](CONTRIBUTING.md).
 
 ## Supported OSs and Rust versions
 
-Linux, OSX and Windows are supported and tested via TravisCI and Appveyor.
+Linux, OSX and Windows are supported and tested via Azure Pipelines and Appveyor.
 
-Rust stable is supported.  Older versions of Rust are supported and tested via TravisCI.  The minimum Rust version is incremented when it becomes inconvenient to support older versions.  The current minimum version of Rust supported can be found in [.travis.yml](.travis.yml).  If a version number is not specified in the `rust` section, only the named versions listed are supported.  This should be stable, beta and nightly.
+Rust stable, beta and nightly are supported.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@
         <td><a href="https://dev.azure.com/matthewkmayer/Rusoto/_build?definitionId=1" title="Pipelines Build Status"><img src="https://dev.azure.com/matthewkmayer/Rusoto/_apis/build/status/rusoto.rusoto?branchName=master" alt="pipelines-badge"></img></a></td>
     </tr>
     <tr>
-        <td><strong>API docs</strong></td>
-        <td><a href="https://travis-ci.org/rusoto/rusoto" title="Travis Build Status"><img src="https://travis-ci.org/rusoto/rusoto.svg?branch=master" alt="travis-badge"></img></a></td>
-    </tr>
-    <tr>
         <td><strong>Windows</strong></td>
         <td><a href="https://ci.appveyor.com/project/matthewkmayer/rusoto/branch/master" title="Appveyor Build Status"><img src="https://ci.appveyor.com/api/projects/status/o83ruaeu7xft0ru5/branch/master?svg=true" alt="appveyor-badge"></img></a></td>
     </tr>
@@ -19,7 +15,7 @@
     </tr>
     <tr>
         <td colspan="2">
-            <a href="https://rusoto.github.io/rusoto/" title="API Docs"><img src="https://img.shields.io/badge/API-docs-blue.svg" alt="api-docs-badge"></img></a>
+            <a href="https://docs.rs/rusoto_core" title="API Docs"><img src="https://img.shields.io/badge/API-docs-blue.svg" alt="api-docs-badge"></img></a>
             <a href="https://crates.io/crates/rusoto_core" title="Crates.io"><img src="https://img.shields.io/crates/v/rusoto_core.svg" alt="crates-io"></img></a>
             <a href="#license" title="License: MIT"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="license-badge"></img></a>
             <img src="https://tokei.rs/b1/github/rusoto/rusoto"></img>
@@ -61,7 +57,7 @@ Breaking changes and migration details are documented at [https://rusoto.org/mig
 Rusoto has a crate for each AWS service, containing Rust types for that service's API.
 A full list of these services can be found [here][supported-aws-services].
 All other public types are reexported to the crate root.
-Consult the rustdoc documentation for full details by running `cargo doc` or visiting the online [documentation](https://rusoto.github.io/rusoto/rusoto/index.html) for the latest crates.io release.
+Consult the rustdoc documentation for full details by running `cargo doc` or visiting the online [documentation](https://docs.rs/rusoto_core) for the latest crates.io release.
 
 A simple example of using Rusoto's DynamoDB API to list the names of all tables in a database:
 
@@ -126,7 +122,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_core "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"
 [rusoto-overview]: https://www.rusoto.org/ "Rusoto overview"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -44,12 +44,6 @@ Examples:
 
 Add a list of user-facing changes to a new release for the tagged version on GitHub: https://github.com/rusoto/rusoto/releases
 
-#### API docs
+#### Mdbook docs
 
-API docs are on Github Pages at [https://rusoto.github.io/rusoto](https://rusoto.github.io/rusoto).
-
-TravisCI builds and publishes the `gh-pages` branch automatically when changes are merged into master.
-
-#### Gitbook docs
-
-See [the Rusoto gitbook project](https://github.com/rusoto/rusoto.github.io).
+See [the Rusoto mdbook project](https://github.com/rusoto/rusoto.github.io).

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Nikita Pekin <contact@nikitapek.in>"
 ]
 description = "AWS SDK for Rust - Request Mocking Helpers"
-documentation = "http://rusoto.github.io/rusoto/rusoto_mock/index.html"
+documentation = "https://docs.rs/rusoto_mock"
 keywords = ["AWS", "Amazon", "mock", "testing"]
 license = "MIT"
 name = "rusoto_mock"

--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 build = "build.rs"
 description = "AWS SDK for Rust - Core"
-documentation = "http://rusoto.github.io/rusoto/rusoto/index.html"
+documentation = "https://docs.rs/rusoto_core"
 keywords = ["AWS", "Amazon"]
 license = "MIT"
 name = "rusoto_core"

--- a/rusoto/core/README.md
+++ b/rusoto/core/README.md
@@ -3,7 +3,7 @@
 <table>
     <tr>
         <td><strong>Linux / OS X</strong></td>
-        <td><a href="https://travis-ci.org/rusoto/rusoto" title="Travis Build Status"><img src="https://travis-ci.org/rusoto/rusoto.svg?branch=master" alt="travis-badge"></img></a></td>
+        <td><a href="https://dev.azure.com/matthewkmayer/Rusoto/_build?definitionId=1" title="Pipelines Build Status"><img src="https://dev.azure.com/matthewkmayer/Rusoto/_apis/build/status/rusoto.rusoto?branchName=master" alt="pipelines-badge"></img></a></td>
     </tr>
     <tr>
         <td><strong>Windows</strong></td>
@@ -118,12 +118,9 @@ See [CONTRIBUTING][contribution].
 
 ## Supported OSs and Rust versions
 
-Linux, OSX and Windows are supported and tested via TravisCI and Appveyor.
+Linux, OSX and Windows are supported and tested via Azure Pipelines and Appveyor.
 
-Rust stable is supported.  Older versions of Rust are supported and tested via TravisCI.  The minimum Rust version is
-incremented when it becomes inconvenient to support older versions.  The current minimum version of Rust supported can
-be found in [.travis.yml][travis].  If a version number is not specified in the `rust` section, only the named versions
-listed are supported.  This should be stable, beta and nightly.
+Rust stable, beta and nightly are supported.
 
 ## License
 
@@ -139,4 +136,3 @@ See [LICENSE][license] for details.
 [aws-credentials]: https://github.com/rusoto/rusoto/blob/master/AWS-CREDENTIALS.md "AWS Credentials"
 [releasing]: https://github.com/rusoto/rusoto/blob/master/RELEASING.md "Releasing Rusoto"
 [contribution]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing to Rusoto"
-[travis]: https://github.com/rusoto/rusoto/blob/master/.travis.yml "Building Rusoto"

--- a/rusoto/core/README.md
+++ b/rusoto/core/README.md
@@ -11,7 +11,7 @@
     </tr>
     <tr>
         <td colspan="2">
-            <a href="https://rusoto.github.io/rusoto/" title="API Docs"><img src="https://img.shields.io/badge/API-docs-blue.svg" alt="api-docs-badge"></img></a>
+            <a href="https://docs.rs/rusoto_core" title="API Docs"><img src="https://img.shields.io/badge/API-docs-blue.svg" alt="api-docs-badge"></img></a>
             <a href="https://crates.io/crates/rusoto_core" title="Crates.io"><img src="https://img.shields.io/crates/v/rusoto_core.svg" alt="crates-io"></img></a>
             <a href="#license" title="License: MIT"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="license-badge"></img></a>
         </td>
@@ -52,7 +52,7 @@ Breaking changes and migration details are documented at [https://rusoto.org/mig
 Rusoto has a crate for each AWS service, containing Rust types for that service's API.
 A full list of these services can be found [here][supported-aws-services].
 All other public types are reexported to the crate root.
-Consult the rustdoc documentation for full details by running `cargo doc` or visiting the online [documentation](https://rusoto.github.io/rusoto/rusoto/index.html) for the latest crates.io release.
+Consult the rustdoc documentation for full details by running `cargo doc` or visiting the online [documentation](https://docs.rs/rusoto_core) for the latest crates.io release.
 
 A simple example of using Rusoto's DynamoDB API to list the names of all tables in a database:
 
@@ -131,7 +131,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_core "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"
 [rusoto-overview]: https://www.rusoto.org/ "Rusoto overview"

--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -7,6 +7,7 @@ authors = [
 ]
 license = "MIT"
 description = "AWS credential tooling"
+documentation = "https://docs.rs/rusoto_credential"
 name = "rusoto_credential"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"

--- a/rusoto/services/acm-pca/Cargo.toml
+++ b/rusoto/services/acm-pca/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Certificate Manager Private Certificate Authority @ 2017-08-22"
-documentation = "https://rusoto.github.io/rusoto/rusoto_acm_pca/index.html"
+documentation = "https://docs.rs/rusoto_acm_pca"
 keywords = ["AWS", "Amazon", "acm-pca"]
 license = "MIT"
 name = "rusoto_acm_pca"

--- a/rusoto/services/acm-pca/README.md
+++ b/rusoto/services/acm-pca/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_acm_pca "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/acm/Cargo.toml
+++ b/rusoto/services/acm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Certificate Manager @ 2015-12-08"
-documentation = "https://rusoto.github.io/rusoto/rusoto_acm/index.html"
+documentation = "https://docs.rs/rusoto_acm"
 keywords = ["AWS", "Amazon", "acm"]
 license = "MIT"
 name = "rusoto_acm"

--- a/rusoto/services/acm/README.md
+++ b/rusoto/services/acm/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_acm "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/alexaforbusiness/Cargo.toml
+++ b/rusoto/services/alexaforbusiness/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Alexa For Business @ 2017-11-09"
-documentation = "https://rusoto.github.io/rusoto/rusoto_alexaforbusiness/index.html"
+documentation = "https://docs.rs/rusoto_alexaforbusiness"
 keywords = ["AWS", "Amazon", "alexaforbusiness"]
 license = "MIT"
 name = "rusoto_alexaforbusiness"

--- a/rusoto/services/alexaforbusiness/README.md
+++ b/rusoto/services/alexaforbusiness/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_alexaforbusiness "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/amplify/Cargo.toml
+++ b/rusoto/services/amplify/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Amplify @ 2017-07-25"
-documentation = "https://rusoto.github.io/rusoto/rusoto_amplify/index.html"
+documentation = "https://docs.rs/rusoto_amplify"
 keywords = ["AWS", "Amazon", "amplify"]
 license = "MIT"
 name = "rusoto_amplify"

--- a/rusoto/services/amplify/README.md
+++ b/rusoto/services/amplify/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_amplify "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/apigateway/Cargo.toml
+++ b/rusoto/services/apigateway/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon API Gateway @ 2015-07-09"
-documentation = "https://rusoto.github.io/rusoto/rusoto_apigateway/index.html"
+documentation = "https://docs.rs/rusoto_apigateway"
 keywords = ["AWS", "Amazon", "apigateway"]
 license = "MIT"
 name = "rusoto_apigateway"

--- a/rusoto/services/apigateway/README.md
+++ b/rusoto/services/apigateway/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_apigateway "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/apigatewaymanagementapi/Cargo.toml
+++ b/rusoto/services/apigatewaymanagementapi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AmazonApiGatewayManagementApi @ 2018-11-29"
-documentation = "https://rusoto.github.io/rusoto/rusoto_apigatewaymanagementapi/index.html"
+documentation = "https://docs.rs/rusoto_apigatewaymanagementapi"
 keywords = ["AWS", "Amazon", "apigatewaymanagement"]
 license = "MIT"
 name = "rusoto_apigatewaymanagementapi"

--- a/rusoto/services/apigatewaymanagementapi/README.md
+++ b/rusoto/services/apigatewaymanagementapi/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_apigatewaymanagementapi "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/apigatewayv2/Cargo.toml
+++ b/rusoto/services/apigatewayv2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AmazonApiGatewayV2 @ 2018-11-29"
-documentation = "https://rusoto.github.io/rusoto/rusoto_apigatewayv2/index.html"
+documentation = "https://docs.rs/rusoto_apigatewayv2"
 keywords = ["AWS", "Amazon", "apigatewayv2"]
 license = "MIT"
 name = "rusoto_apigatewayv2"

--- a/rusoto/services/apigatewayv2/README.md
+++ b/rusoto/services/apigatewayv2/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_apigatewayv2 "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/application-autoscaling/Cargo.toml
+++ b/rusoto/services/application-autoscaling/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Application Auto Scaling @ 2016-02-06"
-documentation = "https://rusoto.github.io/rusoto/rusoto_application_autoscaling/index.html"
+documentation = "https://docs.rs/rusoto_application_autoscaling"
 keywords = ["AWS", "Amazon", "application-autoscal"]
 license = "MIT"
 name = "rusoto_application_autoscaling"

--- a/rusoto/services/application-autoscaling/README.md
+++ b/rusoto/services/application-autoscaling/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_application_autoscaling "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/appstream/Cargo.toml
+++ b/rusoto/services/appstream/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon AppStream @ 2016-12-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_appstream/index.html"
+documentation = "https://docs.rs/rusoto_appstream"
 keywords = ["AWS", "Amazon", "appstream"]
 license = "MIT"
 name = "rusoto_appstream"

--- a/rusoto/services/appstream/README.md
+++ b/rusoto/services/appstream/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_appstream "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/appsync/Cargo.toml
+++ b/rusoto/services/appsync/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS AppSync @ 2017-07-25"
-documentation = "https://rusoto.github.io/rusoto/rusoto_appsync/index.html"
+documentation = "https://docs.rs/rusoto_appsync"
 keywords = ["AWS", "Amazon", "appsync"]
 license = "MIT"
 name = "rusoto_appsync"

--- a/rusoto/services/appsync/README.md
+++ b/rusoto/services/appsync/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_appsync "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/athena/Cargo.toml
+++ b/rusoto/services/athena/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Athena @ 2017-05-18"
-documentation = "https://rusoto.github.io/rusoto/rusoto_athena/index.html"
+documentation = "https://docs.rs/rusoto_athena"
 keywords = ["AWS", "Amazon", "athena"]
 license = "MIT"
 name = "rusoto_athena"

--- a/rusoto/services/athena/README.md
+++ b/rusoto/services/athena/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_athena "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/autoscaling-plans/Cargo.toml
+++ b/rusoto/services/autoscaling-plans/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Auto Scaling Plans @ 2018-01-06"
-documentation = "https://rusoto.github.io/rusoto/rusoto_autoscaling_plans/index.html"
+documentation = "https://docs.rs/rusoto_autoscaling_plans"
 keywords = ["AWS", "Amazon", "autoscaling-plans"]
 license = "MIT"
 name = "rusoto_autoscaling_plans"

--- a/rusoto/services/autoscaling-plans/README.md
+++ b/rusoto/services/autoscaling-plans/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_autoscaling_plans "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/autoscaling/Cargo.toml
+++ b/rusoto/services/autoscaling/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Auto Scaling @ 2011-01-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_autoscaling/index.html"
+documentation = "https://docs.rs/rusoto_autoscaling"
 keywords = ["AWS", "Amazon", "autoscaling"]
 license = "MIT"
 name = "rusoto_autoscaling"

--- a/rusoto/services/autoscaling/README.md
+++ b/rusoto/services/autoscaling/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_autoscaling "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/batch/Cargo.toml
+++ b/rusoto/services/batch/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Batch @ 2016-08-10"
-documentation = "https://rusoto.github.io/rusoto/rusoto_batch/index.html"
+documentation = "https://docs.rs/rusoto_batch"
 keywords = ["AWS", "Amazon", "batch"]
 license = "MIT"
 name = "rusoto_batch"

--- a/rusoto/services/batch/README.md
+++ b/rusoto/services/batch/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_batch "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/budgets/Cargo.toml
+++ b/rusoto/services/budgets/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Budgets @ 2016-10-20"
-documentation = "https://rusoto.github.io/rusoto/rusoto_budgets/index.html"
+documentation = "https://docs.rs/rusoto_budgets"
 keywords = ["AWS", "Amazon", "budgets"]
 license = "MIT"
 name = "rusoto_budgets"

--- a/rusoto/services/budgets/README.md
+++ b/rusoto/services/budgets/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_budgets "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/ce/Cargo.toml
+++ b/rusoto/services/ce/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Cost Explorer Service @ 2017-10-25"
-documentation = "https://rusoto.github.io/rusoto/rusoto_ce/index.html"
+documentation = "https://docs.rs/rusoto_ce"
 keywords = ["AWS", "Amazon", "ce"]
 license = "MIT"
 name = "rusoto_ce"

--- a/rusoto/services/ce/README.md
+++ b/rusoto/services/ce/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_ce "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/chime/Cargo.toml
+++ b/rusoto/services/chime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Chime @ 2018-05-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_chime/index.html"
+documentation = "https://docs.rs/rusoto_chime"
 keywords = ["AWS", "Amazon", "chime"]
 license = "MIT"
 name = "rusoto_chime"

--- a/rusoto/services/chime/README.md
+++ b/rusoto/services/chime/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_chime "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/cloud9/Cargo.toml
+++ b/rusoto/services/cloud9/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Cloud9 @ 2017-09-23"
-documentation = "https://rusoto.github.io/rusoto/rusoto_cloud9/index.html"
+documentation = "https://docs.rs/rusoto_cloud9"
 keywords = ["AWS", "Amazon", "cloud9"]
 license = "MIT"
 name = "rusoto_cloud9"

--- a/rusoto/services/cloud9/README.md
+++ b/rusoto/services/cloud9/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_cloud9 "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/clouddirectory/Cargo.toml
+++ b/rusoto/services/clouddirectory/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon CloudDirectory @ 2016-05-10"
-documentation = "https://rusoto.github.io/rusoto/rusoto_clouddirectory/index.html"
+documentation = "https://docs.rs/rusoto_clouddirectory"
 keywords = ["AWS", "Amazon", "clouddirectory"]
 license = "MIT"
 name = "rusoto_clouddirectory"

--- a/rusoto/services/clouddirectory/README.md
+++ b/rusoto/services/clouddirectory/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_clouddirectory "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/cloudformation/Cargo.toml
+++ b/rusoto/services/cloudformation/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS CloudFormation @ 2010-05-15"
-documentation = "https://rusoto.github.io/rusoto/rusoto_cloudformation/index.html"
+documentation = "https://docs.rs/rusoto_cloudformation"
 keywords = ["AWS", "Amazon", "cloudformation"]
 license = "MIT"
 name = "rusoto_cloudformation"

--- a/rusoto/services/cloudformation/README.md
+++ b/rusoto/services/cloudformation/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_cloudformation "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/cloudfront/Cargo.toml
+++ b/rusoto/services/cloudfront/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon CloudFront @ 2017-03-25"
-documentation = "https://rusoto.github.io/rusoto/rusoto_cloudfront/index.html"
+documentation = "https://docs.rs/rusoto_cloudfront"
 keywords = ["AWS", "Amazon", "cloudfront"]
 license = "MIT"
 name = "rusoto_cloudfront"

--- a/rusoto/services/cloudfront/README.md
+++ b/rusoto/services/cloudfront/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_cloudfront "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/cloudhsm/Cargo.toml
+++ b/rusoto/services/cloudhsm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon CloudHSM @ 2014-05-30"
-documentation = "https://rusoto.github.io/rusoto/rusoto_cloudhsm/index.html"
+documentation = "https://docs.rs/rusoto_cloudhsm"
 keywords = ["AWS", "Amazon", "cloudhsm"]
 license = "MIT"
 name = "rusoto_cloudhsm"

--- a/rusoto/services/cloudhsm/README.md
+++ b/rusoto/services/cloudhsm/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_cloudhsm "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/cloudhsmv2/Cargo.toml
+++ b/rusoto/services/cloudhsmv2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS CloudHSM V2 @ 2017-04-28"
-documentation = "https://rusoto.github.io/rusoto/rusoto_cloudhsmv2/index.html"
+documentation = "https://docs.rs/rusoto_cloudhsmv2"
 keywords = ["AWS", "Amazon", "cloudhsmv2"]
 license = "MIT"
 name = "rusoto_cloudhsmv2"

--- a/rusoto/services/cloudhsmv2/README.md
+++ b/rusoto/services/cloudhsmv2/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_cloudhsmv2 "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/cloudsearch/Cargo.toml
+++ b/rusoto/services/cloudsearch/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon CloudSearch @ 2013-01-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_cloudsearch/index.html"
+documentation = "https://docs.rs/rusoto_cloudsearch"
 keywords = ["AWS", "Amazon", "cloudsearch"]
 license = "MIT"
 name = "rusoto_cloudsearch"

--- a/rusoto/services/cloudsearch/README.md
+++ b/rusoto/services/cloudsearch/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_cloudsearch "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/cloudsearchdomain/Cargo.toml
+++ b/rusoto/services/cloudsearchdomain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon CloudSearch Domain @ 2013-01-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_cloudsearchdomain/index.html"
+documentation = "https://docs.rs/rusoto_cloudsearchdomain"
 keywords = ["AWS", "Amazon", "cloudsearchdomain"]
 license = "MIT"
 name = "rusoto_cloudsearchdomain"

--- a/rusoto/services/cloudsearchdomain/README.md
+++ b/rusoto/services/cloudsearchdomain/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_cloudsearchdomain "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/cloudtrail/Cargo.toml
+++ b/rusoto/services/cloudtrail/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS CloudTrail @ 2013-11-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_cloudtrail/index.html"
+documentation = "https://docs.rs/rusoto_cloudtrail"
 keywords = ["AWS", "Amazon", "cloudtrail"]
 license = "MIT"
 name = "rusoto_cloudtrail"

--- a/rusoto/services/cloudtrail/README.md
+++ b/rusoto/services/cloudtrail/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_cloudtrail "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/cloudwatch/Cargo.toml
+++ b/rusoto/services/cloudwatch/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon CloudWatch @ 2010-08-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_cloudwatch/index.html"
+documentation = "https://docs.rs/rusoto_cloudwatch"
 keywords = ["AWS", "Amazon", "cloudwatch"]
 license = "MIT"
 name = "rusoto_cloudwatch"

--- a/rusoto/services/cloudwatch/README.md
+++ b/rusoto/services/cloudwatch/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_cloudwatch "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/codebuild/Cargo.toml
+++ b/rusoto/services/codebuild/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS CodeBuild @ 2016-10-06"
-documentation = "https://rusoto.github.io/rusoto/rusoto_codebuild/index.html"
+documentation = "https://docs.rs/rusoto_codebuild"
 keywords = ["AWS", "Amazon", "codebuild"]
 license = "MIT"
 name = "rusoto_codebuild"

--- a/rusoto/services/codebuild/README.md
+++ b/rusoto/services/codebuild/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_codebuild "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/codecommit/Cargo.toml
+++ b/rusoto/services/codecommit/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS CodeCommit @ 2015-04-13"
-documentation = "https://rusoto.github.io/rusoto/rusoto_codecommit/index.html"
+documentation = "https://docs.rs/rusoto_codecommit"
 keywords = ["AWS", "Amazon", "codecommit"]
 license = "MIT"
 name = "rusoto_codecommit"

--- a/rusoto/services/codecommit/README.md
+++ b/rusoto/services/codecommit/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_codecommit "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/codedeploy/Cargo.toml
+++ b/rusoto/services/codedeploy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS CodeDeploy @ 2014-10-06"
-documentation = "https://rusoto.github.io/rusoto/rusoto_codedeploy/index.html"
+documentation = "https://docs.rs/rusoto_codedeploy"
 keywords = ["AWS", "Amazon", "codedeploy"]
 license = "MIT"
 name = "rusoto_codedeploy"

--- a/rusoto/services/codedeploy/README.md
+++ b/rusoto/services/codedeploy/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_codedeploy "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/codepipeline/Cargo.toml
+++ b/rusoto/services/codepipeline/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS CodePipeline @ 2015-07-09"
-documentation = "https://rusoto.github.io/rusoto/rusoto_codepipeline/index.html"
+documentation = "https://docs.rs/rusoto_codepipeline"
 keywords = ["AWS", "Amazon", "codepipeline"]
 license = "MIT"
 name = "rusoto_codepipeline"

--- a/rusoto/services/codepipeline/README.md
+++ b/rusoto/services/codepipeline/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_codepipeline "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/codestar/Cargo.toml
+++ b/rusoto/services/codestar/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS CodeStar @ 2017-04-19"
-documentation = "https://rusoto.github.io/rusoto/rusoto_codestar/index.html"
+documentation = "https://docs.rs/rusoto_codestar"
 keywords = ["AWS", "Amazon", "codestar"]
 license = "MIT"
 name = "rusoto_codestar"

--- a/rusoto/services/codestar/README.md
+++ b/rusoto/services/codestar/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_codestar "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/cognito-identity/Cargo.toml
+++ b/rusoto/services/cognito-identity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Cognito Identity @ 2014-06-30"
-documentation = "https://rusoto.github.io/rusoto/rusoto_cognito_identity/index.html"
+documentation = "https://docs.rs/rusoto_cognito_identity"
 keywords = ["AWS", "Amazon", "cognito-identity"]
 license = "MIT"
 name = "rusoto_cognito_identity"

--- a/rusoto/services/cognito-identity/README.md
+++ b/rusoto/services/cognito-identity/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_cognito_identity "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/cognito-idp/Cargo.toml
+++ b/rusoto/services/cognito-idp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Cognito Identity Provider @ 2016-04-18"
-documentation = "https://rusoto.github.io/rusoto/rusoto_cognito_idp/index.html"
+documentation = "https://docs.rs/rusoto_cognito_idp"
 keywords = ["AWS", "Amazon", "cognito-idp"]
 license = "MIT"
 name = "rusoto_cognito_idp"

--- a/rusoto/services/cognito-idp/README.md
+++ b/rusoto/services/cognito-idp/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_cognito_idp "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/cognito-sync/Cargo.toml
+++ b/rusoto/services/cognito-sync/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Cognito Sync @ 2014-06-30"
-documentation = "https://rusoto.github.io/rusoto/rusoto_cognito_sync/index.html"
+documentation = "https://docs.rs/rusoto_cognito_sync"
 keywords = ["AWS", "Amazon", "cognito-sync"]
 license = "MIT"
 name = "rusoto_cognito_sync"

--- a/rusoto/services/cognito-sync/README.md
+++ b/rusoto/services/cognito-sync/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_cognito_sync "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/comprehend/Cargo.toml
+++ b/rusoto/services/comprehend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Comprehend @ 2017-11-27"
-documentation = "https://rusoto.github.io/rusoto/rusoto_comprehend/index.html"
+documentation = "https://docs.rs/rusoto_comprehend"
 keywords = ["AWS", "Amazon", "comprehend"]
 license = "MIT"
 name = "rusoto_comprehend"

--- a/rusoto/services/comprehend/README.md
+++ b/rusoto/services/comprehend/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_comprehend "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/comprehendmedical/Cargo.toml
+++ b/rusoto/services/comprehendmedical/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Comprehend Medical @ 2018-10-30"
-documentation = "https://rusoto.github.io/rusoto/rusoto_comprehendmedical/index.html"
+documentation = "https://docs.rs/rusoto_comprehendmedical"
 keywords = ["AWS", "Amazon", "comprehendmedical"]
 license = "MIT"
 name = "rusoto_comprehendmedical"

--- a/rusoto/services/comprehendmedical/README.md
+++ b/rusoto/services/comprehendmedical/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_comprehendmedical "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/config/Cargo.toml
+++ b/rusoto/services/config/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Config @ 2014-11-12"
-documentation = "https://rusoto.github.io/rusoto/rusoto_config/index.html"
+documentation = "https://docs.rs/rusoto_config"
 keywords = ["AWS", "Amazon", "config"]
 license = "MIT"
 name = "rusoto_config"

--- a/rusoto/services/config/README.md
+++ b/rusoto/services/config/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_config "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/connect/Cargo.toml
+++ b/rusoto/services/connect/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Connect Service @ 2017-08-08"
-documentation = "https://rusoto.github.io/rusoto/rusoto_connect/index.html"
+documentation = "https://docs.rs/rusoto_connect"
 keywords = ["AWS", "Amazon", "connect"]
 license = "MIT"
 name = "rusoto_connect"

--- a/rusoto/services/connect/README.md
+++ b/rusoto/services/connect/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_connect "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/cur/Cargo.toml
+++ b/rusoto/services/cur/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Cost and Usage Report Service @ 2017-01-06"
-documentation = "https://rusoto.github.io/rusoto/rusoto_cur/index.html"
+documentation = "https://docs.rs/rusoto_cur"
 keywords = ["AWS", "Amazon", "cur"]
 license = "MIT"
 name = "rusoto_cur"

--- a/rusoto/services/cur/README.md
+++ b/rusoto/services/cur/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_cur "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/datapipeline/Cargo.toml
+++ b/rusoto/services/datapipeline/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Data Pipeline @ 2012-10-29"
-documentation = "https://rusoto.github.io/rusoto/rusoto_datapipeline/index.html"
+documentation = "https://docs.rs/rusoto_datapipeline"
 keywords = ["AWS", "Amazon", "datapipeline"]
 license = "MIT"
 name = "rusoto_datapipeline"

--- a/rusoto/services/datapipeline/README.md
+++ b/rusoto/services/datapipeline/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_datapipeline "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/dax/Cargo.toml
+++ b/rusoto/services/dax/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon DynamoDB Accelerator (DAX) @ 2017-04-19"
-documentation = "https://rusoto.github.io/rusoto/rusoto_dax/index.html"
+documentation = "https://docs.rs/rusoto_dax"
 keywords = ["AWS", "Amazon", "dax"]
 license = "MIT"
 name = "rusoto_dax"

--- a/rusoto/services/dax/README.md
+++ b/rusoto/services/dax/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_dax "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/devicefarm/Cargo.toml
+++ b/rusoto/services/devicefarm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Device Farm @ 2015-06-23"
-documentation = "https://rusoto.github.io/rusoto/rusoto_devicefarm/index.html"
+documentation = "https://docs.rs/rusoto_devicefarm"
 keywords = ["AWS", "Amazon", "devicefarm"]
 license = "MIT"
 name = "rusoto_devicefarm"

--- a/rusoto/services/devicefarm/README.md
+++ b/rusoto/services/devicefarm/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_devicefarm "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/directconnect/Cargo.toml
+++ b/rusoto/services/directconnect/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Direct Connect @ 2012-10-25"
-documentation = "https://rusoto.github.io/rusoto/rusoto_directconnect/index.html"
+documentation = "https://docs.rs/rusoto_directconnect"
 keywords = ["AWS", "Amazon", "directconnect"]
 license = "MIT"
 name = "rusoto_directconnect"

--- a/rusoto/services/directconnect/README.md
+++ b/rusoto/services/directconnect/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_directconnect "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/discovery/Cargo.toml
+++ b/rusoto/services/discovery/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Application Discovery Service @ 2015-11-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_discovery/index.html"
+documentation = "https://docs.rs/rusoto_discovery"
 keywords = ["AWS", "Amazon", "discovery"]
 license = "MIT"
 name = "rusoto_discovery"

--- a/rusoto/services/discovery/README.md
+++ b/rusoto/services/discovery/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_discovery "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/dms/Cargo.toml
+++ b/rusoto/services/dms/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Database Migration Service @ 2016-01-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_dms/index.html"
+documentation = "https://docs.rs/rusoto_dms"
 keywords = ["AWS", "Amazon", "dms"]
 license = "MIT"
 name = "rusoto_dms"

--- a/rusoto/services/dms/README.md
+++ b/rusoto/services/dms/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_dms "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/docdb/Cargo.toml
+++ b/rusoto/services/docdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon DocumentDB with MongoDB compatibility @ 2014-10-31"
-documentation = "https://rusoto.github.io/rusoto/rusoto_docdb/index.html"
+documentation = "https://docs.rs/rusoto_docdb"
 keywords = ["AWS", "Amazon", "docdb"]
 license = "MIT"
 name = "rusoto_docdb"

--- a/rusoto/services/docdb/README.md
+++ b/rusoto/services/docdb/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_docdb "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/ds/Cargo.toml
+++ b/rusoto/services/ds/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Directory Service @ 2015-04-16"
-documentation = "https://rusoto.github.io/rusoto/rusoto_ds/index.html"
+documentation = "https://docs.rs/rusoto_ds"
 keywords = ["AWS", "Amazon", "ds"]
 license = "MIT"
 name = "rusoto_ds"

--- a/rusoto/services/ds/README.md
+++ b/rusoto/services/ds/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_ds "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/dynamodb/Cargo.toml
+++ b/rusoto/services/dynamodb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon DynamoDB @ 2012-08-10"
-documentation = "https://rusoto.github.io/rusoto/rusoto_dynamodb/index.html"
+documentation = "https://docs.rs/rusoto_dynamodb"
 keywords = ["AWS", "Amazon", "dynamodb"]
 license = "MIT"
 name = "rusoto_dynamodb"

--- a/rusoto/services/dynamodb/README.md
+++ b/rusoto/services/dynamodb/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_dynamodb "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/dynamodbstreams/Cargo.toml
+++ b/rusoto/services/dynamodbstreams/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon DynamoDB Streams @ 2012-08-10"
-documentation = "https://rusoto.github.io/rusoto/rusoto_dynamodbstreams/index.html"
+documentation = "https://docs.rs/rusoto_dynamodbstreams"
 keywords = ["AWS", "Amazon", "dynamodbstreams"]
 license = "MIT"
 name = "rusoto_dynamodbstreams"

--- a/rusoto/services/dynamodbstreams/README.md
+++ b/rusoto/services/dynamodbstreams/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_dynamodbstreams "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/ec2/Cargo.toml
+++ b/rusoto/services/ec2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Elastic Compute Cloud @ 2016-11-15"
-documentation = "https://rusoto.github.io/rusoto/rusoto_ec2/index.html"
+documentation = "https://docs.rs/rusoto_ec2"
 keywords = ["AWS", "Amazon", "ec2"]
 license = "MIT"
 name = "rusoto_ec2"

--- a/rusoto/services/ec2/README.md
+++ b/rusoto/services/ec2/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_ec2 "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/ecr/Cargo.toml
+++ b/rusoto/services/ecr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon EC2 Container Registry @ 2015-09-21"
-documentation = "https://rusoto.github.io/rusoto/rusoto_ecr/index.html"
+documentation = "https://docs.rs/rusoto_ecr"
 keywords = ["AWS", "Amazon", "ecr"]
 license = "MIT"
 name = "rusoto_ecr"

--- a/rusoto/services/ecr/README.md
+++ b/rusoto/services/ecr/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_ecr "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/ecs/Cargo.toml
+++ b/rusoto/services/ecs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon EC2 Container Service @ 2014-11-13"
-documentation = "https://rusoto.github.io/rusoto/rusoto_ecs/index.html"
+documentation = "https://docs.rs/rusoto_ecs"
 keywords = ["AWS", "Amazon", "ecs"]
 license = "MIT"
 name = "rusoto_ecs"

--- a/rusoto/services/ecs/README.md
+++ b/rusoto/services/ecs/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_ecs "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/efs/Cargo.toml
+++ b/rusoto/services/efs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Elastic File System @ 2015-02-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_efs/index.html"
+documentation = "https://docs.rs/rusoto_efs"
 keywords = ["AWS", "Amazon", "efs"]
 license = "MIT"
 name = "rusoto_efs"

--- a/rusoto/services/efs/README.md
+++ b/rusoto/services/efs/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_efs "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/eks/Cargo.toml
+++ b/rusoto/services/eks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Elastic Container Service for Kubernetes @ 2017-11-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_eks/index.html"
+documentation = "https://docs.rs/rusoto_eks"
 keywords = ["AWS", "Amazon", "eks"]
 license = "MIT"
 name = "rusoto_eks"

--- a/rusoto/services/eks/README.md
+++ b/rusoto/services/eks/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_eks "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/elasticache/Cargo.toml
+++ b/rusoto/services/elasticache/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon ElastiCache @ 2015-02-02"
-documentation = "https://rusoto.github.io/rusoto/rusoto_elasticache/index.html"
+documentation = "https://docs.rs/rusoto_elasticache"
 keywords = ["AWS", "Amazon", "elasticache"]
 license = "MIT"
 name = "rusoto_elasticache"

--- a/rusoto/services/elasticache/README.md
+++ b/rusoto/services/elasticache/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_elasticache "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/elasticbeanstalk/Cargo.toml
+++ b/rusoto/services/elasticbeanstalk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Elastic Beanstalk @ 2010-12-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_elasticbeanstalk/index.html"
+documentation = "https://docs.rs/rusoto_elasticbeanstalk"
 keywords = ["AWS", "Amazon", "elasticbeanstalk"]
 license = "MIT"
 name = "rusoto_elasticbeanstalk"

--- a/rusoto/services/elasticbeanstalk/README.md
+++ b/rusoto/services/elasticbeanstalk/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_elasticbeanstalk "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/elastictranscoder/Cargo.toml
+++ b/rusoto/services/elastictranscoder/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Elastic Transcoder @ 2012-09-25"
-documentation = "https://rusoto.github.io/rusoto/rusoto_elastictranscoder/index.html"
+documentation = "https://docs.rs/rusoto_elastictranscoder"
 keywords = ["AWS", "Amazon", "elastictranscoder"]
 license = "MIT"
 name = "rusoto_elastictranscoder"

--- a/rusoto/services/elastictranscoder/README.md
+++ b/rusoto/services/elastictranscoder/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_elastictranscoder "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/elb/Cargo.toml
+++ b/rusoto/services/elb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Elastic Load Balancing @ 2012-06-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_elb/index.html"
+documentation = "https://docs.rs/rusoto_elb"
 keywords = ["AWS", "Amazon", "elb"]
 license = "MIT"
 name = "rusoto_elb"

--- a/rusoto/services/elb/README.md
+++ b/rusoto/services/elb/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_elb "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/elbv2/Cargo.toml
+++ b/rusoto/services/elbv2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Elastic Load Balancing @ 2015-12-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_elbv2/index.html"
+documentation = "https://docs.rs/rusoto_elbv2"
 keywords = ["AWS", "Amazon", "elbv2"]
 license = "MIT"
 name = "rusoto_elbv2"

--- a/rusoto/services/elbv2/README.md
+++ b/rusoto/services/elbv2/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_elbv2 "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/emr/Cargo.toml
+++ b/rusoto/services/emr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Elastic MapReduce @ 2009-03-31"
-documentation = "https://rusoto.github.io/rusoto/rusoto_emr/index.html"
+documentation = "https://docs.rs/rusoto_emr"
 keywords = ["AWS", "Amazon", "emr"]
 license = "MIT"
 name = "rusoto_emr"

--- a/rusoto/services/emr/README.md
+++ b/rusoto/services/emr/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_emr "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/events/Cargo.toml
+++ b/rusoto/services/events/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon CloudWatch Events @ 2015-10-07"
-documentation = "https://rusoto.github.io/rusoto/rusoto_events/index.html"
+documentation = "https://docs.rs/rusoto_events"
 keywords = ["AWS", "Amazon", "events"]
 license = "MIT"
 name = "rusoto_events"

--- a/rusoto/services/events/README.md
+++ b/rusoto/services/events/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_events "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/firehose/Cargo.toml
+++ b/rusoto/services/firehose/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Kinesis Firehose @ 2015-08-04"
-documentation = "https://rusoto.github.io/rusoto/rusoto_firehose/index.html"
+documentation = "https://docs.rs/rusoto_firehose"
 keywords = ["AWS", "Amazon", "firehose"]
 license = "MIT"
 name = "rusoto_firehose"

--- a/rusoto/services/firehose/README.md
+++ b/rusoto/services/firehose/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_firehose "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/fms/Cargo.toml
+++ b/rusoto/services/fms/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Firewall Management Service @ 2018-01-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_fms/index.html"
+documentation = "https://docs.rs/rusoto_fms"
 keywords = ["AWS", "Amazon", "fms"]
 license = "MIT"
 name = "rusoto_fms"

--- a/rusoto/services/fms/README.md
+++ b/rusoto/services/fms/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_fms "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/fsx/Cargo.toml
+++ b/rusoto/services/fsx/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon FSx @ 2018-03-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_fsx/index.html"
+documentation = "https://docs.rs/rusoto_fsx"
 keywords = ["AWS", "Amazon", "fsx"]
 license = "MIT"
 name = "rusoto_fsx"

--- a/rusoto/services/fsx/README.md
+++ b/rusoto/services/fsx/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_fsx "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/gamelift/Cargo.toml
+++ b/rusoto/services/gamelift/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon GameLift @ 2015-10-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_gamelift/index.html"
+documentation = "https://docs.rs/rusoto_gamelift"
 keywords = ["AWS", "Amazon", "gamelift"]
 license = "MIT"
 name = "rusoto_gamelift"

--- a/rusoto/services/gamelift/README.md
+++ b/rusoto/services/gamelift/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_gamelift "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/glacier/Cargo.toml
+++ b/rusoto/services/glacier/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Glacier @ 2012-06-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_glacier/index.html"
+documentation = "https://docs.rs/rusoto_glacier"
 keywords = ["AWS", "Amazon", "glacier"]
 license = "MIT"
 name = "rusoto_glacier"

--- a/rusoto/services/glacier/README.md
+++ b/rusoto/services/glacier/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_glacier "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/glue/Cargo.toml
+++ b/rusoto/services/glue/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Glue @ 2017-03-31"
-documentation = "https://rusoto.github.io/rusoto/rusoto_glue/index.html"
+documentation = "https://docs.rs/rusoto_glue"
 keywords = ["AWS", "Amazon", "glue"]
 license = "MIT"
 name = "rusoto_glue"

--- a/rusoto/services/glue/README.md
+++ b/rusoto/services/glue/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_glue "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/greengrass/Cargo.toml
+++ b/rusoto/services/greengrass/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Greengrass @ 2017-06-07"
-documentation = "https://rusoto.github.io/rusoto/rusoto_greengrass/index.html"
+documentation = "https://docs.rs/rusoto_greengrass"
 keywords = ["AWS", "Amazon", "greengrass"]
 license = "MIT"
 name = "rusoto_greengrass"

--- a/rusoto/services/greengrass/README.md
+++ b/rusoto/services/greengrass/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_greengrass "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/guardduty/Cargo.toml
+++ b/rusoto/services/guardduty/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon GuardDuty @ 2017-11-28"
-documentation = "https://rusoto.github.io/rusoto/rusoto_guardduty/index.html"
+documentation = "https://docs.rs/rusoto_guardduty"
 keywords = ["AWS", "Amazon", "guardduty"]
 license = "MIT"
 name = "rusoto_guardduty"

--- a/rusoto/services/guardduty/README.md
+++ b/rusoto/services/guardduty/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_guardduty "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/health/Cargo.toml
+++ b/rusoto/services/health/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Health APIs and Notifications @ 2016-08-04"
-documentation = "https://rusoto.github.io/rusoto/rusoto_health/index.html"
+documentation = "https://docs.rs/rusoto_health"
 keywords = ["AWS", "Amazon", "health"]
 license = "MIT"
 name = "rusoto_health"

--- a/rusoto/services/health/README.md
+++ b/rusoto/services/health/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_health "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/iam/Cargo.toml
+++ b/rusoto/services/iam/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Identity and Access Management @ 2010-05-08"
-documentation = "https://rusoto.github.io/rusoto/rusoto_iam/index.html"
+documentation = "https://docs.rs/rusoto_iam"
 keywords = ["AWS", "Amazon", "iam"]
 license = "MIT"
 name = "rusoto_iam"

--- a/rusoto/services/iam/README.md
+++ b/rusoto/services/iam/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_iam "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/importexport/Cargo.toml
+++ b/rusoto/services/importexport/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Import/Export @ 2010-06-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_importexport/index.html"
+documentation = "https://docs.rs/rusoto_importexport"
 keywords = ["AWS", "Amazon", "importexport"]
 license = "MIT"
 name = "rusoto_importexport"

--- a/rusoto/services/importexport/README.md
+++ b/rusoto/services/importexport/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_importexport "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/inspector/Cargo.toml
+++ b/rusoto/services/inspector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Inspector @ 2016-02-16"
-documentation = "https://rusoto.github.io/rusoto/rusoto_inspector/index.html"
+documentation = "https://docs.rs/rusoto_inspector"
 keywords = ["AWS", "Amazon", "inspector"]
 license = "MIT"
 name = "rusoto_inspector"

--- a/rusoto/services/inspector/README.md
+++ b/rusoto/services/inspector/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_inspector "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/iot-data/Cargo.toml
+++ b/rusoto/services/iot-data/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS IoT Data Plane @ 2015-05-28"
-documentation = "https://rusoto.github.io/rusoto/rusoto_iot_data/index.html"
+documentation = "https://docs.rs/rusoto_iot_data"
 keywords = ["AWS", "Amazon", "iot-data"]
 license = "MIT"
 name = "rusoto_iot_data"

--- a/rusoto/services/iot-data/README.md
+++ b/rusoto/services/iot-data/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_iot_data "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/iot-jobs-data/Cargo.toml
+++ b/rusoto/services/iot-jobs-data/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS IoT Jobs Data Plane @ 2017-09-29"
-documentation = "https://rusoto.github.io/rusoto/rusoto_iot_jobs_data/index.html"
+documentation = "https://docs.rs/rusoto_iot_jobs_data"
 keywords = ["AWS", "Amazon", "iot-jobs-data"]
 license = "MIT"
 name = "rusoto_iot_jobs_data"

--- a/rusoto/services/iot-jobs-data/README.md
+++ b/rusoto/services/iot-jobs-data/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_iot_jobs_data "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/iot/Cargo.toml
+++ b/rusoto/services/iot/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS IoT @ 2015-05-28"
-documentation = "https://rusoto.github.io/rusoto/rusoto_iot/index.html"
+documentation = "https://docs.rs/rusoto_iot"
 keywords = ["AWS", "Amazon", "iot"]
 license = "MIT"
 name = "rusoto_iot"

--- a/rusoto/services/iot/README.md
+++ b/rusoto/services/iot/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_iot "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/iot1click-devices/Cargo.toml
+++ b/rusoto/services/iot1click-devices/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS IoT 1-Click Devices Service @ 2018-05-14"
-documentation = "https://rusoto.github.io/rusoto/rusoto_iot1click_devices/index.html"
+documentation = "https://docs.rs/rusoto_iot1click_devices"
 keywords = ["AWS", "Amazon", "iot1click-devices"]
 license = "MIT"
 name = "rusoto_iot1click_devices"

--- a/rusoto/services/iot1click-devices/README.md
+++ b/rusoto/services/iot1click-devices/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_iot1click_devices "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/iot1click-projects/Cargo.toml
+++ b/rusoto/services/iot1click-projects/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS IoT 1-Click Projects Service @ 2018-05-14"
-documentation = "https://rusoto.github.io/rusoto/rusoto_iot1click_projects/index.html"
+documentation = "https://docs.rs/rusoto_iot1click_projects"
 keywords = ["AWS", "Amazon", "iot1click-projects"]
 license = "MIT"
 name = "rusoto_iot1click_projects"

--- a/rusoto/services/iot1click-projects/README.md
+++ b/rusoto/services/iot1click-projects/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_iot1click_projects "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/iotanalytics/Cargo.toml
+++ b/rusoto/services/iotanalytics/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS IoT Analytics @ 2017-11-27"
-documentation = "https://rusoto.github.io/rusoto/rusoto_iotanalytics/index.html"
+documentation = "https://docs.rs/rusoto_iotanalytics"
 keywords = ["AWS", "Amazon", "iotanalytics"]
 license = "MIT"
 name = "rusoto_iotanalytics"

--- a/rusoto/services/iotanalytics/README.md
+++ b/rusoto/services/iotanalytics/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_iotanalytics "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/kafka/Cargo.toml
+++ b/rusoto/services/kafka/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Managed Streaming for Kafka @ 2018-11-14"
-documentation = "https://rusoto.github.io/rusoto/rusoto_kafka/index.html"
+documentation = "https://docs.rs/rusoto_kafka"
 keywords = ["AWS", "Amazon", "kafka"]
 license = "MIT"
 name = "rusoto_kafka"

--- a/rusoto/services/kafka/README.md
+++ b/rusoto/services/kafka/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_kafka "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/kinesis-video-archived-media/Cargo.toml
+++ b/rusoto/services/kinesis-video-archived-media/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Kinesis Video Streams Archived Media @ 2017-09-30"
-documentation = "https://rusoto.github.io/rusoto/rusoto_kinesis_video_archived_media/index.html"
+documentation = "https://docs.rs/rusoto_kinesis_video_archived_media"
 keywords = ["AWS", "Amazon", "kinesis-video-archiv"]
 license = "MIT"
 name = "rusoto_kinesis_video_archived_media"

--- a/rusoto/services/kinesis-video-archived-media/README.md
+++ b/rusoto/services/kinesis-video-archived-media/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_kinesis_video_archived_media "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/kinesis-video-media/Cargo.toml
+++ b/rusoto/services/kinesis-video-media/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Kinesis Video Streams Media @ 2017-09-30"
-documentation = "https://rusoto.github.io/rusoto/rusoto_kinesis_video_media/index.html"
+documentation = "https://docs.rs/rusoto_kinesis_video_media"
 keywords = ["AWS", "Amazon", "kinesis-video-media"]
 license = "MIT"
 name = "rusoto_kinesis_video_media"

--- a/rusoto/services/kinesis-video-media/README.md
+++ b/rusoto/services/kinesis-video-media/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_kinesis_video_media "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/kinesis/Cargo.toml
+++ b/rusoto/services/kinesis/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Kinesis @ 2013-12-02"
-documentation = "https://rusoto.github.io/rusoto/rusoto_kinesis/index.html"
+documentation = "https://docs.rs/rusoto_kinesis"
 keywords = ["AWS", "Amazon", "kinesis"]
 license = "MIT"
 name = "rusoto_kinesis"

--- a/rusoto/services/kinesis/README.md
+++ b/rusoto/services/kinesis/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_kinesis "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/kinesisanalytics/Cargo.toml
+++ b/rusoto/services/kinesisanalytics/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Kinesis Analytics @ 2015-08-14"
-documentation = "https://rusoto.github.io/rusoto/rusoto_kinesisanalytics/index.html"
+documentation = "https://docs.rs/rusoto_kinesisanalytics"
 keywords = ["AWS", "Amazon", "kinesisanalytics"]
 license = "MIT"
 name = "rusoto_kinesisanalytics"

--- a/rusoto/services/kinesisanalytics/README.md
+++ b/rusoto/services/kinesisanalytics/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_kinesisanalytics "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/kinesisvideo/Cargo.toml
+++ b/rusoto/services/kinesisvideo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Kinesis Video Streams @ 2017-09-30"
-documentation = "https://rusoto.github.io/rusoto/rusoto_kinesisvideo/index.html"
+documentation = "https://docs.rs/rusoto_kinesisvideo"
 keywords = ["AWS", "Amazon", "kinesisvideo"]
 license = "MIT"
 name = "rusoto_kinesisvideo"

--- a/rusoto/services/kinesisvideo/README.md
+++ b/rusoto/services/kinesisvideo/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_kinesisvideo "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/kms/Cargo.toml
+++ b/rusoto/services/kms/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Key Management Service @ 2014-11-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_kms/index.html"
+documentation = "https://docs.rs/rusoto_kms"
 keywords = ["AWS", "Amazon", "kms"]
 license = "MIT"
 name = "rusoto_kms"

--- a/rusoto/services/kms/README.md
+++ b/rusoto/services/kms/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_kms "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/lambda/Cargo.toml
+++ b/rusoto/services/lambda/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Lambda @ 2015-03-31"
-documentation = "https://rusoto.github.io/rusoto/rusoto_lambda/index.html"
+documentation = "https://docs.rs/rusoto_lambda"
 keywords = ["AWS", "Amazon", "lambda"]
 license = "MIT"
 name = "rusoto_lambda"

--- a/rusoto/services/lambda/README.md
+++ b/rusoto/services/lambda/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_lambda "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/lex-models/Cargo.toml
+++ b/rusoto/services/lex-models/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Lex Model Building Service @ 2017-04-19"
-documentation = "https://rusoto.github.io/rusoto/rusoto_lex_models/index.html"
+documentation = "https://docs.rs/rusoto_lex_models"
 keywords = ["AWS", "Amazon", "lex-models"]
 license = "MIT"
 name = "rusoto_lex_models"

--- a/rusoto/services/lex-models/README.md
+++ b/rusoto/services/lex-models/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_lex_models "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/lex-runtime/Cargo.toml
+++ b/rusoto/services/lex-runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Lex Runtime Service @ 2016-11-28"
-documentation = "https://rusoto.github.io/rusoto/rusoto_lex_runtime/index.html"
+documentation = "https://docs.rs/rusoto_lex_runtime"
 keywords = ["AWS", "Amazon", "lex-runtime"]
 license = "MIT"
 name = "rusoto_lex_runtime"

--- a/rusoto/services/lex-runtime/README.md
+++ b/rusoto/services/lex-runtime/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_lex_runtime "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/license-manager/Cargo.toml
+++ b/rusoto/services/license-manager/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS License Manager @ 2018-08-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_license_manager/index.html"
+documentation = "https://docs.rs/rusoto_license_manager"
 keywords = ["AWS", "Amazon", "license-manager"]
 license = "MIT"
 name = "rusoto_license_manager"

--- a/rusoto/services/license-manager/README.md
+++ b/rusoto/services/license-manager/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_license_manager "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/lightsail/Cargo.toml
+++ b/rusoto/services/lightsail/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Lightsail @ 2016-11-28"
-documentation = "https://rusoto.github.io/rusoto/rusoto_lightsail/index.html"
+documentation = "https://docs.rs/rusoto_lightsail"
 keywords = ["AWS", "Amazon", "lightsail"]
 license = "MIT"
 name = "rusoto_lightsail"

--- a/rusoto/services/lightsail/README.md
+++ b/rusoto/services/lightsail/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_lightsail "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/logs/Cargo.toml
+++ b/rusoto/services/logs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon CloudWatch Logs @ 2014-03-28"
-documentation = "https://rusoto.github.io/rusoto/rusoto_logs/index.html"
+documentation = "https://docs.rs/rusoto_logs"
 keywords = ["AWS", "Amazon", "logs"]
 license = "MIT"
 name = "rusoto_logs"

--- a/rusoto/services/logs/README.md
+++ b/rusoto/services/logs/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_logs "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/machinelearning/Cargo.toml
+++ b/rusoto/services/machinelearning/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Machine Learning @ 2014-12-12"
-documentation = "https://rusoto.github.io/rusoto/rusoto_machinelearning/index.html"
+documentation = "https://docs.rs/rusoto_machinelearning"
 keywords = ["AWS", "Amazon", "machinelearning"]
 license = "MIT"
 name = "rusoto_machinelearning"

--- a/rusoto/services/machinelearning/README.md
+++ b/rusoto/services/machinelearning/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_machinelearning "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/macie/Cargo.toml
+++ b/rusoto/services/macie/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Macie @ 2017-12-19"
-documentation = "https://rusoto.github.io/rusoto/rusoto_macie/index.html"
+documentation = "https://docs.rs/rusoto_macie"
 keywords = ["AWS", "Amazon", "macie"]
 license = "MIT"
 name = "rusoto_macie"

--- a/rusoto/services/macie/README.md
+++ b/rusoto/services/macie/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_macie "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/marketplace-entitlement/Cargo.toml
+++ b/rusoto/services/marketplace-entitlement/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Marketplace Entitlement Service @ 2017-01-11"
-documentation = "https://rusoto.github.io/rusoto/rusoto_marketplace_entitlement/index.html"
+documentation = "https://docs.rs/rusoto_marketplace_entitlement"
 keywords = ["AWS", "Amazon", "marketplace-entitlem"]
 license = "MIT"
 name = "rusoto_marketplace_entitlement"

--- a/rusoto/services/marketplace-entitlement/README.md
+++ b/rusoto/services/marketplace-entitlement/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_marketplace_entitlement "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/marketplacecommerceanalytics/Cargo.toml
+++ b/rusoto/services/marketplacecommerceanalytics/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Marketplace Commerce Analytics @ 2015-07-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_marketplacecommerceanalytics/index.html"
+documentation = "https://docs.rs/rusoto_marketplacecommerceanalytics"
 keywords = ["AWS", "Amazon", "marketplacecommercea"]
 license = "MIT"
 name = "rusoto_marketplacecommerceanalytics"

--- a/rusoto/services/marketplacecommerceanalytics/README.md
+++ b/rusoto/services/marketplacecommerceanalytics/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_marketplacecommerceanalytics "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/mediaconvert/Cargo.toml
+++ b/rusoto/services/mediaconvert/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Elemental MediaConvert @ 2017-08-29"
-documentation = "https://rusoto.github.io/rusoto/rusoto_mediaconvert/index.html"
+documentation = "https://docs.rs/rusoto_mediaconvert"
 keywords = ["AWS", "Amazon", "mediaconvert"]
 license = "MIT"
 name = "rusoto_mediaconvert"

--- a/rusoto/services/mediaconvert/README.md
+++ b/rusoto/services/mediaconvert/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_mediaconvert "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/medialive/Cargo.toml
+++ b/rusoto/services/medialive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Elemental MediaLive @ 2017-10-14"
-documentation = "https://rusoto.github.io/rusoto/rusoto_medialive/index.html"
+documentation = "https://docs.rs/rusoto_medialive"
 keywords = ["AWS", "Amazon", "medialive"]
 license = "MIT"
 name = "rusoto_medialive"

--- a/rusoto/services/medialive/README.md
+++ b/rusoto/services/medialive/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_medialive "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/mediapackage/Cargo.toml
+++ b/rusoto/services/mediapackage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Elemental MediaPackage @ 2017-10-12"
-documentation = "https://rusoto.github.io/rusoto/rusoto_mediapackage/index.html"
+documentation = "https://docs.rs/rusoto_mediapackage"
 keywords = ["AWS", "Amazon", "mediapackage"]
 license = "MIT"
 name = "rusoto_mediapackage"

--- a/rusoto/services/mediapackage/README.md
+++ b/rusoto/services/mediapackage/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_mediapackage "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/mediastore/Cargo.toml
+++ b/rusoto/services/mediastore/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Elemental MediaStore @ 2017-09-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_mediastore/index.html"
+documentation = "https://docs.rs/rusoto_mediastore"
 keywords = ["AWS", "Amazon", "mediastore"]
 license = "MIT"
 name = "rusoto_mediastore"

--- a/rusoto/services/mediastore/README.md
+++ b/rusoto/services/mediastore/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_mediastore "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/mediatailor/Cargo.toml
+++ b/rusoto/services/mediatailor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS MediaTailor @ 2018-04-23"
-documentation = "https://rusoto.github.io/rusoto/rusoto_mediatailor/index.html"
+documentation = "https://docs.rs/rusoto_mediatailor"
 keywords = ["AWS", "Amazon", "mediatailor"]
 license = "MIT"
 name = "rusoto_mediatailor"

--- a/rusoto/services/mediatailor/README.md
+++ b/rusoto/services/mediatailor/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_mediatailor "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/meteringmarketplace/Cargo.toml
+++ b/rusoto/services/meteringmarketplace/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWSMarketplace Metering @ 2016-01-14"
-documentation = "https://rusoto.github.io/rusoto/rusoto_meteringmarketplace/index.html"
+documentation = "https://docs.rs/rusoto_meteringmarketplace"
 keywords = ["AWS", "Amazon", "meteringmarketplace"]
 license = "MIT"
 name = "rusoto_meteringmarketplace"

--- a/rusoto/services/meteringmarketplace/README.md
+++ b/rusoto/services/meteringmarketplace/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_meteringmarketplace "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/mgh/Cargo.toml
+++ b/rusoto/services/mgh/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Migration Hub @ 2017-05-31"
-documentation = "https://rusoto.github.io/rusoto/rusoto_mgh/index.html"
+documentation = "https://docs.rs/rusoto_mgh"
 keywords = ["AWS", "Amazon", "mgh"]
 license = "MIT"
 name = "rusoto_mgh"

--- a/rusoto/services/mgh/README.md
+++ b/rusoto/services/mgh/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_mgh "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/mobile/Cargo.toml
+++ b/rusoto/services/mobile/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Mobile @ 2017-07-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_mobile/index.html"
+documentation = "https://docs.rs/rusoto_mobile"
 keywords = ["AWS", "Amazon", "mobile"]
 license = "MIT"
 name = "rusoto_mobile"

--- a/rusoto/services/mobile/README.md
+++ b/rusoto/services/mobile/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_mobile "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/mq/Cargo.toml
+++ b/rusoto/services/mq/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AmazonMQ @ 2017-11-27"
-documentation = "https://rusoto.github.io/rusoto/rusoto_mq/index.html"
+documentation = "https://docs.rs/rusoto_mq"
 keywords = ["AWS", "Amazon", "mq"]
 license = "MIT"
 name = "rusoto_mq"

--- a/rusoto/services/mq/README.md
+++ b/rusoto/services/mq/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_mq "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/mturk/Cargo.toml
+++ b/rusoto/services/mturk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Mechanical Turk @ 2017-01-17"
-documentation = "https://rusoto.github.io/rusoto/rusoto_mturk/index.html"
+documentation = "https://docs.rs/rusoto_mturk"
 keywords = ["AWS", "Amazon", "mturk"]
 license = "MIT"
 name = "rusoto_mturk"

--- a/rusoto/services/mturk/README.md
+++ b/rusoto/services/mturk/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_mturk "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/neptune/Cargo.toml
+++ b/rusoto/services/neptune/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Neptune @ 2014-10-31"
-documentation = "https://rusoto.github.io/rusoto/rusoto_neptune/index.html"
+documentation = "https://docs.rs/rusoto_neptune"
 keywords = ["AWS", "Amazon", "neptune"]
 license = "MIT"
 name = "rusoto_neptune"

--- a/rusoto/services/neptune/README.md
+++ b/rusoto/services/neptune/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_neptune "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/opsworks/Cargo.toml
+++ b/rusoto/services/opsworks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS OpsWorks @ 2013-02-18"
-documentation = "https://rusoto.github.io/rusoto/rusoto_opsworks/index.html"
+documentation = "https://docs.rs/rusoto_opsworks"
 keywords = ["AWS", "Amazon", "opsworks"]
 license = "MIT"
 name = "rusoto_opsworks"

--- a/rusoto/services/opsworks/README.md
+++ b/rusoto/services/opsworks/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_opsworks "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/opsworkscm/Cargo.toml
+++ b/rusoto/services/opsworkscm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS OpsWorks for Chef Automate @ 2016-11-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_opsworkscm/index.html"
+documentation = "https://docs.rs/rusoto_opsworkscm"
 keywords = ["AWS", "Amazon", "opsworkscm"]
 license = "MIT"
 name = "rusoto_opsworkscm"

--- a/rusoto/services/opsworkscm/README.md
+++ b/rusoto/services/opsworkscm/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_opsworkscm "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/organizations/Cargo.toml
+++ b/rusoto/services/organizations/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Organizations @ 2016-11-28"
-documentation = "https://rusoto.github.io/rusoto/rusoto_organizations/index.html"
+documentation = "https://docs.rs/rusoto_organizations"
 keywords = ["AWS", "Amazon", "organizations"]
 license = "MIT"
 name = "rusoto_organizations"

--- a/rusoto/services/organizations/README.md
+++ b/rusoto/services/organizations/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_organizations "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/pi/Cargo.toml
+++ b/rusoto/services/pi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Performance Insights @ 2018-02-27"
-documentation = "https://rusoto.github.io/rusoto/rusoto_pi/index.html"
+documentation = "https://docs.rs/rusoto_pi"
 keywords = ["AWS", "Amazon", "pi"]
 license = "MIT"
 name = "rusoto_pi"

--- a/rusoto/services/pi/README.md
+++ b/rusoto/services/pi/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_pi "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/polly/Cargo.toml
+++ b/rusoto/services/polly/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Polly @ 2016-06-10"
-documentation = "https://rusoto.github.io/rusoto/rusoto_polly/index.html"
+documentation = "https://docs.rs/rusoto_polly"
 keywords = ["AWS", "Amazon", "polly"]
 license = "MIT"
 name = "rusoto_polly"

--- a/rusoto/services/polly/README.md
+++ b/rusoto/services/polly/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_polly "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/pricing/Cargo.toml
+++ b/rusoto/services/pricing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Price List Service @ 2017-10-15"
-documentation = "https://rusoto.github.io/rusoto/rusoto_pricing/index.html"
+documentation = "https://docs.rs/rusoto_pricing"
 keywords = ["AWS", "Amazon", "pricing"]
 license = "MIT"
 name = "rusoto_pricing"

--- a/rusoto/services/pricing/README.md
+++ b/rusoto/services/pricing/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_pricing "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/ram/Cargo.toml
+++ b/rusoto/services/ram/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Resource Access Manager @ 2018-01-04"
-documentation = "https://rusoto.github.io/rusoto/rusoto_ram/index.html"
+documentation = "https://docs.rs/rusoto_ram"
 keywords = ["AWS", "Amazon", "ram"]
 license = "MIT"
 name = "rusoto_ram"

--- a/rusoto/services/ram/README.md
+++ b/rusoto/services/ram/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_ram "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/rds-data/Cargo.toml
+++ b/rusoto/services/rds-data/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS RDS DataService @ 2018-08-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_rds_data/index.html"
+documentation = "https://docs.rs/rusoto_rds_data"
 keywords = ["AWS", "Amazon", "rds-data"]
 license = "MIT"
 name = "rusoto_rds_data"

--- a/rusoto/services/rds-data/README.md
+++ b/rusoto/services/rds-data/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_rds_data "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/rds/Cargo.toml
+++ b/rusoto/services/rds/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Relational Database Service @ 2014-10-31"
-documentation = "https://rusoto.github.io/rusoto/rusoto_rds/index.html"
+documentation = "https://docs.rs/rusoto_rds"
 keywords = ["AWS", "Amazon", "rds"]
 license = "MIT"
 name = "rusoto_rds"

--- a/rusoto/services/rds/README.md
+++ b/rusoto/services/rds/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_rds "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/redshift/Cargo.toml
+++ b/rusoto/services/redshift/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Redshift @ 2012-12-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_redshift/index.html"
+documentation = "https://docs.rs/rusoto_redshift"
 keywords = ["AWS", "Amazon", "redshift"]
 license = "MIT"
 name = "rusoto_redshift"

--- a/rusoto/services/redshift/README.md
+++ b/rusoto/services/redshift/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_redshift "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/rekognition/Cargo.toml
+++ b/rusoto/services/rekognition/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Rekognition @ 2016-06-27"
-documentation = "https://rusoto.github.io/rusoto/rusoto_rekognition/index.html"
+documentation = "https://docs.rs/rusoto_rekognition"
 keywords = ["AWS", "Amazon", "rekognition"]
 license = "MIT"
 name = "rusoto_rekognition"

--- a/rusoto/services/rekognition/README.md
+++ b/rusoto/services/rekognition/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_rekognition "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/resource-groups/Cargo.toml
+++ b/rusoto/services/resource-groups/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Resource Groups @ 2017-11-27"
-documentation = "https://rusoto.github.io/rusoto/rusoto_resource_groups/index.html"
+documentation = "https://docs.rs/rusoto_resource_groups"
 keywords = ["AWS", "Amazon", "resource-groups"]
 license = "MIT"
 name = "rusoto_resource_groups"

--- a/rusoto/services/resource-groups/README.md
+++ b/rusoto/services/resource-groups/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_resource_groups "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/resourcegroupstaggingapi/Cargo.toml
+++ b/rusoto/services/resourcegroupstaggingapi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Resource Groups Tagging API @ 2017-01-26"
-documentation = "https://rusoto.github.io/rusoto/rusoto_resourcegroupstaggingapi/index.html"
+documentation = "https://docs.rs/rusoto_resourcegroupstaggingapi"
 keywords = ["AWS", "Amazon", "resourcegroupstaggin"]
 license = "MIT"
 name = "rusoto_resourcegroupstaggingapi"

--- a/rusoto/services/resourcegroupstaggingapi/README.md
+++ b/rusoto/services/resourcegroupstaggingapi/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_resourcegroupstaggingapi "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/route53/Cargo.toml
+++ b/rusoto/services/route53/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Route 53 @ 2013-04-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_route53/index.html"
+documentation = "https://docs.rs/rusoto_route53"
 keywords = ["AWS", "Amazon", "route53"]
 license = "MIT"
 name = "rusoto_route53"

--- a/rusoto/services/route53/README.md
+++ b/rusoto/services/route53/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_route53 "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/route53domains/Cargo.toml
+++ b/rusoto/services/route53domains/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Route 53 Domains @ 2014-05-15"
-documentation = "https://rusoto.github.io/rusoto/rusoto_route53domains/index.html"
+documentation = "https://docs.rs/rusoto_route53domains"
 keywords = ["AWS", "Amazon", "route53domains"]
 license = "MIT"
 name = "rusoto_route53domains"

--- a/rusoto/services/route53domains/README.md
+++ b/rusoto/services/route53domains/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_route53domains "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/s3/Cargo.toml
+++ b/rusoto/services/s3/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Simple Storage Service @ 2006-03-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_s3/index.html"
+documentation = "https://docs.rs/rusoto_s3"
 keywords = ["AWS", "Amazon", "s3"]
 license = "MIT"
 name = "rusoto_s3"

--- a/rusoto/services/s3/README.md
+++ b/rusoto/services/s3/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_s3 "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/sagemaker-runtime/Cargo.toml
+++ b/rusoto/services/sagemaker-runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon SageMaker Runtime @ 2017-05-13"
-documentation = "https://rusoto.github.io/rusoto/rusoto_sagemaker_runtime/index.html"
+documentation = "https://docs.rs/rusoto_sagemaker_runtime"
 keywords = ["AWS", "Amazon", "sagemaker-runtime"]
 license = "MIT"
 name = "rusoto_sagemaker_runtime"

--- a/rusoto/services/sagemaker-runtime/README.md
+++ b/rusoto/services/sagemaker-runtime/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_sagemaker_runtime "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/sagemaker/Cargo.toml
+++ b/rusoto/services/sagemaker/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon SageMaker Service @ 2017-07-24"
-documentation = "https://rusoto.github.io/rusoto/rusoto_sagemaker/index.html"
+documentation = "https://docs.rs/rusoto_sagemaker"
 keywords = ["AWS", "Amazon", "sagemaker"]
 license = "MIT"
 name = "rusoto_sagemaker"

--- a/rusoto/services/sagemaker/README.md
+++ b/rusoto/services/sagemaker/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_sagemaker "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/sdb/Cargo.toml
+++ b/rusoto/services/sdb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon SimpleDB @ 2009-04-15"
-documentation = "https://rusoto.github.io/rusoto/rusoto_sdb/index.html"
+documentation = "https://docs.rs/rusoto_sdb"
 keywords = ["AWS", "Amazon", "sdb"]
 license = "MIT"
 name = "rusoto_sdb"

--- a/rusoto/services/sdb/README.md
+++ b/rusoto/services/sdb/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_sdb "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/secretsmanager/Cargo.toml
+++ b/rusoto/services/secretsmanager/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Secrets Manager @ 2017-10-17"
-documentation = "https://rusoto.github.io/rusoto/rusoto_secretsmanager/index.html"
+documentation = "https://docs.rs/rusoto_secretsmanager"
 keywords = ["AWS", "Amazon", "secretsmanager"]
 license = "MIT"
 name = "rusoto_secretsmanager"

--- a/rusoto/services/secretsmanager/README.md
+++ b/rusoto/services/secretsmanager/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_secretsmanager "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/serverlessrepo/Cargo.toml
+++ b/rusoto/services/serverlessrepo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWSServerlessApplicationRepository @ 2017-09-08"
-documentation = "https://rusoto.github.io/rusoto/rusoto_serverlessrepo/index.html"
+documentation = "https://docs.rs/rusoto_serverlessrepo"
 keywords = ["AWS", "Amazon", "serverlessrepo"]
 license = "MIT"
 name = "rusoto_serverlessrepo"

--- a/rusoto/services/serverlessrepo/README.md
+++ b/rusoto/services/serverlessrepo/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_serverlessrepo "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/servicecatalog/Cargo.toml
+++ b/rusoto/services/servicecatalog/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Service Catalog @ 2015-12-10"
-documentation = "https://rusoto.github.io/rusoto/rusoto_servicecatalog/index.html"
+documentation = "https://docs.rs/rusoto_servicecatalog"
 keywords = ["AWS", "Amazon", "servicecatalog"]
 license = "MIT"
 name = "rusoto_servicecatalog"

--- a/rusoto/services/servicecatalog/README.md
+++ b/rusoto/services/servicecatalog/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_servicecatalog "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/servicediscovery/Cargo.toml
+++ b/rusoto/services/servicediscovery/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Cloud Map @ 2017-03-14"
-documentation = "https://rusoto.github.io/rusoto/rusoto_servicediscovery/index.html"
+documentation = "https://docs.rs/rusoto_servicediscovery"
 keywords = ["AWS", "Amazon", "servicediscovery"]
 license = "MIT"
 name = "rusoto_servicediscovery"

--- a/rusoto/services/servicediscovery/README.md
+++ b/rusoto/services/servicediscovery/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_servicediscovery "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/ses/Cargo.toml
+++ b/rusoto/services/ses/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Simple Email Service @ 2010-12-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_ses/index.html"
+documentation = "https://docs.rs/rusoto_ses"
 keywords = ["AWS", "Amazon", "ses"]
 license = "MIT"
 name = "rusoto_ses"

--- a/rusoto/services/ses/README.md
+++ b/rusoto/services/ses/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_ses "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/shield/Cargo.toml
+++ b/rusoto/services/shield/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Shield @ 2016-06-02"
-documentation = "https://rusoto.github.io/rusoto/rusoto_shield/index.html"
+documentation = "https://docs.rs/rusoto_shield"
 keywords = ["AWS", "Amazon", "shield"]
 license = "MIT"
 name = "rusoto_shield"

--- a/rusoto/services/shield/README.md
+++ b/rusoto/services/shield/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_shield "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/sms/Cargo.toml
+++ b/rusoto/services/sms/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Server Migration Service @ 2016-10-24"
-documentation = "https://rusoto.github.io/rusoto/rusoto_sms/index.html"
+documentation = "https://docs.rs/rusoto_sms"
 keywords = ["AWS", "Amazon", "sms"]
 license = "MIT"
 name = "rusoto_sms"

--- a/rusoto/services/sms/README.md
+++ b/rusoto/services/sms/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_sms "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/snowball/Cargo.toml
+++ b/rusoto/services/snowball/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Import/Export Snowball @ 2016-06-30"
-documentation = "https://rusoto.github.io/rusoto/rusoto_snowball/index.html"
+documentation = "https://docs.rs/rusoto_snowball"
 keywords = ["AWS", "Amazon", "snowball"]
 license = "MIT"
 name = "rusoto_snowball"

--- a/rusoto/services/snowball/README.md
+++ b/rusoto/services/snowball/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_snowball "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/sns/Cargo.toml
+++ b/rusoto/services/sns/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Simple Notification Service @ 2010-03-31"
-documentation = "https://rusoto.github.io/rusoto/rusoto_sns/index.html"
+documentation = "https://docs.rs/rusoto_sns"
 keywords = ["AWS", "Amazon", "sns"]
 license = "MIT"
 name = "rusoto_sns"

--- a/rusoto/services/sns/README.md
+++ b/rusoto/services/sns/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_sns "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/sqs/Cargo.toml
+++ b/rusoto/services/sqs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Simple Queue Service @ 2012-11-05"
-documentation = "https://rusoto.github.io/rusoto/rusoto_sqs/index.html"
+documentation = "https://docs.rs/rusoto_sqs"
 keywords = ["AWS", "Amazon", "sqs"]
 license = "MIT"
 name = "rusoto_sqs"

--- a/rusoto/services/sqs/README.md
+++ b/rusoto/services/sqs/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_sqs "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/ssm/Cargo.toml
+++ b/rusoto/services/ssm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Simple Systems Manager (SSM) @ 2014-11-06"
-documentation = "https://rusoto.github.io/rusoto/rusoto_ssm/index.html"
+documentation = "https://docs.rs/rusoto_ssm"
 keywords = ["AWS", "Amazon", "ssm"]
 license = "MIT"
 name = "rusoto_ssm"

--- a/rusoto/services/ssm/README.md
+++ b/rusoto/services/ssm/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_ssm "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/stepfunctions/Cargo.toml
+++ b/rusoto/services/stepfunctions/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Step Functions @ 2016-11-23"
-documentation = "https://rusoto.github.io/rusoto/rusoto_stepfunctions/index.html"
+documentation = "https://docs.rs/rusoto_stepfunctions"
 keywords = ["AWS", "Amazon", "stepfunctions"]
 license = "MIT"
 name = "rusoto_stepfunctions"

--- a/rusoto/services/stepfunctions/README.md
+++ b/rusoto/services/stepfunctions/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_stepfunctions "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/storagegateway/Cargo.toml
+++ b/rusoto/services/storagegateway/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Storage Gateway @ 2013-06-30"
-documentation = "https://rusoto.github.io/rusoto/rusoto_storagegateway/index.html"
+documentation = "https://docs.rs/rusoto_storagegateway"
 keywords = ["AWS", "Amazon", "storagegateway"]
 license = "MIT"
 name = "rusoto_storagegateway"

--- a/rusoto/services/storagegateway/README.md
+++ b/rusoto/services/storagegateway/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_storagegateway "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/sts/Cargo.toml
+++ b/rusoto/services/sts/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Security Token Service @ 2011-06-15"
-documentation = "https://rusoto.github.io/rusoto/rusoto_sts/index.html"
+documentation = "https://docs.rs/rusoto_sts"
 keywords = ["AWS", "Amazon", "sts"]
 license = "MIT"
 name = "rusoto_sts"

--- a/rusoto/services/sts/README.md
+++ b/rusoto/services/sts/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_sts "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/support/Cargo.toml
+++ b/rusoto/services/support/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS Support @ 2013-04-15"
-documentation = "https://rusoto.github.io/rusoto/rusoto_support/index.html"
+documentation = "https://docs.rs/rusoto_support"
 keywords = ["AWS", "Amazon", "support"]
 license = "MIT"
 name = "rusoto_support"

--- a/rusoto/services/support/README.md
+++ b/rusoto/services/support/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_support "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/swf/Cargo.toml
+++ b/rusoto/services/swf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Simple Workflow Service @ 2012-01-25"
-documentation = "https://rusoto.github.io/rusoto/rusoto_swf/index.html"
+documentation = "https://docs.rs/rusoto_swf"
 keywords = ["AWS", "Amazon", "swf"]
 license = "MIT"
 name = "rusoto_swf"

--- a/rusoto/services/swf/README.md
+++ b/rusoto/services/swf/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_swf "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/transcribe/Cargo.toml
+++ b/rusoto/services/transcribe/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Transcribe Service @ 2017-10-26"
-documentation = "https://rusoto.github.io/rusoto/rusoto_transcribe/index.html"
+documentation = "https://docs.rs/rusoto_transcribe"
 keywords = ["AWS", "Amazon", "transcribe"]
 license = "MIT"
 name = "rusoto_transcribe"

--- a/rusoto/services/transcribe/README.md
+++ b/rusoto/services/transcribe/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_transcribe "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/translate/Cargo.toml
+++ b/rusoto/services/translate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon Translate @ 2017-07-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_translate/index.html"
+documentation = "https://docs.rs/rusoto_translate"
 keywords = ["AWS", "Amazon", "translate"]
 license = "MIT"
 name = "rusoto_translate"

--- a/rusoto/services/translate/README.md
+++ b/rusoto/services/translate/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_translate "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/waf-regional/Cargo.toml
+++ b/rusoto/services/waf-regional/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS WAF Regional @ 2016-11-28"
-documentation = "https://rusoto.github.io/rusoto/rusoto_waf_regional/index.html"
+documentation = "https://docs.rs/rusoto_waf_regional"
 keywords = ["AWS", "Amazon", "waf-regional"]
 license = "MIT"
 name = "rusoto_waf_regional"

--- a/rusoto/services/waf-regional/README.md
+++ b/rusoto/services/waf-regional/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_waf_regional "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/waf/Cargo.toml
+++ b/rusoto/services/waf/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS WAF @ 2015-08-24"
-documentation = "https://rusoto.github.io/rusoto/rusoto_waf/index.html"
+documentation = "https://docs.rs/rusoto_waf"
 keywords = ["AWS", "Amazon", "waf"]
 license = "MIT"
 name = "rusoto_waf"

--- a/rusoto/services/waf/README.md
+++ b/rusoto/services/waf/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_waf "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/workdocs/Cargo.toml
+++ b/rusoto/services/workdocs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon WorkDocs @ 2016-05-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_workdocs/index.html"
+documentation = "https://docs.rs/rusoto_workdocs"
 keywords = ["AWS", "Amazon", "workdocs"]
 license = "MIT"
 name = "rusoto_workdocs"

--- a/rusoto/services/workdocs/README.md
+++ b/rusoto/services/workdocs/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_workdocs "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/worklink/Cargo.toml
+++ b/rusoto/services/worklink/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon WorkLink @ 2018-09-25"
-documentation = "https://rusoto.github.io/rusoto/rusoto_worklink/index.html"
+documentation = "https://docs.rs/rusoto_worklink"
 keywords = ["AWS", "Amazon", "worklink"]
 license = "MIT"
 name = "rusoto_worklink"

--- a/rusoto/services/worklink/README.md
+++ b/rusoto/services/worklink/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_worklink "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/workmail/Cargo.toml
+++ b/rusoto/services/workmail/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon WorkMail @ 2017-10-01"
-documentation = "https://rusoto.github.io/rusoto/rusoto_workmail/index.html"
+documentation = "https://docs.rs/rusoto_workmail"
 keywords = ["AWS", "Amazon", "workmail"]
 license = "MIT"
 name = "rusoto_workmail"

--- a/rusoto/services/workmail/README.md
+++ b/rusoto/services/workmail/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_workmail "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/workspaces/Cargo.toml
+++ b/rusoto/services/workspaces/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - Amazon WorkSpaces @ 2015-04-08"
-documentation = "https://rusoto.github.io/rusoto/rusoto_workspaces/index.html"
+documentation = "https://docs.rs/rusoto_workspaces"
 keywords = ["AWS", "Amazon", "workspaces"]
 license = "MIT"
 name = "rusoto_workspaces"

--- a/rusoto/services/workspaces/README.md
+++ b/rusoto/services/workspaces/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_workspaces "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/rusoto/services/xray/Cargo.toml
+++ b/rusoto/services/xray/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Anthony DiMarco <ocramida@gmail.com>", "Jimmy Cuadra <jimmy@jimmycuadra.com>", "Matthew Mayer <matthewkmayer@gmail.com>", "Nikita Pekin <contact@nikitapek.in>"]
 description = "AWS SDK for Rust - AWS X-Ray @ 2016-04-12"
-documentation = "https://rusoto.github.io/rusoto/rusoto_xray/index.html"
+documentation = "https://docs.rs/rusoto_xray"
 keywords = ["AWS", "Amazon", "xray"]
 license = "MIT"
 name = "rusoto_xray"

--- a/rusoto/services/xray/README.md
+++ b/rusoto/services/xray/README.md
@@ -36,7 +36,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/rusoto_xray "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"

--- a/service_crategen/src/commands/generate/mod.rs
+++ b/service_crategen/src/commands/generate/mod.rs
@@ -131,7 +131,7 @@ pub fn generate_services(
                     "Nikita Pekin <contact@nikitapek.in>".into()
                 ]),
                 description: Some(format!("AWS SDK for Rust - {} @ {}", service.full_name(), service.api_version())),
-                documentation: Some(format!("https://rusoto.github.io/rusoto/{}/index.html", crate_name)),
+                documentation: Some(format!("https://docs.rs/{}", crate_name)),
                 keywords: Some(vec!["AWS".into(), "Amazon".into(), name_for_keyword]),
                 license: Some("MIT".into()),
                 name: crate_name.clone(),
@@ -196,7 +196,7 @@ Rusoto is distributed under the terms of the MIT license.
 
 See [LICENSE][license] for details.
 
-[api-documentation]: https://rusoto.github.io/rusoto/rusoto/ "API documentation"
+[api-documentation]: https://docs.rs/{crate_name} "API documentation"
 [license]: https://github.com/rusoto/rusoto/blob/master/LICENSE "MIT License"
 [contributing]: https://github.com/rusoto/rusoto/blob/master/CONTRIBUTING.md "Contributing Guide"
 [rusoto-help]: https://www.rusoto.org/help.html "Getting help with Rusoto"


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Move all documentation links to docs.rs.

Gets most of https://github.com/rusoto/rusoto/issues/1027 done! 🎉 

After https://github.com/rusoto/rusoto/pull/1410 gets merged this should also remove the TravisCI job file and the badge in our READMEs.