### PR TITLE
Update skeptic tests for v0.42.0

### DIFF
--- a/skeptical/Cargo.toml
+++ b/skeptical/Cargo.toml
@@ -6,11 +6,11 @@ build = "build.rs"
 edition = "2018"
 
 [dependencies]
-rusoto_core = "0.41"
-rusoto_dynamodb = "0.41"
-rusoto_s3 = "0.41"
-rusoto_ec2 = "0.41"
-rusoto_sts = "0.41"
+rusoto_core = "0.42"
+rusoto_dynamodb = "0.42"
+rusoto_s3 = "0.42"
+rusoto_ec2 = "0.42"
+rusoto_sts = "0.42"
 env_logger = "0.5"
 
 [build-dependencies]


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Update skeptic tests for v0.42.0