### PR TITLE
Introduce Sign Trait; Feature Flag on std::future::Future in rusoto_signature

### DIFF
--- a/rusoto/signature/Cargo.toml
+++ b/rusoto/signature/Cargo.toml
@@ -35,7 +35,7 @@ hyper-alpha = { package = "hyper", version = "=0.13.0-alpha.4", default_features
 
 futures = { version = "0.1.16", optional = true }
 tokio = { version = "0.1.7", optional = true }
-hyper = { package = "hyper", default_features = false, optional = true }
+hyper = { version = "0.12.35", default_features = false, optional = true }
 
 hmac = "0.7.1"
 http = "0.1.17"

--- a/rusoto/signature/Cargo.toml
+++ b/rusoto/signature/Cargo.toml
@@ -20,15 +20,25 @@ edition = "2018"
 appveyor = { repository = "matthewkmayer/rusoto", branch = "master" }
 azure-devops = { project = "matthewkmayer/Rusoto", pipeline = "rusoto.rusoto", build="1" }
 
+[features]
+default = ["futures-01"]
+futures-01 = ["tokio", "futures", "hyper"]
+async-await = ["futures-preview", "hyper-alpha"]
+
 [build-dependencies]
 rustc_version = "0.2.1"
 
 [dependencies]
 bytes = "0.4.12"
-futures = "0.1.16"
+futures-preview = { version = "=0.3.0-alpha.19", features = ["async-await"], optional = true }
+hyper-alpha = { package = "hyper", features = ["unstable-stream"], version = "=0.13.0-alpha.4", optional = true }
+
+futures = { version = "0.1.16", optional = true }
+tokio = { version = "0.1.7", optional = true }
+hyper = { version = "0.12", optional = true }
+
 hmac = "0.7.1"
 http = "0.1.17"
-hyper = "0.12"
 log = "0.4.1"
 md5 = "0.6"
 base64 = "0.10"
@@ -37,7 +47,6 @@ serde = "1.0.2"
 sha2 = "0.8.0"
 time = "0.1.35"
 percent-encoding = "2.1.0"
-tokio = "0.1.7"
 
 [dependencies.rusoto_credential]
 path = "../credential"

--- a/rusoto/signature/Cargo.toml
+++ b/rusoto/signature/Cargo.toml
@@ -31,11 +31,11 @@ rustc_version = "0.2.1"
 [dependencies]
 bytes = "0.4.12"
 futures-preview = { version = "=0.3.0-alpha.19", features = ["async-await"], optional = true }
-hyper-alpha = { package = "hyper", features = ["unstable-stream"], version = "=0.13.0-alpha.4", optional = true }
+hyper-alpha = { package = "hyper", version = "=0.13.0-alpha.4", default_features = false, features = ["unstable-stream"], optional = true }
 
 futures = { version = "0.1.16", optional = true }
 tokio = { version = "0.1.7", optional = true }
-hyper = { version = "0.12", optional = true }
+hyper = { package = "hyper", default_features = false, optional = true }
 
 hmac = "0.7.1"
 http = "0.1.17"

--- a/rusoto/signature/src/lib.rs
+++ b/rusoto/signature/src/lib.rs
@@ -11,8 +11,15 @@
 #![cfg_attr(not(feature = "unstable"), deny(warnings))]
 pub extern crate rusoto_credential as credential;
 pub mod region;
+pub mod sign;
 pub mod signature;
+
+#[cfg(feature = "futures-01")]
 pub mod stream;
 pub use region::Region;
-pub use signature::{SignedRequest, SignedRequestPayload};
+pub use sign::Sign;
+pub use signature::SignedRequest;
+#[cfg(feature = "futures-01")]
+pub use signature::SignedRequestPayload;
+#[cfg(feature = "futures-01")]
 pub use stream::ByteStream;

--- a/rusoto/signature/src/sign.rs
+++ b/rusoto/signature/src/sign.rs
@@ -37,7 +37,7 @@ pub trait Sign: Sized {
 /// ```rust,edition2018
 /// use rusoto_signature::{Sign, Region, credential::AwsCredentials};
 /// use http::request;
-/// # use hyper_alpha::Body;
+/// # use hyper::Body;
 /// # use std::error::Error;
 ///
 /// # fn main() -> Result<(), Box<dyn Error>> {

--- a/rusoto/signature/src/sign.rs
+++ b/rusoto/signature/src/sign.rs
@@ -1,0 +1,181 @@
+#[cfg(feature = "futures-01")]
+use crate::stream::ByteStream;
+#[cfg(feature = "futures-01")]
+use futures::stream::Stream;
+#[cfg(feature = "futures-01")]
+use hyper::{Body, Chunk};
+
+#[cfg(feature = "async-await")]
+use futures::stream::TryStreamExt;
+#[cfg(feature = "async-await")]
+use hyper_alpha::{Body, Chunk};
+
+use crate::credential::AwsCredentials;
+use crate::{Region, SignedRequest};
+use http::{Error, Request};
+use std::convert::TryInto;
+
+/// A trait to apply AWS' signatures. At the moment, this trait is only implemented for
+/// [http::Request] with Hyper's default body.
+pub trait Sign: Sized {
+    type Error;
+    /// Returns a copy of self, signed
+    fn sign(
+        self,
+        service: &str,
+        region: &Region,
+        credentials: &AwsCredentials,
+    ) -> Result<Self, Self::Error>;
+}
+
+#[cfg(feature = "futures-01")]
+/// Signs an `http::Request` with a set of AWS credentials.
+///
+/// The endpoint should be provided as an [http::Uri] _or_ as as value
+/// that can be successfully converted into an [http::Uri].
+///
+/// ```rust,edition2018
+/// use rusoto_signature::{Sign, Region, credential::AwsCredentials};
+/// use http::request;
+/// # use hyper_alpha::Body;
+/// # use std::error::Error;
+///
+/// # fn main() -> Result<(), Box<dyn Error>> {
+/// request::Builder::new()
+///     .uri("https://xxx.execute-api.us-east-1.amazon.com/dev/?key=value")
+///     .method("GET")
+///     .body(Body::default())?
+///     .sign(
+///         "execute-api",
+///         &Region::UsEast1,
+///         &AwsCredentials::new("key", "secret", None, None)
+///     )?;
+/// # Ok(())
+/// # }
+/// ```
+impl Sign for Request<Body> {
+    type Error = Error;
+    fn sign(
+        self,
+        service: &str,
+        region: &Region,
+        credentials: &AwsCredentials,
+    ) -> Result<Self, Self::Error> {
+        let query = self.uri().query().clone();
+        let custom_region = Region::Custom {
+            name: region.name().into(),
+            endpoint: self
+                .uri()
+                .to_string()
+                .splitn(2, '?')
+                .next()
+                .expect("invalid uri")
+                .to_string(),
+        };
+        let mut signer = SignedRequest::new(
+            self.method().as_ref(),
+            service,
+            &custom_region,
+            Default::default(),
+        );
+        for (key, value) in self.headers() {
+            if let Ok(value) = value.to_str() {
+                signer.add_header(key.as_str(), value);
+            }
+        }
+        if let Some(query) = query {
+            for param in query.split('&') {
+                match &param.splitn(2, '=').collect::<Vec<_>>()[..] {
+                    [key, value] => signer.add_param(*key, *value),
+                    _ => (),
+                }
+            }
+        }
+        let body = self.into_body();
+        signer.set_payload_stream(ByteStream::new(body.map(Chunk::into_bytes).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("invalid request: {}", e),
+            )
+        })));
+        signer.sign(credentials);
+        signer.try_into()
+    }
+}
+
+#[cfg(feature = "async-await")]
+/// Signs an `http::Request` with a set of AWS credentials.
+///
+/// The endpoint should be provided as an [http::Uri] _or_ as as value
+/// that can be successfully converted into an [http::Uri].
+///
+/// ```rust,edition2018
+/// use rusoto_signature::{Sign, Region, credential::AwsCredentials};
+/// use http::request;
+/// # use hyper_alpha::Body;
+/// # use std::error::Error;
+///
+/// # fn main() -> Result<(), Box<dyn Error>> {
+/// request::Builder::new()
+///     .uri("https://xxx.execute-api.us-east-1.amazon.com/dev/?key=value")
+///     .method("GET")
+///     .body(Body::default())?
+///     .sign(
+///         "execute-api",
+///         &Region::UsEast1,
+///         &AwsCredentials::new("key", "secret", None, None)
+///     )?;
+/// # Ok(())
+/// # }
+/// ```
+impl Sign for Request<Body> {
+    type Error = Error;
+    fn sign(
+        self,
+        service: &str,
+        region: &Region,
+        credentials: &AwsCredentials,
+    ) -> Result<Self, Self::Error> {
+        let query = self.uri().query().clone();
+        let custom_region = Region::Custom {
+            name: region.name().into(),
+            endpoint: self
+                .uri()
+                .to_string()
+                .splitn(2, '?')
+                .next()
+                .expect("invalid uri")
+                .to_string(),
+        };
+        let mut signer = SignedRequest::new(
+            self.method().as_ref(),
+            service,
+            &custom_region,
+            Default::default(),
+        );
+        for (key, value) in self.headers() {
+            if let Ok(value) = value.to_str() {
+                signer.add_header(key.as_str(), value);
+            }
+        }
+        if let Some(query) = query {
+            for param in query.split('&') {
+                match &param.splitn(2, '=').collect::<Vec<_>>()[..] {
+                    [key, value] => signer.add_param(*key, *value),
+                    _ => (),
+                }
+            }
+        }
+        let body = self.into_body();
+        let body = body.map_ok(|chunk| Chunk::into_bytes(chunk)).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("invalid request: {}", e),
+            )
+            .into()
+        });
+        signer.set_payload_stream(Box::pin(body));
+        signer.sign(credentials);
+        signer.try_into()
+    }
+}

