### PR TITLE
Limit publishing rate by reducing parallel compilations.

### DIFF
--- a/rusoto/services/publish-services.sh
+++ b/rusoto/services/publish-services.sh
@@ -2,5 +2,7 @@
 
 for D in `find . -maxdepth 1 -mindepth 1 -type d | sort`;
 do
-    (cd $D ; echo "I am in `pwd`" ; cargo publish)
+    # Limit parallelization of compilation to avoid hitting crates.io rate limit.
+    # See https://github.com/rusoto/rusoto/issues/1610 .
+    (cd $D ; echo "I am in `pwd`" ; cargo publish --jobs 4)
 done


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

N/A - publishing script adjustment.

Part of https://github.com/rusoto/rusoto/issues/1610 .