### PR TITLE
Remove clippy nightly requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,14 +52,8 @@ See the [README](service_crategen/README.md) in the service_crategen subcrate.
 ## Clippy
 
 Instructions on [clippy's homepage](https://github.com/Manishearth/rust-clippy) have details on how to install and run.
-A nightly version of Rust is required.  To get the latest nightly version of Rust and switch to it, you can run:
 
-`rustup update && rustup default nightly`
+To run clippy:
 
-To run clippy against the checked-in code, assuming nightly Rust is used:
+`cargo clippy`
 
-`cargo build --no-default-features --features nightly-testing`
-
-To run clippy against the generated code as well as the checked-in code, assuming nightly Rust is used:
-
-`rustup run nightly cargo build --features "nightly-testing all"`

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -39,5 +39,5 @@ default_features = false
 features = ["native-tls"]
 
 [features]
-nightly-testing = ["clippy", "rusoto_core/nightly-testing"]
+nightly-testing = ["rusoto_core/nightly-testing"]
 unstable = []

--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -64,7 +64,7 @@ serde_test = "1.0.1"
 
 [features]
 default = ["native-tls"]
-nightly-testing = ["clippy", "rusoto_credential/nightly-testing"]
+nightly-testing = ["rusoto_credential/nightly-testing"]
 native-tls = ["hyper-tls"]
 rustls = ["hyper-rustls"]
 unstable = []

--- a/rusoto/core/src/lib.rs
+++ b/rusoto/core/src/lib.rs
@@ -3,7 +3,6 @@
 )]
 #![cfg_attr(feature = "unstable", feature(proc_macro))]
 #![cfg_attr(feature = "nightly-testing", feature(plugin))]
-#![cfg_attr(feature = "nightly-testing", plugin(clippy))]
 #![cfg_attr(
     feature = "nightly-testing",
     allow(

--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -41,5 +41,5 @@ optional = true
 version = "0.0"
 
 [features]
-nightly-testing = ["clippy"]
+nightly-testing = []
 unstable = []

--- a/rusoto/credential/src/lib.rs
+++ b/rusoto/credential/src/lib.rs
@@ -2,7 +2,6 @@
     html_logo_url = "https://raw.githubusercontent.com/rusoto/rusoto/master/assets/logo-square.png"
 )]
 #![cfg_attr(feature = "nightly-testing", feature(plugin))]
-#![cfg_attr(feature = "nightly-testing", plugin(clippy))]
 #![cfg_attr(not(feature = "unstable"), deny(warnings))]
 #![deny(missing_docs)]
 

--- a/service_crategen/Cargo.toml
+++ b/service_crategen/Cargo.toml
@@ -35,5 +35,5 @@ debug = false
 debug-assertions = false
 
 [features]
-nightly-testing = ["clippy"]
+nightly-testing = []
 unstable = []

--- a/service_crategen/src/main.rs
+++ b/service_crategen/src/main.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(feature = "nightly-testing", feature(plugin))]
-#![cfg_attr(feature = "nightly-testing", plugin(clippy))]
 
 mod botocore;
 mod cargo;


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:
Removing nightly requirement for clippy since it is in stable now. As per https://github.com/rusoto/rusoto/issues/1457

