### PR TITLE
Anonymous credentials support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ params for s3 `list_objects` methods
 - Add SecurityHub service
 - Add Transfer service
 - Introducing `rusoto_signature`, a standalone crate for signing HTTP requests.
-- Add anonymous credentials support for S3
+- Make static credentials into a credential provider
+- Add anonymous credentials support
 
 ## [0.41.0] - 2019-10-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ params for s3 `list_objects` methods
 - Add SecurityHub service
 - Add Transfer service
 - Introducing `rusoto_signature`, a standalone crate for signing HTTP requests.
+- Add anonymous credentials support for S3
 
 ## [0.41.0] - 2019-10-07
 

--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -36,6 +36,8 @@ lazy_static = "1.4.0"
 [dev-dependencies]
 quickcheck = "0.6"
 tokio-core = "0.1"
+rusoto_core = { path = "../core" }
+rusoto_s3 = { path = "../services/s3" }
 
 [dependencies.clippy]
 optional = true

--- a/rusoto/credential/src/lib.rs
+++ b/rusoto/credential/src/lib.rs
@@ -50,9 +50,41 @@ use futures::future::{err, Either, Shared, SharedItem};
 use futures::{Async, Future, Poll};
 use hyper::Error as HyperError;
 
+/// Representation of anonymity
+pub trait Anonymous {
+    /// Return true if a type is anonymous, false otherwise
+    fn is_anonymous(&self) -> bool;
+}
+
+impl Anonymous for AwsCredentials {
+    fn is_anonymous(&self) -> bool {
+        self.aws_access_key_id().is_empty() && self.aws_secret_access_key().is_empty()
+    }
+}
+
 /// AWS API access credentials, including access key, secret key, token (for IAM profiles),
 /// expiration timestamp, and claims from federated login.
-#[derive(Clone, Deserialize)]
+///
+/// # Anonymous example
+///
+/// Some AWS services, like [s3](https://docs.aws.amazon.com/AmazonS3/latest/API/Welcome.html)
+/// do not require authenticated credential identity. For these
+/// cases you can use a default set which are considered anonymous
+///
+/// ```rust,2018edition
+/// use rusoto_credential::{StaticProvider, AwsCredentials};
+/// # use std::error::Error;
+///
+/// # fn main() -> Result<(), Box<dyn Error>> {
+/// let s3 = rusoto_s3::S3Client::new_with(
+///     rusoto_core::request::HttpClient::new()?,
+///     StaticProvider::from(AwsCredentials::default()),
+///     Default::default()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone, Deserialize, Default)]
 pub struct AwsCredentials {
     #[serde(rename = "AccessKeyId")]
     key: String,
@@ -548,6 +580,16 @@ mod tests {
     use futures::Future;
 
     use super::*;
+
+    #[test]
+    fn default_empty_credentials_are_considered_anonymous() {
+        assert!(AwsCredentials::default().is_anonymous())
+    }
+
+    #[test]
+    fn credentials_with_values_are_not_considered_anonymous() {
+        assert!(!AwsCredentials::new("foo", "bar", None, None).is_anonymous())
+    }
 
     #[test]
     fn providers_are_send_and_sync() {

--- a/rusoto/credential/src/lib.rs
+++ b/rusoto/credential/src/lib.rs
@@ -72,12 +72,14 @@ impl Anonymous for AwsCredentials {
 /// cases you can use a default set which are considered anonymous
 ///
 /// ```rust,2018edition
+/// use rusoto_core::request::HttpClient;
+/// use rusoto_s3::S3Client;
 /// use rusoto_credential::{StaticProvider, AwsCredentials};
 /// # use std::error::Error;
 ///
 /// # fn main() -> Result<(), Box<dyn Error>> {
-/// let s3 = rusoto_s3::S3Client::new_with(
-///     rusoto_core::request::HttpClient::new()?,
+/// let s3 = S3Client::new_with(
+///     HttpClient::new()?,
 ///     StaticProvider::from(AwsCredentials::default()),
 ///     Default::default()
 /// );

--- a/rusoto/credential/src/static_provider.rs
+++ b/rusoto/credential/src/static_provider.rs
@@ -77,6 +77,12 @@ impl ProvideAwsCredentials for StaticProvider {
     }
 }
 
+impl From<AwsCredentials> for StaticProvider {
+    fn from(credentials: AwsCredentials) -> Self {
+        StaticProvider{ credentials, valid_for: None }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use futures::Future;
@@ -86,6 +92,13 @@ mod tests {
     use super::*;
     use crate::test_utils::{is_secret_hidden_behind_asterisks, SECRET};
     use crate::ProvideAwsCredentials;
+
+    #[test]
+    fn static_provider_impl_from_for_awscredentials() {
+        let provider = StaticProvider::from(AwsCredentials::default());
+        assert_eq!(provider.get_aws_access_key_id(), "");
+        assert_eq!(*provider.is_valid_for(), None);
+    }
 
     #[test]
     fn test_static_provider_creation() {


### PR DESCRIPTION
Closes #1286.

I do not have an AWS account, but I tested this with with the Internet Archive's S3 API. That is my use case, and the reason I wrote this.