### PR TITLE
Make helper for wrapping STS provider with a caching provider.

### DIFF
--- a/integration_tests/tests/sts.rs
+++ b/integration_tests/tests/sts.rs
@@ -15,6 +15,17 @@ use rusoto_sts::{Sts, StsClient};
 use rusoto_sts::{StsAssumeRoleSessionCredentialsProvider, StsSessionCredentialsProvider};
 
 #[test]
+fn caching_provider() {
+    let sts_creds_provider = StsSessionCredentialsProvider::new(StsClient::new(Region::UsEast1), None, None);
+    let cached_sts_creds_provider = sts_creds_provider.to_auto_refresh_credentials().expect("Conversion should work.");
+
+    match cached_sts_creds_provider.credentials().wait() {
+        Err(e) => panic!("sts credentials provider error: {:?}", e),
+        Ok(r) => println!("sts credentials provider result: {:?}", r),
+    }
+}
+
+#[test]
 fn main() {
     let sts = StsClient::new(Region::UsEast1);
 

--- a/rusoto/services/sts/src/custom/credential.rs
+++ b/rusoto/services/sts/src/custom/credential.rs
@@ -4,7 +4,7 @@ use futures::{Async, Future, Poll};
 
 use rusoto_core;
 
-use rusoto_core::credential::AwsCredentials;
+use rusoto_core::credential::{AutoRefreshingProvider, AwsCredentials};
 use rusoto_core::{CredentialsError, ProvideAwsCredentials, RusotoFuture};
 use crate::{
     AssumeRoleError, AssumeRoleRequest, AssumeRoleResponse, AssumeRoleWithSAMLError,
@@ -194,6 +194,12 @@ impl StsSessionCredentialsProvider {
         StsSessionCredentialsProviderFuture {
             inner: self.sts_client.get_session_token(request),
         }
+    }
+
+    /// Convert the credential provider to one that caches the result instead of
+    /// making a call every time credentials are needed.
+    pub fn to_auto_refresh_credentials(self) -> Result<AutoRefreshingProvider<StsSessionCredentialsProvider>, CredentialsError> {
+        AutoRefreshingProvider::new(self)
     }
 }
 


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Make helper function for wrapping STS credential provider in an autorefresher

My take on https://github.com/rusoto/rusoto/issues/1179 . There's an issue in the new integration test where there doesn't appear to be a tokio runtime running, I'm taking a peek.

```
failures:

---- caching_provider stdout ----
thread 'caching_provider' panicked at 'sts credentials provider error:
 CredentialsError { message: "StsProvider get_session_token error: 
HttpDispatch(
HttpDispatchError { message: \"executor failed to spawn task: tokio::spawn failed (is a tokio runtime running this future?)\" })" }', tests/sts.rs:33:19
note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

This PR should also have some docs to point people to using this instead of the provider directly.

🤔 I'm pretty sure I've a lot to relearn on how this external credential crate works. 😆 