### PR TITLE
exclude-test-resources-when-publishing-generated-crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Rusoto changes
 
 ## [Unreleased]
-(Please put notes here)
+- Exclude `test_resources` in cargo manifest
 
 ## [0.39.0] - 2019-05-19
 

--- a/rusoto/services/acm-pca/Cargo.toml
+++ b/rusoto/services/acm-pca/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/acm-pca/README.md
+++ b/rusoto/services/acm-pca/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/acm/Cargo.toml
+++ b/rusoto/services/acm/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/acm/README.md
+++ b/rusoto/services/acm/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/alexaforbusiness/Cargo.toml
+++ b/rusoto/services/alexaforbusiness/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/alexaforbusiness/README.md
+++ b/rusoto/services/alexaforbusiness/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/amplify/Cargo.toml
+++ b/rusoto/services/amplify/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/amplify/README.md
+++ b/rusoto/services/amplify/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/apigateway/Cargo.toml
+++ b/rusoto/services/apigateway/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/apigateway/README.md
+++ b/rusoto/services/apigateway/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/apigatewaymanagementapi/Cargo.toml
+++ b/rusoto/services/apigatewaymanagementapi/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/apigatewaymanagementapi/README.md
+++ b/rusoto/services/apigatewaymanagementapi/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/apigatewayv2/Cargo.toml
+++ b/rusoto/services/apigatewayv2/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/apigatewayv2/README.md
+++ b/rusoto/services/apigatewayv2/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/application-autoscaling/Cargo.toml
+++ b/rusoto/services/application-autoscaling/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/application-autoscaling/README.md
+++ b/rusoto/services/application-autoscaling/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/appstream/Cargo.toml
+++ b/rusoto/services/appstream/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/appstream/README.md
+++ b/rusoto/services/appstream/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/appsync/Cargo.toml
+++ b/rusoto/services/appsync/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/appsync/README.md
+++ b/rusoto/services/appsync/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/athena/Cargo.toml
+++ b/rusoto/services/athena/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/athena/README.md
+++ b/rusoto/services/athena/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/autoscaling-plans/Cargo.toml
+++ b/rusoto/services/autoscaling-plans/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/autoscaling-plans/README.md
+++ b/rusoto/services/autoscaling-plans/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/autoscaling/Cargo.toml
+++ b/rusoto/services/autoscaling/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/autoscaling/README.md
+++ b/rusoto/services/autoscaling/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/batch/Cargo.toml
+++ b/rusoto/services/batch/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/batch/README.md
+++ b/rusoto/services/batch/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/budgets/Cargo.toml
+++ b/rusoto/services/budgets/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/budgets/README.md
+++ b/rusoto/services/budgets/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/ce/Cargo.toml
+++ b/rusoto/services/ce/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/ce/README.md
+++ b/rusoto/services/ce/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/chime/Cargo.toml
+++ b/rusoto/services/chime/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/chime/README.md
+++ b/rusoto/services/chime/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/cloud9/Cargo.toml
+++ b/rusoto/services/cloud9/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/cloud9/README.md
+++ b/rusoto/services/cloud9/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/clouddirectory/Cargo.toml
+++ b/rusoto/services/clouddirectory/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/clouddirectory/README.md
+++ b/rusoto/services/clouddirectory/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/cloudformation/Cargo.toml
+++ b/rusoto/services/cloudformation/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/cloudformation/README.md
+++ b/rusoto/services/cloudformation/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/cloudfront/Cargo.toml
+++ b/rusoto/services/cloudfront/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/cloudfront/README.md
+++ b/rusoto/services/cloudfront/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/cloudhsm/Cargo.toml
+++ b/rusoto/services/cloudhsm/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/cloudhsm/README.md
+++ b/rusoto/services/cloudhsm/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/cloudhsmv2/Cargo.toml
+++ b/rusoto/services/cloudhsmv2/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/cloudhsmv2/README.md
+++ b/rusoto/services/cloudhsmv2/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/cloudsearch/Cargo.toml
+++ b/rusoto/services/cloudsearch/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/cloudsearch/README.md
+++ b/rusoto/services/cloudsearch/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/cloudsearchdomain/Cargo.toml
+++ b/rusoto/services/cloudsearchdomain/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/cloudsearchdomain/README.md
+++ b/rusoto/services/cloudsearchdomain/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/cloudtrail/Cargo.toml
+++ b/rusoto/services/cloudtrail/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/cloudtrail/README.md
+++ b/rusoto/services/cloudtrail/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/cloudwatch/Cargo.toml
+++ b/rusoto/services/cloudwatch/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/cloudwatch/README.md
+++ b/rusoto/services/cloudwatch/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/codebuild/Cargo.toml
+++ b/rusoto/services/codebuild/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/codebuild/README.md
+++ b/rusoto/services/codebuild/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/codecommit/Cargo.toml
+++ b/rusoto/services/codecommit/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/codecommit/README.md
+++ b/rusoto/services/codecommit/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/codedeploy/Cargo.toml
+++ b/rusoto/services/codedeploy/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/codedeploy/README.md
+++ b/rusoto/services/codedeploy/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/codepipeline/Cargo.toml
+++ b/rusoto/services/codepipeline/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/codepipeline/README.md
+++ b/rusoto/services/codepipeline/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/codestar/Cargo.toml
+++ b/rusoto/services/codestar/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/codestar/README.md
+++ b/rusoto/services/codestar/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/cognito-identity/Cargo.toml
+++ b/rusoto/services/cognito-identity/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/cognito-identity/README.md
+++ b/rusoto/services/cognito-identity/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/cognito-idp/Cargo.toml
+++ b/rusoto/services/cognito-idp/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/cognito-idp/README.md
+++ b/rusoto/services/cognito-idp/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/cognito-sync/Cargo.toml
+++ b/rusoto/services/cognito-sync/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/cognito-sync/README.md
+++ b/rusoto/services/cognito-sync/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/comprehend/Cargo.toml
+++ b/rusoto/services/comprehend/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/comprehend/README.md
+++ b/rusoto/services/comprehend/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/comprehendmedical/Cargo.toml
+++ b/rusoto/services/comprehendmedical/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/comprehendmedical/README.md
+++ b/rusoto/services/comprehendmedical/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/config/Cargo.toml
+++ b/rusoto/services/config/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/config/README.md
+++ b/rusoto/services/config/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/connect/Cargo.toml
+++ b/rusoto/services/connect/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/connect/README.md
+++ b/rusoto/services/connect/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/cur/Cargo.toml
+++ b/rusoto/services/cur/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/cur/README.md
+++ b/rusoto/services/cur/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/datapipeline/Cargo.toml
+++ b/rusoto/services/datapipeline/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/datapipeline/README.md
+++ b/rusoto/services/datapipeline/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/dax/Cargo.toml
+++ b/rusoto/services/dax/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/dax/README.md
+++ b/rusoto/services/dax/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/devicefarm/Cargo.toml
+++ b/rusoto/services/devicefarm/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/devicefarm/README.md
+++ b/rusoto/services/devicefarm/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/directconnect/Cargo.toml
+++ b/rusoto/services/directconnect/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/directconnect/README.md
+++ b/rusoto/services/directconnect/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/discovery/Cargo.toml
+++ b/rusoto/services/discovery/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/discovery/README.md
+++ b/rusoto/services/discovery/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/dms/Cargo.toml
+++ b/rusoto/services/dms/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/dms/README.md
+++ b/rusoto/services/dms/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/docdb/Cargo.toml
+++ b/rusoto/services/docdb/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/docdb/README.md
+++ b/rusoto/services/docdb/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/ds/Cargo.toml
+++ b/rusoto/services/ds/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/ds/README.md
+++ b/rusoto/services/ds/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/dynamodb/Cargo.toml
+++ b/rusoto/services/dynamodb/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/dynamodb/README.md
+++ b/rusoto/services/dynamodb/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/dynamodbstreams/Cargo.toml
+++ b/rusoto/services/dynamodbstreams/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/dynamodbstreams/README.md
+++ b/rusoto/services/dynamodbstreams/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/ec2/Cargo.toml
+++ b/rusoto/services/ec2/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/ec2/README.md
+++ b/rusoto/services/ec2/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/ecr/Cargo.toml
+++ b/rusoto/services/ecr/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/ecr/README.md
+++ b/rusoto/services/ecr/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/ecs/Cargo.toml
+++ b/rusoto/services/ecs/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/ecs/README.md
+++ b/rusoto/services/ecs/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/efs/Cargo.toml
+++ b/rusoto/services/efs/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/efs/README.md
+++ b/rusoto/services/efs/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/eks/Cargo.toml
+++ b/rusoto/services/eks/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/eks/README.md
+++ b/rusoto/services/eks/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/elasticache/Cargo.toml
+++ b/rusoto/services/elasticache/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/elasticache/README.md
+++ b/rusoto/services/elasticache/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/elasticbeanstalk/Cargo.toml
+++ b/rusoto/services/elasticbeanstalk/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/elasticbeanstalk/README.md
+++ b/rusoto/services/elasticbeanstalk/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/elastictranscoder/Cargo.toml
+++ b/rusoto/services/elastictranscoder/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/elastictranscoder/README.md
+++ b/rusoto/services/elastictranscoder/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/elb/Cargo.toml
+++ b/rusoto/services/elb/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/elb/README.md
+++ b/rusoto/services/elb/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/elbv2/Cargo.toml
+++ b/rusoto/services/elbv2/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/elbv2/README.md
+++ b/rusoto/services/elbv2/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/emr/Cargo.toml
+++ b/rusoto/services/emr/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/emr/README.md
+++ b/rusoto/services/emr/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/events/Cargo.toml
+++ b/rusoto/services/events/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/events/README.md
+++ b/rusoto/services/events/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/firehose/Cargo.toml
+++ b/rusoto/services/firehose/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/firehose/README.md
+++ b/rusoto/services/firehose/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/fms/Cargo.toml
+++ b/rusoto/services/fms/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/fms/README.md
+++ b/rusoto/services/fms/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/fsx/Cargo.toml
+++ b/rusoto/services/fsx/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/fsx/README.md
+++ b/rusoto/services/fsx/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/gamelift/Cargo.toml
+++ b/rusoto/services/gamelift/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/gamelift/README.md
+++ b/rusoto/services/gamelift/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/glacier/Cargo.toml
+++ b/rusoto/services/glacier/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/glacier/README.md
+++ b/rusoto/services/glacier/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/glue/Cargo.toml
+++ b/rusoto/services/glue/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/glue/README.md
+++ b/rusoto/services/glue/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/greengrass/Cargo.toml
+++ b/rusoto/services/greengrass/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/greengrass/README.md
+++ b/rusoto/services/greengrass/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/guardduty/Cargo.toml
+++ b/rusoto/services/guardduty/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/guardduty/README.md
+++ b/rusoto/services/guardduty/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/health/Cargo.toml
+++ b/rusoto/services/health/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/health/README.md
+++ b/rusoto/services/health/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/iam/Cargo.toml
+++ b/rusoto/services/iam/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/iam/README.md
+++ b/rusoto/services/iam/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/importexport/Cargo.toml
+++ b/rusoto/services/importexport/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/importexport/README.md
+++ b/rusoto/services/importexport/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/inspector/Cargo.toml
+++ b/rusoto/services/inspector/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/inspector/README.md
+++ b/rusoto/services/inspector/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/iot-data/Cargo.toml
+++ b/rusoto/services/iot-data/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/iot-data/README.md
+++ b/rusoto/services/iot-data/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/iot-jobs-data/Cargo.toml
+++ b/rusoto/services/iot-jobs-data/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/iot-jobs-data/README.md
+++ b/rusoto/services/iot-jobs-data/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/iot/Cargo.toml
+++ b/rusoto/services/iot/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/iot/README.md
+++ b/rusoto/services/iot/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/iot1click-devices/Cargo.toml
+++ b/rusoto/services/iot1click-devices/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/iot1click-devices/README.md
+++ b/rusoto/services/iot1click-devices/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/iot1click-projects/Cargo.toml
+++ b/rusoto/services/iot1click-projects/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/iot1click-projects/README.md
+++ b/rusoto/services/iot1click-projects/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/iotanalytics/Cargo.toml
+++ b/rusoto/services/iotanalytics/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/iotanalytics/README.md
+++ b/rusoto/services/iotanalytics/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/kafka/Cargo.toml
+++ b/rusoto/services/kafka/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/kafka/README.md
+++ b/rusoto/services/kafka/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/kinesis-video-archived-media/Cargo.toml
+++ b/rusoto/services/kinesis-video-archived-media/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/kinesis-video-archived-media/README.md
+++ b/rusoto/services/kinesis-video-archived-media/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/kinesis-video-media/Cargo.toml
+++ b/rusoto/services/kinesis-video-media/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/kinesis-video-media/README.md
+++ b/rusoto/services/kinesis-video-media/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/kinesis/Cargo.toml
+++ b/rusoto/services/kinesis/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/kinesis/README.md
+++ b/rusoto/services/kinesis/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/kinesisanalytics/Cargo.toml
+++ b/rusoto/services/kinesisanalytics/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/kinesisanalytics/README.md
+++ b/rusoto/services/kinesisanalytics/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/kinesisvideo/Cargo.toml
+++ b/rusoto/services/kinesisvideo/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/kinesisvideo/README.md
+++ b/rusoto/services/kinesisvideo/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/kms/Cargo.toml
+++ b/rusoto/services/kms/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/kms/README.md
+++ b/rusoto/services/kms/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/lambda/Cargo.toml
+++ b/rusoto/services/lambda/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/lambda/README.md
+++ b/rusoto/services/lambda/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/lex-models/Cargo.toml
+++ b/rusoto/services/lex-models/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/lex-models/README.md
+++ b/rusoto/services/lex-models/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/lex-runtime/Cargo.toml
+++ b/rusoto/services/lex-runtime/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/lex-runtime/README.md
+++ b/rusoto/services/lex-runtime/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/license-manager/Cargo.toml
+++ b/rusoto/services/license-manager/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/license-manager/README.md
+++ b/rusoto/services/license-manager/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/lightsail/Cargo.toml
+++ b/rusoto/services/lightsail/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/lightsail/README.md
+++ b/rusoto/services/lightsail/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/logs/Cargo.toml
+++ b/rusoto/services/logs/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/logs/README.md
+++ b/rusoto/services/logs/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/machinelearning/Cargo.toml
+++ b/rusoto/services/machinelearning/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/machinelearning/README.md
+++ b/rusoto/services/machinelearning/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/macie/Cargo.toml
+++ b/rusoto/services/macie/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/macie/README.md
+++ b/rusoto/services/macie/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/marketplace-entitlement/Cargo.toml
+++ b/rusoto/services/marketplace-entitlement/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/marketplace-entitlement/README.md
+++ b/rusoto/services/marketplace-entitlement/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/marketplacecommerceanalytics/Cargo.toml
+++ b/rusoto/services/marketplacecommerceanalytics/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/marketplacecommerceanalytics/README.md
+++ b/rusoto/services/marketplacecommerceanalytics/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/mediaconvert/Cargo.toml
+++ b/rusoto/services/mediaconvert/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/mediaconvert/README.md
+++ b/rusoto/services/mediaconvert/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/medialive/Cargo.toml
+++ b/rusoto/services/medialive/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/medialive/README.md
+++ b/rusoto/services/medialive/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/mediapackage/Cargo.toml
+++ b/rusoto/services/mediapackage/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/mediapackage/README.md
+++ b/rusoto/services/mediapackage/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/mediastore/Cargo.toml
+++ b/rusoto/services/mediastore/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/mediastore/README.md
+++ b/rusoto/services/mediastore/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/mediatailor/Cargo.toml
+++ b/rusoto/services/mediatailor/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/mediatailor/README.md
+++ b/rusoto/services/mediatailor/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/meteringmarketplace/Cargo.toml
+++ b/rusoto/services/meteringmarketplace/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/meteringmarketplace/README.md
+++ b/rusoto/services/meteringmarketplace/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/mgh/Cargo.toml
+++ b/rusoto/services/mgh/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/mgh/README.md
+++ b/rusoto/services/mgh/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/mobile/Cargo.toml
+++ b/rusoto/services/mobile/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/mobile/README.md
+++ b/rusoto/services/mobile/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/mq/Cargo.toml
+++ b/rusoto/services/mq/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/mq/README.md
+++ b/rusoto/services/mq/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/mturk/Cargo.toml
+++ b/rusoto/services/mturk/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/mturk/README.md
+++ b/rusoto/services/mturk/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/neptune/Cargo.toml
+++ b/rusoto/services/neptune/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/neptune/README.md
+++ b/rusoto/services/neptune/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/opsworks/Cargo.toml
+++ b/rusoto/services/opsworks/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/opsworks/README.md
+++ b/rusoto/services/opsworks/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/opsworkscm/Cargo.toml
+++ b/rusoto/services/opsworkscm/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/opsworkscm/README.md
+++ b/rusoto/services/opsworkscm/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/organizations/Cargo.toml
+++ b/rusoto/services/organizations/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/organizations/README.md
+++ b/rusoto/services/organizations/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/pi/Cargo.toml
+++ b/rusoto/services/pi/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/pi/README.md
+++ b/rusoto/services/pi/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/polly/Cargo.toml
+++ b/rusoto/services/polly/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/polly/README.md
+++ b/rusoto/services/polly/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/pricing/Cargo.toml
+++ b/rusoto/services/pricing/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/pricing/README.md
+++ b/rusoto/services/pricing/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/ram/Cargo.toml
+++ b/rusoto/services/ram/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/ram/README.md
+++ b/rusoto/services/ram/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/rds-data/Cargo.toml
+++ b/rusoto/services/rds-data/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/rds-data/README.md
+++ b/rusoto/services/rds-data/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/rds/Cargo.toml
+++ b/rusoto/services/rds/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/rds/README.md
+++ b/rusoto/services/rds/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/redshift/Cargo.toml
+++ b/rusoto/services/redshift/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/redshift/README.md
+++ b/rusoto/services/redshift/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/rekognition/Cargo.toml
+++ b/rusoto/services/rekognition/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/rekognition/README.md
+++ b/rusoto/services/rekognition/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/resource-groups/Cargo.toml
+++ b/rusoto/services/resource-groups/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/resource-groups/README.md
+++ b/rusoto/services/resource-groups/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/resourcegroupstaggingapi/Cargo.toml
+++ b/rusoto/services/resourcegroupstaggingapi/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/resourcegroupstaggingapi/README.md
+++ b/rusoto/services/resourcegroupstaggingapi/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/route53/Cargo.toml
+++ b/rusoto/services/route53/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/route53/README.md
+++ b/rusoto/services/route53/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/route53domains/Cargo.toml
+++ b/rusoto/services/route53domains/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/route53domains/README.md
+++ b/rusoto/services/route53domains/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/s3/Cargo.toml
+++ b/rusoto/services/s3/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/s3/README.md
+++ b/rusoto/services/s3/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/sagemaker-runtime/Cargo.toml
+++ b/rusoto/services/sagemaker-runtime/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/sagemaker-runtime/README.md
+++ b/rusoto/services/sagemaker-runtime/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/sagemaker/Cargo.toml
+++ b/rusoto/services/sagemaker/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/sagemaker/README.md
+++ b/rusoto/services/sagemaker/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/sdb/Cargo.toml
+++ b/rusoto/services/sdb/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/sdb/README.md
+++ b/rusoto/services/sdb/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/secretsmanager/Cargo.toml
+++ b/rusoto/services/secretsmanager/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/secretsmanager/README.md
+++ b/rusoto/services/secretsmanager/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/serverlessrepo/Cargo.toml
+++ b/rusoto/services/serverlessrepo/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/serverlessrepo/README.md
+++ b/rusoto/services/serverlessrepo/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/servicecatalog/Cargo.toml
+++ b/rusoto/services/servicecatalog/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/servicecatalog/README.md
+++ b/rusoto/services/servicecatalog/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/servicediscovery/Cargo.toml
+++ b/rusoto/services/servicediscovery/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/servicediscovery/README.md
+++ b/rusoto/services/servicediscovery/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/ses/Cargo.toml
+++ b/rusoto/services/ses/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/ses/README.md
+++ b/rusoto/services/ses/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/shield/Cargo.toml
+++ b/rusoto/services/shield/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/shield/README.md
+++ b/rusoto/services/shield/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/sms/Cargo.toml
+++ b/rusoto/services/sms/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/sms/README.md
+++ b/rusoto/services/sms/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/snowball/Cargo.toml
+++ b/rusoto/services/snowball/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/snowball/README.md
+++ b/rusoto/services/snowball/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/sns/Cargo.toml
+++ b/rusoto/services/sns/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/sns/README.md
+++ b/rusoto/services/sns/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/sqs/Cargo.toml
+++ b/rusoto/services/sqs/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/sqs/README.md
+++ b/rusoto/services/sqs/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/ssm/Cargo.toml
+++ b/rusoto/services/ssm/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/ssm/README.md
+++ b/rusoto/services/ssm/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/stepfunctions/Cargo.toml
+++ b/rusoto/services/stepfunctions/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/stepfunctions/README.md
+++ b/rusoto/services/stepfunctions/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/storagegateway/Cargo.toml
+++ b/rusoto/services/storagegateway/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/storagegateway/README.md
+++ b/rusoto/services/storagegateway/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/sts/Cargo.toml
+++ b/rusoto/services/sts/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/sts/README.md
+++ b/rusoto/services/sts/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/support/Cargo.toml
+++ b/rusoto/services/support/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/support/README.md
+++ b/rusoto/services/support/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/swf/Cargo.toml
+++ b/rusoto/services/swf/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/swf/README.md
+++ b/rusoto/services/swf/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/transcribe/Cargo.toml
+++ b/rusoto/services/transcribe/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/transcribe/README.md
+++ b/rusoto/services/transcribe/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/translate/Cargo.toml
+++ b/rusoto/services/translate/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/translate/README.md
+++ b/rusoto/services/translate/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/waf-regional/Cargo.toml
+++ b/rusoto/services/waf-regional/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/waf-regional/README.md
+++ b/rusoto/services/waf-regional/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/waf/Cargo.toml
+++ b/rusoto/services/waf/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/waf/README.md
+++ b/rusoto/services/waf/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/workdocs/Cargo.toml
+++ b/rusoto/services/workdocs/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/workdocs/README.md
+++ b/rusoto/services/workdocs/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/worklink/Cargo.toml
+++ b/rusoto/services/worklink/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/worklink/README.md
+++ b/rusoto/services/worklink/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/workmail/Cargo.toml
+++ b/rusoto/services/workmail/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/workmail/README.md
+++ b/rusoto/services/workmail/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/workspaces/Cargo.toml
+++ b/rusoto/services/workspaces/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/workspaces/README.md
+++ b/rusoto/services/workspaces/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/rusoto/services/xray/Cargo.toml
+++ b/rusoto/services/xray/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusoto/rusoto"
 version = "0.39.0"
 homepage = "https://www.rusoto.org/"
 edition = "2018"
