### PR TITLE
Remove old clippy cargo feature.

### DIFF
--- a/service_crategen/Cargo.toml
+++ b/service_crategen/Cargo.toml
@@ -30,10 +30,6 @@ default-features = false
 version = "2.33.0"
 default-features = false
 
-[dependencies.clippy]
-optional = true
-version = "0.0"
-
 [profile.dev]
 opt-level = 1
 codegen-units = 2


### PR DESCRIPTION
### Please help keep the CHANGELOG up to date by providing a one sentence summary of your change:

N/A - remove an unused and outdated set of flags for old clippy versions.

`cargo clippy` runs without these lines, let's get rid of this old way of running clippy!