### PR TITLE
skip type generation for unused shapes

### DIFF
--- a/rusoto/services/apigatewayv2/src/generated.rs
+++ b/rusoto/services/apigatewayv2/src/generated.rs
@@ -109,26 +109,6 @@ pub struct ApiMapping {
     pub stage: String,
 }
 
-/// <p>Represents a collection of ApiMappings resources.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ApiMappings {
-    /// <p>The elements from this collection.</p>
-    pub items: Option<Vec<ApiMapping>>,
-    /// <p>The next page of elements from this collection. Not valid for the last element of
-    /// the collection.</p>
-    pub next_token: Option<String>,
-}
-
-/// <p>Represents a collection of APIs.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct Apis {
-    /// <p>The elements from this collection.</p>
-    pub items: Option<Vec<Api>>,
-    /// <p>The next page of elements from this collection. Not valid for the last element of
-    /// the collection.</p>
-    pub next_token: Option<String>,
-}
-
 /// <p>Represents an authorizer.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 #[cfg_attr(test, derive(Serialize))]
@@ -201,47 +181,6 @@ pub struct Authorizer {
     #[serde(rename = "ProviderArns")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider_arns: Option<Vec<String>>,
-}
-
-/// <p>Represents a collection of authorizers.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct Authorizers {
-    /// <p>The elements from this collection.</p>
-    pub items: Option<Vec<Authorizer>>,
-    /// <p>The next page of elements from this collection. Not valid for the last element of
-    /// the collection.</p>
-    pub next_token: Option<String>,
-}
-
-/// <p>Represents the input parameters for a CreateApi request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct CreateApiInput {
-    /// <p>An API key selection expression. See <a href="https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-apikey-selection-expressions">API Key Selection Expressions</a>.</p>
-    pub api_key_selection_expression: Option<String>,
-    /// <p>The description of the API.</p>
-    pub description: Option<String>,
-    /// <p>Avoid validating models when creating a deployment.</p>
-    pub disable_schema_validation: Option<bool>,
-    /// <p>The name of the API.</p>
-    pub name: String,
-    /// <p>The API protocol: Currently only WEBSOCKET is supported.</p>
-    pub protocol_type: String,
-    /// <p>The route selection expression for the API.</p>
-    pub route_selection_expression: String,
-    /// <p>A version identifier for the API.</p>
-    pub version: Option<String>,
-}
-
-/// <p>Represents the input parameters for a CreateApiMapping
-/// request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct CreateApiMappingInput {
-    /// <p>The API identifier.</p>
-    pub api_id: String,
-
-    pub api_mapping_key: Option<String>,
-    /// <p>The API stage.</p>
-    pub stage: String,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -361,61 +300,6 @@ pub struct CreateApiResponse {
     #[serde(rename = "Warnings")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warnings: Option<Vec<String>>,
-}
-
-/// <p>Represents the input parameters for a CreateAuthorizer
-/// request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct CreateAuthorizerInput {
-    /// <p>Specifies the required credentials as an IAM role for API Gateway to invoke the
-    /// authorizer. To specify an IAM role for API Gateway to assume, use the role's Amazon
-    /// Resource Name (ARN). To use resource-based permissions on the Lambda function,
-    /// specify null.</p>
-    pub authorizer_credentials_arn: Option<String>,
-    /// <p>The time to live (TTL), in seconds, of cached authorizer results. If it equals 0,
-    /// authorization caching is disabled. If it is greater than 0, API Gateway will cache
-    /// authorizer responses. If this field is not set, the default value is 300. The maximum
-    /// value is 3600, or 1 hour.</p>
-    pub authorizer_result_ttl_in_seconds: Option<i64>,
-    /// <p>The authorizer type. Currently the only valid value is REQUEST, for a
-    /// Lambda function using incoming request parameters.</p>
-    pub authorizer_type: String,
-    /// <p>The authorizer's Uniform Resource Identifier (URI). For
-    /// REQUEST authorizers, this must be a
-    /// well-formed Lambda function URI, for example,
-    /// arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:{account_id}:function:{lambda_function_name}/invocations.
-    /// In general, the URI has this form:
-    /// arn:aws:apigateway:{region}:lambda:path/{service_api}
-    /// , where {region} is the same as the region hosting the Lambda
-    /// function, path indicates that the remaining substring in the URI should be treated as
-    /// the path to the resource, including the initial /. For Lambda functions,
-    /// this is usually of the form
-    /// /2015-03-31/functions/[FunctionARN]/invocations.</p>
-    pub authorizer_uri: String,
-    /// <p>The identity source for which authorization is requested.</p><p>For the REQUEST authorizer, this is required when authorization
-    /// caching is enabled. The value is a comma-separated string of one or more mapping
-    /// expressions of the specified request parameters. For example, if an Auth
-    /// header and a Name query string parameters are defined as identity
-    /// sources, this value is method.request.header.Auth,
-    /// method.request.querystring.Name. These parameters will be used to
-    /// derive the authorization caching key and to perform runtime validation of the
-    /// REQUEST authorizer by verifying all of the identity-related request
-    /// parameters are present, not null, and non-empty. Only when this is true does the
-    /// authorizer invoke the authorizer Lambda function, otherwise, it returns a 401
-    /// Unauthorized response without calling the Lambda function. The valid value
-    /// is a string of comma-separated mapping expressions of the specified request
-    /// parameters. When the authorization caching is not enabled, this property is
-    /// optional.</p>
-    pub identity_source: Vec<String>,
-    /// <p>The
-    /// validation expression does not apply to the REQUEST authorizer.</p>
-    pub identity_validation_expression: Option<String>,
-    /// <p>The name of the authorizer.</p>
-    pub name: String,
-    /// <p>For
-    /// REQUEST authorizer, this is not
-    /// defined.</p>
-    pub provider_arns: Option<Vec<String>>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -560,17 +444,6 @@ pub struct CreateAuthorizerResponse {
     pub provider_arns: Option<Vec<String>>,
 }
 
-/// <p>Represents the input parameters for a CreateDeployment
-/// request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct CreateDeploymentInput {
-    /// <p>The description for the deployment resource.</p>
-    pub description: Option<String>,
-    /// <p>The name of the Stage resource for the Deployment
-    /// resource to create.</p>
-    pub stage_name: Option<String>,
-}
-
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDeploymentRequest {
     /// <p>The API identifier.</p>
@@ -613,16 +486,6 @@ pub struct CreateDeploymentResponse {
     pub description: Option<String>,
 }
 
-/// <p>Represents the input parameters for a CreateDomainName
-/// request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct CreateDomainNameInput {
-    /// <p>The domain name.</p>
-    pub domain_name: String,
-    /// <p>The domain name configurations.</p>
-    pub domain_name_configurations: Option<Vec<DomainNameConfiguration>>,
-}
-
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateDomainNameRequest {
     /// <p>The domain name.</p>
@@ -649,95 +512,6 @@ pub struct CreateDomainNameResponse {
     #[serde(rename = "DomainNameConfigurations")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub domain_name_configurations: Option<Vec<DomainNameConfiguration>>,
-}
-
-/// <p>Represents the input parameters for a CreateIntegration
-/// request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct CreateIntegrationInput {
-    /// <p>The connection ID.</p>
-    pub connection_id: Option<String>,
-    /// <p>The type of the network connection to the integration endpoint. Currently the only
-    /// valid value is INTERNET, for connections through the public routable
-    /// internet.</p>
-    pub connection_type: Option<String>,
-    /// <p>Specifies how to handle response payload content type conversions. Supported
-    /// values are CONVERT_TO_BINARY and CONVERT_TO_TEXT, with the
-    /// following behaviors:</p><p>
-    /// CONVERT_TO_BINARY: Converts a response payload from a Base64-encoded
-    /// string to the corresponding binary blob.</p><p>
-    /// CONVERT_TO_TEXT: Converts a response payload from a binary blob to a
-    /// Base64-encoded string.</p><p>If this property is not defined, the response payload will be passed through from
-    /// the integration response to the route response or method response without
-    /// modification.</p>
-    pub content_handling_strategy: Option<String>,
-    /// <p>Specifies the credentials required for the integration, if any. For AWS
-    /// integrations, three options are available. To specify an IAM Role for API Gateway to
-    /// assume, use the role's Amazon Resource Name (ARN). To require that the caller's
-    /// identity be passed through from the request, specify the string
-    /// arn:aws:iam::*:user/*. To use resource-based permissions on supported
-    /// AWS services, specify null.</p>
-    pub credentials_arn: Option<String>,
-    /// <p>The description of the integration.</p>
-    pub description: Option<String>,
-    /// <p>Specifies the integration's HTTP method type.</p>
-    pub integration_method: Option<String>,
-    /// <p>The integration type of an integration. One of the following:</p><p>
-    /// AWS: for integrating the route or method request with an AWS service
-    /// action, including the Lambda function-invoking action. With the Lambda
-    /// function-invoking action, this is referred to as the Lambda custom integration. With
-    /// any other AWS service action, this is known as AWS integration.</p><p>
-    /// AWS_PROXY: for integrating the route or method request with the Lambda
-    /// function-invoking action with the client request passed through as-is. This
-    /// integration is also referred to as Lambda proxy integration.</p><p>
-    /// HTTP: for integrating the route or method request with an HTTP
-    /// endpoint. This
-    /// integration is also referred to as HTTP custom integration.</p><p>
-    /// HTTP_PROXY: for integrating route or method request with an HTTP
-    /// endpoint, with the client
-    /// request passed through as-is. This is also referred to as HTTP proxy
-    /// integration.</p><p>
-    /// MOCK: for integrating the route or method request with API Gateway as a
-    /// "loopback" endpoint without invoking any backend.</p>
-    pub integration_type: String,
-    /// <p>For a Lambda proxy integration, this is the URI of the Lambda function.</p>
-    pub integration_uri: Option<String>,
-    /// <p>Specifies the pass-through behavior for incoming requests based on the
-    /// Content-Type header in the request, and the available mapping
-    /// templates specified as the requestTemplates property on the
-    /// Integration resource. There are three valid values:
-    /// WHEN_NO_MATCH, WHEN_NO_TEMPLATES, and
-    /// NEVER.</p><p>
-    /// WHEN_NO_MATCH passes the request body for unmapped content types through
-    /// to the integration backend without transformation.</p><p>
-    /// NEVER rejects unmapped content types with an HTTP 415 Unsupported
-    /// Media Type response.</p><p>
-    /// WHEN_NO_TEMPLATES allows pass-through when the integration has no
-    /// content types mapped to templates. However, if there is at least one content type
-    /// defined, unmapped content types will be rejected with the same HTTP 415
-    /// Unsupported Media Type response.</p>
-    pub passthrough_behavior: Option<String>,
-    /// <p>A key-value map specifying request parameters that are passed from the method
-    /// request to the backend. The key is an integration request parameter name and the
-    /// associated value is a method request parameter value or static value that must be
-    /// enclosed within single quotes and pre-encoded as required by the backend. The method
-    /// request parameter value must match the pattern of
-    /// method.request.{location}.{name}
-    /// , where
-    /// {location}
-    /// is querystring, path, or header; and
-    /// {name}
-    /// must be a valid and unique method request parameter name.</p>
-    pub request_parameters: Option<::std::collections::HashMap<String, String>>,
-    /// <p>Represents a map of Velocity templates that are applied on the request payload
-    /// based on the value of the Content-Type header sent by the client. The content type
-    /// value is the key in this map, and the template (as a String) is the value.</p>
-    pub request_templates: Option<::std::collections::HashMap<String, String>>,
-    /// <p>The template selection expression for the integration.</p>
-    pub template_selection_expression: Option<String>,
-    /// <p>Custom timeout between 50 and 29,000 milliseconds. The default value is 29,000
-    /// milliseconds or 29 seconds.</p>
-    pub timeout_in_millis: Option<i64>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -977,42 +751,6 @@ pub struct CreateIntegrationResponse {
     pub timeout_in_millis: Option<i64>,
 }
 
-/// <p>Represents the input parameters for a CreateIntegrationResponse
-/// request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct CreateIntegrationResponseInput {
-    /// <p>Specifies how to handle response payload content type conversions. Supported
-    /// values are CONVERT_TO_BINARY and CONVERT_TO_TEXT, with the
-    /// following behaviors:</p><p>
-    /// CONVERT_TO_BINARY: Converts a response payload from a Base64-encoded
-    /// string to the corresponding binary blob.</p><p>
-    /// CONVERT_TO_TEXT: Converts a response payload from a binary blob to a
-    /// Base64-encoded string.</p><p>If this property is not defined, the response payload will be passed through from
-    /// the integration response to the route response or method response without
-    /// modification.</p>
-    pub content_handling_strategy: Option<String>,
-    /// <p>The integration response key.</p>
-    pub integration_response_key: String,
-    /// <p>A key-value map specifying response parameters that are passed to the method
-    /// response from the backend. The key is a method response header parameter name and the
-    /// mapped value is an integration response header value, a static value enclosed within
-    /// a pair of single quotes, or a JSON expression from the integration response body. The
-    /// mapping key must match the pattern of method.response.header.{name},
-    /// where {name} is a valid and unique header name. The mapped non-static
-    /// value must match the pattern of integration.response.header.{name} or
-    /// integration.response.body.{JSON-expression}, where
-    /// {name} is a valid and unique response header name and
-    /// {JSON-expression} is a valid JSON expression without the $
-    /// prefix.</p>
-    pub response_parameters: Option<::std::collections::HashMap<String, String>>,
-    /// <p>The collection of response templates for the integration response as a
-    /// string-to-string map of key-value pairs. Response templates are represented as a
-    /// key/value map, with a content-type as the key and a template as the value.</p>
-    pub response_templates: Option<::std::collections::HashMap<String, String>>,
-    /// <p>The template selection expression for the integration response.</p>
-    pub template_selection_expression: Option<String>,
-}
-
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateIntegrationResponseRequest {
     /// <p>The API identifier.</p>
@@ -1109,20 +847,6 @@ pub struct CreateIntegrationResponseResponse {
     pub template_selection_expression: Option<String>,
 }
 
-/// <p>Represents the input parameters for a CreateModel request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct CreateModelInput {
-    /// <p>The content-type for the model, for example, "application/json".</p>
-    pub content_type: Option<String>,
-    /// <p>The description of the model.</p>
-    pub description: Option<String>,
-    /// <p>The name of the model. Must be alphanumeric.</p>
-    pub name: String,
-    /// <p>The schema for the model. For application/json models, this should be JSON schema
-    /// draft 4 model.</p>
-    pub schema: String,
-}
-
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateModelRequest {
     /// <p>The API identifier.</p>
@@ -1169,40 +893,6 @@ pub struct CreateModelResponse {
     #[serde(rename = "Schema")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub schema: Option<String>,
-}
-
-/// <p>Represents the input parameters for a CreateRoute request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct CreateRouteInput {
-    /// <p>Specifies whether an API key is required for the route.</p>
-    pub api_key_required: Option<bool>,
-    /// <p>The authorization scopes supported by this
-    /// route.</p>
-    pub authorization_scopes: Option<Vec<String>>,
-    /// <p>The authorization type for the route. Valid values are NONE for open
-    /// access, AWS_IAM for using AWS IAM permissions, and CUSTOM
-    /// for using a Lambda
-    /// authorizer.</p>
-    pub authorization_type: Option<String>,
-    /// <p>The identifier of the Authorizer resource to be associated with this
-    /// route, if the authorizationType is CUSTOM
-    /// . The authorizer identifier is generated by API Gateway
-    /// when you created the authorizer.</p>
-    pub authorizer_id: Option<String>,
-    /// <p>The model selection expression for the route.</p>
-    pub model_selection_expression: Option<String>,
-    /// <p>The operation name for the route.</p>
-    pub operation_name: Option<String>,
-    /// <p>The request models for the route.</p>
-    pub request_models: Option<::std::collections::HashMap<String, String>>,
-    /// <p>The request parameters for the route.</p>
-    pub request_parameters: Option<::std::collections::HashMap<String, ParameterConstraints>>,
-    /// <p>The route key for the route.</p>
-    pub route_key: String,
-    /// <p>The route response selection expression for the route.</p>
-    pub route_response_selection_expression: Option<String>,
-    /// <p>The target for the route.</p>
-    pub target: Option<String>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1327,20 +1017,6 @@ pub struct CreateRouteResponse {
     pub target: Option<String>,
 }
 
-/// <p>Represents the input parameters for an CreateRouteResponse
-/// request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct CreateRouteResponseInput {
-    /// <p>The model selection expression for the route response.</p>
-    pub model_selection_expression: Option<String>,
-    /// <p>The response models for the route response.</p>
-    pub response_models: Option<::std::collections::HashMap<String, String>>,
-    /// <p>The route response parameters.</p>
-    pub response_parameters: Option<::std::collections::HashMap<String, ParameterConstraints>>,
-    /// <p>The route response key.</p>
-    pub route_response_key: String,
-}
-
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateRouteResponseRequest {
     /// <p>The API identifier.</p>
@@ -1389,29 +1065,6 @@ pub struct CreateRouteResponseResponse {
     #[serde(rename = "RouteResponseKey")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub route_response_key: Option<String>,
-}
-
-/// <p>Represents the input parameters for a CreateStage request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct CreateStageInput {
-    /// <p>Settings for logging access in this stage.</p>
-    pub access_log_settings: Option<AccessLogSettings>,
-    /// <p>The identifier of a client certificate for a Stage.</p>
-    pub client_certificate_id: Option<String>,
-    /// <p>The default route settings for the stage.</p>
-    pub default_route_settings: Option<RouteSettings>,
-    /// <p>The deployment identifier of the API stage.</p>
-    pub deployment_id: Option<String>,
-    /// <p>The description for the API stage.</p>
-    pub description: Option<String>,
-    /// <p>Route settings for the stage.</p>
-    pub route_settings: Option<::std::collections::HashMap<String, RouteSettings>>,
-    /// <p>The name of the stage.</p>
-    pub stage_name: String,
-    /// <p>A map that defines the stage variables for a Stage. Variable names
-    /// can have alphanumeric and underscore characters, and the values must match
-    /// [A-Za-z0-9-._~:/?#&=,]+.</p>
-    pub stage_variables: Option<::std::collections::HashMap<String, String>>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1641,18 +1294,6 @@ pub struct Deployment {
     pub description: Option<String>,
 }
 
-/// <p>A collection resource that contains zero or more references to your existing
-/// deployments, and links that guide you on how to interact with your collection. The
-/// collection offers a paginated view of the contained deployments.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct Deployments {
-    /// <p>The elements from this collection.</p>
-    pub items: Option<Vec<Deployment>>,
-    /// <p>The next page of elements from this collection. Not valid for the last element of
-    /// the collection.</p>
-    pub next_token: Option<String>,
-}
-
 /// <p>Represents a domain name.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 #[cfg_attr(test, derive(Serialize))]
