### PR TITLE
dont decode uri before encoding it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Fix service_crategen to parse operations with multiple static params
 - Refactor S3 integration tests - about a `#[test]` per behavior
 - Add support for non signing clients
+- Don't decode query string parameters before encoding it. Results in fixing the prefix and marker
+params for s3 `list_objects` methods
 
 ## [0.40.0] - 2019-06-28
 

--- a/rusoto/core/src/signature.rs
+++ b/rusoto/core/src/signature.rs
@@ -5,6 +5,9 @@
 //!
 //! If needed, the request will be re-issued to a temporary redirect endpoint.  This can happen with
 //! newly created S3 buckets not in us-standard/us-east-1.
+//!
+//! Please note that this module does not expect URIs to already be encoded.
+//!
 
 use std::borrow::Cow;
 use std::collections::btree_map::Entry;

--- a/rusoto/core/src/signature.rs
+++ b/rusoto/core/src/signature.rs
@@ -18,10 +18,10 @@ use bytes::Bytes;
 use hex;
 use hmac::{Hmac, Mac};
 use md5;
+use percent_encoding::{percent_decode, utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 use sha2::{Digest, Sha256};
 use time::now_utc;
 use time::Tm;
-use percent_encoding::{percent_decode, utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 
 use crate::credential::AwsCredentials;
 use crate::param::{Params, ServiceParams};
@@ -677,7 +677,7 @@ pub fn encode_uri_path(uri: &str) -> String {
 
 #[inline]
 fn encode_uri_strict(uri: &str) -> String {
-    utf8_percent_encode(&decode_uri(uri), &STRICT_ENCODE_SET).collect::<String>()
+    utf8_percent_encode(uri, &STRICT_ENCODE_SET).collect::<String>()
 }
 
 #[inline]
@@ -837,7 +837,7 @@ mod tests {
         request.add_param("arg2%7B+%2B", "+%2B");
         assert_eq!(
             super::build_canonical_query_string(&request.params),
-            "arg1%7B=arg1%7B&arg2%7B%20%2B=%20%2B"
+            "arg1%257B=arg1%257B&arg2%257B%20%252B=%20%252B"
         );
         assert_eq!(
             super::canonical_uri(&request.path, &Region::default()),


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Fixes #1371

I wasn't sure if the solution was to remove the `decode_uri` at first because it caused a failing test in `signature.rs`. However after experimenting with boto3 and reading https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html#query-string-auth-v4-signin, I feel that it should be removed and that the failing test should be updated accordingly. I'll keep an eye out on the tests run by the CI but didn't run into errors locally.