### PR TITLE
Regenerate crates with Rust 1.38.0.

### DIFF
--- a/rusoto/services/route53/src/generated.rs
+++ b/rusoto/services/route53/src/generated.rs
@@ -14771,5 +14771,4 @@ mod protocol_tests {
         let result = client.get_hosted_zone(request).sync();
         assert!(!result.is_ok(), "parse error: {:?}", result);
     }
-
 }


### PR DESCRIPTION
Regenerate crates with Rust 1.38.0 to fix a rustfmt difference. See https://github.com/rusoto/rusoto/pull/1500 .