@@ -1700,16 +1341,6 @@ pub struct DomainNameConfiguration {
     #[serde(rename = "HostedZoneId")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hosted_zone_id: Option<String>,
-}
-
-/// <p>Represents a collection of domain names.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct DomainNames {
-    /// <p>The elements from this collection.</p>
-    pub items: Option<Vec<DomainName>>,
-    /// <p>The next page of elements from this collection. Not valid for the last element of
-    /// the collection.</p>
-    pub next_token: Option<String>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -2864,35 +2495,6 @@ pub struct IntegrationResponse {
     pub template_selection_expression: Option<String>,
 }
 
-/// <p>Represents a collection of integration responses.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct IntegrationResponses {
-    /// <p>The elements from this collection.</p>
-    pub items: Option<Vec<IntegrationResponse>>,
-    /// <p>The next page of elements from this collection. Not valid for the last element of
-    /// the collection.</p>
-    pub next_token: Option<String>,
-}
-
-/// <p>Represents a collection of integrations.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct Integrations {
-    /// <p>The elements from this collection.</p>
-    pub items: Option<Vec<Integration>>,
-    /// <p>The next page of elements from this collection. Not valid for the last element of
-    /// the collection.</p>
-    pub next_token: Option<String>,
-}
-
-/// <p>A limit has been exceeded. See the accompanying error message for details.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct LimitExceededException {
-    /// <p>The limit type.</p>
-    pub limit_type: Option<String>,
-    /// <p>Describes the error encountered.</p>
-    pub message: Option<String>,
-}
-
 /// <p>Represents a data model for an API. See <a href="https://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html">Create Models and Mapping Templates for Request and Response
 /// Mappings</a>.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
@@ -2918,17 +2520,6 @@ pub struct Model {
     #[serde(rename = "Schema")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub schema: Option<String>,
-}
-
-/// <p>Represents a collection of data models. See <a href="https://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html">Create Models and Mapping Templates for Request and Response
-/// Mappings</a>.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct Models {
-    /// <p>The elements from this collection.</p>
-    pub items: Option<Vec<Model>>,
-    /// <p>The next page of elements from this collection. Not valid for the last element of
-    /// the collection.</p>
-    pub next_token: Option<String>,
 }
 
 /// <p>Validation constraints imposed on parameters of a request (path, query string,
@@ -3031,16 +2622,6 @@ pub struct RouteResponse {
     pub route_response_key: String,
 }
 
-/// <p>Represents a collection of route responses.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct RouteResponses {
-    /// <p>The elements from this collection.</p>
-    pub items: Option<Vec<RouteResponse>>,
-    /// <p>The next page of elements from this collection. Not valid for the last element of
-    /// the collection.</p>
-    pub next_token: Option<String>,
-}
-
 /// <p>Represents a collection of route settings.</p>
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RouteSettings {
@@ -3068,16 +2649,6 @@ pub struct RouteSettings {
     #[serde(rename = "ThrottlingRateLimit")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub throttling_rate_limit: Option<f64>,
-}
-
-/// <p>Represents a collection of routes.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct Routes {
-    /// <p>The elements from this collection.</p>
-    pub items: Option<Vec<Route>>,
-    /// <p>The next page of elements from this collection. Not valid for the last element of
-    /// the collection.</p>
-    pub next_token: Option<String>,
 }
 
 /// <p>Represents an API stage.</p>
@@ -3126,53 +2697,6 @@ pub struct Stage {
     #[serde(rename = "StageVariables")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stage_variables: Option<::std::collections::HashMap<String, String>>,
-}
-
-/// <p>A collection of Stage resources that are associated with the ApiKey
-/// resource.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct Stages {
-    /// <p>The elements from this collection.</p>
-    pub items: Option<Vec<Stage>>,
-    /// <p>The next page of elements from this collection. Not valid for the last element of
-    /// the collection.</p>
-    pub next_token: Option<String>,
-}
-
-/// <p>Represents a template.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct Template {
-    /// <p>The template value.</p>
-    pub value: Option<String>,
-}
-
-/// <p>Represents the input parameters for an UpdateApi request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateApiInput {
-    /// <p>An API key selection expression. See <a href="https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-apikey-selection-expressions">API Key Selection Expressions</a>.</p>
-    pub api_key_selection_expression: Option<String>,
-    /// <p>The description of the API.</p>
-    pub description: Option<String>,
-    /// <p>Avoid validating models when creating a deployment.</p>
-    pub disable_schema_validation: Option<bool>,
-    /// <p>The name of the API.</p>
-    pub name: Option<String>,
-    /// <p>The route selection expression for the API.</p>
-    pub route_selection_expression: Option<String>,
-    /// <p>A version identifier for the API.</p>
-    pub version: Option<String>,
-}
-
-/// <p>Represents the input parameters for an UpdateApiMapping
-/// request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateApiMappingInput {
-    /// <p>The API identifier.</p>
-    pub api_id: Option<String>,
-    /// <p>The API mapping key.</p>
-    pub api_mapping_key: Option<String>,
-    /// <p>The API stage.</p>
-    pub stage: Option<String>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -3298,59 +2822,6 @@ pub struct UpdateApiResponse {
     #[serde(rename = "Warnings")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warnings: Option<Vec<String>>,
-}
-
-/// <p>The input parameters for an UpdateAuthorizer request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateAuthorizerInput {
-    /// <p>Specifies the required credentials as an IAM role for API Gateway to invoke the
-    /// authorizer. To specify an IAM role for API Gateway to assume, use the role's Amazon
-    /// Resource Name (ARN). To use resource-based permissions on the Lambda function,
-    /// specify null.</p>
-    pub authorizer_credentials_arn: Option<String>,
-    /// <p>The time to live (TTL), in seconds, of cached authorizer results. If it is zero,
-    /// authorization caching is disabled. If it is greater than zero, API Gateway will cache
-    /// authorizer responses. If this field is not set, the default value is 300. The maximum
-    /// value is 3600, or 1 hour.</p>
-    pub authorizer_result_ttl_in_seconds: Option<i64>,
-    /// <p>The authorizer type. Currently the only valid value is REQUEST, for a
-    /// Lambda function using incoming request parameters.</p>
-    pub authorizer_type: Option<String>,
-    /// <p>The authorizer's Uniform Resource Identifier (URI). For
-    /// REQUEST authorizers, this must be a
-    /// well-formed Lambda function URI, for example,
-    /// arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:{account_id}:function:{lambda_function_name}/invocations.
-    /// In general, the URI has this form:
-    /// arn:aws:apigateway:{region}:lambda:path/{service_api}
-    /// , where {region} is the same as the region hosting the Lambda
-    /// function, path indicates that the remaining substring in the URI should be treated as
-    /// the path to the resource, including the initial /. For Lambda functions,
-    /// this is usually of the form
-    /// /2015-03-31/functions/[FunctionARN]/invocations.</p>
-    pub authorizer_uri: Option<String>,
-    /// <p>The identity source for which authorization is requested.</p><p>For the REQUEST authorizer, this is required when authorization
-    /// caching is enabled. The value is a comma-separated string of one or more mapping
-    /// expressions of the specified request parameters. For example, if an Auth header, a
-    /// Name query string parameter are defined as identity sources, this value is
-    /// $method.request.header.Auth, $method.request.querystring.Name. These
-    /// parameters will be used to derive the authorization caching key and to perform
-    /// runtime validation of the REQUEST authorizer by verifying all of the
-    /// identity-related request parameters are present, not null and non-empty. Only when
-    /// this is true does the authorizer invoke the authorizer Lambda function, otherwise, it
-    /// returns a 401 Unauthorized response without calling the Lambda function.
-    /// The valid value is a string of comma-separated mapping expressions of the specified
-    /// request parameters. When the authorization caching is not enabled, this property is
-    /// optional.</p>
-    pub identity_source: Option<Vec<String>>,
-    /// <p>The
-    /// validation expression does not apply to the REQUEST authorizer.</p>
-    pub identity_validation_expression: Option<String>,
-    /// <p>The name of the authorizer.</p>
-    pub name: Option<String>,
-    /// <p>For
-    /// REQUEST authorizer, this is not
-    /// defined.</p>
-    pub provider_arns: Option<Vec<String>>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -3501,14 +2972,6 @@ pub struct UpdateAuthorizerResponse {
     pub provider_arns: Option<Vec<String>>,
 }
 
