### PR TITLE
Rusoto credential 0.41.1

### DIFF
--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/rusoto_credential"
 name = "rusoto_credential"
 readme = "README.md"
 repository = "https://github.com/rusoto/rusoto"
-version = "0.41.0"
+version = "0.41.1"
 exclude = ["tests/sample-data/*"]
 edition = "2018"
 


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Rusoto credential 0.41.1 release.