### PR TITLE
Sample s3 bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,3 +163,8 @@ exclude = [
     "service_crategen",
     "skeptical"
 ]
+
+[profile.bench]
+opt-level = 3
+debug = false
+debug-assertions = false

--- a/Makefile
+++ b/Makefile
@@ -53,4 +53,4 @@ time_credentials:
 
 .PHONY: bench_s3
 bench_s3:
-	(cd rusoto/services/s3 && cargo +$$RUST_VERSION bench)
+	(cd rusoto/services/s3 && cargo +nightly bench)

--- a/Makefile
+++ b/Makefile
@@ -50,3 +50,7 @@ check_service_defintions:
 .PHONY: time_credentials
 time_credentials:
 	(cd rusoto/credential && cargo clean --package rusoto_credential && touch src/lib.rs && time cargo +$$RUST_VERSION build)
+
+.PHONY: bench_s3
+bench_s3:
+	(cd rusoto/services/s3 && cargo +$$RUST_VERSION bench)

--- a/rusoto/services/s3/src/custom/custom_tests.rs
+++ b/rusoto/services/s3/src/custom/custom_tests.rs
@@ -7,7 +7,6 @@ use futures::{Future, Stream};
 use rusoto_core::{Region, RusotoError};
 use rusoto_core::signature::SignedRequest;
 use self::rusoto_mock::*;
-use test::Bencher;
 
 #[test]
 fn test_multipart_upload_copy_response() {
@@ -265,8 +264,10 @@ fn list_multipart_uploads_no_uploads() {
 }
 
 
+#[cfg(nightly)]
 #[bench]
 fn bench_parse_list_buckets_response(b: &mut Bencher) {
+    use test::Bencher;
     let mock = MockRequestDispatcher::with_status(200)
         .with_body(r#"
         <?xml version="1.0" encoding="UTF-8"?>

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -22006,6 +22006,7 @@ impl S3 for S3Client {
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
                     let _start_document = stack.next();
                     let actual_tag_name = peek_at_name(&mut stack)?;
+                    // std::thread::sleep(std::time::Duration::from_millis(1));
                     result =
                         ListBucketsOutputDeserializer::deserialize(&actual_tag_name, &mut stack)?;
                 }

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -22006,7 +22006,6 @@ impl S3 for S3Client {
                     let mut stack = XmlResponse::new(reader.into_iter().peekable());
                     let _start_document = stack.next();
                     let actual_tag_name = peek_at_name(&mut stack)?;
-                    // std::thread::sleep(std::time::Duration::from_millis(1));
                     result =
                         ListBucketsOutputDeserializer::deserialize(&actual_tag_name, &mut stack)?;
                 }

--- a/rusoto/services/s3/src/lib.rs
+++ b/rusoto/services/s3/src/lib.rs
@@ -16,12 +16,13 @@
 //!
 //! If you're using the service, you're probably looking for [S3Client](struct.S3Client.html) and [S3](trait.S3.html).
 
-#![feature(test)]
-extern crate test;
 extern crate bytes;
 extern crate futures;
 extern crate rusoto_core;
 extern crate xml;
+#![feature(test)]
+extern crate test;
+
 
 mod generated;
 mod custom;

--- a/rusoto/services/s3/src/lib.rs
+++ b/rusoto/services/s3/src/lib.rs
@@ -16,6 +16,8 @@
 //!
 //! If you're using the service, you're probably looking for [S3Client](struct.S3Client.html) and [S3](trait.S3.html).
 
+#![feature(test)]
+extern crate test;
 extern crate bytes;
 extern crate futures;
 extern crate rusoto_core;

--- a/rusoto/services/s3/src/lib.rs
+++ b/rusoto/services/s3/src/lib.rs
@@ -20,7 +20,7 @@ extern crate bytes;
 extern crate futures;
 extern crate rusoto_core;
 extern crate xml;
-#![feature(test)]
+#[cfg(nightly)]
 extern crate test;
 
 

--- a/rusoto/services/s3/src/lib.rs
+++ b/rusoto/services/s3/src/lib.rs
@@ -23,7 +23,6 @@ extern crate xml;
 #[cfg(nightly)]
 extern crate test;
 
-
 mod generated;
 mod custom;
 

--- a/service_crategen/src/commands/generate/mod.rs
+++ b/service_crategen/src/commands/generate/mod.rs
@@ -103,7 +103,7 @@ pub fn generate_services(
         }).collect::<Vec<String>>().join("\n");
         // S3 needs the external test crate for benchmark tests
         if service.full_name() == "Amazon Simple Storage Service" {
-            extern_crates.push_str("\n#![feature(test)]\nextern crate test;\n");
+            extern_crates.push_str("\n#[cfg(nightly)]\nextern crate test;\n");
         }
 
         let mut cargo_manifest = BufWriter::new(

--- a/service_crategen/src/commands/generate/mod.rs
+++ b/service_crategen/src/commands/generate/mod.rs
@@ -103,7 +103,7 @@ pub fn generate_services(
         }).collect::<Vec<String>>().join("\n");
         // S3 needs the external test crate for benchmark tests
         if service.full_name() == "Amazon Simple Storage Service" {
-            extern_crates.push_str("\n#[cfg(nightly)]\nextern crate test;\n");
+            extern_crates.push_str("\n#[cfg(nightly)]\nextern crate test;");
         }
 
         let mut cargo_manifest = BufWriter::new(

--- a/service_crategen/src/commands/generate/mod.rs
+++ b/service_crategen/src/commands/generate/mod.rs
@@ -90,7 +90,7 @@ pub fn generate_services(
         let service_dependencies = service.get_dependencies();
         let service_dev_dependencies = service.get_dev_dependencies();
 
-        let extern_crates = service_dependencies.iter().map(|(k, _)| {
+        let mut extern_crates = service_dependencies.iter().map(|(k, _)| {
             if k == "xml-rs" {
                 return "extern crate xml;".into();
             }
@@ -101,6 +101,10 @@ pub fn generate_services(
             }
             format!("extern crate {};", safe_name)
         }).collect::<Vec<String>>().join("\n");
+        // S3 needs the external test crate for benchmark tests
+        if service.full_name() == "Amazon Simple Storage Service" {
+            extern_crates.push_str("\n#![feature(test)]\nextern crate test;\n");
+        }
 
         let mut cargo_manifest = BufWriter::new(
             OpenOptions::new()


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Add a benchmark test to our S3 custom tests.

Fixes https://github.com/rusoto/rusoto/issues/1345 .

Output of `make bench_s3`:

```
test custom::custom_tests::bench_parse_list_buckets_response ... 
bench:     150,116 ns/iter (+/- 63,384)
```