+exclude = ["test_resources/*"]
 
 [build-dependencies]
 

--- a/rusoto/services/xray/README.md
+++ b/rusoto/services/xray/README.md
@@ -12,7 +12,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.

--- a/service_crategen/src/cargo.rs
+++ b/service_crategen/src/cargo.rs
@@ -30,6 +30,7 @@ pub struct Metadata {
     pub version: String,
     pub homepage: Option<String>,
     pub edition: String,
+    pub exclude: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/service_crategen/src/commands/generate/mod.rs
+++ b/service_crategen/src/commands/generate/mod.rs
@@ -133,7 +133,8 @@ pub fn generate_services(
                 repository: Some("https://github.com/rusoto/rusoto".into()),
                 version: service_config.version.clone(),
                 homepage: Some("https://www.rusoto.org/".into()),
-                edition: "2018".into()
+                edition: "2018".into(),
+                exclude: Some(vec!["test_resources/*".into()])
             },
             features: Some(features),
             dependencies: service_dependencies,
@@ -166,7 +167,7 @@ You may be looking for:
 ## Requirements
 
 Rust stable or beta are required to use Rusoto. Nightly is tested, but not guaranteed to be supported. Older
-versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project 
+versions _may_ be supported. The currently supported Rust versions can be found in the Rusoto project
 [`travis.yml`](https://github.com/rusoto/rusoto/blob/master/.travis.yml).
 
 On Linux, OpenSSL is required.


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Added `exclude = ["test_resources/*"]` to `package` in codegen
