### PR TITLE
Address remaining clippy lints for services.

### DIFF
--- a/rusoto/services/route53/src/custom/util.rs
+++ b/rusoto/services/route53/src/custom/util.rs
@@ -13,10 +13,10 @@
 /// ```
 pub fn quote_txt_record(record_contents: &str) -> String {
     let mut quoted_string = String::from(record_contents);
-    if !quoted_string.starts_with("\"") {
+    if !quoted_string.starts_with('\"') {
         quoted_string = format!("\"{}", quoted_string);
     }
-    if !quoted_string.ends_with("\"") {
+    if !quoted_string.ends_with('\"') {
         quoted_string = format!("{}\"", quoted_string);
     }
     quoted_string


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Address clippy lint in Route53 helper.

This is the last part of https://github.com/rusoto/rusoto/issues/1402 . 🎉 Thanks to @sepiropht for the great work he's done for that issue. 👍 

I think this can wait until after the 0.42.0 release tomorrow. 😄 