### PR TITLE
Parse Athena error message

### DIFF
--- a/rusoto/core/src/proto/json/error.rs
+++ b/rusoto/core/src/proto/json/error.rs
@@ -6,7 +6,7 @@ use super::super::super::request::BufferedHttpResponse;
 struct RawError {
     #[serde(rename = "__type", default)]
     typ: Option<String>,
-    #[serde(default)]
+    #[serde(alias = "Message", default)]
     message: Option<String>,
 }
 
@@ -87,5 +87,25 @@ fn deserialize_dynamodb_error() {
     assert_eq!(
         error.msg,
         "Requested resource not found: Table: tablename not found"
+    );
+}
+
+#[test]
+fn deserialize_athena_error() {
+    use http::StatusCode;
+
+    let payload = r#"{"__type":"InvalidRequestException","AthenaErrorCode":"MALFORMED_QUERY","ErrorCode":"MALFORMED_QUERY","Message":"line 6:18: mismatched input '.' expecting {<EOF>, ',', 'ADD', 'AS', 'ALL', 'SOME', 'ANY', 'WHERE', 'GROUP', 'ORDER', 'HAVING', 'LIMIT', 'AT', 'NO', 'SUBSTRING', 'POSITION', 'TINYINT', 'SMALLINT', 'INTEGER', 'DATE', 'TIME', 'TIMESTAMP', 'INTERVAL', 'YEAR', 'MONTH', 'DAY', 'HOUR', 'MINUTE', 'SECOND', 'ZONE', 'JOIN', 'CROSS', 'INNER', 'LEFT', 'RIGHT', 'FULL', 'NATURAL', 'FILTER', 'OVER', 'PARTITION', 'RANGE', 'ROWS', 'PRECEDING', 'FOLLOWING', 'CURRENT', 'ROW', 'SCHEMA', 'COMMENT', 'VIEW', 'REPLACE', 'GRANT', 'REVOKE', 'PRIVILEGES', 'PUBLIC', 'OPTION', 'EXPLAIN', 'ANALYZE', 'FORMAT', 'TYPE', 'TEXT', 'GRAPHVIZ', 'LOGICAL', 'DISTRIBUTED', 'VALIDATE', 'SHOW', 'TABLES', 'VIEWS', 'SCHEMAS', 'CATALOGS', 'COLUMNS', 'COLUMN', 'USE', 'PARTITIONS', 'FUNCTIONS', 'UNION', 'EXCEPT', 'INTERSECT', 'TO', 'SYSTEM', 'BERNOULLI', 'POISSONIZED', 'TABLESAMPLE', 'ARRAY', 'MAP', 'SET', 'RESET', 'SESSION', 'DATA', 'START', 'TRANSACTION', 'COMMIT', 'ROLLBACK', 'WORK', 'ISOLATION', 'LEVEL', 'SERIALIZABLE', 'REPEATABLE', 'COMMITTED', 'UNCOMMITTED', 'READ', 'WRITE', 'ONLY', 'CALL', 'INPUT', 'OUTPUT', 'CASCADE', 'RESTRICT', 'INCLUDING', 'EXCLUDING', 'PROPERTIES', 'FUNCTION', 'RETURNS', 'LANGUAGE', 'OPTIONS', 'SCALAR', 'AGGREGATE', 'WINDOW', 'NFD', 'NFC', 'NFKD', 'NFKC', 'IF', 'NULLIF', 'COALESCE', IDENTIFIER, DIGIT_IDENTIFIER, QUOTED_IDENTIFIER, BACKQUOTED_IDENTIFIER}"}"#;
+    let response = BufferedHttpResponse {
+        status: StatusCode::NOT_FOUND,
+        body: payload.into(),
+        headers: Default::default(),
+    };
+
+    let error = Error::parse(&response).unwrap();
+
+    assert_eq!(error.typ, "InvalidRequestException");
+    assert_eq!(
+        error.msg,
+        r#"line 6:18: mismatched input '.' expecting {<EOF>, ',', 'ADD', 'AS', 'ALL', 'SOME', 'ANY', 'WHERE', 'GROUP', 'ORDER', 'HAVING', 'LIMIT', 'AT', 'NO', 'SUBSTRING', 'POSITION', 'TINYINT', 'SMALLINT', 'INTEGER', 'DATE', 'TIME', 'TIMESTAMP', 'INTERVAL', 'YEAR', 'MONTH', 'DAY', 'HOUR', 'MINUTE', 'SECOND', 'ZONE', 'JOIN', 'CROSS', 'INNER', 'LEFT', 'RIGHT', 'FULL', 'NATURAL', 'FILTER', 'OVER', 'PARTITION', 'RANGE', 'ROWS', 'PRECEDING', 'FOLLOWING', 'CURRENT', 'ROW', 'SCHEMA', 'COMMENT', 'VIEW', 'REPLACE', 'GRANT', 'REVOKE', 'PRIVILEGES', 'PUBLIC', 'OPTION', 'EXPLAIN', 'ANALYZE', 'FORMAT', 'TYPE', 'TEXT', 'GRAPHVIZ', 'LOGICAL', 'DISTRIBUTED', 'VALIDATE', 'SHOW', 'TABLES', 'VIEWS', 'SCHEMAS', 'CATALOGS', 'COLUMNS', 'COLUMN', 'USE', 'PARTITIONS', 'FUNCTIONS', 'UNION', 'EXCEPT', 'INTERSECT', 'TO', 'SYSTEM', 'BERNOULLI', 'POISSONIZED', 'TABLESAMPLE', 'ARRAY', 'MAP', 'SET', 'RESET', 'SESSION', 'DATA', 'START', 'TRANSACTION', 'COMMIT', 'ROLLBACK', 'WORK', 'ISOLATION', 'LEVEL', 'SERIALIZABLE', 'REPEATABLE', 'COMMITTED', 'UNCOMMITTED', 'READ', 'WRITE', 'ONLY', 'CALL', 'INPUT', 'OUTPUT', 'CASCADE', 'RESTRICT', 'INCLUDING', 'EXCLUDING', 'PROPERTIES', 'FUNCTION', 'RETURNS', 'LANGUAGE', 'OPTIONS', 'SCALAR', 'AGGREGATE', 'WINDOW', 'NFD', 'NFC', 'NFKD', 'NFKC', 'IF', 'NULLIF', 'COALESCE', IDENTIFIER, DIGIT_IDENTIFIER, QUOTED_IDENTIFIER, BACKQUOTED_IDENTIFIER}"#
     );
 }