-/// <p>Represents the input parameters for an UpdateDeployment
-/// request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateDeploymentInput {
-    /// <p>The description for the deployment resource.</p>
-    pub description: Option<String>,
-}
-
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDeploymentRequest {
     /// <p>The API identifier.</p>
@@ -3549,14 +3012,6 @@ pub struct UpdateDeploymentResponse {
     pub description: Option<String>,
 }
 
-/// <p>Represents the input parameters for an UpdateDomainName
-/// request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateDomainNameInput {
-    /// <p>The domain name configurations.</p>
-    pub domain_name_configurations: Option<Vec<DomainNameConfiguration>>,
-}
-
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateDomainNameRequest {
     /// <p>The domain name.</p>
@@ -3583,95 +3038,6 @@ pub struct UpdateDomainNameResponse {
     #[serde(rename = "DomainNameConfigurations")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub domain_name_configurations: Option<Vec<DomainNameConfiguration>>,
-}
-
-/// <p>Represents the input parameters for an UpdateIntegration
-/// request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateIntegrationInput {
-    /// <p>The connection ID.</p>
-    pub connection_id: Option<String>,
-    /// <p>The type of the network connection to the integration endpoint. Currently the only
-    /// valid value is INTERNET, for connections through the public routable
-    /// internet.</p>
-    pub connection_type: Option<String>,
-    /// <p>Specifies how to handle response payload content type conversions. Supported
-    /// values are CONVERT_TO_BINARY and CONVERT_TO_TEXT, with the
-    /// following behaviors:</p><p>
-    /// CONVERT_TO_BINARY: Converts a response payload from a Base64-encoded
-    /// string to the corresponding binary blob.</p><p>
-    /// CONVERT_TO_TEXT: Converts a response payload from a binary blob to a
-    /// Base64-encoded string.</p><p>If this property is not defined, the response payload will be passed through from
-    /// the integration response to the route response or method response without
-    /// modification.</p>
-    pub content_handling_strategy: Option<String>,
-    /// <p>Specifies the credentials required for the integration, if any. For AWS
-    /// integrations, three options are available. To specify an IAM Role for API Gateway to
-    /// assume, use the role's Amazon Resource Name (ARN). To require that the caller's
-    /// identity be passed through from the request, specify the string
-    /// arn:aws:iam::*:user/*. To use resource-based permissions on supported
-    /// AWS services, specify null.</p>
-    pub credentials_arn: Option<String>,
-    /// <p>The description of the integration</p>
-    pub description: Option<String>,
-    /// <p>Specifies the integration's HTTP method type.</p>
-    pub integration_method: Option<String>,
-    /// <p>The integration type of an integration. One of the following:</p><p>
-    /// AWS: for integrating the route or method request with an AWS service
-    /// action, including the Lambda function-invoking action. With the Lambda
-    /// function-invoking action, this is referred to as the Lambda custom integration. With
-    /// any other AWS service action, this is known as AWS integration.</p><p>
-    /// AWS_PROXY: for integrating the route or method request with the Lambda
-    /// function-invoking action with the client request passed through as-is. This
-    /// integration is also referred to as Lambda proxy integration.</p><p>
-    /// HTTP: for integrating the route or method request with an HTTP
-    /// endpoint. This
-    /// integration is also referred to as the HTTP custom integration.</p><p>
-    /// HTTP_PROXY: for integrating route or method request with an HTTP
-    /// endpoint, with the client
-    /// request passed through as-is. This is also referred to as HTTP proxy
-    /// integration.</p><p>
-    /// MOCK: for integrating the route or method request with API Gateway as a
-    /// "loopback" endpoint without invoking any backend.</p>
-    pub integration_type: Option<String>,
-    /// <p>For a Lambda proxy integration, this is the URI of the Lambda function.</p>
-    pub integration_uri: Option<String>,
-    /// <p>Specifies the pass-through behavior for incoming requests based on the
-    /// Content-Type header in the request, and the available mapping
-    /// templates specified as the requestTemplates property on the
-    /// Integration resource. There are three valid values:
-    /// WHEN_NO_MATCH, WHEN_NO_TEMPLATES, and
-    /// NEVER.</p><p>
-    /// WHEN_NO_MATCH passes the request body for unmapped content types through
-    /// to the integration backend without transformation.</p><p>
-    /// NEVER rejects unmapped content types with an HTTP 415 Unsupported
-    /// Media Type response.</p><p>
-    /// WHEN_NO_TEMPLATES allows pass-through when the integration has no
-    /// content types mapped to templates. However, if there is at least one content type
-    /// defined, unmapped content types will be rejected with the same HTTP 415
-    /// Unsupported Media Type response.</p>
-    pub passthrough_behavior: Option<String>,
-    /// <p>A key-value map specifying request parameters that are passed from the method
-    /// request to the backend. The key is an integration request parameter name and the
-    /// associated value is a method request parameter value or static value that must be
-    /// enclosed within single quotes and pre-encoded as required by the backend. The method
-    /// request parameter value must match the pattern of
-    /// method.request.{location}.{name}
-    /// , where
-    /// {location}
-    /// is querystring, path, or header; and
-    /// {name}
-    /// must be a valid and unique method request parameter name.</p>
-    pub request_parameters: Option<::std::collections::HashMap<String, String>>,
-    /// <p>Represents a map of Velocity templates that are applied on the request payload
-    /// based on the value of the Content-Type header sent by the client. The content type
-    /// value is the key in this map, and the template (as a String) is the value.</p>
-    pub request_templates: Option<::std::collections::HashMap<String, String>>,
-    /// <p>The template selection expression for the integration.</p>
-    pub template_selection_expression: Option<String>,
-    /// <p>Custom timeout between 50 and 29,000 milliseconds. The default value is 29,000
-    /// milliseconds or 29 seconds.</p>
-    pub timeout_in_millis: Option<i64>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -3915,47 +3281,6 @@ pub struct UpdateIntegrationResponse {
     pub timeout_in_millis: Option<i64>,
 }
 
-/// <p>Represents the input parameters for an UpdateIntegrationResponse
-/// request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateIntegrationResponseInput {
-    /// <p>Specifies how to handle response payload content type conversions. Supported
-    /// values are CONVERT_TO_BINARY and CONVERT_TO_TEXT, with the
-    /// following behaviors:</p><p>
-    /// CONVERT_TO_BINARY: Converts a response payload from a Base64-encoded
-    /// string to the corresponding binary blob.</p><p>
-    /// CONVERT_TO_TEXT: Converts a response payload from a binary blob to a
-    /// Base64-encoded string.</p><p>If this property is not defined, the response payload will be passed through from
-    /// the integration response to the route response or method response without
-    /// modification.</p>
-    pub content_handling_strategy: Option<String>,
-    /// <p>The integration response key.</p>
-    pub integration_response_key: Option<String>,
-    /// <p>A key-value map specifying response parameters that are passed to the method
-    /// response from the backend. The key is a method response header parameter name and the
-    /// mapped value is an integration response header value, a static value enclosed within
-    /// a pair of single quotes, or a JSON expression from the integration response body. The
-    /// mapping key must match the pattern of
-    /// method.response.header.{name}
-    /// , where name is a valid and unique header name. The mapped non-static value
-    /// must match the pattern of
-    /// integration.response.header.{name}
-    /// or
-    /// integration.response.body.{JSON-expression}
-    /// , where
-    /// {name}
-    /// is a valid and unique response header name and
-    /// {JSON-expression}
-    /// is a valid JSON expression without the $ prefix.</p>
-    pub response_parameters: Option<::std::collections::HashMap<String, String>>,
-    /// <p>The collection of response templates for the integration response as a
-    /// string-to-string map of key-value pairs. Response templates are represented as a
-    /// key/value map, with a content-type as the key and a template as the value.</p>
-    pub response_templates: Option<::std::collections::HashMap<String, String>>,
-    /// <p>The template selection expression for the integration response.</p>
-    pub template_selection_expression: Option<String>,
-}
-
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateIntegrationResponseRequest {
     /// <p>The API identifier.</p>
@@ -4061,20 +3386,6 @@ pub struct UpdateIntegrationResponseResponse {
     pub template_selection_expression: Option<String>,
 }
 
-/// <p>Represents the input parameters for an UpdateModel request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateModelInput {
-    /// <p>The content-type for the model, for example, "application/json".</p>
-    pub content_type: Option<String>,
-    /// <p>The description of the model.</p>
-    pub description: Option<String>,
-    /// <p>The name of the model.</p>
-    pub name: Option<String>,
-    /// <p>The schema for the model. For application/json models, this should be JSON schema
-    /// draft 4 model.</p>
-    pub schema: Option<String>,
-}
-
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateModelRequest {
     /// <p>The API identifier.</p>
@@ -4126,40 +3437,6 @@ pub struct UpdateModelResponse {
     #[serde(rename = "Schema")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub schema: Option<String>,
-}
-
-/// <p>Represents the input parameters for an UpdateRoute request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateRouteInput {
-    /// <p>Specifies whether an API key is required for the route.</p>
-    pub api_key_required: Option<bool>,
-    /// <p>The authorization scopes supported by this
-    /// route.</p>
-    pub authorization_scopes: Option<Vec<String>>,
-    /// <p>The authorization type for the route. Valid values are NONE for open
-    /// access, AWS_IAM for using AWS IAM permissions, and CUSTOM
-    /// for using a Lambda
-    /// authorizer.</p>
-    pub authorization_type: Option<String>,
-    /// <p>The identifier of the Authorizer resource to be associated with this
-    /// route, if the authorizationType is CUSTOM
-    /// . The authorizer identifier is generated by API Gateway
-    /// when you created the authorizer.</p>
-    pub authorizer_id: Option<String>,
-    /// <p>The model selection expression for the route.</p>
-    pub model_selection_expression: Option<String>,
-    /// <p>The operation name for the route.</p>
-    pub operation_name: Option<String>,
-    /// <p>The request models for the route.</p>
-    pub request_models: Option<::std::collections::HashMap<String, String>>,
-    /// <p>The request parameters for the route.</p>
-    pub request_parameters: Option<::std::collections::HashMap<String, ParameterConstraints>>,
-    /// <p>The route key for the route.</p>
-    pub route_key: Option<String>,
-    /// <p>The route response selection expression for the route.</p>
-    pub route_response_selection_expression: Option<String>,
-    /// <p>The target for the route.</p>
-    pub target: Option<String>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -4288,20 +3565,6 @@ pub struct UpdateRouteResponse {
     pub target: Option<String>,
 }
 
-/// <p>Represents the input parameters for an UpdateRouteResponse
-/// request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateRouteResponseInput {
-    /// <p>The model selection expression for the route response.</p>
-    pub model_selection_expression: Option<String>,
-    /// <p>The response models for the route response.</p>
-    pub response_models: Option<::std::collections::HashMap<String, String>>,
-    /// <p>The route response parameters.</p>
-    pub response_parameters: Option<::std::collections::HashMap<String, ParameterConstraints>>,
-    /// <p>The route response key.</p>
-    pub route_response_key: Option<String>,
-}
-
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateRouteResponseRequest {
     /// <p>The API identifier.</p>
@@ -4354,27 +3617,6 @@ pub struct UpdateRouteResponseResponse {
     #[serde(rename = "RouteResponseKey")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub route_response_key: Option<String>,
-}
-
-/// <p>Represents the input parameters for an UpdateStage request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateStageInput {
-    /// <p>Settings for logging access in this stage.</p>
-    pub access_log_settings: Option<AccessLogSettings>,
-    /// <p>The identifier of a client certificate for a Stage.</p>
-    pub client_certificate_id: Option<String>,
-    /// <p>The default route settings for the stage.</p>
-    pub default_route_settings: Option<RouteSettings>,
-    /// <p>The deployment identifier for the API stage.</p>
-    pub deployment_id: Option<String>,
-    /// <p>The description for the API stage.</p>
-    pub description: Option<String>,
-    /// <p>Route settings for the stage.</p>
-    pub route_settings: Option<::std::collections::HashMap<String, RouteSettings>>,
-    /// <p>A map that defines the stage variables for a Stage. Variable names
-    /// can have alphanumeric and underscore characters, and the values must match
-    /// [A-Za-z0-9-._~:/?#&=,]+.</p>
-    pub stage_variables: Option<::std::collections::HashMap<String, String>>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]

