### PR TITLE
This clippy lint should be ignored in crategen.

### DIFF
--- a/service_crategen/src/commands/generate/mod.rs
+++ b/service_crategen/src/commands/generate/mod.rs
@@ -68,6 +68,8 @@ pub fn generate_services(
             return;
         }
 
+        // Panicking on error is okay because we can't do anything if the definition isn't present
+        #[allow(clippy::match_wild_err_arm)]
         let service = match ServiceDefinition::load(name, &service_config.protocol_version) {
             Ok(sd) => Service::new(service_config, sd),
             Err(_) => panic!("Failed to load service {}. Make sure the botocore submodule has been initialized!", name),


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

N/A - clippy lint ignore in crategen.

Fixes last bit of https://github.com/rusoto/rusoto/issues/1401 . 🎉 