### PR TITLE
credential: Remove circular dev-dependencies

### DIFF
--- a/rusoto/credential/Cargo.toml
+++ b/rusoto/credential/Cargo.toml
@@ -36,8 +36,6 @@ lazy_static = "1.4.0"
 [dev-dependencies]
 quickcheck = "0.6"
 tokio-core = "0.1"
-rusoto_core = { path = "../core" }
-rusoto_s3 = { path = "../services/s3" }
 
 [dependencies.clippy]
 optional = true

--- a/rusoto/credential/src/lib.rs
+++ b/rusoto/credential/src/lib.rs
@@ -71,7 +71,7 @@ impl Anonymous for AwsCredentials {
 /// do not require authenticated credential identity. For these
 /// cases you can use a default set which are considered anonymous
 ///
-/// ```rust,2018edition
+/// ```rust,ignore
 /// use rusoto_core::request::HttpClient;
 /// use rusoto_s3::S3Client;
 /// use rusoto_credential::{StaticProvider, AwsCredentials};


### PR DESCRIPTION
Fixes #1600 by marking the single test creating a circular dependency as `ignore`.

### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

[no changelog entry necessary]