### PR TITLE
Fix profile config comments should not load when '=' char is on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 (Please put changes here)
 
 - Deserialize PostTextResponse correctly by allowing null values in the slots field
+- Fix Profile Config Loading should ignore comments with '=' chars
 
 ## [0.40.0] - 2019-06-28
 

--- a/rusoto/credential/src/profile.rs
+++ b/rusoto/credential/src/profile.rs
@@ -279,7 +279,7 @@ fn parse_config_file(file_path: &Path) -> Option<HashMap<String, HashMap<String,
             line.ok()
                 .map(|l| l.trim_matches(' ').to_owned())
                 .into_iter()
-                .find(|l| !l.starts_with('#') || !l.is_empty())
+                .find(|l| !l.starts_with('#') && !l.is_empty())
         })
         .fold(Default::default(), |(mut result, profile), line| {
             if profile_regex.is_match(&line) {
@@ -466,6 +466,7 @@ mod tests {
             .expect("No bar profile in multiple_profile_credentials");
         assert_eq!(bar_profile.get(REGION), Some(&"us-east-4".to_string()));
         assert_eq!(bar_profile.get("output"), Some(&"json".to_string()));
+        assert_eq!(bar_profile.get("# comments"), None);
     }
 
     #[test]

--- a/rusoto/credential/tests/sample-data/multiple_profile_config
+++ b/rusoto/credential/tests/sample-data/multiple_profile_config
@@ -4,6 +4,9 @@ region = us-east-2
 [profile foo]
 region = us-east-3
 output = json
+
 [profile bar]
 region = us-east-4
 output = json
+# comments = comments
+# comments


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:
Changed the logic so comments are not loaded into profile configuration.
This happens when you have a '=' char on a comment inside a profile config.