--- a/rusoto/services/greengrass/src/generated.rs
+++ b/rusoto/services/greengrass/src/generated.rs
@@ -1260,10 +1260,6 @@ pub struct DisassociateServiceRoleFromAccountResponse {
     pub disassociated_at: Option<String>,
 }
 
-/// <p>Empty</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct Empty {}
-
 /// <p>Details about the error.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 #[cfg_attr(test, derive(Serialize))]
@@ -1403,15 +1399,6 @@ pub struct FunctionRunAsConfig {
     #[serde(rename = "Uid")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uid: Option<i64>,
-}
-
-/// <p>General error information.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct GeneralError {
-    /// <p>Details about the error.</p>
-    pub error_details: Option<Vec<ErrorDetail>>,
-    /// <p>A message containing information about the error.</p>
-    pub message: Option<String>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -2278,17 +2265,6 @@ pub struct GroupCertificateAuthorityProperties {
     pub group_certificate_authority_id: Option<String>,
 }
 
-/// <p>Information about a group certificate configuration.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct GroupCertificateConfiguration {
-    /// <p>The amount of time remaining before the certificate authority expires, in milliseconds.</p>
-    pub certificate_authority_expiry_in_milliseconds: Option<String>,
-    /// <p>The amount of time remaining before the certificate expires, in milliseconds.</p>
-    pub certificate_expiry_in_milliseconds: Option<String>,
-    /// <p>The ID of the group certificate configuration.</p>
-    pub group_id: Option<String>,
-}
-
 /// <p>Information about a group.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 #[cfg_attr(test, derive(Serialize))]
@@ -2525,15 +2501,6 @@ pub struct ListCoreDefinitionsResponse {
     /// <p>The token for the next set of results, or &#39;&#39;null&#39;&#39; if there are no additional results.</p>
     #[serde(rename = "NextToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub next_token: Option<String>,
-}
-
-/// <p>A list of definitions.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ListDefinitionsResponse {
-    /// <p>Information about a definition.</p>
-    pub definitions: Option<Vec<DefinitionInformation>>,
-    /// <p>The token for the next set of results, or &#39;&#39;null&#39;&#39; if there are no additional results.</p>
     pub next_token: Option<String>,
 }
 
@@ -2913,15 +2880,6 @@ pub struct ListTagsForResourceResponse {
     #[serde(rename = "tags")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<::std::collections::HashMap<String, String>>,
-}
-
-/// <p>A list of versions.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ListVersionsResponse {
-    /// <p>The token for the next set of results, or &#39;&#39;null&#39;&#39; if there are no additional results.</p>
-    pub next_token: Option<String>,
-    /// <p>Information about a version.</p>
-    pub versions: Option<Vec<VersionInformation>>,
 }
 
 /// <p>Attributes that define a local device resource.</p>

--- a/rusoto/services/guardduty/src/generated.rs
+++ b/rusoto/services/guardduty/src/generated.rs
@@ -513,15 +513,6 @@ pub struct DnsRequestAction {
 #[cfg_attr(test, derive(Serialize))]
 pub struct DomainDetails {}
 
-/// <p>Error response object.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ErrorResponse {
-    /// <p>The error message.</p>
-    pub message: Option<String>,
-    /// <p>The error type.</p>
-    pub type_: Option<String>,
-}
-
 /// <p>Representation of a abnormal or suspicious activity.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 #[cfg_attr(test, derive(Serialize))]

--- a/rusoto/services/iot1click-devices/src/generated.rs
+++ b/rusoto/services/iot1click-devices/src/generated.rs
@@ -83,12 +83,6 @@ pub struct Device {
     pub type_: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct DeviceClaimResponse {
-    /// <p>The device's final claim state.</p>
-    pub state: Option<String>,
-}
-
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 #[cfg_attr(test, derive(Serialize))]
 pub struct DeviceDescription {
@@ -137,15 +131,6 @@ pub struct DeviceEvent {
     pub std_event: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct DeviceEventsResponse {
-    /// <p>An array of zero or more elements describing the event(s) associated with the
-    /// device.</p>
-    pub events: Option<Vec<DeviceEvent>>,
-    /// <p>The token to retrieve the next set of results.</p>
-    pub next_token: Option<String>,
-}
-
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DeviceMethod {
     /// <p>The type of the device, such as "button".</p>
@@ -157,10 +142,6 @@ pub struct DeviceMethod {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub method_name: Option<String>,
 }
-
-/// <p>On success, an empty object is returned.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct Empty {}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct FinalizeDeviceClaimRequest {

--- a/rusoto/services/kafka/src/generated.rs
+++ b/rusoto/services/kafka/src/generated.rs
@@ -426,15 +426,6 @@ pub struct EncryptionInfo {
     pub encryption_at_rest: Option<EncryptionAtRest>,
 }
 
-/// <p>Returns information about an error.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct KafkaError {
-    /// <p>The parameter that caused the error.</p>
-    pub invalid_parameter: Option<String>,
-    /// <p>The description of the error.</p>
-    pub message: Option<String>,
-}
-
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetBootstrapBrokersRequest {
     /// <p>The Amazon Resource Name (ARN) that uniquely identifies the cluster.</p>

--- a/rusoto/services/mediaconvert/src/generated.rs
+++ b/rusoto/services/mediaconvert/src/generated.rs
@@ -1306,11 +1306,6 @@ pub struct EsamSignalProcessingNotification {
     pub scc_xml: Option<String>,
 }
 
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ExceptionBody {
-    pub message: Option<String>,
-}
-
 /// <p>Settings for F4v container</p>
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct F4vSettings {

--- a/rusoto/services/medialive/src/generated.rs
+++ b/rusoto/services/medialive/src/generated.rs
@@ -101,12 +101,6 @@ pub struct Ac3Settings {
     pub metadata_control: Option<String>,
 }
 
-/// <p>Placeholder documentation for AccessDenied</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct AccessDenied {
-    pub message: Option<String>,
-}
-
 /// <p>Archive Container Settings</p>
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ArchiveContainerSettings {
@@ -414,15 +408,6 @@ pub struct BatchUpdateScheduleResponse {
     pub deletes: Option<BatchScheduleActionDeleteResult>,
 }
 
-/// <p>Results of a batch schedule update.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct BatchUpdateScheduleResult {
-    /// <p>Schedule actions created in the schedule.</p>
-    pub creates: Option<BatchScheduleActionCreateResult>,
-    /// <p>Schedule actions deleted from the schedule.</p>
-    pub deletes: Option<BatchScheduleActionDeleteResult>,
-}
-
 /// <p>Blackout Slate</p>
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BlackoutSlate {
@@ -699,14 +684,6 @@ pub struct Channel {
     pub tags: Option<::std::collections::HashMap<String, String>>,
 }
 
-/// <p>Placeholder documentation for ChannelConfigurationValidationError</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ChannelConfigurationValidationError {
-    pub message: Option<String>,
-    /// <p>A collection of validation error responses.</p>
-    pub validation_errors: Option<Vec<ValidationError>>,
-}
-
 /// <p>Placeholder documentation for ChannelEgressEndpoint</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 #[cfg_attr(test, derive(Serialize))]
@@ -775,30 +752,6 @@ pub struct ChannelSummary {
     pub tags: Option<::std::collections::HashMap<String, String>>,
 }
 
-/// <p>Placeholder documentation for CreateChannel</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct CreateChannel {
-    /// <p>The class for this channel. STANDARD for a channel with two pipelines or SINGLE_PIPELINE for a channel with one pipeline.</p>
-    pub channel_class: Option<String>,
-    pub destinations: Option<Vec<OutputDestination>>,
-    pub encoder_settings: Option<EncoderSettings>,
-    /// <p>List of input attachments for channel.</p>
-    pub input_attachments: Option<Vec<InputAttachment>>,
-    /// <p>Specification of input for this channel (max. bitrate, resolution, codec, etc.)</p>
-    pub input_specification: Option<InputSpecification>,
-    /// <p>The log level to write to CloudWatch Logs.</p>
-    pub log_level: Option<String>,
-    /// <p>Name of channel.</p>
-    pub name: Option<String>,
-    /// <p>Unique request ID to be specified. This is needed to prevent retries from
-    /// creating multiple resources.</p>
-    pub request_id: Option<String>,
-    /// <p>An optional Amazon Resource Name (ARN) of the role to assume when running the Channel.</p>
-    pub role_arn: Option<String>,
-    /// <p>A collection of key-value pairs.</p>
-    pub tags: Option<::std::collections::HashMap<String, String>>,
-}
-
 /// <p>A request to create a channel</p>
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateChannelRequest {
@@ -850,40 +803,6 @@ pub struct CreateChannelResponse {
     #[serde(rename = "Channel")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub channel: Option<Channel>,
-}
-
-/// <p>Placeholder documentation for CreateChannelResultModel</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct CreateChannelResultModel {
-    pub channel: Option<Channel>,
-}
-
-/// <p>Placeholder documentation for CreateInput</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct CreateInput {
-    /// <p>Destination settings for PUSH type inputs.</p>
-    pub destinations: Option<Vec<InputDestinationRequest>>,
-    /// <p>A list of security groups referenced by IDs to attach to the input.</p>
-    pub input_security_groups: Option<Vec<String>>,
-    /// <p>A list of the MediaConnect Flows that you want to use in this input. You can specify as few as one
-    /// Flow and presently, as many as two. The only requirement is when you have more than one is that each Flow is in a
-    /// separate Availability Zone as this ensures your EML input is redundant to AZ issues.</p>
-    pub media_connect_flows: Option<Vec<MediaConnectFlowRequest>>,
-    /// <p>Name of the input.</p>
-    pub name: Option<String>,
-    /// <p>Unique identifier of the request to ensure the request is handled
-    /// exactly once in case of retries.</p>
-    pub request_id: Option<String>,
-    /// <p>The Amazon Resource Name (ARN) of the role this input assumes during and after creation.</p>
-    pub role_arn: Option<String>,
-    /// <p>The source URLs for a PULL-type input. Every PULL type input needs
-    /// exactly two source URLs for redundancy.
-    /// Only specify sources for PULL type Inputs. Leave Destinations empty.</p>
-    pub sources: Option<Vec<InputSourceRequest>>,
-    /// <p>A collection of key-value pairs.</p>
-    pub tags: Option<::std::collections::HashMap<String, String>>,
-    pub type_: Option<String>,
-    pub vpc: Option<InputVpcRequest>,
 }
 
 /// <p>The name of the input</p>
@@ -943,12 +862,6 @@ pub struct CreateInputResponse {
     pub input: Option<Input>,
 }
 
-/// <p>Placeholder documentation for CreateInputResultModel</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct CreateInputResultModel {
-    pub input: Option<Input>,
-}
-
 /// <p>The IPv4 CIDRs to whitelist for this Input Security Group</p>
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateInputSecurityGroupRequest {
@@ -968,12 +881,6 @@ pub struct CreateInputSecurityGroupRequest {
 pub struct CreateInputSecurityGroupResponse {
     #[serde(rename = "SecurityGroup")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub security_group: Option<InputSecurityGroup>,
-}
-
-/// <p>Placeholder documentation for CreateInputSecurityGroupResultModel</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct CreateInputSecurityGroupResultModel {
     pub security_group: Option<InputSecurityGroup>,
 }
 
@@ -1775,10 +1682,6 @@ pub struct EmbeddedSourceSettings {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_608_track_number: Option<i64>,
 }
-
-/// <p>Placeholder documentation for Empty</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct Empty {}
 
 /// <p>Encoder Settings</p>
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -2629,15 +2532,6 @@ pub struct InputSecurityGroup {
     pub whitelist_rules: Option<Vec<InputWhitelistRule>>,
 }
 
-/// <p>Request of IPv4 CIDR addresses to whitelist in a security group.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct InputSecurityGroupWhitelistRequest {
-    /// <p>A collection of key-value pairs.</p>
-    pub tags: Option<::std::collections::HashMap<String, String>>,
-    /// <p>List of IPv4 CIDR addresses to whitelist</p>
-    pub whitelist_rules: Option<Vec<InputWhitelistRuleCidr>>,
-}
-
 /// <p>Live Event input parameters. There can be multiple inputs in a single Live Event.</p>
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct InputSettings {
@@ -2780,30 +2674,12 @@ pub struct InputWhitelistRuleCidr {
     pub cidr: Option<String>,
 }
 
-/// <p>Placeholder documentation for InternalServiceError</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct InternalServiceError {
-    pub message: Option<String>,
-}
-
-/// <p>Placeholder documentation for InvalidRequest</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct InvalidRequest {
-    pub message: Option<String>,
-}
-
 /// <p>Key Provider Settings</p>
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct KeyProviderSettings {
     #[serde(rename = "StaticKeySettings")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub static_key_settings: Option<StaticKeySettings>,
-}
-
-/// <p>Placeholder documentation for LimitExceeded</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct LimitExceeded {
-    pub message: Option<String>,
 }
 
 /// <p>Placeholder documentation for ListChannelsRequest</p>
