### PR TITLE
more clippy fixes on service crategen

### DIFF
--- a/service_crategen/src/commands/generate/codegen/query.rs
+++ b/service_crategen/src/commands/generate/codegen/query.rs
@@ -217,16 +217,15 @@ fn list_member_format(service: &Service<'_>, flattened: bool) -> String {
 fn generate_map_serializer(service: &Service<'_>, shape: &Shape) -> String {
     let mut parts = Vec::new();
 
-    let prefix_snip: String;
-    if service.service_id() == Some("SNS")
+     let prefix_snip = if service.service_id() == Some("SNS")
         && shape.value.is_some()
         && (shape.value.as_ref().unwrap().shape == "MessageAttributeValue"
             || shape.value.as_ref().unwrap().shape == "AttributeValue")
     {
-        prefix_snip = "let prefix = format!(\"{}.entry.{}\", name, index+1);".to_string();
+        "let prefix = format!(\"{}.entry.{}\", name, index+1);".to_string()
     } else {
-        prefix_snip = "let prefix = format!(\"{}.{}\", name, index+1);".to_string();
-    }
+        "let prefix = format!(\"{}.{}\", name, index+1);".to_string()
+    };
 
     // the key is always a string type
     parts.push(format!(
@@ -243,9 +242,9 @@ fn generate_map_serializer(service: &Service<'_>, shape: &Shape) -> String {
     let primitive_value = value_shape.is_primitive();
 
     if primitive_value {
-        parts.push(format!(
-            "params.put(&format!(\"{{}}.{{}}\", prefix, \"Value\"), &value);"
-        ));
+        parts.push(
+            "params.put(&format!(\"{}.{}\", prefix, \"Value\"), &value);".to_string()
+        );
     } else {
         parts.push(format!(
             "{value_type}Serializer::serialize(

--- a/service_crategen/src/commands/generate/codegen/rest_json.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_json.rs
@@ -226,10 +226,9 @@ fn generate_payload(service: &Service<'_>, input_shape: Option<&Shape>) -> Optio
         }
     };
 
-    if declare_payload.is_some() {
-        Some(declare_payload.unwrap() + "request.set_payload(encoded);")
-    } else {
-        None
+    match declare_payload {
+        Some(value) => Some(value + "request.set_payload(encoded);"),
+        _ => None
     }
 }
 
@@ -388,15 +387,16 @@ fn payload_body_parser(
     mutable_result: bool,
     payload_required: bool,
 ) -> String {
-    let response_body = match payload_required {
-        true => match payload_type {
+    let response_body = if payload_required {
+        match payload_type {
             ShapeType::Blob => "response.body",
             _ => "String::from_utf8_lossy(response.body.as_ref())",
-        },
-        false => match payload_type {
+        }
+    } else {
+        match payload_type {
             ShapeType::Blob => "Some(response.body)",
             _ => "Some(String::from_utf8_lossy(response.body.as_ref()).into_owned())",
-        },
+        }
     };
 
     format!(

--- a/service_crategen/src/commands/generate/codegen/rest_xml.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_xml.rs
@@ -155,13 +155,10 @@ fn generate_documentation(operation: &Operation, service: &Service<'_>) -> Strin
     };
 
     // Specialized docs for services:
-    match service.name().to_ascii_lowercase().as_ref() {
-        "route 53" => {
+    if let "route 53" = service.name().to_ascii_lowercase().as_ref() {
             if operation.name == "ChangeResourceRecordSets" {
                 docs = format!("/// For TXT records, see <a href=\"./util/fn.quote_txt_record.html\">util::quote_txt_record</a>\n{}", docs);
             }
-        }
-        _ => (),
     }
 
     docs

--- a/service_crategen/src/commands/generate/codegen/xml_payload_parser.rs
+++ b/service_crategen/src/commands/generate/codegen/xml_payload_parser.rs
@@ -205,8 +205,7 @@ fn xml_body_parser(
 }
 
 fn generate_deserializer_body(name: &str, shape: &Shape, service: &Service<'_>) -> String {
-    match (service.endpoint_prefix(), name) {
-        ("s3", "GetBucketLocationOutput") => {
+    if let ("s3", "GetBucketLocationOutput") = (service.endpoint_prefix(), name) {
             // override custom deserializer
             let struct_field_deserializers = shape
                 .members
@@ -236,8 +235,6 @@ fn generate_deserializer_body(name: &str, shape: &Shape, service: &Service<'_>) 
                 name = name,
                 struct_field_deserializers = struct_field_deserializers
             );
-        }
-        _ => {}
     }
     match shape.shape_type {
         ShapeType::List => generate_list_deserializer(shape, service),


### PR DESCRIPTION
[#1402](https://github.com/rusoto/rusoto/issues/1402)
There only two warnings remaining, but their fix aren't obvious
@matthewkmayer Do you have some hint for the one with the TODO src/commands/generate/codegen/rest_json.rs:359:21 ? 
When you change `s > 0` to `!s.empty()` it break the build
 
