### PR TITLE
[WIP] Compress payload by gzip

### DIFF
--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -47,6 +47,8 @@ url = "1.6.0"
 tokio = "0.1.7"
 tokio-timer = "0.2.6"
 xml-rs = "0.7"
+# TODO convert to a feature
+libflate = "0.1"
 
 [dependencies.rusoto_credential]
 path = "../credential"

--- a/rusoto/core/src/compression.rs
+++ b/rusoto/core/src/compression.rs
@@ -1,0 +1,33 @@
+use std::rc::Rc;
+use std::sync::Arc;
+use crate::signature::SignedRequest;
+
+pub struct CompressionOptions {
+    pub min_payload_size_for_compression: Option<usize>,
+}
+
+/// Trait for implementing request payload compression
+pub trait CompressRequestPayload {
+    fn compress(&self, request: &mut SignedRequest, compression_options: &CompressionOptions);
+    fn compression_options(&self) -> &Option<CompressionOptions>;
+}
+
+impl<C: CompressRequestPayload> CompressRequestPayload for Rc<C> {
+    fn compress(&self, request: &mut SignedRequest, compression_options: &CompressionOptions) {
+        C::compress(&*self, request, compression_options)
+    }
+
+    fn compression_options(&self) -> &Option<CompressionOptions> {
+        C::compression_options(&*self)
+    }
+}
+
+impl<C: CompressRequestPayload> CompressRequestPayload for Arc<C> {
+    fn compress(&self, request: &mut SignedRequest, compression_options: &CompressionOptions) {
+        C::compress(&*self, request, compression_options)
+    }
+
+    fn compression_options(&self) -> &Option<CompressionOptions> {
+        C::compression_options(&*self)
+    }
+}

--- a/rusoto/core/src/lib.rs
+++ b/rusoto/core/src/lib.rs
@@ -62,6 +62,8 @@ pub use crate::client::Client;
 pub mod proto;
 #[doc(hidden)]
 pub mod serialization;
+#[doc(hidden)]
+pub mod compression;
 
 pub use crate::credential::{CredentialsError, DefaultCredentialsProvider, ProvideAwsCredentials};
 pub use crate::error::{RusotoError, RusotoResult};