@@ -2826,13 +2702,6 @@ pub struct ListChannelsResponse {
     pub channels: Option<Vec<ChannelSummary>>,
     #[serde(rename = "NextToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub next_token: Option<String>,
-}
-
-/// <p>Placeholder documentation for ListChannelsResultModel</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ListChannelsResultModel {
-    pub channels: Option<Vec<ChannelSummary>>,
     pub next_token: Option<String>,
 }
 
@@ -2860,14 +2729,6 @@ pub struct ListInputSecurityGroupsResponse {
     pub next_token: Option<String>,
 }
 
-/// <p>Result of input security group list request</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ListInputSecurityGroupsResultModel {
-    /// <p>List of input security groups</p>
-    pub input_security_groups: Option<Vec<InputSecurityGroup>>,
-    pub next_token: Option<String>,
-}
-
 /// <p>Placeholder documentation for ListInputsRequest</p>
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListInputsRequest {
@@ -2888,13 +2749,6 @@ pub struct ListInputsResponse {
     pub inputs: Option<Vec<Input>>,
     #[serde(rename = "NextToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub next_token: Option<String>,
-}
-
-/// <p>Placeholder documentation for ListInputsResultModel</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ListInputsResultModel {
-    pub inputs: Option<Vec<Input>>,
     pub next_token: Option<String>,
 }
 
@@ -2959,15 +2813,6 @@ pub struct ListOfferingsResponse {
     pub offerings: Option<Vec<Offering>>,
 }
 
-/// <p>ListOfferings response</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ListOfferingsResultModel {
-    /// <p>Token to retrieve the next page of results</p>
-    pub next_token: Option<String>,
-    /// <p>List of offerings</p>
-    pub offerings: Option<Vec<Offering>>,
-}
-
 /// <p>Placeholder documentation for ListReservationsRequest</p>
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListReservationsRequest {
@@ -3022,15 +2867,6 @@ pub struct ListReservationsResponse {
     /// <p>List of reservations</p>
     #[serde(rename = "Reservations")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reservations: Option<Vec<Reservation>>,
-}
-
-/// <p>ListReservations response</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ListReservationsResultModel {
-    /// <p>Token to retrieve the next page of results</p>
-    pub next_token: Option<String>,
-    /// <p>List of reservations</p>
     pub reservations: Option<Vec<Reservation>>,
 }
 
@@ -3686,21 +3522,6 @@ pub struct PipelinePauseStateSettings {
     pub pipeline_id: String,
 }
 
-/// <p>PurchaseOffering request</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct PurchaseOffering {
-    /// <p>Number of resources</p>
-    pub count: i64,
-    /// <p>Name for the new reservation</p>
-    pub name: Option<String>,
-    /// <p>Unique request ID to be specified. This is needed to prevent retries from creating multiple resources.</p>
-    pub request_id: Option<String>,
-    /// <p>Requested reservation start time (UTC) in ISO-8601 format. The specified time must be between the first day of the current month and one year from now. If no value is given, the default is now.</p>
-    pub start: Option<String>,
-    /// <p>A collection of key-value pairs</p>
-    pub tags: Option<::std::collections::HashMap<String, String>>,
-}
-
 /// <p>Placeholder documentation for PurchaseOfferingRequest</p>
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct PurchaseOfferingRequest {
@@ -3734,12 +3555,6 @@ pub struct PurchaseOfferingRequest {
 pub struct PurchaseOfferingResponse {
     #[serde(rename = "Reservation")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reservation: Option<Reservation>,
-}
-
-/// <p>PurchaseOffering response</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct PurchaseOfferingResultModel {
     pub reservation: Option<Reservation>,
 }
 
@@ -3876,18 +3691,6 @@ pub struct ReservationResourceSpecification {
     pub video_quality: Option<String>,
 }
 
-/// <p>Placeholder documentation for ResourceConflict</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ResourceConflict {
-    pub message: Option<String>,
-}
-
-/// <p>Placeholder documentation for ResourceNotFound</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ResourceNotFound {
-    pub message: Option<String>,
-}
-
 /// <p>Rtmp Caption Info Destination Settings</p>
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RtmpCaptionInfoDestinationSettings {}
@@ -4008,19 +3811,6 @@ pub struct ScheduleActionStartSettings {
     #[serde(rename = "FollowModeScheduleActionStartSettings")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub follow_mode_schedule_action_start_settings: Option<FollowModeScheduleActionStartSettings>,
-}
-
-/// <p>Result of a schedule deletion.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ScheduleDeleteResultModel {}
-
-/// <p>Results of a schedule describe.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ScheduleDescribeResultModel {
-    /// <p>The next token; for use in pagination.</p>
-    pub next_token: Option<String>,
-    /// <p>The list of actions in the schedule.</p>
-    pub schedule_actions: Vec<ScheduleAction>,
 }
 
 /// <p>Scte20 Plus Embedded Destination Settings</p>
@@ -4421,12 +4211,6 @@ pub struct StopChannelResponse {
     pub tags: Option<::std::collections::HashMap<String, String>>,
 }
 
-/// <p>Placeholder documentation for TagsModel</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct TagsModel {
-    pub tags: Option<::std::collections::HashMap<String, String>>,
-}
-
 /// <p>Teletext Destination Settings</p>
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TeletextDestinationSettings {}
@@ -4507,33 +4291,6 @@ pub struct UdpOutputSettings {
     pub fec_output_settings: Option<FecOutputSettings>,
 }
 
-/// <p>Placeholder documentation for UpdateChannel</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateChannel {
-    /// <p>A list of output destinations for this channel.</p>
-    pub destinations: Option<Vec<OutputDestination>>,
-    /// <p>The encoder settings for this channel.</p>
-    pub encoder_settings: Option<EncoderSettings>,
-    pub input_attachments: Option<Vec<InputAttachment>>,
-    /// <p>Specification of input for this channel (max. bitrate, resolution, codec, etc.)</p>
-    pub input_specification: Option<InputSpecification>,
-    /// <p>The log level to write to CloudWatch Logs.</p>
-    pub log_level: Option<String>,
-    /// <p>The name of the channel.</p>
-    pub name: Option<String>,
-    /// <p>An optional Amazon Resource Name (ARN) of the role to assume when running the Channel. If you do not specify this on an update call but the role was previously set that role will be removed.</p>
-    pub role_arn: Option<String>,
-}
-
-/// <p>Placeholder documentation for UpdateChannelClass</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateChannelClass {
-    /// <p>The channel class that you wish to update this channel to use.</p>
-    pub channel_class: String,
-    /// <p>A list of output destinations for this channel.</p>
-    pub destinations: Option<Vec<OutputDestination>>,
-}
-
 /// <p>Channel class that the channel should be updated to.</p>
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateChannelClassRequest {
@@ -4602,33 +4359,6 @@ pub struct UpdateChannelResponse {
     pub channel: Option<Channel>,
 }
 
-/// <p>The updated channel&#39;s description.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateChannelResultModel {
-    pub channel: Option<Channel>,
-}
-
-/// <p>Placeholder documentation for UpdateInput</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateInput {
-    /// <p>Destination settings for PUSH type inputs.</p>
-    pub destinations: Option<Vec<InputDestinationRequest>>,
-    /// <p>A list of security groups referenced by IDs to attach to the input.</p>
-    pub input_security_groups: Option<Vec<String>>,
-    /// <p>A list of the MediaConnect Flow ARNs that you want to use as the source of the input. You can specify as few as one
-    /// Flow and presently, as many as two. The only requirement is when you have more than one is that each Flow is in a
-    /// separate Availability Zone as this ensures your EML input is redundant to AZ issues.</p>
-    pub media_connect_flows: Option<Vec<MediaConnectFlowRequest>>,
-    /// <p>Name of the input.</p>
-    pub name: Option<String>,
-    /// <p>The Amazon Resource Name (ARN) of the role this input assumes during and after creation.</p>
-    pub role_arn: Option<String>,
-    /// <p>The source URLs for a PULL-type input. Every PULL type input needs
-    /// exactly two source URLs for redundancy.
-    /// Only specify sources for PULL type Inputs. Leave Destinations empty.</p>
-    pub sources: Option<Vec<InputSourceRequest>>,
-}
-
 /// <p>A request to update an input.</p>
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateInputRequest {
@@ -4674,12 +4404,6 @@ pub struct UpdateInputResponse {
     pub input: Option<Input>,
 }
 
-/// <p>Placeholder documentation for UpdateInputResultModel</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateInputResultModel {
-    pub input: Option<Input>,
-}
-
 /// <p>The request to update some combination of the Input Security Group name and the IPv4 CIDRs the Input Security Group should allow.</p>
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateInputSecurityGroupRequest {
@@ -4705,19 +4429,6 @@ pub struct UpdateInputSecurityGroupResponse {
     pub security_group: Option<InputSecurityGroup>,
 }
 
-/// <p>Placeholder documentation for UpdateInputSecurityGroupResultModel</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateInputSecurityGroupResultModel {
-    pub security_group: Option<InputSecurityGroup>,
-}
-
-/// <p>UpdateReservation request</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateReservation {
-    /// <p>Name of the reservation</p>
-    pub name: Option<String>,
-}
-
 /// <p>Request to update a reservation</p>
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateReservationRequest {
@@ -4736,12 +4447,6 @@ pub struct UpdateReservationRequest {
 pub struct UpdateReservationResponse {
     #[serde(rename = "Reservation")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reservation: Option<Reservation>,
-}
-
-/// <p>UpdateReservation response</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateReservationResultModel {
     pub reservation: Option<Reservation>,
 }
 

--- a/rusoto/services/mediapackage/src/generated.rs
+++ b/rusoto/services/mediapackage/src/generated.rs
@@ -49,33 +49,6 @@ pub struct Channel {
     pub tags: Option<::std::collections::HashMap<String, String>>,
 }
 
-/// <p>Configuration parameters for a new Channel.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ChannelCreateParameters {
-    /// <p>A short text description of the Channel.</p>
-    pub description: Option<String>,
-    /// <p>The ID of the Channel. The ID must be unique within the region and it
-    /// cannot be changed after a Channel is created.</p>
-    pub id: String,
-    pub tags: Option<::std::collections::HashMap<String, String>>,
-}
-
-/// <p>A collection of Channel records.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ChannelList {
-    /// <p>A list of Channel records.</p>
-    pub channels: Option<Vec<Channel>>,
-    /// <p>A token that can be used to resume pagination from the end of the collection.</p>
-    pub next_token: Option<String>,
-}
-
-/// <p>Configuration parameters for updating an existing Channel.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ChannelUpdateParameters {
-    /// <p>A short text description of the Channel.</p>
-    pub description: Option<String>,
-}
-
 /// <p>A Common Media Application Format (CMAF) encryption configuration.</p>
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CmafEncryption {
@@ -825,64 +798,6 @@ pub struct OriginEndpoint {
     pub whitelist: Option<Vec<String>>,
 }
 
-/// <p>Configuration parameters for a new OriginEndpoint.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct OriginEndpointCreateParameters {
-    /// <p>The ID of the Channel that the OriginEndpoint will be associated with.
-    /// This cannot be changed after the OriginEndpoint is created.</p>
-    pub channel_id: String,
-    pub cmaf_package: Option<CmafPackageCreateOrUpdateParameters>,
-    pub dash_package: Option<DashPackage>,
-    /// <p>A short text description of the OriginEndpoint.</p>
-    pub description: Option<String>,
-    pub hls_package: Option<HlsPackage>,
-    /// <p>The ID of the OriginEndpoint.  The ID must be unique within the region
-    /// and it cannot be changed after the OriginEndpoint is created.</p>
-    pub id: String,
-    /// <p>A short string that will be used as the filename of the OriginEndpoint URL (defaults to &quot;index&quot;).</p>
-    pub manifest_name: Option<String>,
-    pub mss_package: Option<MssPackage>,
-    /// <p>Maximum duration (seconds) of content to retain for startover playback.
-    /// If not specified, startover playback will be disabled for the OriginEndpoint.</p>
-    pub startover_window_seconds: Option<i64>,
-    pub tags: Option<::std::collections::HashMap<String, String>>,
-    /// <p>Amount of delay (seconds) to enforce on the playback of live content.
-    /// If not specified, there will be no time delay in effect for the OriginEndpoint.</p>
-    pub time_delay_seconds: Option<i64>,
-    /// <p>A list of source IP CIDR blocks that will be allowed to access the OriginEndpoint.</p>
-    pub whitelist: Option<Vec<String>>,
-}
-
-/// <p>A collection of OriginEndpoint records.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct OriginEndpointList {
-    /// <p>A token that can be used to resume pagination from the end of the collection.</p>
-    pub next_token: Option<String>,
-    /// <p>A list of OriginEndpoint records.</p>
-    pub origin_endpoints: Option<Vec<OriginEndpoint>>,
-}
-
-/// <p>Configuration parameters for updating an existing OriginEndpoint.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct OriginEndpointUpdateParameters {
-    pub cmaf_package: Option<CmafPackageCreateOrUpdateParameters>,
-    pub dash_package: Option<DashPackage>,
-    /// <p>A short text description of the OriginEndpoint.</p>
-    pub description: Option<String>,
-    pub hls_package: Option<HlsPackage>,
-    /// <p>A short string that will be appended to the end of the Endpoint URL.</p>
-    pub manifest_name: Option<String>,
-    pub mss_package: Option<MssPackage>,
-    /// <p>Maximum duration (in seconds) of content to retain for startover playback.
-    /// If not specified, startover playback will be disabled for the OriginEndpoint.</p>
-    pub startover_window_seconds: Option<i64>,
-    /// <p>Amount of delay (in seconds) to enforce on the playback of live content.
-    /// If not specified, there will be no time delay in effect for the OriginEndpoint.</p>
-    pub time_delay_seconds: Option<i64>,
-    /// <p>A list of source IP CIDR blocks that will be allowed to access the OriginEndpoint.</p>
-    pub whitelist: Option<Vec<String>>,
-}
-
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct RotateChannelCredentialsRequest {
     /// <p>The ID of the channel to update.</p>
@@ -992,11 +907,6 @@ pub struct TagResourceRequest {
     #[serde(rename = "ResourceArn")]
     pub resource_arn: String,
     #[serde(rename = "Tags")]
-    pub tags: ::std::collections::HashMap<String, String>,
-}
-
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct TagsModel {
     pub tags: ::std::collections::HashMap<String, String>,
 }
 

--- a/rusoto/services/mediatailor/src/generated.rs
+++ b/rusoto/services/mediatailor/src/generated.rs
@@ -80,9 +80,6 @@ pub struct DeletePlaybackConfigurationRequest {
 #[cfg_attr(test, derive(Serialize))]
 pub struct DeletePlaybackConfigurationResponse {}
 
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct Empty {}
-
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct GetPlaybackConfigurationRequest {
     /// <p>The identifier for the playback configuration.</p>
@@ -354,18 +351,6 @@ pub struct TagResourceRequest {
     /// }
     /// </p>
     #[serde(rename = "Tags")]
-    pub tags: ::std::collections::HashMap<String, String>,
-}
-
-/// <p>A set of tags assigned to a resource. </p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct TagsModel {
-    /// <p>A comma-separated list of tag key:value pairs. For example:
-    /// {
-    /// "Key1": "Value1",
-    /// "Key2": "Value2"
-    /// }
-    /// </p>
     pub tags: ::std::collections::HashMap<String, String>,
 }
 

--- a/rusoto/services/mq/src/generated.rs
+++ b/rusoto/services/mq/src/generated.rs
@@ -49,17 +49,6 @@ pub struct BrokerEngineType {
     pub engine_versions: Option<Vec<EngineVersion>>,
 }
 
-/// <p>Returns a list of broker engine type.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct BrokerEngineTypeOutput {
-    /// <p>List of available engine types and versions.</p>
-    pub broker_engine_types: Option<Vec<BrokerEngineType>>,
-    /// <p>Required. The maximum number of engine types that can be returned per page (20 by default). This value must be an integer from 5 to 100.</p>
-    pub max_results: Option<i64>,
-    /// <p>The token that specifies the next page of results Amazon MQ should return. To request the first page, leave nextToken empty.</p>
-    pub next_token: Option<String>,
-}
-
 /// <p>Returns information about all brokers.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 #[cfg_attr(test, derive(Serialize))]
@@ -98,17 +87,6 @@ pub struct BrokerInstanceOption {
     #[serde(rename = "SupportedEngineVersions")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub supported_engine_versions: Option<Vec<String>>,
-}
-
-/// <p>Returns a list of broker instance options.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct BrokerInstanceOptionsOutput {
-    /// <p>List of available broker instance options.</p>
-    pub broker_instance_options: Option<Vec<BrokerInstanceOption>>,
-    /// <p>Required. The maximum number of instance options that can be returned per page (20 by default). This value must be an integer from 5 to 100.</p>
-    pub max_results: Option<i64>,
-    /// <p>The token that specifies the next page of results Amazon MQ should return. To request the first page, leave nextToken empty.</p>
-    pub next_token: Option<String>,
 }
 
 /// <p>The Amazon Resource Name (ARN) of the broker.</p>