### PR DESCRIPTION
## Why
When I run an invalid query using Athena, the error message is empty.
I want to display this error message in the `Message` in the response body.

## How
Changed `message` key to case-insensitive when parsing response body.

## Result
part of example code:
```rust
fn main() {
    let cred_filepath = format!("{}/.aws/credentials", dirs::home_dir().unwrap().to_str().unwrap());
    let creds = ProfileProvider::with_configuration(cred_filepath, "example");
    let client = AthenaClient::new_with(
        HttpClient::new().expect("failed"),
        creds,
        Region::ApNortheast1,
        );

    let query_input = StartQueryExecutionInput {};  // include invalid query string
    match client.start_query_execution(query_input).sync() {
        Ok(output) => {
            match output.query_execution_id {
                Some(query_id) => println!("{}", query_id),
                None => println!("query running."),
            }
        },
        Err(error) => {
            println!("Error: {:?}", error);
        },
    }
}
```

before:
```
Error: Service(InvalidRequest(""))
```

after:
```
Error: Service(InvalidRequest("line 6:18: mismatched input \'.\' expecting {<EOF>, \',\', \'ADD\', \'AS\', \'ALL\', \'SOME\', \'ANY\', \'WHERE\', \'GROUP\', \'ORDER\', \'HAVING\', \'LIMIT\', \'AT\', \'NO\', \'SUBSTRING\', \'POSITION\', \'TINYINT\', \'SMALLINT\', \'INTEGER\', \'DATE\', \'TIME\', \'TIMESTAMP\', \'INTERVAL\', \'YEAR\', \'MONTH\', \'DAY\', \'HOUR\', \'MINUTE\', \'SECOND\', \'ZONE\', \'JOIN\', \'CROSS\', \'INNER\', \'LEFT\', \'RIGHT\', \'FULL\', \'NATURAL\', \'FILTER\', \'OVER\', \'PARTITION\', \'RANGE\', \'ROWS\', \'PRECEDING\', \'FOLLOWING\', \'CURRENT\', \'ROW\', \'SCHEMA\', \'COMMENT\', \'VIEW\', \'REPLACE\', \'GRANT\', \'REVOKE\', \'PRIVILEGES\', \'PUBLIC\', \'OPTION\', \'EXPLAIN\', \'ANALYZE\', \'FORMAT\', \'TYPE\', \'TEXT\', \'GRAPHVIZ\', \'LOGICAL\', \'DISTRIBUTED\', \'VALIDATE\', \'SHOW\', \'TABLES\', \'VIEWS\', \'SCHEMAS\', \'CATALOGS\', \'COLUMNS\', \'COLUMN\', \'USE\', \'PARTITIONS\', \'FUNCTIONS\', \'UNION\', \'EXCEPT\', \'INTERSECT\', \'TO\', \'SYSTEM\', \'BERNOULLI\', \'POISSONIZED\', \'TABLESAMPLE\', \'ARRAY\', \'MAP\', \'SET\', \'RESET\', \'SESSION\', \'DATA\', \'START\', \'TRANSACTION\', \'COMMIT\', \'ROLLBACK\', \'WORK\', \'ISOLATION\', \'LEVEL\', \'SERIALIZABLE\', \'REPEATABLE\', \'COMMITTED\', \'UNCOMMITTED\', \'READ\', \'WRITE\', \'ONLY\', \'CALL\', \'INPUT\', \'OUTPUT\', \'CASCADE\', \'RESTRICT\', \'INCLUDING\', \'EXCLUDING\', \'PROPERTIES\', \'FUNCTION\', \'RETURNS\', \'LANGUAGE\', \'OPTIONS\', \'SCALAR\', \'AGGREGATE\', \'WINDOW\', \'NFD\', \'NFC\', \'NFKD\', \'NFKC\', \'IF\', \'NULLIF\', \'COALESCE\', IDENTIFIER, DIGIT_IDENTIFIER, QUOTED_IDENTIFIER, BACKQUOTED_IDENTIFIER}"))
```

