### PR TITLE
Remove some Clone derivations in crategen.

### DIFF
--- a/service_crategen/src/cargo.rs
+++ b/service_crategen/src/cargo.rs
@@ -3,7 +3,7 @@ use toml;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 pub struct Manifest {
     pub package: Metadata,
     pub badges: Option<BTreeMap<String, Badge>>,
@@ -18,7 +18,7 @@ pub struct Manifest {
     pub features: Option<BTreeMap<String, Vec<String>>>,
 }
 
-#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 pub struct Metadata {
     pub authors: Option<Vec<String>>,
     pub description: Option<String>,
@@ -34,7 +34,7 @@ pub struct Metadata {
     pub exclude: Option<Vec<String>>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Badge {
     pub repository: String,
     pub branch: String,

--- a/service_crategen/src/config.rs
+++ b/service_crategen/src/config.rs
@@ -10,7 +10,7 @@ use serde_json;
 
 use crate::cargo;
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct ServiceConfig {
     pub version: String,
     #[serde(rename = "coreVersion")]


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Removed some `Clone` derives we don't use in crategen.

Less code to generate and compile is more better. 😉 