--- a/rusoto/signature/src/signature.rs
+++ b/rusoto/signature/src/signature.rs
@@ -170,7 +170,6 @@ impl SignedRequest {
         self.hostname = Some(build_hostname(&endpoint_prefix, &self.region));
     }
 
-    #[cfg(feature = "async-await")]
     /// Sets the new body (payload)
     pub fn set_payload<B: Into<Bytes>>(&mut self, payload: Option<B>) {
         self.payload = payload.map(|chunk| SignedRequestPayload::Buffer(chunk.into()));


### PR DESCRIPTION
This is a PR follows up on: https://github.com/rusoto/rusoto/pull/1555.

1. An `async-await` feature flag that enables the use of the Hyper's alpha releases. To use it, 
`rusoto_signature` should be added as: `rusoto_credential = { version = "0.42", default_features = false, features = ["async-await"] }`. This flag is _mutually exclusive_ with the default `futures-01` feature flag.
2. An implementation of @softprops' proposed `Sign` trait that enables signing `http::Request<hyper::Body>`. `Sign` is implemented on _both_ Hyper 0.12 and Hyper 0.13's `Body` structs, but it is not implemented on _both_ simultaneously.

I hope that this PR feature flag enables:

- An incremental migration of Rusoto to `std::future` and async/await.
- Customers to sign `http::Request` with SigV4 signatures, so that they can either call API Gateway-backed services _or_ enable them to make requests to AWS services by providing their own serialization and de-serialization logic.

### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

- Introduce `Sign` Trait, implement on `http::Request<hyper::Body>`.
- Conditionally support `std::future::Future` behind an off-by-default (`async-await`) feature-flag.
