### PR TITLE
[draft] Make HttpDispatchError an enum

### DIFF
--- a/rusoto/core/src/request.rs
+++ b/rusoto/core/src/request.rs
@@ -156,42 +156,46 @@ impl HttpResponse {
 
 #[derive(Clone, Debug, PartialEq)]
 /// An error produced when sending the request, such as a timeout error.
-pub struct HttpDispatchError {
-    message: String,
-}
-
-impl HttpDispatchError {
-    /// Construct a new HttpDispatchError for testing purposes
-    pub fn new(message: String) -> HttpDispatchError {
-        HttpDispatchError { message }
-    }
+pub enum HttpDispatchError {
+    /// Request timed out
+    Timeout,
+    /// Error from client future
+    ClientFutureError (String),
+    /// Internal error in deadline implementation.
+    DeadlineError (String),
+    /// Error from hyper
+    HyperError (String),
+    /// Io error
+    IoError (String),
 }
 
 impl Error for HttpDispatchError {
     fn description(&self) -> &str {
-        &self.message
+        match self {
+            Self::Timeout => "Request timed out",
+            Self::ClientFutureError(s)
+            | Self::DeadlineError(s)
+            | Self::HyperError (s)
+            | Self::IoError (s) => &s,
+        }
     }
 }
 
 impl fmt::Display for HttpDispatchError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.message)
+        write!(f, "{}", self.description())
     }
 }
 
 impl From<HyperError> for HttpDispatchError {
     fn from(err: HyperError) -> HttpDispatchError {
-        HttpDispatchError {
-            message: err.to_string(),
-        }
+        HttpDispatchError::HyperError (err.to_string())
     }
 }
 
 impl From<IoError> for HttpDispatchError {
     fn from(err: IoError) -> HttpDispatchError {
-        HttpDispatchError {
-            message: err.to_string(),
-        }
+        HttpDispatchError::IoError (err.to_string())
     }
 }
 
@@ -232,9 +236,7 @@ impl Future for HttpClientFuture {
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         match self.0 {
-            ClientFutureInner::Error(ref message) => Err(HttpDispatchError {
-                message: message.clone(),
-            }),
+            ClientFutureInner::Error(ref message) => Err(HttpDispatchError::ClientFutureError (message.clone())),
             ClientFutureInner::Hyper(ref mut hyper_future) => {
                 Ok(hyper_future.poll()?.map(HttpResponse::from_hyper))
             }
@@ -242,15 +244,11 @@ impl Future for HttpClientFuture {
                 match deadline_future.poll() {
                     Err(deadline_err) => {
                         if deadline_err.is_elapsed() {
-                            Err(HttpDispatchError {
-                                message: "Request timed out".into(),
-                            })
+                            Err(HttpDispatchError::Timeout)
                         } else if deadline_err.is_inner() {
                             Err(deadline_err.into_inner().unwrap().into())
                         } else {
-                            Err(HttpDispatchError {
-                                message: format!("deadline error: {}", deadline_err),
-                            })
+                            Err(HttpDispatchError::DeadlineError (deadline_err.to_string()))
                         }
                     }
                     Ok(Async::NotReady) => Ok(Async::NotReady),


### PR DESCRIPTION
Following #1530, I made `HttpDispatchError` into an enum to see how it would work. 

However, I would also like to discuss this idea:

#### Flattening `HttpDispatchError` into `RusotoError`
That means making futures that currently returns `HttpDispatchError` return `RusotoError` instead:
```
impl Future for HttpClientFuture {
    type Item = HttpResponse;
    type Error = RusotoError;
```

And flattening current `HttpDispatchError` variants onto `RusotoError`:

```
#[derive(Debug, PartialEq)]
pub enum RusotoError<E> {
    /// A service-specific error occurred.
    Service(E),
    /// Request timed out
    Timeout,
    /// Error from client future
    ClientFutureError (String),
    /// Internal error in deadline implementation.
    DeadlineError (String),
    /// Error from hyper
    HyperError (String),
    /// Io error
    IoError (String),
    /// An error was encountered with AWS credentials.
    Credentials(CredentialsError),
    /// A validation error occurred.  Details from AWS are provided.
    Validation(String),
    /// An error occurred parsing the response payload.
    ParseError(String),
    /// An unknown error occurred.  The raw HTTP response is provided.
    Unknown(BufferedHttpResponse),
}
```

(I wasn't exactly sure how to describe ClientFuture error etc yet)

Do you find the implemented or aforedescribed ideas ok, or do we need to find another way to fix #1530?