### PR TITLE
empty value based anon credentials

### DIFF
--- a/rusoto/credential/src/lib.rs
+++ b/rusoto/credential/src/lib.rs
@@ -50,9 +50,41 @@ use futures::future::{err, Either, Shared, SharedItem};
 use futures::{Async, Future, Poll};
 use hyper::Error as HyperError;
 
+/// Representation of anonymity
+pub trait Anonymous {
+    /// Return true if a type is anonymous, false otherwise
+    fn is_anonymous(&self) -> bool;
+}
+
+impl Anonymous for AwsCredentials {
+    fn is_anonymous(&self) -> bool {
+        self.aws_access_key_id().is_empty() && self.aws_secret_access_key().is_empty()
+    }
+}
+
 /// AWS API access credentials, including access key, secret key, token (for IAM profiles),
 /// expiration timestamp, and claims from federated login.
-#[derive(Clone, Deserialize)]
+///
+/// # Anonymous example
+///
+/// Some AWS services, like [s3](https://docs.aws.amazon.com/AmazonS3/latest/API/Welcome.html)
+/// do not require authenticated credential identity. For these
+/// cases you can use a default set which are considered anonymous
+///
+/// ```rust,2018edition
+/// use rusoto_credential::{StaticProvider, AwsCredentials};
+/// # use std::error::Error;
+///
+/// # fn main() -> Result<(), Box<dyn Error>> {
+/// let s3 = rusoto_s3::S3Client::new_with(
+///     rusoto_core::request::HttpClient::new()?,
+///     StaticProvider::from(AwsCredentials::default()),
+///     Default::default()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone, Deserialize, Default)]
 pub struct AwsCredentials {
     #[serde(rename = "AccessKeyId")]
     key: String,
@@ -548,6 +580,16 @@ mod tests {
     use futures::Future;
 
     use super::*;
+
+    #[test]
+    fn default_empty_credentials_are_considered_anonymous() {
+        assert!(AwsCredentials::default().is_anonymous())
+    }
+
+    #[test]
+    fn credentials_with_values_are_not_considered_anonymous() {
+        assert!(!AwsCredentials::new("foo", "bar", None, None).is_anonymous())
+    }
 
     #[test]
     fn providers_are_send_and_sync() {

--- a/rusoto/credential/src/profile.rs
+++ b/rusoto/credential/src/profile.rs
@@ -10,9 +10,9 @@ use std::process::Command;
 use dirs::home_dir;
 use futures::future::{result, FutureResult};
 use futures::{Future, Poll};
+use lazy_static::lazy_static;
 use regex::Regex;
 use tokio_process::{CommandExt, OutputAsync};
-use lazy_static::lazy_static;
 
 use crate::{non_empty_env_var, AwsCredentials, CredentialsError, ProvideAwsCredentials};
 
@@ -23,7 +23,8 @@ const DEFAULT: &str = "default";
 const REGION: &str = "region";
 
 lazy_static! {
-    static ref PROFILE_REGEX: Regex = Regex::new(r"^\[(profile )?([^\]]+)\]$").expect("Failed to compile regex");
+    static ref PROFILE_REGEX: Regex =
+        Regex::new(r"^\[(profile )?([^\]]+)\]$").expect("Failed to compile regex");
 }
 
 /// Provides AWS credentials from a profile in a credentials file, or from a credential process.

--- a/rusoto/credential/src/static_provider.rs
+++ b/rusoto/credential/src/static_provider.rs
@@ -79,7 +79,10 @@ impl ProvideAwsCredentials for StaticProvider {
 
 impl From<AwsCredentials> for StaticProvider {
     fn from(credentials: AwsCredentials) -> Self {
-        StaticProvider{ credentials, valid_for: None }
+        StaticProvider {
+            credentials,
+            valid_for: None,
+        }
     }
 }
 

--- a/rusoto/credential/src/static_provider.rs
+++ b/rusoto/credential/src/static_provider.rs
@@ -77,6 +77,12 @@ impl ProvideAwsCredentials for StaticProvider {
     }
 }
 
+impl From<AwsCredentials> for StaticProvider {
+    fn from(credentials: AwsCredentials) -> Self {
+        StaticProvider{ credentials, valid_for: None }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use futures::Future;
@@ -86,6 +92,13 @@ mod tests {
     use super::*;
     use crate::test_utils::{is_secret_hidden_behind_asterisks, SECRET};
     use crate::ProvideAwsCredentials;
+
+    #[test]
+    fn static_provider_impl_from_for_awscredentials() {
+        let provider = StaticProvider::from(AwsCredentials::default());
+        assert_eq!(provider.get_aws_access_key_id(), "");
+        assert_eq!(*provider.is_valid_for(), None);
+    }
 
     #[test]
     fn test_static_provider_creation() {


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

fixes: #1286

this is an alternative solution for supporting anonymous credentials that aligns a little more closely with other aws sdk approaches
