### PR TITLE
switch form of boolean evaluation

### DIFF
--- a/service_crategen/src/commands/generate/codegen/rest_json.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_json.rs
@@ -356,7 +356,7 @@ fn generate_body_parser(operation: &Operation, service: &Service<'_>) -> String 
                 Some(ref s) => {
                     // if there's any required shape present the body payload parser will handle it
                     // This can't be converted to `s.is_empty()`. TODO: find out why.
-                    s.len() > 0
+                    !s.is_empty()
                 }
                 None => false,
             };

--- a/service_crategen/src/commands/generate/codegen/rest_json.rs
+++ b/service_crategen/src/commands/generate/codegen/rest_json.rs
@@ -354,8 +354,6 @@ fn generate_body_parser(operation: &Operation, service: &Service<'_>) -> String 
             // is the shape required?
             let payload_shape_required = match output_shape.required {
                 Some(ref s) => {
-                    // if there's any required shape present the body payload parser will handle it
-                    // This can't be converted to `s.is_empty()`. TODO: find out why.
                     !s.is_empty()
                 }
                 None => false,

--- a/service_crategen/src/commands/generate/codegen/tests.rs
+++ b/service_crategen/src/commands/generate/codegen/tests.rs
@@ -163,13 +163,13 @@ impl Response {
                 );
 
                 service_name.and_then(|s| {
-                    action.and_then(|a| {
-                        Some(Response {
+                    action.map(|a| {
+                        Response {
                             service: s,
                             action: a,
                             file_name: file_name.to_string_lossy().into_owned(),
                             full_path: path.to_owned(),
-                        })
+                        }
                     })
                 })
             } else {


### PR DESCRIPTION
[#1402 ](https://github.com/rusoto/rusoto/issues/1402) 
Pr to test the switch of `s < 0 `  to ` !s.empty()` which is required by clippy but doesn't work.