### PR TITLE
credential: `credential_process` fixes + test improvements

### DIFF
--- a/rusoto/credential/src/container.rs
+++ b/rusoto/credential/src/container.rs
@@ -170,13 +170,13 @@ fn new_request(uri: &str, env_var_name: &str) -> Result<Request<Body>, Credentia
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{lock, ENV_MUTEX};
+    use crate::test_utils::lock_env;
     use std::env;
 
     #[test]
     fn request_from_relative_uri() {
         let path = "/xxx";
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         env::set_var(AWS_CONTAINER_CREDENTIALS_RELATIVE_URI, path);
         env::set_var(AWS_CONTAINER_CREDENTIALS_FULL_URI, "dummy");
         env::set_var(AWS_CONTAINER_AUTHORIZATION_TOKEN, "dummy");
@@ -192,7 +192,7 @@ mod tests {
 
     #[test]
     fn error_from_missing_env_vars() {
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         env::remove_var(AWS_CONTAINER_CREDENTIALS_RELATIVE_URI);
         env::remove_var(AWS_CONTAINER_CREDENTIALS_FULL_URI);
         let result = request_from_env_vars();
@@ -201,7 +201,7 @@ mod tests {
 
     #[test]
     fn error_from_empty_env_vars() {
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         env::set_var(AWS_CONTAINER_CREDENTIALS_RELATIVE_URI, "");
         env::set_var(AWS_CONTAINER_CREDENTIALS_FULL_URI, "");
         env::set_var(AWS_CONTAINER_AUTHORIZATION_TOKEN, "");
@@ -215,7 +215,7 @@ mod tests {
     #[test]
     fn request_from_full_uri_with_token() {
         let url = "http://localhost/xxx";
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         env::remove_var(AWS_CONTAINER_CREDENTIALS_RELATIVE_URI);
         env::set_var(AWS_CONTAINER_CREDENTIALS_FULL_URI, url);
         env::set_var(AWS_CONTAINER_AUTHORIZATION_TOKEN, "dummy");
@@ -231,7 +231,7 @@ mod tests {
     #[test]
     fn request_from_full_uri_without_token() {
         let url = "http://localhost/xxx";
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         env::remove_var(AWS_CONTAINER_CREDENTIALS_RELATIVE_URI);
         env::set_var(AWS_CONTAINER_CREDENTIALS_FULL_URI, url);
         env::remove_var(AWS_CONTAINER_AUTHORIZATION_TOKEN);
@@ -246,7 +246,7 @@ mod tests {
     #[test]
     fn request_from_full_uri_with_empty_token() {
         let url = "http://localhost/xxx";
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         env::remove_var(AWS_CONTAINER_CREDENTIALS_RELATIVE_URI);
         env::set_var(AWS_CONTAINER_CREDENTIALS_FULL_URI, url);
         env::set_var(AWS_CONTAINER_AUTHORIZATION_TOKEN, "");

--- a/rusoto/credential/src/environment.rs
+++ b/rusoto/credential/src/environment.rs
@@ -191,7 +191,7 @@ fn get_critical_variable(var_name: String) -> Result<String, CredentialsError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{lock, ENV_MUTEX};
+    use crate::test_utils::lock_env;
     use chrono::Utc;
     use std::env;
 
@@ -206,7 +206,7 @@ mod tests {
 
     #[test]
     fn get_temporary_credentials_from_env() {
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         env::set_var(AWS_ACCESS_KEY_ID, "id");
         env::set_var(AWS_SECRET_ACCESS_KEY, "secret");
         env::set_var(AWS_SESSION_TOKEN, "token");
@@ -223,7 +223,7 @@ mod tests {
 
     #[test]
     fn get_non_temporary_credentials_from_env() {
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         env::set_var(AWS_ACCESS_KEY_ID, "id");
         env::set_var(AWS_SECRET_ACCESS_KEY, "secret");
         env::remove_var(AWS_SESSION_TOKEN);
@@ -239,7 +239,7 @@ mod tests {
 
     #[test]
     fn environment_provider_missing_key_id() {
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         env::remove_var(AWS_ACCESS_KEY_ID);
         env::set_var(AWS_SECRET_ACCESS_KEY, "secret");
         env::remove_var(AWS_SESSION_TOKEN);
@@ -254,7 +254,7 @@ mod tests {
 
     #[test]
     fn environment_provider_missing_secret() {
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         env::remove_var(AWS_SECRET_ACCESS_KEY);
         env::set_var(AWS_ACCESS_KEY_ID, "id");
         env::remove_var(AWS_SESSION_TOKEN);
@@ -269,7 +269,7 @@ mod tests {
 
     #[test]
     fn environment_provider_missing_credentials() {
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         env::remove_var(AWS_SECRET_ACCESS_KEY);
         env::remove_var(AWS_ACCESS_KEY_ID);
         env::remove_var(AWS_SESSION_TOKEN);
@@ -283,7 +283,7 @@ mod tests {
 
     #[test]
     fn environment_provider_bad_expiration() {
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         env::set_var(AWS_ACCESS_KEY_ID, "id");
         env::set_var(AWS_SECRET_ACCESS_KEY, "secret");
         env::set_var(AWS_SESSION_TOKEN, "token");
@@ -302,7 +302,7 @@ mod tests {
 
     #[test]
     fn get_temporary_credentials_with_expiration_from_env() {
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         let now = Utc::now();
         let now_str = now.to_rfc3339();
         env::set_var(AWS_ACCESS_KEY_ID, "id");
@@ -324,7 +324,7 @@ mod tests {
 
     #[test]
     fn regression_test_rfc_3339_compat() {
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         // RFC 3339 expiration times with lower case 't' could not be parsed by earlier
         // implementations.
         env::set_var(AWS_CREDENTIAL_EXPIRATION, "1996-12-19t16:39:57-08:00");
@@ -346,7 +346,7 @@ mod tests {
         // NOTE: not strictly neccessary here, since we are using a non-standard
         // prefix, so we shouldn't collide with the other env interactions in
         // the other tests.
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
 
         let now = Utc::now();
         let now_str = now.to_rfc3339();

--- a/rusoto/credential/src/lib.rs
+++ b/rusoto/credential/src/lib.rs
@@ -58,7 +58,7 @@ pub struct AwsCredentials {
     key: String,
     #[serde(rename = "SecretAccessKey")]
     secret: String,
-    #[serde(rename = "Token")]
+    #[serde(rename = "SessionToken")]
     token: Option<String>,
     #[serde(rename = "Expiration")]
     expires_at: Option<DateTime<Utc>>,

--- a/rusoto/credential/src/lib.rs
+++ b/rusoto/credential/src/lib.rs
@@ -544,7 +544,7 @@ mod tests {
     use std::io::Read;
     use std::path::Path;
 
-    use crate::test_utils::{is_secret_hidden_behind_asterisks, lock, ENV_MUTEX, SECRET};
+    use crate::test_utils::{is_secret_hidden_behind_asterisks, lock_env, SECRET};
     use futures::Future;
 
     use super::*;
@@ -568,7 +568,7 @@ mod tests {
 
     #[test]
     fn profile_provider_finds_right_credentials_in_file() {
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         let profile_provider = ProfileProvider::with_configuration(
             "tests/sample-data/multiple_profile_credentials",
             "foo",

--- a/rusoto/credential/src/profile.rs
+++ b/rusoto/credential/src/profile.rs
@@ -430,7 +430,7 @@ mod tests {
     use std::path::Path;
 
     use super::*;
-    use crate::test_utils::{lock, ENV_MUTEX};
+    use crate::test_utils::lock_env;
     use crate::{CredentialsError, ProvideAwsCredentials};
 
     #[test]
@@ -544,7 +544,7 @@ mod tests {
 
     #[test]
     fn profile_provider_happy_path() {
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         let provider = ProfileProvider::with_configuration(
             "tests/sample-data/multiple_profile_credentials",
             "foo",
@@ -560,7 +560,7 @@ mod tests {
 
     #[test]
     fn profile_provider_via_environment_variable() {
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         let credentials_path = "tests/sample-data/default_profile_credentials";
         env::set_var(AWS_SHARED_CREDENTIALS_FILE, credentials_path);
         let result = ProfileProvider::new();
@@ -572,7 +572,7 @@ mod tests {
 
     #[test]
     fn profile_provider_profile_name_via_environment_variable() {
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         let credentials_path = "tests/sample-data/multiple_profile_credentials";
         env::set_var(AWS_SHARED_CREDENTIALS_FILE, credentials_path);
         env::set_var(AWS_PROFILE, "bar");
@@ -588,7 +588,7 @@ mod tests {
 
     #[test]
     fn profile_provider_bad_profile() {
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         let provider = ProfileProvider::with_configuration(
             "tests/sample-data/multiple_profile_credentials",
             "not_a_profile",
@@ -604,7 +604,7 @@ mod tests {
 
     #[test]
     fn profile_provider_credential_process() {
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         env::set_var(
             AWS_CONFIG_FILE,
             "tests/sample-data/credential_process_config",
@@ -622,7 +622,7 @@ mod tests {
 
     #[test]
     fn profile_provider_profile_name() {
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         let mut provider = ProfileProvider::new().unwrap();
         assert_eq!(DEFAULT, provider.profile());
         provider.set_profile("foo");
@@ -679,7 +679,7 @@ mod tests {
 
     #[test]
     fn default_profile_name_from_env_var() {
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         env::set_var(AWS_PROFILE, "bar");
         assert_eq!("bar", ProfileProvider::default_profile_name());
         env::remove_var(AWS_PROFILE);
@@ -687,7 +687,7 @@ mod tests {
 
     #[test]
     fn default_profile_name_from_empty_env_var() {
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         env::set_var(AWS_PROFILE, "");
         assert_eq!(DEFAULT, ProfileProvider::default_profile_name());
         env::remove_var(AWS_PROFILE);
@@ -695,14 +695,14 @@ mod tests {
 
     #[test]
     fn default_profile_name() {
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         env::remove_var(AWS_PROFILE);
         assert_eq!(DEFAULT, ProfileProvider::default_profile_name());
     }
 
     #[test]
     fn default_profile_location_from_env_var() {
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         env::set_var(AWS_SHARED_CREDENTIALS_FILE, "bar");
         assert_eq!(
             Ok(PathBuf::from("bar")),
@@ -713,7 +713,7 @@ mod tests {
 
     #[test]
     fn default_profile_location_from_empty_env_var() {
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         env::set_var(AWS_SHARED_CREDENTIALS_FILE, "");
         assert_eq!(
             ProfileProvider::hardcoded_profile_location(),
@@ -724,7 +724,7 @@ mod tests {
 
     #[test]
     fn default_profile_location() {
-        let _guard = lock(&ENV_MUTEX);
+        let _guard = lock_env();
         env::remove_var(AWS_SHARED_CREDENTIALS_FILE);
         assert_eq!(
             ProfileProvider::hardcoded_profile_location(),

--- a/rusoto/credential/src/profile.rs
+++ b/rusoto/credential/src/profile.rs
@@ -617,6 +617,11 @@ mod tests {
         let creds = result.ok().unwrap();
         assert_eq!(creds.aws_access_key_id(), "baz_access_key");
         assert_eq!(creds.aws_secret_access_key(), "baz_secret_key");
+        assert_eq!(
+            creds.token().as_ref().expect("session token not parsed"),
+            "baz_session_token"
+        );
+        assert!(creds.expires_at().is_some());
         env::remove_var(AWS_CONFIG_FILE);
     }
 

--- a/rusoto/credential/src/test_utils.rs
+++ b/rusoto/credential/src/test_utils.rs
@@ -1,5 +1,7 @@
 #![cfg(test)]
 
+use std::collections::HashMap;
+use std::ffi::OsString;
 use std::fmt::Debug;
 use std::sync::{Mutex, MutexGuard};
 
@@ -13,18 +15,35 @@ where
     !debug.contains(SECRET) && debug.contains("**********")
 }
 
-// cargo runs tests in parallel, which leads to race conditions when changing
-// environment variables. Therefore we use a global mutex for all tests which
-// rely on environment variables.
-lazy_static! {
-    pub static ref ENV_MUTEX: Mutex<()> = Mutex::new(());
-}
+// cargo runs tests in parallel, which leads to race conditions when changing environment
+// variables. Therefore we use a global mutex for all tests which rely on environment variables.
+//
+// As failed (panic) tests will poison the global mutex, we use a helper which recovers from
+// poisoned mutex.
+//
+// The first time the helper is called it stores the original environment. If the lock is poisoned,
+// the environment is reset to the original state.
+pub fn lock_env() -> MutexGuard<'static, ()> {
+    lazy_static! {
+        static ref ENV_MUTEX: Mutex<()> = Mutex::new(());
+        static ref ORIGINAL_ENVIRONMENT: HashMap<OsString, OsString> =
+            std::env::vars_os().collect();
+    }
 
-// As failed (panic) tests will poison the global mutex, we use a helper which
-// recovers from poisoned mutex.
-pub fn lock<'a, T>(mutex: &'a Mutex<T>) -> MutexGuard<'a, T> {
-    match mutex.lock() {
+    let guard = ENV_MUTEX.lock();
+    lazy_static::initialize(&ORIGINAL_ENVIRONMENT);
+    match guard {
         Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
+        Err(poisoned) => {
+            for (name, _) in std::env::vars_os() {
+                if !ORIGINAL_ENVIRONMENT.contains_key(&name) {
+                    std::env::remove_var(name);
+                }
+            }
+            for (name, value) in ORIGINAL_ENVIRONMENT.iter() {
+                std::env::set_var(name, value);
+            }
+            poisoned.into_inner()
+        }
     }
 }

--- a/rusoto/credential/tests/sample-data/credential_process_config
+++ b/rusoto/credential/tests/sample-data/credential_process_config
@@ -1,3 +1,7 @@
 [default]
 credential_process = cat tests/sample-data/credential_process_sample_response
 region = us-east-2
+
+[profile foo]
+credential_process = cat tests/sample-data/credential_process_sample_response_foo
+region = us-east-2

--- a/rusoto/credential/tests/sample-data/credential_process_sample_response
+++ b/rusoto/credential/tests/sample-data/credential_process_sample_response
@@ -1,1 +1,1 @@
-{"Version":1,"AccessKeyId":"baz_access_key","SecretAccessKey":"baz_secret_key"}
+{"Version":1,"AccessKeyId":"baz_access_key","SecretAccessKey":"baz_secret_key","SessionToken":"baz_session_token","Expiration":"2019-03-21T01:23:45+00:00"}

--- a/rusoto/credential/tests/sample-data/credential_process_sample_response_foo
+++ b/rusoto/credential/tests/sample-data/credential_process_sample_response_foo
@@ -1,0 +1,1 @@
+{"Version":1,"AccessKeyId":"foo_access_key","SecretAccessKey":"foo_secret_key","SessionToken":"foo_session_token","Expiration":"2019-03-21T01:23:45+00:00"}


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

- Fix [`credential_process`](https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes) behavior when using the non-default profile
- Correctly read session tokens from `credential_process`

The session token fix changes what `token` deserializes from in `AwsCredentials`. This is breaking a public API, but I assume the next version will be 0.41.0 and not 0.40.1. I didn't see anywhere else that used `AwsCredentials::deserialize`.

Additionally I put some more work into the environment variable mutex as part of rusoto_credentials' test suite; to help other developers focus on individual failures it restores the original environment if a panic occurs in another thread.