### PR TITLE
Add README.md for signature

### DIFF
--- a/rusoto/signature/README.md
+++ b/rusoto/signature/README.md
@@ -1,0 +1,11 @@
+# Rusoto signature
+
+This crate contains the functionality necessary for signing AWS
+API requests. It was designed for use in
+[Rusoto](https://github.com/rusoto/rusoto).
+
+## Development
+
+The Rusoto signature crate is packaged and published separately from the Rusoto
+crate itself. The crate does not depend on Rusoto itself. The signature crate
+is published as a versioned dependency of Rusoto on crates.io.


### PR DESCRIPTION
Here's another thing `cargo package --no-verify` didn't check...

```
   Uploading rusoto_signature v0.42.0 (/home/ec2-user/rusoto/rusoto/signature)
error: failed to read `/home/ec2-user/rusoto/rusoto/signature/README.md`
```

### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

[no changelog entry necessary]