@@ -236,50 +214,6 @@ pub struct Configurations {
     pub pending: Option<ConfigurationId>,
 }
 
-/// <p>Required. The time period during which Amazon MQ applies pending updates or patches to the broker.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct CreateBrokerInput {
-    /// <p>Required. Enables automatic upgrades to new minor versions for brokers, as Apache releases the versions. The automatic upgrades occur during the maintenance window of the broker or after a manual broker reboot.</p>
-    pub auto_minor_version_upgrade: Option<bool>,
-    /// <p>Required. The name of the broker. This value must be unique in your AWS account, 1-50 characters long, must contain only letters, numbers, dashes, and underscores, and must not contain whitespaces, brackets, wildcard characters, or special characters.</p>
-    pub broker_name: Option<String>,
-    /// <p>A list of information about the configuration.</p>
-    pub configuration: Option<ConfigurationId>,
-    /// <p>The unique ID that the requester receives for the created broker. Amazon MQ passes your ID with the API action. Note: We recommend using a Universally Unique Identifier (UUID) for the creatorRequestId. You may omit the creatorRequestId if your application doesn&#39;t require idempotency.</p>
-    pub creator_request_id: Option<String>,
-    /// <p>Required. The deployment mode of the broker.</p>
-    pub deployment_mode: Option<String>,
-    /// <p>Required. The type of broker engine. Note: Currently, Amazon MQ supports only ACTIVEMQ.</p>
-    pub engine_type: Option<String>,
-    /// <p>Required. The version of the broker engine. For a list of supported engine versions, see https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-engine.html</p>
-    pub engine_version: Option<String>,
-    /// <p>Required. The broker&#39;s instance type.</p>
-    pub host_instance_type: Option<String>,
-    /// <p>Enables Amazon CloudWatch logging for brokers.</p>
-    pub logs: Option<Logs>,
-    /// <p>The parameters that determine the WeeklyStartTime.</p>
-    pub maintenance_window_start_time: Option<WeeklyStartTime>,
-    /// <p>Required. Enables connections from applications outside of the VPC that hosts the broker&#39;s subnets.</p>
-    pub publicly_accessible: Option<bool>,
-    /// <p>The list of rules (1 minimum, 125 maximum) that authorize connections to brokers.</p>
-    pub security_groups: Option<Vec<String>>,
-    /// <p>The list of groups (2 maximum) that define which subnets and IP ranges the broker can use from different Availability Zones. A SINGLE<em>INSTANCE deployment requires one subnet (for example, the default subnet). An ACTIVE</em>STANDBY<em>MULTI</em>AZ deployment requires two subnets.</p>
-    pub subnet_ids: Option<Vec<String>>,
-    /// <p>Create tags when creating the broker.</p>
-    pub tags: Option<::std::collections::HashMap<String, String>>,
-    /// <p>Required. The list of ActiveMQ users (persons or applications) who can access queues and topics. This value can contain only alphanumeric characters, dashes, periods, underscores, and tildes (- . _ ~). This value must be 2-100 characters long.</p>
-    pub users: Option<Vec<User>>,
-}
-
-/// <p>Returns information about the created broker.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct CreateBrokerOutput {
-    /// <p>The Amazon Resource Name (ARN) of the broker.</p>
-    pub broker_arn: Option<String>,
-    /// <p>The unique ID that Amazon MQ generates for the broker.</p>
-    pub broker_id: Option<String>,
-}
-
 /// <p>Creates a broker using the specified properties.</p>
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateBrokerRequest {
@@ -359,34 +293,6 @@ pub struct CreateBrokerResponse {
 }
 
 /// <p>Creates a new configuration for the specified configuration name. Amazon MQ uses the default configuration (the engine type and version).</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct CreateConfigurationInput {
-    /// <p>Required. The type of broker engine. Note: Currently, Amazon MQ supports only ACTIVEMQ.</p>
-    pub engine_type: Option<String>,
-    /// <p>Required. The version of the broker engine. For a list of supported engine versions, see https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-engine.html</p>
-    pub engine_version: Option<String>,
-    /// <p>Required. The name of the configuration. This value can contain only alphanumeric characters, dashes, periods, underscores, and tildes (- . _ ~). This value must be 1-150 characters long.</p>
-    pub name: Option<String>,
-    /// <p>Create tags when creating the configuration.</p>
-    pub tags: Option<::std::collections::HashMap<String, String>>,
-}
-
-/// <p>Returns information about the created configuration.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct CreateConfigurationOutput {
-    /// <p>Required. The Amazon Resource Name (ARN) of the configuration.</p>
-    pub arn: Option<String>,
-    /// <p>Required. The date and time of the configuration.</p>
-    pub created: Option<f64>,
-    /// <p>Required. The unique ID that Amazon MQ generates for the configuration.</p>
-    pub id: Option<String>,
-    /// <p>The latest revision of the configuration.</p>
-    pub latest_revision: Option<ConfigurationRevision>,
-    /// <p>Required. The name of the configuration. This value can contain only alphanumeric characters, dashes, periods, underscores, and tildes (- . _ ~). This value must be 1-150 characters long.</p>
-    pub name: Option<String>,
-}
-
-/// <p>Creates a new configuration for the specified configuration name. Amazon MQ uses the default configuration (the engine type and version).</p>
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateConfigurationRequest {
     /// <p>Required. The type of broker engine. Note: Currently, Amazon MQ supports only ACTIVEMQ.</p>
@@ -445,17 +351,6 @@ pub struct CreateTagsRequest {
 }
 
 /// <p>Creates a new ActiveMQ user.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct CreateUserInput {
-    /// <p>Enables access to the the ActiveMQ Web Console for the ActiveMQ user.</p>
-    pub console_access: Option<bool>,
-    /// <p>The list of groups (20 maximum) to which the ActiveMQ user belongs. This value can contain only alphanumeric characters, dashes, periods, underscores, and tildes (- . _ ~). This value must be 2-100 characters long.</p>
-    pub groups: Option<Vec<String>>,
-    /// <p>Required. The password of the user. This value must be at least 12 characters long, must contain at least 4 unique characters, and must not contain commas.</p>
-    pub password: Option<String>,
-}
-
-/// <p>Creates a new ActiveMQ user.</p>
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateUserRequest {
     /// <p>The unique ID that Amazon MQ generates for the broker.</p>
@@ -481,13 +376,6 @@ pub struct CreateUserRequest {
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 #[cfg_attr(test, derive(Serialize))]
 pub struct CreateUserResponse {}
-
-/// <p>Returns information about the deleted broker.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct DeleteBrokerOutput {
-    /// <p>The unique ID that Amazon MQ generates for the broker.</p>
-    pub broker_id: Option<String>,
-}
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DeleteBrokerRequest {
@@ -597,51 +485,6 @@ pub struct DescribeBrokerInstanceOptionsResponse {
     #[serde(rename = "NextToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_token: Option<String>,
-}
-
-/// <p>The version of the broker engine. For a list of supported engine versions, see https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-engine.html</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct DescribeBrokerOutput {
-    /// <p>Required. Enables automatic upgrades to new minor versions for brokers, as Apache releases the versions. The automatic upgrades occur during the maintenance window of the broker or after a manual broker reboot.</p>
-    pub auto_minor_version_upgrade: Option<bool>,
-    /// <p>The Amazon Resource Name (ARN) of the broker.</p>
-    pub broker_arn: Option<String>,
-    /// <p>The unique ID that Amazon MQ generates for the broker.</p>
-    pub broker_id: Option<String>,
-    /// <p>A list of information about allocated brokers.</p>
-    pub broker_instances: Option<Vec<BrokerInstance>>,
-    /// <p>The name of the broker. This value must be unique in your AWS account, 1-50 characters long, must contain only letters, numbers, dashes, and underscores, and must not contain whitespaces, brackets, wildcard characters, or special characters.</p>
-    pub broker_name: Option<String>,
-    /// <p>The status of the broker.</p>
-    pub broker_state: Option<String>,
-    /// <p>The list of all revisions for the specified configuration.</p>
-    pub configurations: Option<Configurations>,
-    /// <p>The time when the broker was created.</p>
-    pub created: Option<f64>,
-    /// <p>Required. The deployment mode of the broker.</p>
-    pub deployment_mode: Option<String>,
-    /// <p>Required. The type of broker engine. Note: Currently, Amazon MQ supports only ACTIVEMQ.</p>
-    pub engine_type: Option<String>,
-    /// <p>The version of the broker engine. For a list of supported engine versions, see https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-engine.html</p>
-    pub engine_version: Option<String>,
-    /// <p>The broker&#39;s instance type.</p>
-    pub host_instance_type: Option<String>,
-    /// <p>The list of information about logs currently enabled and pending to be deployed for the specified broker.</p>
-    pub logs: Option<LogsSummary>,
-    /// <p>The parameters that determine the WeeklyStartTime.</p>
-    pub maintenance_window_start_time: Option<WeeklyStartTime>,
-    /// <p>The version of the broker engine to upgrade to. For a list of supported engine versions, see https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-engine.html</p>
-    pub pending_engine_version: Option<String>,
-    /// <p>Required. Enables connections from applications outside of the VPC that hosts the broker&#39;s subnets.</p>
-    pub publicly_accessible: Option<bool>,
-    /// <p>Required. The list of rules (1 minimum, 125 maximum) that authorize connections to brokers.</p>
-    pub security_groups: Option<Vec<String>>,
-    /// <p>The list of groups (2 maximum) that define which subnets and IP ranges the broker can use from different Availability Zones. A SINGLE<em>INSTANCE deployment requires one subnet (for example, the default subnet). An ACTIVE</em>STANDBY<em>MULTI</em>AZ deployment requires two subnets.</p>
-    pub subnet_ids: Option<Vec<String>>,
-    /// <p>The list of all tags associated with this broker.</p>
-    pub tags: Option<::std::collections::HashMap<String, String>>,
-    /// <p>The list of all ActiveMQ usernames for the specified broker.</p>
-    pub users: Option<Vec<UserSummary>>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -784,19 +627,6 @@ pub struct DescribeConfigurationResponse {
     pub tags: Option<::std::collections::HashMap<String, String>>,
 }
 
-/// <p>Returns the specified configuration revision for the specified configuration.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct DescribeConfigurationRevisionOutput {
-    /// <p>Required. The unique ID that Amazon MQ generates for the configuration.</p>
-    pub configuration_id: Option<String>,
-    /// <p>Required. The date and time of the configuration.</p>
-    pub created: Option<f64>,
-    /// <p>Required. The base64-encoded XML configuration.</p>
-    pub data: Option<String>,
-    /// <p>The description of the configuration.</p>
-    pub description: Option<String>,
-}
-
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct DescribeConfigurationRevisionRequest {
     /// <p>The unique ID that Amazon MQ generates for the configuration.</p>
@@ -826,21 +656,6 @@ pub struct DescribeConfigurationRevisionResponse {
     #[serde(rename = "Description")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-}
-
-/// <p>Returns information about an ActiveMQ user.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct DescribeUserOutput {
-    /// <p>Required. The unique ID that Amazon MQ generates for the broker.</p>
-    pub broker_id: Option<String>,
-    /// <p>Enables access to the the ActiveMQ Web Console for the ActiveMQ user.</p>
-    pub console_access: Option<bool>,
-    /// <p>The list of groups (20 maximum) to which the ActiveMQ user belongs. This value can contain only alphanumeric characters, dashes, periods, underscores, and tildes (- . _ ~). This value must be 2-100 characters long.</p>
-    pub groups: Option<Vec<String>>,
-    /// <p>The status of the changes pending for the ActiveMQ user.</p>
-    pub pending: Option<UserPendingChanges>,
-    /// <p>Required. The username of the ActiveMQ user. This value can contain only alphanumeric characters, dashes, periods, underscores, and tildes (- . _ ~). This value must be 2-100 characters long.</p>
-    pub username: Option<String>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -888,24 +703,6 @@ pub struct EngineVersion {
     pub name: Option<String>,
 }
 
-/// <p>Returns information about an error.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct MQError {
-    /// <p>The attribute which caused the error.</p>
-    pub error_attribute: Option<String>,
-    /// <p>The explanation of the error.</p>
-    pub message: Option<String>,
-}
-
-/// <p>A list of information about all brokers.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ListBrokersOutput {
-    /// <p>A list of information about all brokers.</p>
-    pub broker_summaries: Option<Vec<BrokerSummary>>,
-    /// <p>The token that specifies the next page of results Amazon MQ should return. To request the first page, leave nextToken empty.</p>
-    pub next_token: Option<String>,
-}
-
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct ListBrokersRequest {
     /// <p>The maximum number of brokers that Amazon MQ can return per page (20 by default). This value must be an integer from 5 to 100.</p>
@@ -929,19 +726,6 @@ pub struct ListBrokersResponse {
     #[serde(rename = "NextToken")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_token: Option<String>,
-}
-
-/// <p>Returns a list of all revisions for the specified configuration.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ListConfigurationRevisionsOutput {
-    /// <p>The unique ID that Amazon MQ generates for the configuration.</p>
-    pub configuration_id: Option<String>,
-    /// <p>The maximum number of configuration revisions that can be returned per page (20 by default). This value must be an integer from 5 to 100.</p>
-    pub max_results: Option<i64>,
-    /// <p>The token that specifies the next page of results Amazon MQ should return. To request the first page, leave nextToken empty.</p>
-    pub next_token: Option<String>,
-    /// <p>The list of all revisions for the specified configuration.</p>
-    pub revisions: Option<Vec<ConfigurationRevision>>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -978,17 +762,6 @@ pub struct ListConfigurationRevisionsResponse {
     #[serde(rename = "Revisions")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub revisions: Option<Vec<ConfigurationRevision>>,
-}
-
-/// <p>Returns a list of all configurations.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ListConfigurationsOutput {
-    /// <p>The list of all revisions for the specified configuration.</p>
-    pub configurations: Option<Vec<Configuration>>,
-    /// <p>The maximum number of configurations that Amazon MQ can return per page (20 by default). This value must be an integer from 5 to 100.</p>
-    pub max_results: Option<i64>,
-    /// <p>The token that specifies the next page of results Amazon MQ should return. To request the first page, leave nextToken empty.</p>
-    pub next_token: Option<String>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1034,19 +807,6 @@ pub struct ListTagsResponse {
     #[serde(rename = "Tags")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<::std::collections::HashMap<String, String>>,
-}
-
-/// <p>Returns a list of all ActiveMQ users.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ListUsersOutput {
-    /// <p>Required. The unique ID that Amazon MQ generates for the broker.</p>
-    pub broker_id: Option<String>,
-    /// <p>Required. The maximum number of ActiveMQ users that can be returned per page (20 by default). This value must be an integer from 5 to 100.</p>
-    pub max_results: Option<i64>,
-    /// <p>The token that specifies the next page of results Amazon MQ should return. To request the first page, leave nextToken empty.</p>
-    pub next_token: Option<String>,
-    /// <p>Required. The list of all ActiveMQ usernames for the specified broker.</p>
-    pub users: Option<Vec<UserSummary>>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1167,41 +927,6 @@ pub struct SanitizationWarning {
     pub reason: Option<String>,
 }
 
-/// <p>A map of the key-value pairs for the resource tag.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct Tags {
-    /// <p>The key-value pair for the resource tag.</p>
-    pub tags: Option<::std::collections::HashMap<String, String>>,
-}
-
-/// <p>Updates the broker using the specified properties.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateBrokerInput {
-    /// <p>Enables automatic upgrades to new minor versions for brokers, as Apache releases the versions. The automatic upgrades occur during the maintenance window of the broker or after a manual broker reboot.</p>
-    pub auto_minor_version_upgrade: Option<bool>,
-    /// <p>A list of information about the configuration.</p>
-    pub configuration: Option<ConfigurationId>,
-    /// <p>The version of the broker engine. For a list of supported engine versions, see https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-engine.html</p>
-    pub engine_version: Option<String>,
-    /// <p>Enables Amazon CloudWatch logging for brokers.</p>
-    pub logs: Option<Logs>,
-}
-
-/// <p>Returns information about the updated broker.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateBrokerOutput {
-    /// <p>The new value of automatic upgrades to new minor version for brokers.</p>
-    pub auto_minor_version_upgrade: Option<bool>,
-    /// <p>Required. The unique ID that Amazon MQ generates for the broker.</p>
-    pub broker_id: Option<String>,
-    /// <p>The ID of the updated configuration.</p>
-    pub configuration: Option<ConfigurationId>,
-    /// <p>The version of the broker engine to upgrade to. For a list of supported engine versions, see https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-engine.html</p>
-    pub engine_version: Option<String>,
-    /// <p>The list of information about logs to be enabled for the specified broker.</p>
-    pub logs: Option<Logs>,
-}
-
 /// <p>Updates the broker using the specified properties.</p>
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateBrokerRequest {
@@ -1252,32 +977,6 @@ pub struct UpdateBrokerResponse {
 }
 
 /// <p>Updates the specified configuration.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateConfigurationInput {
-    /// <p>Required. The base64-encoded XML configuration.</p>
-    pub data: Option<String>,
-    /// <p>The description of the configuration.</p>
-    pub description: Option<String>,
-}
-
-/// <p>Returns information about the updated configuration.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateConfigurationOutput {
-    /// <p>Required. The Amazon Resource Name (ARN) of the configuration.</p>
-    pub arn: Option<String>,
-    /// <p>Required. The date and time of the configuration.</p>
-    pub created: Option<f64>,
-    /// <p>Required. The unique ID that Amazon MQ generates for the configuration.</p>
-    pub id: Option<String>,
-    /// <p>The latest revision of the configuration.</p>
-    pub latest_revision: Option<ConfigurationRevision>,
-    /// <p>Required. The name of the configuration. This value can contain only alphanumeric characters, dashes, periods, underscores, and tildes (- . _ ~). This value must be 1-150 characters long.</p>
-    pub name: Option<String>,
-    /// <p>The list of the first 20 warnings about the configuration XML elements or attributes that were sanitized.</p>
-    pub warnings: Option<Vec<SanitizationWarning>>,
-}
-
-/// <p>Updates the specified configuration.</p>
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct UpdateConfigurationRequest {
     /// <p>The unique ID that Amazon MQ generates for the configuration.</p>
@@ -1320,17 +1019,6 @@ pub struct UpdateConfigurationResponse {
     #[serde(rename = "Warnings")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warnings: Option<Vec<SanitizationWarning>>,
-}
-
-/// <p>Updates the information for an ActiveMQ user.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateUserInput {
-    /// <p>Enables access to the the ActiveMQ Web Console for the ActiveMQ user.</p>
-    pub console_access: Option<bool>,
-    /// <p>The list of groups (20 maximum) to which the ActiveMQ user belongs. This value can contain only alphanumeric characters, dashes, periods, underscores, and tildes (- . _ ~). This value must be 2-100 characters long.</p>
-    pub groups: Option<Vec<String>>,
-    /// <p>The password of the user. This value must be at least 12 characters long, must contain at least 4 unique characters, and must not contain commas.</p>
-    pub password: Option<String>,
 }
 
 /// <p>Updates the information for an ActiveMQ user.</p>

