### PR TITLE
Added special case for CodePipeline

### DIFF
--- a/rusoto/services/codepipeline/src/generated.rs
+++ b/rusoto/services/codepipeline/src/generated.rs
@@ -215,10 +215,10 @@ pub struct ActionExecution {
 pub struct ActionRevision {
     /// <p>The date and time when the most recent version of the action was created, in timestamp format.</p>
     #[serde(rename = "created")]
-    pub created: f64,
+    pub created: Option<f64>,
     /// <p>The unique identifier of the change that set the state to this revision, for example a deployment ID or timestamp.</p>
     #[serde(rename = "revisionChangeId")]
-    pub revision_change_id: String,
+    pub revision_change_id: Option<String>,
     /// <p>The system-generated unique ID that identifies the revision number of the action.</p>
     #[serde(rename = "revisionId")]
     pub revision_id: String,

--- a/service_crategen/src/commands/generate/codegen/mod.rs
+++ b/service_crategen/src/commands/generate/codegen/mod.rs
@@ -526,7 +526,12 @@ fn generate_struct_fields<P: GenerateProtocol>(
                 lines.push(format!("pub {}: Box<Option<{}>>,", name, rs_type))
             }
         } else {
-            if shape.required(member_name) {
+            // In the official documentation the fields revision_change_id and created are required
+            // but when looking at the responses from aws those are not always set.
+            // See https://github.com/rusoto/rusoto/issues/1419 for more information
+            if service.name() == "CodePipeline" && shape_name == "ActionRevision" && name == "revision_change_id" || name == "created" {
+                lines.push(format!("pub {}: Option<{}>,", name, rs_type))
+            } else if shape.required(member_name) {
                 lines.push(format!("pub {}: {},", name, rs_type))
             } else if name == "type" {
                 lines.push(format!("pub aws_{}: Option<{}>,", name,rs_type))


### PR DESCRIPTION
The fields revision_change_id and created are not required even
if the official documentation says so.

### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:
Fixed CodePipeline missing fields exception when calling `get_pipeline_state`

Connected issue: #1419 

I am unsure if this is the best location for the fix. Please let me know if it should be moved.

Have a nice day :)