--- a/rusoto/services/acm-pca/src/generated.rs
+++ b/rusoto/services/acm-pca/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1997,7 +1998,7 @@ impl AcmPcaClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         AcmPcaClient {

--- a/rusoto/services/acm/src/generated.rs
+++ b/rusoto/services/acm/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1237,7 +1238,7 @@ impl AcmClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         AcmClient {

--- a/rusoto/services/alexaforbusiness/src/generated.rs
+++ b/rusoto/services/alexaforbusiness/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -7181,7 +7182,7 @@ impl AlexaForBusinessClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         AlexaForBusinessClient {

--- a/rusoto/services/amplify/src/generated.rs
+++ b/rusoto/services/amplify/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -2186,7 +2187,7 @@ impl AmplifyClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         AmplifyClient {

--- a/rusoto/services/apigateway/src/generated.rs
+++ b/rusoto/services/apigateway/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -10598,7 +10599,7 @@ impl ApiGatewayClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         ApiGatewayClient {

--- a/rusoto/services/apigatewaymanagementapi/src/generated.rs
+++ b/rusoto/services/apigatewaymanagementapi/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -123,7 +124,7 @@ impl ApiGatewayManagementApiClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         ApiGatewayManagementApiClient {

--- a/rusoto/services/apigatewayv2/src/generated.rs
+++ b/rusoto/services/apigatewayv2/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -6717,7 +6718,7 @@ impl ApiGatewayV2Client {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         ApiGatewayV2Client {

--- a/rusoto/services/application-autoscaling/src/generated.rs
+++ b/rusoto/services/application-autoscaling/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1237,7 +1238,7 @@ impl ApplicationAutoScalingClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         ApplicationAutoScalingClient {

--- a/rusoto/services/appstream/src/generated.rs
+++ b/rusoto/services/appstream/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -4373,7 +4374,7 @@ impl AppStreamClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         AppStreamClient {

--- a/rusoto/services/appsync/src/generated.rs
+++ b/rusoto/services/appsync/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -3634,7 +3635,7 @@ impl AppSyncClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         AppSyncClient {

--- a/rusoto/services/athena/src/generated.rs
+++ b/rusoto/services/athena/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1731,7 +1732,7 @@ impl AthenaClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         AthenaClient {

--- a/rusoto/services/autoscaling-plans/src/generated.rs
+++ b/rusoto/services/autoscaling-plans/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -815,7 +816,7 @@ impl AutoscalingPlansClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         AutoscalingPlansClient {

--- a/rusoto/services/autoscaling/src/generated.rs
+++ b/rusoto/services/autoscaling/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -10283,7 +10284,7 @@ impl AutoscalingClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         AutoscalingClient {

--- a/rusoto/services/batch/src/generated.rs
+++ b/rusoto/services/batch/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -2015,7 +2016,7 @@ impl BatchClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         BatchClient {

--- a/rusoto/services/budgets/src/generated.rs
+++ b/rusoto/services/budgets/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1449,7 +1450,7 @@ impl BudgetsClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         BudgetsClient {

--- a/rusoto/services/ce/src/generated.rs
+++ b/rusoto/services/ce/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1474,7 +1475,7 @@ impl CostExplorerClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         CostExplorerClient {

--- a/rusoto/services/chime/src/generated.rs
+++ b/rusoto/services/chime/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -6313,7 +6314,7 @@ impl ChimeClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         ChimeClient {

--- a/rusoto/services/cloud9/src/generated.rs
+++ b/rusoto/services/cloud9/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1191,7 +1192,7 @@ impl Cloud9Client {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         Cloud9Client {

--- a/rusoto/services/clouddirectory/src/generated.rs
+++ b/rusoto/services/clouddirectory/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -8535,7 +8536,7 @@ impl CloudDirectoryClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         CloudDirectoryClient {

--- a/rusoto/services/cloudformation/src/generated.rs
+++ b/rusoto/services/cloudformation/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -9817,7 +9818,7 @@ impl CloudFormationClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         CloudFormationClient {

--- a/rusoto/services/cloudfront/src/generated.rs
+++ b/rusoto/services/cloudfront/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -12107,7 +12108,7 @@ impl CloudFrontClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         CloudFrontClient {

--- a/rusoto/services/cloudhsm/src/generated.rs
+++ b/rusoto/services/cloudhsm/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1632,7 +1633,7 @@ impl CloudHsmClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         CloudHsmClient {

--- a/rusoto/services/cloudhsmv2/src/generated.rs
+++ b/rusoto/services/cloudhsmv2/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1391,7 +1392,7 @@ impl CloudHsmv2Client {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         CloudHsmv2Client {

--- a/rusoto/services/cloudsearch/src/generated.rs
+++ b/rusoto/services/cloudsearch/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -5611,7 +5612,7 @@ impl CloudSearchClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         CloudSearchClient {

--- a/rusoto/services/cloudsearchdomain/src/generated.rs
+++ b/rusoto/services/cloudsearchdomain/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -488,7 +489,7 @@ impl CloudSearchDomainClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         CloudSearchDomainClient {

--- a/rusoto/services/cloudtrail/src/generated.rs
+++ b/rusoto/services/cloudtrail/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -2048,7 +2049,7 @@ impl CloudTrailClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         CloudTrailClient {

--- a/rusoto/services/cloudwatch/src/generated.rs
+++ b/rusoto/services/cloudwatch/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -4244,7 +4245,7 @@ impl CloudWatchClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         CloudWatchClient {

--- a/rusoto/services/codebuild/src/generated.rs
+++ b/rusoto/services/codebuild/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -2182,7 +2183,7 @@ impl CodeBuildClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         CodeBuildClient {

--- a/rusoto/services/codecommit/src/generated.rs
+++ b/rusoto/services/codecommit/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -7384,7 +7385,7 @@ impl CodeCommitClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         CodeCommitClient {

--- a/rusoto/services/codedeploy/src/generated.rs
+++ b/rusoto/services/codedeploy/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -6356,7 +6357,7 @@ impl CodeDeployClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         CodeDeployClient {

--- a/rusoto/services/codepipeline/src/generated.rs
+++ b/rusoto/services/codepipeline/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -3760,7 +3761,7 @@ impl CodePipelineClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         CodePipelineClient {

--- a/rusoto/services/codestar/src/generated.rs
+++ b/rusoto/services/codestar/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1651,7 +1652,7 @@ impl CodeStarClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         CodeStarClient {

--- a/rusoto/services/cognito-identity/src/generated.rs
+++ b/rusoto/services/cognito-identity/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -2204,7 +2205,7 @@ impl CognitoIdentityClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         CognitoIdentityClient {

--- a/rusoto/services/cognito-idp/src/generated.rs
+++ b/rusoto/services/cognito-idp/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -12584,7 +12585,7 @@ impl CognitoIdentityProviderClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         CognitoIdentityProviderClient {

--- a/rusoto/services/cognito-sync/src/generated.rs
+++ b/rusoto/services/cognito-sync/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1872,7 +1873,7 @@ impl CognitoSyncClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         CognitoSyncClient {

--- a/rusoto/services/comprehend/src/generated.rs
+++ b/rusoto/services/comprehend/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -5218,7 +5219,7 @@ impl ComprehendClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         ComprehendClient {

--- a/rusoto/services/comprehendmedical/src/generated.rs
+++ b/rusoto/services/comprehendmedical/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -342,7 +343,7 @@ impl ComprehendMedicalClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         ComprehendMedicalClient {

--- a/rusoto/services/config/src/generated.rs
+++ b/rusoto/services/config/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -5458,7 +5459,7 @@ impl ConfigServiceClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         ConfigServiceClient {

--- a/rusoto/services/connect/src/generated.rs
+++ b/rusoto/services/connect/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -2394,7 +2395,7 @@ impl ConnectClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         ConnectClient {

--- a/rusoto/services/cur/src/generated.rs
+++ b/rusoto/services/cur/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -277,7 +278,7 @@ impl CostAndUsageReportClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         CostAndUsageReportClient {

--- a/rusoto/services/datapipeline/src/generated.rs
+++ b/rusoto/services/datapipeline/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1811,7 +1812,7 @@ impl DataPipelineClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         DataPipelineClient {

--- a/rusoto/services/dax/src/generated.rs
+++ b/rusoto/services/dax/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -2517,7 +2518,7 @@ impl DynamodbAcceleratorClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         DynamodbAcceleratorClient {

--- a/rusoto/services/devicefarm/src/generated.rs
+++ b/rusoto/services/devicefarm/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -6840,7 +6841,7 @@ impl DeviceFarmClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         DeviceFarmClient {

--- a/rusoto/services/directconnect/src/generated.rs
+++ b/rusoto/services/directconnect/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -4494,7 +4495,7 @@ impl DirectConnectClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         DirectConnectClient {

--- a/rusoto/services/discovery/src/generated.rs
+++ b/rusoto/services/discovery/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -2723,7 +2724,7 @@ impl DiscoveryClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         DiscoveryClient {

--- a/rusoto/services/dms/src/generated.rs
+++ b/rusoto/services/dms/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -5214,7 +5215,7 @@ impl DatabaseMigrationServiceClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         DatabaseMigrationServiceClient {

--- a/rusoto/services/docdb/src/generated.rs
+++ b/rusoto/services/docdb/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -8630,7 +8631,7 @@ impl DocdbClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         DocdbClient {

--- a/rusoto/services/ds/src/generated.rs
+++ b/rusoto/services/ds/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -5173,7 +5174,7 @@ impl DirectoryServiceClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         DirectoryServiceClient {

--- a/rusoto/services/dynamodb/src/generated.rs
+++ b/rusoto/services/dynamodb/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -4670,7 +4671,7 @@ impl DynamoDbClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         DynamoDbClient {

--- a/rusoto/services/dynamodbstreams/src/generated.rs
+++ b/rusoto/services/dynamodbstreams/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -611,7 +612,7 @@ impl DynamoDbStreamsClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         DynamoDbStreamsClient {

--- a/rusoto/services/ec2/src/generated.rs
+++ b/rusoto/services/ec2/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -64990,7 +64991,7 @@ impl Ec2Client {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         Ec2Client {

--- a/rusoto/services/ecr/src/generated.rs
+++ b/rusoto/services/ecr/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -2572,7 +2573,7 @@ impl EcrClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         EcrClient {

--- a/rusoto/services/ecs/src/generated.rs
+++ b/rusoto/services/ecs/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -5750,7 +5751,7 @@ impl EcsClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         EcsClient {

--- a/rusoto/services/efs/src/generated.rs
+++ b/rusoto/services/efs/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1387,7 +1388,7 @@ impl EfsClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         EfsClient {

--- a/rusoto/services/eks/src/generated.rs
+++ b/rusoto/services/eks/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -949,7 +950,7 @@ impl EksClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         EksClient {

--- a/rusoto/services/elasticache/src/generated.rs
+++ b/rusoto/services/elasticache/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -11281,7 +11282,7 @@ impl ElastiCacheClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         ElastiCacheClient {

--- a/rusoto/services/elasticbeanstalk/src/generated.rs
+++ b/rusoto/services/elasticbeanstalk/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -9933,7 +9934,7 @@ impl ElasticBeanstalkClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         ElasticBeanstalkClient {

--- a/rusoto/services/elastictranscoder/src/generated.rs
+++ b/rusoto/services/elastictranscoder/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -2453,7 +2454,7 @@ impl EtsClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         EtsClient {

--- a/rusoto/services/elb/src/generated.rs
+++ b/rusoto/services/elb/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -6167,7 +6168,7 @@ impl ElbClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         ElbClient {

--- a/rusoto/services/elbv2/src/generated.rs
+++ b/rusoto/services/elbv2/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -8663,7 +8664,7 @@ impl ElbClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         ElbClient {

--- a/rusoto/services/emr/src/generated.rs
+++ b/rusoto/services/emr/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -3580,7 +3581,7 @@ impl EmrClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         EmrClient {

--- a/rusoto/services/events/src/generated.rs
+++ b/rusoto/services/events/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1656,7 +1657,7 @@ impl CloudWatchEventsClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         CloudWatchEventsClient {

--- a/rusoto/services/firehose/src/generated.rs
+++ b/rusoto/services/firehose/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -2101,7 +2102,7 @@ impl KinesisFirehoseClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         KinesisFirehoseClient {

--- a/rusoto/services/fms/src/generated.rs
+++ b/rusoto/services/fms/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1258,7 +1259,7 @@ impl FmsClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         FmsClient {

--- a/rusoto/services/fsx/src/generated.rs
+++ b/rusoto/services/fsx/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1486,7 +1487,7 @@ impl FsxClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         FsxClient {

--- a/rusoto/services/gamelift/src/generated.rs
+++ b/rusoto/services/gamelift/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -7731,7 +7732,7 @@ impl GameLiftClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         GameLiftClient {

--- a/rusoto/services/glacier/src/generated.rs
+++ b/rusoto/services/glacier/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -3343,7 +3344,7 @@ impl GlacierClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         GlacierClient {

--- a/rusoto/services/glue/src/generated.rs
+++ b/rusoto/services/glue/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -10203,7 +10204,7 @@ impl GlueClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         GlueClient {

--- a/rusoto/services/greengrass/src/generated.rs
+++ b/rusoto/services/greengrass/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -7080,7 +7081,7 @@ impl GreenGrassClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         GreenGrassClient {

--- a/rusoto/services/guardduty/src/generated.rs
+++ b/rusoto/services/guardduty/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -3576,7 +3577,7 @@ impl GuardDutyClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         GuardDutyClient {

--- a/rusoto/services/health/src/generated.rs
+++ b/rusoto/services/health/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -743,7 +744,7 @@ impl AWSHealthClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         AWSHealthClient {

--- a/rusoto/services/iam/src/generated.rs
+++ b/rusoto/services/iam/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -20396,7 +20397,7 @@ impl IamClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         IamClient {

--- a/rusoto/services/importexport/src/generated.rs
+++ b/rusoto/services/importexport/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1594,7 +1595,7 @@ impl ImportExportClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         ImportExportClient {

--- a/rusoto/services/inspector/src/generated.rs
+++ b/rusoto/services/inspector/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -3831,7 +3832,7 @@ impl InspectorClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         InspectorClient {

--- a/rusoto/services/iot-data/src/generated.rs
+++ b/rusoto/services/iot-data/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -441,7 +442,7 @@ impl IotDataClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         IotDataClient {

--- a/rusoto/services/iot-jobs-data/src/generated.rs
+++ b/rusoto/services/iot-jobs-data/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -568,7 +569,7 @@ impl IotJobsDataClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         IotJobsDataClient {

--- a/rusoto/services/iot/src/generated.rs
+++ b/rusoto/services/iot/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -18032,7 +18033,7 @@ impl IotClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         IotClient {

--- a/rusoto/services/iot1click-devices/src/generated.rs
+++ b/rusoto/services/iot1click-devices/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1116,7 +1117,7 @@ impl Iot1ClickDevicesClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         Iot1ClickDevicesClient {

--- a/rusoto/services/iot1click-projects/src/generated.rs
+++ b/rusoto/services/iot1click-projects/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1338,7 +1339,7 @@ impl Iot1ClickProjectsClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         Iot1ClickProjectsClient {

--- a/rusoto/services/iotanalytics/src/generated.rs
+++ b/rusoto/services/iotanalytics/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -3972,7 +3973,7 @@ impl IotAnalyticsClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         IotAnalyticsClient {

--- a/rusoto/services/kafka/src/generated.rs
+++ b/rusoto/services/kafka/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -2432,7 +2433,7 @@ impl KafkaClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         KafkaClient {

--- a/rusoto/services/kinesis-video-archived-media/src/generated.rs
+++ b/rusoto/services/kinesis-video-archived-media/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -444,7 +445,7 @@ impl KinesisVideoArchivedMediaClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         KinesisVideoArchivedMediaClient {

--- a/rusoto/services/kinesis-video-media/src/generated.rs
+++ b/rusoto/services/kinesis-video-media/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -161,7 +162,7 @@ impl KinesisVideoMediaClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         KinesisVideoMediaClient {

--- a/rusoto/services/kinesis/src/generated.rs
+++ b/rusoto/services/kinesis/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -2783,7 +2784,7 @@ impl KinesisClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         KinesisClient {

--- a/rusoto/services/kinesisanalytics/src/generated.rs
+++ b/rusoto/services/kinesisanalytics/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -2649,7 +2650,7 @@ impl KinesisAnalyticsClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         KinesisAnalyticsClient {

--- a/rusoto/services/kinesisvideo/src/generated.rs
+++ b/rusoto/services/kinesisvideo/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -994,7 +995,7 @@ impl KinesisVideoClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         KinesisVideoClient {

--- a/rusoto/services/kms/src/generated.rs
+++ b/rusoto/services/kms/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -4061,7 +4062,7 @@ impl KmsClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         KmsClient {

--- a/rusoto/services/lambda/src/generated.rs
+++ b/rusoto/services/lambda/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -4016,7 +4017,7 @@ impl LambdaClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         LambdaClient {

--- a/rusoto/services/lex-models/src/generated.rs
+++ b/rusoto/services/lex-models/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -4039,7 +4040,7 @@ impl LexModelsClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         LexModelsClient {

--- a/rusoto/services/lex-runtime/src/generated.rs
+++ b/rusoto/services/lex-runtime/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -406,7 +407,7 @@ impl LexRuntimeClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         LexRuntimeClient {

--- a/rusoto/services/license-manager/src/generated.rs
+++ b/rusoto/services/license-manager/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1826,7 +1827,7 @@ impl LicenseManagerClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         LicenseManagerClient {

--- a/rusoto/services/lightsail/src/generated.rs
+++ b/rusoto/services/lightsail/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -12180,7 +12181,7 @@ impl LightsailClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         LightsailClient {

--- a/rusoto/services/logs/src/generated.rs
+++ b/rusoto/services/logs/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -3477,7 +3478,7 @@ impl CloudWatchLogsClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         CloudWatchLogsClient {

--- a/rusoto/services/machinelearning/src/generated.rs
+++ b/rusoto/services/machinelearning/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -3113,7 +3114,7 @@ impl MachineLearningClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         MachineLearningClient {

--- a/rusoto/services/macie/src/generated.rs
+++ b/rusoto/services/macie/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -633,7 +634,7 @@ impl MacieClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         MacieClient {

--- a/rusoto/services/marketplace-entitlement/src/generated.rs
+++ b/rusoto/services/marketplace-entitlement/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -187,7 +188,7 @@ impl MarketplaceEntitlementClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         MarketplaceEntitlementClient {

--- a/rusoto/services/marketplacecommerceanalytics/src/generated.rs
+++ b/rusoto/services/marketplacecommerceanalytics/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -210,7 +211,7 @@ impl MarketplaceCommerceAnalyticsClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         MarketplaceCommerceAnalyticsClient {

--- a/rusoto/services/mediaconvert/src/generated.rs
+++ b/rusoto/services/mediaconvert/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -5810,7 +5811,7 @@ impl MediaConvertClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         MediaConvertClient {

--- a/rusoto/services/medialive/src/generated.rs
+++ b/rusoto/services/medialive/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -6927,7 +6928,7 @@ impl MediaLiveClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         MediaLiveClient {

--- a/rusoto/services/mediapackage/src/generated.rs
+++ b/rusoto/services/mediapackage/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -2054,7 +2055,7 @@ impl MediaPackageClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         MediaPackageClient {

--- a/rusoto/services/mediastore/src/generated.rs
+++ b/rusoto/services/mediastore/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1139,7 +1140,7 @@ impl MediaStoreClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         MediaStoreClient {

--- a/rusoto/services/mediatailor/src/generated.rs
+++ b/rusoto/services/mediatailor/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -631,7 +632,7 @@ impl MediaTailorClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         MediaTailorClient {

--- a/rusoto/services/meteringmarketplace/src/generated.rs
+++ b/rusoto/services/meteringmarketplace/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -498,7 +499,7 @@ impl MarketplaceMeteringClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         MarketplaceMeteringClient {

--- a/rusoto/services/mgh/src/generated.rs
+++ b/rusoto/services/mgh/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1844,7 +1845,7 @@ impl MigrationHubClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         MigrationHubClient {

--- a/rusoto/services/mobile/src/generated.rs
+++ b/rusoto/services/mobile/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -993,7 +994,7 @@ impl MobileClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         MobileClient {

--- a/rusoto/services/mq/src/generated.rs
+++ b/rusoto/services/mq/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -2435,7 +2436,7 @@ impl MQClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         MQClient {

--- a/rusoto/services/mturk/src/generated.rs
+++ b/rusoto/services/mturk/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -3385,7 +3386,7 @@ impl MechanicalTurkClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         MechanicalTurkClient {

--- a/rusoto/services/neptune/src/generated.rs
+++ b/rusoto/services/neptune/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -12731,7 +12732,7 @@ impl NeptuneClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         NeptuneClient {

--- a/rusoto/services/opsworks/src/generated.rs
+++ b/rusoto/services/opsworks/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -6129,7 +6130,7 @@ impl OpsWorksClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         OpsWorksClient {

--- a/rusoto/services/opsworkscm/src/generated.rs
+++ b/rusoto/services/opsworkscm/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1435,7 +1436,7 @@ impl OpsWorksCMClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         OpsWorksCMClient {

--- a/rusoto/services/organizations/src/generated.rs
+++ b/rusoto/services/organizations/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -5163,7 +5164,7 @@ impl OrganizationsClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         OrganizationsClient {

--- a/rusoto/services/pi/src/generated.rs
+++ b/rusoto/services/pi/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -381,7 +382,7 @@ impl PerformanceInsightsClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         PerformanceInsightsClient {

--- a/rusoto/services/polly/src/generated.rs
+++ b/rusoto/services/polly/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1010,7 +1011,7 @@ impl PollyClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         PollyClient {

--- a/rusoto/services/pricing/src/generated.rs
+++ b/rusoto/services/pricing/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -388,7 +389,7 @@ impl PricingClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         PricingClient {

--- a/rusoto/services/ram/src/generated.rs
+++ b/rusoto/services/ram/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -2145,7 +2146,7 @@ impl RamClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         RamClient {

--- a/rusoto/services/rds-data/src/generated.rs
+++ b/rusoto/services/rds-data/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -965,7 +966,7 @@ impl RdsDataClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         RdsDataClient {

--- a/rusoto/services/rds/src/generated.rs
+++ b/rusoto/services/rds/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -25143,7 +25144,7 @@ impl RdsClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         RdsClient {

--- a/rusoto/services/redshift/src/generated.rs
+++ b/rusoto/services/redshift/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -16752,7 +16753,7 @@ impl RedshiftClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         RedshiftClient {

--- a/rusoto/services/rekognition/src/generated.rs
+++ b/rusoto/services/rekognition/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -4790,7 +4791,7 @@ impl RekognitionClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         RekognitionClient {

--- a/rusoto/services/resource-groups/src/generated.rs
+++ b/rusoto/services/resource-groups/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1249,7 +1250,7 @@ impl ResourceGroupsClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         ResourceGroupsClient {

--- a/rusoto/services/resourcegroupstaggingapi/src/generated.rs
+++ b/rusoto/services/resourcegroupstaggingapi/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -502,7 +503,7 @@ impl ResourceGroupsTaggingApiClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         ResourceGroupsTaggingApiClient {

--- a/rusoto/services/route53/src/generated.rs
+++ b/rusoto/services/route53/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -11870,7 +11871,7 @@ impl Route53Client {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         Route53Client {

--- a/rusoto/services/route53domains/src/generated.rs
+++ b/rusoto/services/route53domains/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -2237,7 +2238,7 @@ impl Route53DomainsClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         Route53DomainsClient {

--- a/rusoto/services/s3/src/generated.rs
+++ b/rusoto/services/s3/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -18848,7 +18849,7 @@ impl S3Client {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         S3Client {

--- a/rusoto/services/sagemaker-runtime/src/generated.rs
+++ b/rusoto/services/sagemaker-runtime/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -147,7 +148,7 @@ impl SageMakerRuntimeClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         SageMakerRuntimeClient {

--- a/rusoto/services/sagemaker/src/generated.rs
+++ b/rusoto/services/sagemaker/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -7298,7 +7299,7 @@ impl SageMakerClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         SageMakerClient {

--- a/rusoto/services/sdb/src/generated.rs
+++ b/rusoto/services/sdb/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1658,7 +1659,7 @@ impl SimpleDbClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         SimpleDbClient {

--- a/rusoto/services/secretsmanager/src/generated.rs
+++ b/rusoto/services/secretsmanager/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1870,7 +1871,7 @@ impl SecretsManagerClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         SecretsManagerClient {

--- a/rusoto/services/serverlessrepo/src/generated.rs
+++ b/rusoto/services/serverlessrepo/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1895,7 +1896,7 @@ impl ServerlessRepoClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         ServerlessRepoClient {

--- a/rusoto/services/servicecatalog/src/generated.rs
+++ b/rusoto/services/servicecatalog/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -7774,7 +7775,7 @@ impl ServiceCatalogClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         ServiceCatalogClient {

--- a/rusoto/services/servicediscovery/src/generated.rs
+++ b/rusoto/services/servicediscovery/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -2003,7 +2004,7 @@ impl ServiceDiscoveryClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         ServiceDiscoveryClient {

--- a/rusoto/services/ses/src/generated.rs
+++ b/rusoto/services/ses/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -11026,7 +11027,7 @@ impl SesClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         SesClient {

--- a/rusoto/services/shield/src/generated.rs
+++ b/rusoto/services/shield/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1620,7 +1621,7 @@ impl ShieldClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         ShieldClient {

--- a/rusoto/services/sms/src/generated.rs
+++ b/rusoto/services/sms/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -3088,7 +3089,7 @@ impl ServerMigrationServiceClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         ServerMigrationServiceClient {

--- a/rusoto/services/snowball/src/generated.rs
+++ b/rusoto/services/snowball/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1781,7 +1782,7 @@ impl SnowballClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         SnowballClient {

--- a/rusoto/services/sns/src/generated.rs
+++ b/rusoto/services/sns/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -5052,7 +5053,7 @@ impl SnsClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         SnsClient {

--- a/rusoto/services/sqs/src/generated.rs
+++ b/rusoto/services/sqs/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -3072,7 +3073,7 @@ impl SqsClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         SqsClient {

--- a/rusoto/services/ssm/src/generated.rs
+++ b/rusoto/services/ssm/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -14888,7 +14889,7 @@ impl SsmClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         SsmClient {

--- a/rusoto/services/stepfunctions/src/generated.rs
+++ b/rusoto/services/stepfunctions/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -2263,7 +2264,7 @@ impl StepFunctionsClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         StepFunctionsClient {

--- a/rusoto/services/storagegateway/src/generated.rs
+++ b/rusoto/services/storagegateway/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -6332,7 +6333,7 @@ impl StorageGatewayClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         StorageGatewayClient {

--- a/rusoto/services/sts/src/generated.rs
+++ b/rusoto/services/sts/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1478,7 +1479,7 @@ impl StsClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         StsClient {

--- a/rusoto/services/support/src/generated.rs
+++ b/rusoto/services/support/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -1443,7 +1444,7 @@ impl AWSSupportClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         AWSSupportClient {

--- a/rusoto/services/swf/src/generated.rs
+++ b/rusoto/services/swf/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -4478,7 +4479,7 @@ impl SwfClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         SwfClient {

--- a/rusoto/services/transcribe/src/generated.rs
+++ b/rusoto/services/transcribe/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -966,7 +967,7 @@ impl TranscribeClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         TranscribeClient {

--- a/rusoto/services/translate/src/generated.rs
+++ b/rusoto/services/translate/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -592,7 +593,7 @@ impl TranslateClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         TranslateClient {

--- a/rusoto/services/waf-regional/src/generated.rs
+++ b/rusoto/services/waf-regional/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -7418,7 +7419,7 @@ impl WAFRegionalClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         WAFRegionalClient {

--- a/rusoto/services/waf/src/generated.rs
+++ b/rusoto/services/waf/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -7091,7 +7092,7 @@ impl WafClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         WafClient {

--- a/rusoto/services/workdocs/src/generated.rs
+++ b/rusoto/services/workdocs/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -4899,7 +4900,7 @@ impl WorkdocsClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         WorkdocsClient {

--- a/rusoto/services/worklink/src/generated.rs
+++ b/rusoto/services/worklink/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -2973,7 +2974,7 @@ impl WorklinkClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         WorklinkClient {

--- a/rusoto/services/workmail/src/generated.rs
+++ b/rusoto/services/workmail/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -3425,7 +3426,7 @@ impl WorkmailClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         WorkmailClient {

--- a/rusoto/services/workspaces/src/generated.rs
+++ b/rusoto/services/workspaces/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -2859,7 +2860,7 @@ impl WorkspacesClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         WorkspacesClient {

--- a/rusoto/services/xray/src/generated.rs
+++ b/rusoto/services/xray/src/generated.rs
@@ -16,6 +16,7 @@ use std::fmt;
 #[allow(warnings)]
 use futures::future;
 use futures::Future;
+use rusoto_core::compression::CompressRequestPayload;
 use rusoto_core::credential::ProvideAwsCredentials;
 use rusoto_core::region;
 use rusoto_core::request::{BufferedHttpResponse, DispatchSignedRequest};
@@ -2463,7 +2464,7 @@ impl XRayClient {
     where
         P: ProvideAwsCredentials + Send + Sync + 'static,
         P::Future: Send,
-        D: DispatchSignedRequest + Send + Sync + 'static,
+        D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
         D::Future: Send,
     {
         XRayClient {

--- a/service_crategen/src/commands/generate/codegen/mod.rs
+++ b/service_crategen/src/commands/generate/codegen/mod.rs
@@ -138,6 +138,7 @@ where
         use rusoto_core::region;
         use rusoto_core::credential::ProvideAwsCredentials;
         use rusoto_core::{{Client, RusotoFuture, RusotoError}};
+        use rusoto_core::compression::CompressRequestPayload;
     "
     )?;
 
@@ -193,7 +194,7 @@ where
             pub fn new_with<P, D>(request_dispatcher: D, credentials_provider: P, region: region::Region) -> {type_name}
                 where P: ProvideAwsCredentials + Send + Sync + 'static,
                       P::Future: Send,
-                      D: DispatchSignedRequest + Send + Sync + 'static,
+                      D: DispatchSignedRequest + CompressRequestPayload + Send + Sync + 'static,
                       D::Future: Send
             {{
                 {type_name} {{


### PR DESCRIPTION
I have implemented a compression option for request payload compression using gzip #1461.

* Since not all of services accept compressed payloads, I allow it to be optional for user to choose it.
* I have created `CompressRequestPayload` trait and current dispatcher(HttpClient on default) implements it. 
* The name dispatcher should be changed if we decide to continue in this way because now it is overloaded. 
* I also recommend converting this trait to something like `PreSignedRequestManipulator` which will 
allow other people to modify request before it's get signed. I used this approach for compression but there could be other use cases too.

* I have created another PR #1470 that uses a `compressor` implementation, which is going to be passed to service clients as a parameter. This will make code look more tidy, but this will break backwards compatibility since it changes every service client signature.

I have verified compression by creating an integration test for Cloudwatch PutLogEvents and sending log to destination correctly on my account.

One thing I need help is to how should we handle if request's payload is a stream?

I will create a more tidied up PR when we reach a consensus for implementation.