### PR TITLE
Allow rustls testing for all.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,8 @@ check_integration_test:
 
 .PHONY: rustls_unit_test
 rustls_unit_test:
-	cargo +$$RUST_VERSION test --all -v --no-default-features --features=rustls
+	(cd rusoto/core && cargo +$$RUST_VERSION test --no-default-features --features=rustls)
+	(cd rusoto/services && ./rustls-unit-test.sh $$RUST_VERSION)
 
 .PHONY: check_service_defintions
 check_service_defintions:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,12 +17,24 @@ jobs:
       displayName: 'Install Rust'
     - script: make unit_test
       displayName: 'Run unit tests'
-    - script: |
-        cargo clean
-        make rustls_unit_test
-      displayName: 'Run unit tests with rustls'
     - script: make check_integration_test
       displayName: 'Cargo check integration tests'
+
+- job: 'rustls_unit_tests_linux'
+  displayName: 'Rustls unit tests on Linux'
+  pool:
+    vmImage: 'Ubuntu-16.04'
+
+  steps:
+    - checkout: self
+      fetchDepth: 5
+    - script: |
+        set -e
+        curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+        echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
+      displayName: 'Install Rust'
+    - script: make rustls_unit_test
+      displayName: 'Run unit tests with rustls'
 
 - job: 'unit_and_integration_tests_linux_beta'
   displayName: 'Unit and integration tests on Linux (beta channel)'
@@ -43,12 +55,26 @@ jobs:
       displayName: 'Install Rust beta'
     - script: RUST_VERSION=beta make unit_test
       displayName: 'Run unit tests'
+
+- job: 'rustls_unit_tests_linux_beta'
+  displayName: 'Rustls unit tests on Linux (beta channel)'
+  pool:
+    vmImage: 'Ubuntu-16.04'
+
+  steps:
+    - checkout: self
+      fetchDepth: 5
     - script: |
-        cargo clean
-        RUST_VERSION=beta make rustls_unit_test
+        set -e
+        curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain beta-x86_64-unknown-linux-gnu -y
+        echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
+      displayName: 'Install Rustup'
+    - script: |
+        rustup install beta
+        rustup default beta
+      displayName: 'Install Rust beta'
+    - script: RUST_VERSION=beta make rustls_unit_test
       displayName: 'Run unit tests with rustls'
-    - script: RUST_VERSION=beta make check_integration_test
-      displayName: 'Cargo check integration tests'
 
 - job: 'unit_and_integration_tests_linux_nightly'
   displayName: 'Unit and integration tests on Linux (nightly channel)'
@@ -70,13 +96,29 @@ jobs:
     - script: RUST_VERSION=nightly make unit_test
       displayName: 'Run unit tests'
       continueOnError: true
-    - script: |
-        cargo clean
-        RUST_VERSION=nightly make rustls_unit_test
-      displayName: 'Run unit tests with rustls'
-      continueOnError: true
     - script: RUST_VERSION=nightly make check_integration_test
       displayName: 'Cargo check integration tests'
+      continueOnError: true
+
+- job: 'rustls_unit_tests_linux_nightly'
+  displayName: 'Rustls unit tests on Linux (nightly channel)'
+  pool:
+    vmImage: 'Ubuntu-16.04'
+
+  steps:
+    - checkout: self
+      fetchDepth: 5
+    - script: |
+        set -e
+        curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-x86_64-unknown-linux-gnu -y
+        echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
+      displayName: 'Install Rustup'
+    - script: |
+        rustup install nightly
+        rustup default nightly
+      displayName: 'Install Rust beta'
+    - script:  RUST_VERSION=nightly make rustls_unit_test
+      displayName: 'Run unit tests with rustls'
       continueOnError: true
 
 - job: 'unit_and_integration_tests_osx'
@@ -94,12 +136,24 @@ jobs:
       displayName: 'Install Rust'
     - script: make unit_test
       displayName: 'Run unit tests'
-    - script: |
-        cargo clean
-        make rustls_unit_test
-      displayName: 'Run unit tests with rustls'
     - script: make check_integration_test
       displayName: 'Cargo check integration tests'
