### PR TITLE
Fix regression in session token handling (#1527)

### DIFF
--- a/rusoto/credential/src/lib.rs
+++ b/rusoto/credential/src/lib.rs
@@ -58,7 +58,7 @@ pub struct AwsCredentials {
     key: String,
     #[serde(rename = "SecretAccessKey")]
     secret: String,
-    #[serde(rename = "SessionToken")]
+    #[serde(rename = "SessionToken", alias = "Token")]
     token: Option<String>,
     #[serde(rename = "Expiration")]
     expires_at: Option<DateTime<Utc>>,
@@ -615,6 +615,7 @@ mod tests {
             credentials.aws_secret_access_key(),
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
         );
+        assert!(credentials.token().is_some());
 
         assert_eq!(
             credentials.expires_at().expect(""),


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:
* Fix regression in handling session tokens from EC2 instance metadata and ECS task metadata

Fixes #1527. Went digging in the serde test cases to figure out how to do this. 😅

Verified with an instance role and a `rusoto_ec2::Ec2::describe_regions` call with a locally patched `rusoto_credential`.

@matthewkmayer I'd propose this for a 0.41.1 release of rusoto_credential, if that's possible?