--- a/rusoto/services/serverlessrepo/src/generated.rs
+++ b/rusoto/services/serverlessrepo/src/generated.rs
@@ -25,42 +25,6 @@ use rusoto_core::param::{Params, ServiceParams};
 use rusoto_core::proto;
 use rusoto_core::signature::SignedRequest;
 use serde_json;
-/// <p>Details about the application.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct Application {
-    /// <p>The application Amazon Resource Name (ARN).</p>
-    pub application_id: String,
-    /// <p>The name of the author publishing the app.</p><p>Minimum length=1. Maximum length=127.</p><p>Pattern "^[a-z0-9](([a-z0-9]|-(?!-))*[a-z0-9])?$";</p>
-    pub author: String,
-    /// <p>The date and time this resource was created.</p>
-    pub creation_time: Option<String>,
-    /// <p>The description of the application.</p><p>Minimum length=1. Maximum length=256</p>
-    pub description: String,
-    /// <p>A URL with more information about the application, for example the location of your GitHub repository for the application.</p>
-    pub home_page_url: Option<String>,
-    /// <p>Labels to improve discovery of apps in search results.</p><p>Minimum length=1. Maximum length=127. Maximum number of labels: 10</p><p>Pattern: "^[a-zA-Z0-9+\\-_:\\/@]+$";</p>
-    pub labels: Option<Vec<String>>,
-    /// <p>A link to a license file of the app that matches the spdxLicenseID value of your application.</p><p>Maximum size 5 MB</p>
-    pub license_url: Option<String>,
-    /// <p>The name of the application.</p><p>Minimum length=1. Maximum length=140</p><p>Pattern: "[a-zA-Z0-9\\-]+";</p>
-    pub name: String,
-    /// <p>A link to the readme file in Markdown language that contains a more detailed description of the application and how it works.</p><p>Maximum size 5 MB</p>
-    pub readme_url: Option<String>,
-    /// <p>A valid identifier from https://spdx.org/licenses/.</p>
-    pub spdx_license_id: Option<String>,
-    /// <p>Version information about the application.</p>
-    pub version: Option<Version>,
-}
-
-/// <p>A list of application summaries nested in the application.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ApplicationDependencyPage {
-    /// <p>An array of application summaries nested in the application.</p>
-    pub dependencies: Vec<ApplicationDependencySummary>,
-    /// <p>The token to request the next page of results.</p>
-    pub next_token: Option<String>,
-}
-
 /// <p>A nested application summary.</p>
 #[derive(Default, Debug, Clone, PartialEq, Deserialize)]
 #[cfg_attr(test, derive(Serialize))]
