### PR TITLE
Try without clap dependencies.

### DIFF
--- a/service_crategen/Cargo.toml
+++ b/service_crategen/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2018"
 
 [dependencies]
 Inflector = "0.7.0"
-clap = "2.33.0"
 hoedown = "6.0.0"
 lazy_static = "1.3.0"
 rayon = "1.0.3"
@@ -23,6 +22,10 @@ serde = "1.0.91"
 serde_derive = "1.0.91"
 serde_json = "1.0.39"
 toml = "0.5.1"
+
+[dependencies.clap]
+version = "2.33.0"
+default-features = false
 
 [dependencies.clippy]
 optional = true


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

(N/A - changes to our crate generation)

Related to https://github.com/rusoto/rusoto/issues/1413 : since use of the service_crategen project is usually driven by our Makefile, there's probably not much need for the fancier things clap can do like coloring output and giving suggestions on commands that are close to commands service_crategen understands.

## Before:

<img width="880" alt="Screen Shot 2019-10-12 at 10 52 28 AM" src="https://user-images.githubusercontent.com/4998189/66705694-c85ddc00-ecde-11e9-92e6-57593bdb80d4.png">


## After:

<img width="884" alt="Screen Shot 2019-10-12 at 10 52 52 AM" src="https://user-images.githubusercontent.com/4998189/66705697-ce53bd00-ecde-11e9-948d-48aaa5bbeebd.png">


This removes four dependencies when building `service_crategen`.