### PR TITLE
Appveyor may not have been compiling beta.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,8 @@ install:
 build: off
 test_script:
   - cargo update
+  - set RUST_VERSION=%CHANNEL%
+  - echo using rust_version %RUST_VERSION%
   - make unit_test
   - make rustls_unit_test
   - make check_integration_test


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

N/A - fix a Windows build issue.

I'm pretty sure after the move to the Makefile we missed overriding what version of Rust to use, so Appveyor has always been compiling with `stable`, even on the `beta` channel. 