@@ -71,22 +35,6 @@ pub struct ApplicationDependencySummary {
     /// <p>The semantic version of the nested application.</p>
     #[serde(rename = "SemanticVersion")]
     pub semantic_version: String,
-}
-
-/// <p>A list of application details.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ApplicationPage {
-    /// <p>An array of application summaries.</p>
-    pub applications: Vec<ApplicationSummary>,
-    /// <p>The token to request the next page of results.</p>
-    pub next_token: Option<String>,
-}
-
-/// <p>Policy statements applied to the application.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ApplicationPolicy {
-    /// <p>An array of policy statements applied to the application.</p>
-    pub statements: Vec<ApplicationPolicyStatement>,
 }
 
 /// <p>Policy statement applied to the application.</p>
@@ -137,70 +85,6 @@ pub struct ApplicationSummary {
     #[serde(rename = "SpdxLicenseId")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub spdx_license_id: Option<String>,
-}
-
-/// <p>A list of version summaries for the application.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ApplicationVersionPage {
-    /// <p>The token to request the next page of results.</p>
-    pub next_token: Option<String>,
-    /// <p>An array of version summaries for the application.</p>
-    pub versions: Vec<VersionSummary>,
-}
-
-/// <p>Details of the change set.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct ChangeSetDetails {
-    /// <p>The application Amazon Resource Name (ARN).</p>
-    pub application_id: String,
-    /// <p>The Amazon Resource Name (ARN) of the change set.</p><p>Length constraints: Minimum length of 1.</p><p>Pattern: ARN:[-a-zA-Z0-9:/]*</p>
-    pub change_set_id: String,
-    /// <p>The semantic version of the application:</p><p>
-    /// <a href="https://semver.org/">https://semver.org/</a>
-    /// </p>
-    pub semantic_version: String,
-    /// <p>The unique ID of the stack.</p>
-    pub stack_id: String,
-}
-
-/// <p>Create an application request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct CreateApplicationInput {
-    /// <p>The name of the author publishing the app.</p><p>Minimum length=1. Maximum length=127.</p><p>Pattern "^[a-z0-9](([a-z0-9]|-(?!-))*[a-z0-9])?$";</p>
-    pub author: String,
-    /// <p>The description of the application.</p><p>Minimum length=1. Maximum length=256</p>
-    pub description: String,
-    /// <p>A URL with more information about the application, for example the location of your GitHub repository for the application.</p>
-    pub home_page_url: Option<String>,
-    /// <p>Labels to improve discovery of apps in search results.</p><p>Minimum length=1. Maximum length=127. Maximum number of labels: 10</p><p>Pattern: "^[a-zA-Z0-9+\\-_:\\/@]+$";</p>
-    pub labels: Option<Vec<String>>,
-    /// <p>A local text file that contains the license of the app that matches the spdxLicenseID value of your application.
-    /// The file has the format file://&lt;path>/&lt;filename>.</p><p>Maximum size 5 MB</p><p>You can specify only one of licenseBody and licenseUrl; otherwise, an error results.</p>
-    pub license_body: Option<String>,
-    /// <p>A link to the S3 object that contains the license of the app that matches the spdxLicenseID value of your application.</p><p>Maximum size 5 MB</p><p>You can specify only one of licenseBody and licenseUrl; otherwise, an error results.</p>
-    pub license_url: Option<String>,
-    /// <p>The name of the application that you want to publish.</p><p>Minimum length=1. Maximum length=140</p><p>Pattern: "[a-zA-Z0-9\\-]+";</p>
-    pub name: String,
-    /// <p>A local text readme file in Markdown language that contains a more detailed description of the application and how it works.
-    /// The file has the format file://&lt;path>/&lt;filename>.</p><p>Maximum size 5 MB</p><p>You can specify only one of readmeBody and readmeUrl; otherwise, an error results.</p>
-    pub readme_body: Option<String>,
-    /// <p>A link to the S3 object in Markdown language that contains a more detailed description of the application and how it works.</p><p>Maximum size 5 MB</p><p>You can specify only one of readmeBody and readmeUrl; otherwise, an error results.</p>
-    pub readme_url: Option<String>,
-    /// <p>The semantic version of the application:</p><p>
-    /// <a href="https://semver.org/">https://semver.org/</a>
-    /// </p>
-    pub semantic_version: Option<String>,
-    /// <p>A link to the S3 object that contains the ZIP archive of the source code for this version of your application.</p><p>Maximum size 50 MB</p>
-    pub source_code_archive_url: Option<String>,
-    /// <p>A link to a public repository for the source code of your application, for example the URL of a specific GitHub commit.</p>
-    pub source_code_url: Option<String>,
-    /// <p>A valid identifier from <a href="https://spdx.org/licenses/">https://spdx.org/licenses/</a>.</p>
-    pub spdx_license_id: Option<String>,
-    /// <p>The local raw packaged AWS SAM template file of your application.
-    /// The file has the format file://&lt;path>/&lt;filename>.</p><p>You can specify only one of templateBody and templateUrl; otherwise an error results.</p>
-    pub template_body: Option<String>,
-    /// <p>A link to the S3 object containing the packaged AWS SAM template of your application.</p><p>You can specify only one of templateBody and templateUrl; otherwise an error results.</p>
-    pub template_url: Option<String>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -318,19 +202,6 @@ pub struct CreateApplicationResponse {
     pub version: Option<Version>,
 }
 
-/// <p>Create a version request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct CreateApplicationVersionInput {
-    /// <p>A link to the S3 object that contains the ZIP archive of the source code for this version of your application.</p><p>Maximum size 50 MB</p>
-    pub source_code_archive_url: Option<String>,
-    /// <p>A link to a public repository for the source code of your application, for example the URL of a specific GitHub commit.</p>
-    pub source_code_url: Option<String>,
-    /// <p>The raw packaged AWS SAM template of your application.</p>
-    pub template_body: Option<String>,
-    /// <p>A link to the packaged AWS SAM template of your application.</p>
-    pub template_url: Option<String>,
-}
-
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
 pub struct CreateApplicationVersionRequest {
     /// <p>The Amazon Resource Name (ARN) of the application.</p>
@@ -421,67 +292,6 @@ pub struct CreateApplicationVersionResponse {
     #[serde(rename = "TemplateUrl")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub template_url: Option<String>,
-}
-
-/// <p>Create an application change set request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct CreateCloudFormationChangeSetInput {
-    /// <p>A list of values that you must specify before you can deploy certain applications.
-    /// Some applications might include resources that can affect permissions in your AWS
-    /// account, for example, by creating new AWS Identity and Access Management (IAM) users.
-    /// For those applications, you must explicitly acknowledge their capabilities by
-    /// specifying this parameter.</p><p>The only valid values are CAPABILITY_IAM, CAPABILITY_NAMED_IAM,
-    /// CAPABILITY_RESOURCE_POLICY, and CAPABILITY_AUTO_EXPAND.</p><p>The following resources require you to specify CAPABILITY_IAM or
-    /// CAPABILITY_NAMED_IAM:
-    /// <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-group.html">AWS::IAM::Group</a>,
-    /// <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html">AWS::IAM::InstanceProfile</a>,
-    /// <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html">AWS::IAM::Policy</a>, and
-    /// <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html">AWS::IAM::Role</a>.
-    /// If the application contains IAM resources, you can specify either CAPABILITY_IAM
-    /// or CAPABILITY_NAMED_IAM. If the application contains IAM resources
-    /// with custom names, you must specify CAPABILITY_NAMED_IAM.</p><p>The following resources require you to specify CAPABILITY_RESOURCE_POLICY:
-    /// <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-permission.html">AWS::Lambda::Permission</a>,
-    /// <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html">AWS::IAM:Policy</a>,
-    /// <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationautoscaling-scalingpolicy.html">AWS::ApplicationAutoScaling::ScalingPolicy</a>,
-    /// <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-policy.html">AWS::S3::BucketPolicy</a>,
-    /// <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-policy.html">AWS::SQS::QueuePolicy</a>, and
-    /// <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sns-policy.html">AWS::SNS:TopicPolicy</a>.</p><p>Applications that contain one or more nested applications require you to specify
-    /// CAPABILITY_AUTO_EXPAND.</p><p>If your application template contains any of the above resources, we recommend that you review
-    /// all permissions associated with the application before deploying. If you don't specify
-    /// this parameter for an application that requires capabilities, the call will fail.</p>
-    pub capabilities: Option<Vec<String>>,
-    /// <p>This property corresponds to the parameter of the same name for the <i>AWS CloudFormation <a href="https://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/CreateChangeSet">CreateChangeSet</a>
-    /// </i> API.</p>
-    pub change_set_name: Option<String>,
-    /// <p>This property corresponds to the parameter of the same name for the <i>AWS CloudFormation <a href="https://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/CreateChangeSet">CreateChangeSet</a>
-    /// </i> API.</p>
-    pub client_token: Option<String>,
-    /// <p>This property corresponds to the parameter of the same name for the <i>AWS CloudFormation <a href="https://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/CreateChangeSet">CreateChangeSet</a>
-    /// </i> API.</p>
-    pub description: Option<String>,
-    /// <p>This property corresponds to the parameter of the same name for the <i>AWS CloudFormation <a href="https://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/CreateChangeSet">CreateChangeSet</a>
-    /// </i> API.</p>
-    pub notification_arns: Option<Vec<String>>,
-    /// <p>A list of parameter values for the parameters of the application.</p>
-    pub parameter_overrides: Option<Vec<ParameterValue>>,
-    /// <p>This property corresponds to the parameter of the same name for the <i>AWS CloudFormation <a href="https://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/CreateChangeSet">CreateChangeSet</a>
-    /// </i> API.</p>
-    pub resource_types: Option<Vec<String>>,
-    /// <p>This property corresponds to the parameter of the same name for the <i>AWS CloudFormation <a href="https://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/CreateChangeSet">CreateChangeSet</a>
-    /// </i> API.</p>
-    pub rollback_configuration: Option<RollbackConfiguration>,
-    /// <p>The semantic version of the application:</p><p>
-    /// <a href="https://semver.org/">https://semver.org/</a>
-    /// </p>
-    pub semantic_version: Option<String>,
-    /// <p>This property corresponds to the parameter of the same name for the <i>AWS CloudFormation <a href="https://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/CreateChangeSet">CreateChangeSet</a>
-    /// </i> API.</p>
-    pub stack_name: String,
-    /// <p>This property corresponds to the parameter of the same name for the <i>AWS CloudFormation <a href="https://docs.aws.amazon.com/goto/WebAPI/cloudformation-2010-05-15/CreateChangeSet">CreateChangeSet</a>
-    /// </i> API.</p>
-    pub tags: Option<Vec<Tag>>,
-    /// <p>The UUID returned by CreateCloudFormationTemplate.</p><p>Pattern: [0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}</p>
-    pub template_id: Option<String>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]
@@ -1008,47 +818,6 @@ pub struct Tag {
     /// Data Type.</p>
     #[serde(rename = "Value")]
     pub value: String,
-}
-
-/// <p>Details of the template.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct TemplateDetails {
-    /// <p>The application Amazon Resource Name (ARN).</p>
-    pub application_id: String,
-    /// <p>The date and time this resource was created.</p>
-    pub creation_time: String,
-    /// <p>The date and time this template expires. Templates
-    /// expire 1 hour after creation.</p>
-    pub expiration_time: String,
-    /// <p>The semantic version of the application:</p><p>
-    /// <a href="https://semver.org/">https://semver.org/</a>
-    /// </p>
-    pub semantic_version: String,
-    /// <p>Status of the template creation workflow.</p><p>Possible values: PREPARING | ACTIVE | EXPIRED
-    /// </p>
-    pub status: String,
-    /// <p>The UUID returned by CreateCloudFormationTemplate.</p><p>Pattern: [0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}</p>
-    pub template_id: String,
-    /// <p>A link to the template that can be used to deploy the application using
-    /// AWS CloudFormation.</p>
-    pub template_url: String,
-}
-
-/// <p>Update the application request.</p>
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct UpdateApplicationInput {
-    /// <p>The name of the author publishing the app.</p><p>Minimum length=1. Maximum length=127.</p><p>Pattern "^[a-z0-9](([a-z0-9]|-(?!-))*[a-z0-9])?$";</p>
-    pub author: Option<String>,
-    /// <p>The description of the application.</p><p>Minimum length=1. Maximum length=256</p>
-    pub description: Option<String>,
-    /// <p>A URL with more information about the application, for example the location of your GitHub repository for the application.</p>
-    pub home_page_url: Option<String>,
-    /// <p>Labels to improve discovery of apps in search results.</p><p>Minimum length=1. Maximum length=127. Maximum number of labels: 10</p><p>Pattern: "^[a-zA-Z0-9+\\-_:\\/@]+$";</p>
-    pub labels: Option<Vec<String>>,
-    /// <p>A text readme file in Markdown language that contains a more detailed description of the application and how it works.</p><p>Maximum size 5 MB</p>
-    pub readme_body: Option<String>,
-    /// <p>A link to the readme file in Markdown language that contains a more detailed description of the application and how it works.</p><p>Maximum size 5 MB</p>
-    pub readme_url: Option<String>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize)]


### PR DESCRIPTION
Make sure we only generate struct definitions for shapes that are actually used, i.e. referenced from an operation.

Needed this as part of my prototyping work and thought it could be an easy win to backport to master and shave off a couple of lines of code.

Let me know what you think!