### PR TITLE
Update inflector

### DIFF
--- a/service_crategen/Cargo.toml
+++ b/service_crategen/Cargo.toml
@@ -13,7 +13,6 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-Inflector = "0.7.0"
 hoedown = "6.0.0"
 lazy_static = "1.3.0"
 rayon = "1.0.3"
@@ -22,6 +21,10 @@ serde = "1.0.91"
 serde_derive = "1.0.91"
 serde_json = "1.0.39"
 toml = "0.5.1"
+
+[dependencies.Inflector]
+version = "0.11.4"
+default-features = false
 
 [dependencies.clap]
 version = "2.33.0"

--- a/service_crategen/src/commands/generate/codegen/rest_request_generator.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_request_generator.rs
@@ -194,10 +194,8 @@ fn generate_snake_case_uri(request_uri: &str) -> String {
     // convert fooBar to foo_bar
     for caps in URI_ARGS_SNAKE_REGEX.captures_iter(request_uri) {
         let to_find = caps.get(0).expect("nothing captured").as_str();
-        // this silliness is because {fooBar} gets converted to {foo_bar_} and sometimes {_foo_bar}.
-        let replacement = Inflector::to_snake_case(caps.get(0).unwrap().as_str())
-            .replace("_}", "}")
-            .replace("{_", "{");
+        // Wrap with curly braces again:
+        let replacement = format!("{{{}}}", Inflector::to_snake_case(caps.get(0).unwrap().as_str()));
         snake = snake.replace(to_find, &replacement);
     }
 


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

N/A - update a dependency in crategen.

This update allows us to build less dependencies: the new version of inflector uses the same regex version as the crategen project uses. 🎉 

Builds on https://github.com/rusoto/rusoto/pull/1533 . Combined this reduces compilation time of crategen by 30 to 60 seconds on my laptop. 👍 

Related to https://github.com/rusoto/rusoto/issues/1413 .