### PR TITLE
Set rusoto_mock to same version as rusoto_core in crategen.

### DIFF
--- a/service_crategen/src/service.rs
+++ b/service_crategen/src/service.rs
@@ -192,7 +192,7 @@ impl<'b> Service<'b> {
             "rusoto_mock".to_owned(),
             cargo::Dependency::Extended {
                 path: Some("../../../mock".into()),
-                version: Some("0.42.0".into()),
+                version: Some(self.config.core_version.clone()),
                 optional: None,
                 default_features: Some(false),
                 features: None,


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

Modifies crategen to use `rusoto_core` version as required version for `rusoto_mock`.

Fixes https://github.com/rusoto/rusoto/issues/1602 .