+
+- job: 'rustls_unit_tests_osx'
+  displayName: 'Unit and integration tests on OSX'
+  pool:
+    vmImage: 'macos-10.13'
+
+  steps:
+    - checkout: self
+      fetchDepth: 5
+    - script: |
+        set -e
+        curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+        echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
+      displayName: 'Install Rust'
+    - script: make rustls_unit_test
+      displayName: 'Run unit tests with rustls'
 
 - job: 'unit_and_integration_tests_osx_beta'
   displayName: 'Unit and integration tests on OSX (beta channel)'
@@ -116,12 +170,24 @@ jobs:
       displayName: 'Install Rust'
     - script: RUST_VERSION=beta make unit_test
       displayName: 'Run unit tests'
-    - script: |
-        cargo clean
-        RUST_VERSION=beta make rustls_unit_test
-      displayName: 'Run unit tests with rustls'
     - script: RUST_VERSION=beta make check_integration_test
       displayName: 'Cargo check integration tests'
+
+- job: 'rustls_unit_tests_osx_beta'
+  displayName: 'Rustls unit tests on OSX (beta channel)'
+  pool:
+    vmImage: 'macos-10.13'
+
+  steps:
+    - checkout: self
+      fetchDepth: 5
+    - script: |
+        set -e
+        curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain beta
+        echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
+      displayName: 'Install Rust'
+    - script: RUST_VERSION=beta make rustls_unit_test
+      displayName: 'Run unit tests with rustls'
 
 - job: 'unit_and_integration_tests_osx_nightly'
   displayName: 'Unit and integration tests on OSX (nightly channel)'
@@ -139,13 +205,25 @@ jobs:
     - script: RUST_VERSION=nightly make unit_test
       displayName: 'Run unit tests'
       continueOnError: true
-    - script: |
-        cargo clean
-        RUST_VERSION=nightly make rustls_unit_test
-      displayName: 'Run unit tests with rustls'
-      continueOnError: true
     - script: RUST_VERSION=nightly make check_integration_test
       displayName: 'Cargo check integration tests'
+      continueOnError: true
+
+- job: 'rustls_unit_tests_osx_nightly'
+  displayName: 'Rustls unit tests on OSX (nightly channel)'
+  pool:
+    vmImage: 'macos-10.13'
+
+  steps:
+    - checkout: self
+      fetchDepth: 5
+    - script: |
+        set -e
+        curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly
+        echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
+      displayName: 'Install Rust'
+    - script: RUST_VERSION=nightly make rustls_unit_test
+      displayName: 'Run unit tests with rustls'
       continueOnError: true
 
 - job: 'crate_gen_linux'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,9 @@ jobs:
       displayName: 'Install Rust'
     - script: make unit_test
       displayName: 'Run unit tests'
-    - script: make rustls_unit_test
+    - script: |
+        cargo clean
+        make rustls_unit_test
       displayName: 'Run unit tests with rustls'
     - script: make check_integration_test
       displayName: 'Cargo check integration tests'
@@ -41,7 +43,9 @@ jobs:
       displayName: 'Install Rust beta'
     - script: RUST_VERSION=beta make unit_test
       displayName: 'Run unit tests'
-    - script: RUST_VERSION=beta make rustls_unit_test
+    - script: |
+        cargo clean
+        RUST_VERSION=beta make rustls_unit_test
       displayName: 'Run unit tests with rustls'
     - script: RUST_VERSION=beta make check_integration_test
       displayName: 'Cargo check integration tests'
@@ -66,7 +70,9 @@ jobs:
     - script: RUST_VERSION=nightly make unit_test
       displayName: 'Run unit tests'
       continueOnError: true
-    - script: RUST_VERSION=nightly make rustls_unit_test
+    - script: |
+        cargo clean
+        RUST_VERSION=nightly make rustls_unit_test
       displayName: 'Run unit tests with rustls'
       continueOnError: true
     - script: RUST_VERSION=nightly make check_integration_test
@@ -88,7 +94,9 @@ jobs:
       displayName: 'Install Rust'
     - script: make unit_test
       displayName: 'Run unit tests'
-    - script: make rustls_unit_test
+    - script: |
+        cargo clean
+        make rustls_unit_test
       displayName: 'Run unit tests with rustls'
     - script: make check_integration_test
       displayName: 'Cargo check integration tests'
@@ -108,7 +116,9 @@ jobs:
       displayName: 'Install Rust'
     - script: RUST_VERSION=beta make unit_test
       displayName: 'Run unit tests'
