### PR TITLE
Less doctests for Appveyor.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,11 @@ docs:
 unit_test:
 	cargo +$$RUST_VERSION test --all
 
+# Doctests can be very slow to compile and run. This option lets us skip those if needed.
+.PHONY: unit_test_no_doctests
+unit_test_no_doctests:
+	cargo +$$RUST_VERSION test --all --lib
+
 .PHONY: skeptical
 skeptical:
 	(cd skeptical && cargo +$$RUST_VERSION test)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ test_script:
   - cargo update
   - set RUST_VERSION=%CHANNEL%
   - echo using rust_version %RUST_VERSION%
-  - make unit_test
+  - make unit_test_no_doctests
   - make rustls_unit_test
   - make check_integration_test
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,6 @@ test_script:
   - set RUST_VERSION=%CHANNEL%
   - echo using rust_version %RUST_VERSION%
   - make unit_test_no_doctests
-  - make rustls_unit_test
   - make check_integration_test
 
 branches:


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Skip running doctests on Appveyor.

See https://github.com/rusoto/rusoto/issues/1425 . Let's see if this finishes in less time!