### PR TITLE
Bump hyper-rustls version to 0.17 (fix #1483)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Add `HttpClient::from_builder`
+- Upgrade hyper-rustls library
 
 (Please put changes here)
 

--- a/rusoto/core/Cargo.toml
+++ b/rusoto/core/Cargo.toml
@@ -32,7 +32,7 @@ hmac = "0.5.0"
 http = "0.1.17"
 hyper = "0.12"
 hyper-tls = { version = "0.3.0", optional = true }
-hyper-rustls = { version = "0.16.0", optional = true }
+hyper-rustls = { version = "0.17.0", optional = true }
 lazy_static = "1.0"
 log = "0.4.1"
 md5 = "0.3.6"


### PR DESCRIPTION
Changelog of hyper-rustls is available [here](https://github.com/ctz/hyper-rustls/compare/v/0.16.0..v/0.17.0)

Thanks!