-    - script: RUST_VERSION=beta make rustls_unit_test
+    - script: |
+        cargo clean
+        RUST_VERSION=beta make rustls_unit_test
       displayName: 'Run unit tests with rustls'
     - script: RUST_VERSION=beta make check_integration_test
       displayName: 'Cargo check integration tests'
@@ -129,7 +139,9 @@ jobs:
     - script: RUST_VERSION=nightly make unit_test
       displayName: 'Run unit tests'
       continueOnError: true
-    - script: RUST_VERSION=nightly make rustls_unit_test
+    - script: |
+        cargo clean
+        RUST_VERSION=nightly make rustls_unit_test
       displayName: 'Run unit tests with rustls'
       continueOnError: true
     - script: RUST_VERSION=nightly make check_integration_test

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -23,13 +23,10 @@ debug = false
 [dependencies.rusoto_core]
 path = "../rusoto/core"
 default-features = false
-features = ["rustls"]
 
 [dependencies.rusoto_acm]
 optional = true
 path = "../rusoto/services/acm"
-default-features = false
-features = ["rustls"]
 
 [dependencies.rusoto_acm_pca]
 optional = true
@@ -974,3 +971,6 @@ qldb = ["rusoto_qldb"]
 nightly-testing = ["rusoto_core/nightly-testing"]
 disable_ceph_unsupported = []
 disable_minio_unsupported = []
+default = ["native-tls"]
+native-tls = ["rusoto_core/native-tls"]
+rustls = ["rusoto_core/rustls"]

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -22,10 +22,14 @@ debug = false
 
 [dependencies.rusoto_core]
 path = "../rusoto/core"
+default-features = false
+features = ["rustls"]
 
 [dependencies.rusoto_acm]
 optional = true
 path = "../rusoto/services/acm"
+default-features = false
+features = ["rustls"]
 
 [dependencies.rusoto_acm_pca]
 optional = true

--- a/mock/Cargo.toml
+++ b/mock/Cargo.toml
@@ -36,8 +36,10 @@ version = "0.0"
 version = "> 0.25.0"
 path = "../rusoto/core"
 default_features = false
-features = ["native-tls"]
 
 [features]
 nightly-testing = ["rusoto_core/nightly-testing"]
 unstable = []
+rustls = ["rusoto_core/rustls"]
+native-tls = ["rusoto_core/native-tls"]
+default = ["native-tls"]

