### PR TITLE
(WIP) Test should fail with rustls.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ check_integration_test:
 
 .PHONY: rustls_unit_test
 rustls_unit_test:
-	cargo +$$RUST_VERSION test --all -v --no-default-features --features=rustls
+	(cd rusoto/core && cargo +$$RUST_VERSION test --no-default-features --features=rustls)
 
 .PHONY: check_service_defintions
 check_service_defintions:

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ check_integration_test:
 .PHONY: rustls_unit_test
 rustls_unit_test:
 	(cd rusoto/core && cargo +$$RUST_VERSION test --no-default-features --features=rustls)
+	(cd rusoto/services && ./rustls-unit-test.sh $$RUST_VERSION)
 
 .PHONY: check_service_defintions
 check_service_defintions:

--- a/rusoto/core/src/lib.rs
+++ b/rusoto/core/src/lib.rs
@@ -13,7 +13,7 @@
     )
 )]
 #![allow(dead_code)]
-#![cfg_attr(not(feature = "unstable"), deny(warnings))]
+// #![cfg_attr(not(feature = "unstable"), deny(warnings))]
 #![deny(missing_docs)]
 
 //! Rusoto is an [AWS](https://aws.amazon.com/) SDK for Rust.

--- a/rusoto/core/src/request.rs
+++ b/rusoto/core/src/request.rs
@@ -327,6 +327,10 @@ impl HttpClient {
         #[cfg(feature = "rustls")]
         let connector = HttpsConnector::new(4);
 
+        #[cfg(feature = "rustls")]
+        panic!("expected test failure");
+
+
         Ok(Self::from_connector(connector))
     }
 
@@ -344,6 +348,9 @@ impl HttpClient {
 
         #[cfg(feature = "rustls")]
         let connector = HttpsConnector::new(4);
+
+        #[cfg(feature = "rustls")]
+        panic!("expected test failure");
 
         Ok(Self::from_connector_with_config(connector, config))
     }

--- a/rusoto/services/rustls-unit-test.sh
+++ b/rusoto/services/rustls-unit-test.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+for D in `find . -maxdepth 1 -mindepth 1 -type d`;
+do
+    (cd $D ; cargo +$1 test --no-default-features --features=rustls )
+done


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

N/A - trying to fix nightly builds by showing a failure first. Related to https://github.com/rusoto/rusoto/issues/1548 .

More to come as I'm becoming more convinced we should adjust how we test our `rustls` feature. I'm not convinced this actually tests the implementation. Do maintainers need to run integration tests with rustls in addition to the standard native-tls checks?