raw response body:
```json
{"__type":"InvalidRequestException","AthenaErrorCode":"MALFORMED_QUERY","ErrorCode":"MALFORMED_QUERY","Message":"line 6:22: mismatched input '.' expecting {<EOF>, ',', 'ADD', 'AS', 'ALL', 'SOME', 'ANY', 'WHERE', 'GROUP', 'ORDER', 'HAVING', 'LIMIT', 'AT', 'NO', 'SUBSTRING', 'POSITION', 'TINYINT', 'SMALLINT', 'INTEGER', 'DATE', 'TIME', 'TIMESTAMP', 'INTERVAL', 'YEAR', 'MONTH', 'DAY', 'HOUR', 'MINUTE', 'SECOND', 'ZONE', 'JOIN', 'CROSS', 'INNER', 'LEFT', 'RIGHT', 'FULL', 'NATURAL', 'FILTER', 'OVER', 'PARTITION', 'RANGE', 'ROWS', 'PRECEDING', 'FOLLOWING', 'CURRENT', 'ROW', 'SCHEMA', 'COMMENT', 'VIEW', 'REPLACE', 'GRANT', 'REVOKE', 'PRIVILEGES', 'PUBLIC', 'OPTION', 'EXPLAIN', 'ANALYZE', 'FORMAT', 'TYPE', 'TEXT', 'GRAPHVIZ', 'LOGICAL', 'DISTRIBUTED', 'VALIDATE', 'SHOW', 'TABLES', 'VIEWS', 'SCHEMAS', 'CATALOGS', 'COLUMNS', 'COLUMN', 'USE', 'PARTITIONS', 'FUNCTIONS', 'UNION', 'EXCEPT', 'INTERSECT', 'TO', 'SYSTEM', 'BERNOULLI', 'POISSONIZED', 'TABLESAMPLE', 'ARRAY', 'MAP', 'SET', 'RESET', 'SESSION', 'DATA', 'START', 'TRANSACTION', 'COMMIT', 'ROLLBACK', 'WORK', 'ISOLATION', 'LEVEL', 'SERIALIZABLE', 'REPEATABLE', 'COMMITTED', 'UNCOMMITTED', 'READ', 'WRITE', 'ONLY', 'CALL', 'INPUT', 'OUTPUT', 'CASCADE', 'RESTRICT', 'INCLUDING', 'EXCLUDING', 'PROPERTIES', 'FUNCTION', 'RETURNS', 'LANGUAGE', 'OPTIONS', 'SCALAR', 'AGGREGATE', 'WINDOW', 'NFD', 'NFC', 'NFKD', 'NFKC', 'IF', 'NULLIF', 'COALESCE', IDENTIFIER, DIGIT_IDENTIFIER, QUOTED_IDENTIFIER, BACKQUOTED_IDENTIFIER}"}
```

Thanks