--- a/rusoto/services/acm-pca/Cargo.toml
+++ b/rusoto/services/acm-pca/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/acm/Cargo.toml
+++ b/rusoto/services/acm/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/alexaforbusiness/Cargo.toml
+++ b/rusoto/services/alexaforbusiness/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/amplify/Cargo.toml
+++ b/rusoto/services/amplify/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/apigateway/Cargo.toml
+++ b/rusoto/services/apigateway/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/apigatewaymanagementapi/Cargo.toml
+++ b/rusoto/services/apigatewaymanagementapi/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/apigatewayv2/Cargo.toml
+++ b/rusoto/services/apigatewayv2/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/application-autoscaling/Cargo.toml
+++ b/rusoto/services/application-autoscaling/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/appmesh/Cargo.toml
+++ b/rusoto/services/appmesh/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/appstream/Cargo.toml
+++ b/rusoto/services/appstream/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/appsync/Cargo.toml
+++ b/rusoto/services/appsync/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/athena/Cargo.toml
+++ b/rusoto/services/athena/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/autoscaling-plans/Cargo.toml
+++ b/rusoto/services/autoscaling-plans/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/autoscaling/Cargo.toml
+++ b/rusoto/services/autoscaling/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/batch/Cargo.toml
+++ b/rusoto/services/batch/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/budgets/Cargo.toml
+++ b/rusoto/services/budgets/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/ce/Cargo.toml
+++ b/rusoto/services/ce/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/chime/Cargo.toml
+++ b/rusoto/services/chime/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/cloud9/Cargo.toml
+++ b/rusoto/services/cloud9/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/clouddirectory/Cargo.toml
+++ b/rusoto/services/clouddirectory/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/cloudformation/Cargo.toml
+++ b/rusoto/services/cloudformation/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/cloudfront/Cargo.toml
+++ b/rusoto/services/cloudfront/Cargo.toml
@@ -26,6 +26,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/cloudhsm/Cargo.toml
+++ b/rusoto/services/cloudhsm/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/cloudhsmv2/Cargo.toml
+++ b/rusoto/services/cloudhsmv2/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/cloudsearch/Cargo.toml
+++ b/rusoto/services/cloudsearch/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/cloudsearchdomain/Cargo.toml
+++ b/rusoto/services/cloudsearchdomain/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/cloudtrail/Cargo.toml
+++ b/rusoto/services/cloudtrail/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/cloudwatch/Cargo.toml
+++ b/rusoto/services/cloudwatch/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/codebuild/Cargo.toml
+++ b/rusoto/services/codebuild/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/codecommit/Cargo.toml
+++ b/rusoto/services/codecommit/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/codedeploy/Cargo.toml
+++ b/rusoto/services/codedeploy/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/codepipeline/Cargo.toml
+++ b/rusoto/services/codepipeline/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/codestar/Cargo.toml
+++ b/rusoto/services/codestar/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/cognito-identity/Cargo.toml
+++ b/rusoto/services/cognito-identity/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/cognito-idp/Cargo.toml
+++ b/rusoto/services/cognito-idp/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/cognito-sync/Cargo.toml
+++ b/rusoto/services/cognito-sync/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/comprehend/Cargo.toml
+++ b/rusoto/services/comprehend/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/comprehendmedical/Cargo.toml
+++ b/rusoto/services/comprehendmedical/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/config/Cargo.toml
+++ b/rusoto/services/config/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/connect/Cargo.toml
+++ b/rusoto/services/connect/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/cur/Cargo.toml
+++ b/rusoto/services/cur/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/datapipeline/Cargo.toml
+++ b/rusoto/services/datapipeline/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/dax/Cargo.toml
+++ b/rusoto/services/dax/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/devicefarm/Cargo.toml
+++ b/rusoto/services/devicefarm/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/directconnect/Cargo.toml
+++ b/rusoto/services/directconnect/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/discovery/Cargo.toml
+++ b/rusoto/services/discovery/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/dms/Cargo.toml
+++ b/rusoto/services/dms/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/docdb/Cargo.toml
+++ b/rusoto/services/docdb/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/ds/Cargo.toml
+++ b/rusoto/services/ds/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/dynamodb/Cargo.toml
+++ b/rusoto/services/dynamodb/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/dynamodbstreams/Cargo.toml
+++ b/rusoto/services/dynamodbstreams/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/ec2-instance-connect/Cargo.toml
+++ b/rusoto/services/ec2-instance-connect/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/ec2/Cargo.toml
+++ b/rusoto/services/ec2/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/ecr/Cargo.toml
+++ b/rusoto/services/ecr/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/ecs/Cargo.toml
+++ b/rusoto/services/ecs/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/efs/Cargo.toml
+++ b/rusoto/services/efs/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/eks/Cargo.toml
+++ b/rusoto/services/eks/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/elasticache/Cargo.toml
+++ b/rusoto/services/elasticache/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/elasticbeanstalk/Cargo.toml
+++ b/rusoto/services/elasticbeanstalk/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/elastictranscoder/Cargo.toml
+++ b/rusoto/services/elastictranscoder/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/elb/Cargo.toml
+++ b/rusoto/services/elb/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/elbv2/Cargo.toml
+++ b/rusoto/services/elbv2/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/emr/Cargo.toml
+++ b/rusoto/services/emr/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/events/Cargo.toml
+++ b/rusoto/services/events/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/firehose/Cargo.toml
+++ b/rusoto/services/firehose/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/fms/Cargo.toml
+++ b/rusoto/services/fms/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/fsx/Cargo.toml
+++ b/rusoto/services/fsx/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/gamelift/Cargo.toml
+++ b/rusoto/services/gamelift/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/glacier/Cargo.toml
+++ b/rusoto/services/glacier/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/glue/Cargo.toml
+++ b/rusoto/services/glue/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/greengrass/Cargo.toml
+++ b/rusoto/services/greengrass/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/guardduty/Cargo.toml
+++ b/rusoto/services/guardduty/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/health/Cargo.toml
+++ b/rusoto/services/health/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/iam/Cargo.toml
+++ b/rusoto/services/iam/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/importexport/Cargo.toml
+++ b/rusoto/services/importexport/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/inspector/Cargo.toml
+++ b/rusoto/services/inspector/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/iot-data/Cargo.toml
+++ b/rusoto/services/iot-data/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/iot-jobs-data/Cargo.toml
+++ b/rusoto/services/iot-jobs-data/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/iot/Cargo.toml
+++ b/rusoto/services/iot/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/iot1click-devices/Cargo.toml
+++ b/rusoto/services/iot1click-devices/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/iot1click-projects/Cargo.toml
+++ b/rusoto/services/iot1click-projects/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/iotanalytics/Cargo.toml
+++ b/rusoto/services/iotanalytics/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/kafka/Cargo.toml
+++ b/rusoto/services/kafka/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/kinesis-video-archived-media/Cargo.toml
+++ b/rusoto/services/kinesis-video-archived-media/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/kinesis-video-media/Cargo.toml
+++ b/rusoto/services/kinesis-video-media/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/kinesis/Cargo.toml
+++ b/rusoto/services/kinesis/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/kinesisanalytics/Cargo.toml
+++ b/rusoto/services/kinesisanalytics/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/kinesisvideo/Cargo.toml
+++ b/rusoto/services/kinesisvideo/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/kms/Cargo.toml
+++ b/rusoto/services/kms/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/lambda/Cargo.toml
+++ b/rusoto/services/lambda/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/lex-models/Cargo.toml
+++ b/rusoto/services/lex-models/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/lex-runtime/Cargo.toml
+++ b/rusoto/services/lex-runtime/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/license-manager/Cargo.toml
+++ b/rusoto/services/license-manager/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/lightsail/Cargo.toml
+++ b/rusoto/services/lightsail/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/logs/Cargo.toml
+++ b/rusoto/services/logs/Cargo.toml
@@ -32,6 +32,7 @@ chrono = "0.4"
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/machinelearning/Cargo.toml
+++ b/rusoto/services/machinelearning/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/macie/Cargo.toml
+++ b/rusoto/services/macie/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/marketplace-entitlement/Cargo.toml
+++ b/rusoto/services/marketplace-entitlement/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/marketplacecommerceanalytics/Cargo.toml
+++ b/rusoto/services/marketplacecommerceanalytics/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/mediaconvert/Cargo.toml
+++ b/rusoto/services/mediaconvert/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/medialive/Cargo.toml
+++ b/rusoto/services/medialive/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/mediapackage/Cargo.toml
+++ b/rusoto/services/mediapackage/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/mediastore/Cargo.toml
+++ b/rusoto/services/mediastore/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/mediatailor/Cargo.toml
+++ b/rusoto/services/mediatailor/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/meteringmarketplace/Cargo.toml
+++ b/rusoto/services/meteringmarketplace/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/mgh/Cargo.toml
+++ b/rusoto/services/mgh/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/mobile/Cargo.toml
+++ b/rusoto/services/mobile/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/mq/Cargo.toml
+++ b/rusoto/services/mq/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/mturk/Cargo.toml
+++ b/rusoto/services/mturk/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/neptune/Cargo.toml
+++ b/rusoto/services/neptune/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/opsworks/Cargo.toml
+++ b/rusoto/services/opsworks/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/opsworkscm/Cargo.toml
+++ b/rusoto/services/opsworkscm/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/organizations/Cargo.toml
+++ b/rusoto/services/organizations/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/pi/Cargo.toml
+++ b/rusoto/services/pi/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/polly/Cargo.toml
+++ b/rusoto/services/polly/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/pricing/Cargo.toml
+++ b/rusoto/services/pricing/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/qldb-session/Cargo.toml
+++ b/rusoto/services/qldb-session/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/qldb/Cargo.toml
+++ b/rusoto/services/qldb/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/ram/Cargo.toml
+++ b/rusoto/services/ram/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/rds-data/Cargo.toml
+++ b/rusoto/services/rds-data/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/rds/Cargo.toml
+++ b/rusoto/services/rds/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/redshift/Cargo.toml
+++ b/rusoto/services/redshift/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/rekognition/Cargo.toml
+++ b/rusoto/services/rekognition/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/resource-groups/Cargo.toml
+++ b/rusoto/services/resource-groups/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/resourcegroupstaggingapi/Cargo.toml
+++ b/rusoto/services/resourcegroupstaggingapi/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/route53/Cargo.toml
+++ b/rusoto/services/route53/Cargo.toml
@@ -26,6 +26,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/route53domains/Cargo.toml
+++ b/rusoto/services/route53domains/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/rustls-unit-test.sh
+++ b/rusoto/services/rustls-unit-test.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+for D in `find . -maxdepth 1 -mindepth 1 -type d`;
+do
+    (cd $D ; cargo +$1 test --no-default-features --features=rustls )
+done 

--- a/rusoto/services/s3/Cargo.toml
+++ b/rusoto/services/s3/Cargo.toml
@@ -26,6 +26,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/sagemaker-runtime/Cargo.toml
+++ b/rusoto/services/sagemaker-runtime/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/sagemaker/Cargo.toml
+++ b/rusoto/services/sagemaker/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/sdb/Cargo.toml
+++ b/rusoto/services/sdb/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/secretsmanager/Cargo.toml
+++ b/rusoto/services/secretsmanager/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/securityhub/Cargo.toml
+++ b/rusoto/services/securityhub/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/serverlessrepo/Cargo.toml
+++ b/rusoto/services/serverlessrepo/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/servicecatalog/Cargo.toml
+++ b/rusoto/services/servicecatalog/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/servicediscovery/Cargo.toml
+++ b/rusoto/services/servicediscovery/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/ses/Cargo.toml
+++ b/rusoto/services/ses/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/shield/Cargo.toml
+++ b/rusoto/services/shield/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/sms/Cargo.toml
+++ b/rusoto/services/sms/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/snowball/Cargo.toml
+++ b/rusoto/services/snowball/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/sns/Cargo.toml
+++ b/rusoto/services/sns/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/sqs/Cargo.toml
+++ b/rusoto/services/sqs/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/ssm/Cargo.toml
+++ b/rusoto/services/ssm/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/stepfunctions/Cargo.toml
+++ b/rusoto/services/stepfunctions/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/storagegateway/Cargo.toml
+++ b/rusoto/services/storagegateway/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/sts/Cargo.toml
+++ b/rusoto/services/sts/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/support/Cargo.toml
+++ b/rusoto/services/support/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/swf/Cargo.toml
+++ b/rusoto/services/swf/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/textract/Cargo.toml
+++ b/rusoto/services/textract/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/transcribe/Cargo.toml
+++ b/rusoto/services/transcribe/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/transfer/Cargo.toml
+++ b/rusoto/services/transfer/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/translate/Cargo.toml
+++ b/rusoto/services/translate/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/waf-regional/Cargo.toml
+++ b/rusoto/services/waf-regional/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/waf/Cargo.toml
+++ b/rusoto/services/waf/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/workdocs/Cargo.toml
+++ b/rusoto/services/workdocs/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/worklink/Cargo.toml
+++ b/rusoto/services/worklink/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/workmail/Cargo.toml
+++ b/rusoto/services/workmail/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/workspaces/Cargo.toml
+++ b/rusoto/services/workspaces/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/rusoto/services/xray/Cargo.toml
+++ b/rusoto/services/xray/Cargo.toml
@@ -28,6 +28,7 @@ default-features = false
 [dev-dependencies.rusoto_mock]
 version = "0.41.0"
 path = "../../../mock"
+default-features = false
 
 [features]
 default = ["native-tls"]

--- a/service_crategen/src/service.rs
+++ b/service_crategen/src/service.rs
@@ -194,7 +194,7 @@ impl<'b> Service<'b> {
                 path: Some("../../../mock".into()),
                 version: Some("0.41.0".into()),
                 optional: None,
-                default_features: None,
+                default_features: Some(false),
                 features: None,
             },
         );


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Let rusoto_mock and services properly control bringing in rustls over native-tls.

This is similar to https://github.com/rusoto/rusoto/pull/1375 , related to https://github.com/rusoto/rusoto/issues/1426 and hopefully fixes https://github.com/rusoto/rusoto/issues/1548 .

The changes here are mostly focused on getting the build working again on nightly. There's still improvements to be made on how we select which TLS connector to use: https://github.com/rusoto/rusoto/issues/1426 . If we can figure out how to change behavior based solely on the presence of the `rustls` flag that'd probably the best path forward.